### PR TITLE
Implement ReduceMinLoc, ReduceMaxLoc; added unit tests as well

### DIFF
--- a/include/RAJA/exec-cuda/MemUtils_CUDA.hxx
+++ b/include/RAJA/exec-cuda/MemUtils_CUDA.hxx
@@ -13,6 +13,7 @@
 #define RAJA_MemUtils_CUDA_HXX
 
 #include "RAJA/config.hxx"
+#include "RAJA/int_datatypes.hxx"
 
 #if defined(RAJA_USE_CUDA)
 
@@ -63,11 +64,15 @@ namespace RAJA {
 
 #define RAJA_CUDA_REDUCE_BLOCK_LENGTH (1024 + 8) * 16
 
+
 ///
 /// Typedef defining common data type for RAJA-Cuda reduction data blocks
 /// (use this in all cases to avoid type confusion).
 ///
 typedef double CudaReductionBlockDataType;
+
+typedef struct{double val; Index_type idx;} CudaReductionLocBlockDataType; 
+
 
 /*!
 *************************************************************************
@@ -110,6 +115,8 @@ void releaseCudaReductionId(int id);
  */
 CudaReductionBlockDataType* getCudaReductionMemBlock(int id);
 
+CudaReductionLocBlockDataType * getCudaReductionLocMemBlock(int id);
+
 /*!
  ******************************************************************************
  *
@@ -118,6 +125,8 @@ CudaReductionBlockDataType* getCudaReductionMemBlock(int id);
  ******************************************************************************
  */
 void freeCudaReductionMemBlock();
+
+void freeCudaReductionLocMemBlock();
 
 
 }  // closing brace for RAJA namespace

--- a/include/RAJA/exec-cuda/reduce_cuda.hxx
+++ b/include/RAJA/exec-cuda/reduce_cuda.hxx
@@ -1156,13 +1156,13 @@ public:
           retiredBlocks[m_myID] = 0;
         }
 
-        CudaReductionLocBlockDataType lmin;
-        lmin.val = m_reduced_val;
-        lmin.idx = m_reduced_idx;
+        CudaReductionLocBlockDataType lmax;
+        lmax.val = m_reduced_val;
+        lmax.idx = m_reduced_idx;
         for (int i = threadIdx.x; i < gridDim.x; i += BLOCK_SIZE) {
-            lmin = RAJA_MAXLOC(lmin,m_blockdata[m_blockoffset+i+1]);
+            lmax = RAJA_MAXLOC(lmax,m_blockdata[m_blockoffset+i+1]);
         }
-        sd[threadIdx.x] = lmin;
+        sd[threadIdx.x] = lmax;
         __syncthreads();
 
         for (int i = BLOCK_SIZE / 2; i >= WARP_SIZE; i /= 2) {

--- a/include/RAJA/exec-cuda/reduce_cuda.hxx
+++ b/include/RAJA/exec-cuda/reduce_cuda.hxx
@@ -794,6 +794,430 @@ private:
 } ;
 
 
+
+///
+/// each reduce variable involved in either ReduceMinLoc or ReduceMaxLoc
+/// uses retiredBlocks as a way to complete the reduction in a single pass
+/// Although the algorithm updates retiredBlocks via an atomicAdd(int) the actual
+/// reduction values do not use atomics and require a finsihing stage performed
+/// by the last block
+__device__ __managed__ int retiredBlocks[RAJA_MAX_REDUCE_VARS] ;
+
+
+
+template <size_t BLOCK_SIZE, typename T>
+class ReduceMinLoc< cuda_reduce<BLOCK_SIZE>, T > 
+{
+public:
+   //
+   // Constructor takes default value (default ctor is disabled).
+   //
+   explicit ReduceMinLoc(T init_val, Index_type init_loc)
+   {
+      m_is_copy = false;
+      m_reduced_val = init_val;
+      m_reduced_idx = init_loc;
+      m_myID = getCudaReductionId();
+      retiredBlocks[m_myID] = 0;
+      m_blockdata = getCudaReductionLocMemBlock(m_myID) ;
+      m_blockoffset = 1;
+      m_blockdata[m_blockoffset].val = init_val;
+      m_blockdata[m_blockoffset].idx = init_loc;
+
+      for (int j = 1; j <= RAJA_CUDA_REDUCE_BLOCK_LENGTH; ++j) {
+         m_blockdata[m_blockoffset+j].val = init_val;
+         m_blockdata[m_blockoffset+j].idx = init_loc;
+
+      }
+      cudaErrchk(cudaDeviceSynchronize());
+   }
+
+
+   //
+   // Copy ctor executes on both host and device.
+   //
+   __host__ __device__ 
+   ReduceMinLoc( const ReduceMinLoc< cuda_reduce<BLOCK_SIZE> , T >& other )
+   {
+      *this = other;
+      m_is_copy = true;
+   }
+
+   //
+   // Destructor executes on both host and device.
+   // Destruction on host releases the unique id for others to use. 
+   //
+   __host__ __device__ 
+   ~ReduceMinLoc< cuda_reduce<BLOCK_SIZE> , T >()
+   {
+      if (!m_is_copy) {
+#if defined( __CUDA_ARCH__ ) 
+#else
+         releaseCudaReductionId(m_myID); 
+#endif
+         // OK to perform cudaFree of cudaMalloc vars if needed...
+      }
+   }
+
+   //
+   // Operator to retrieve reduced min value (before object is destroyed).
+   // Accessor only operates on host.
+   //
+   operator T()
+   {
+      cudaErrchk(cudaDeviceSynchronize()) ;
+      m_reduced_val = static_cast<T>(m_blockdata[m_blockoffset].val);
+      return m_reduced_val;
+   }
+
+   //
+   // Operator to retrieve index value of min (before object is destroyed).
+   //
+   Index_type getMinLoc()
+   {
+      cudaErrchk(cudaDeviceSynchronize()) ; //it would be good not to call this
+      m_reduced_idx = m_blockdata[m_blockoffset].idx;
+      return m_reduced_idx;
+   }
+
+   //
+   // Min-loc function 
+   //
+   __device__
+   ReduceMinLoc< cuda_reduce<BLOCK_SIZE>, T> minloc(T val, Index_type idx) const 
+   {
+
+      __shared__ CudaReductionLocBlockDataType sd[BLOCK_SIZE];
+      __shared__ bool lastBlock;
+
+      // initialize shared memory
+      for ( int i = BLOCK_SIZE / 2; i > 0; i /=2 ) {     
+          // this descends all the way to 1
+          if ( threadIdx.x < i ) {                                
+             // no need for __syncthreads()
+             sd[threadIdx.x + i].val = m_reduced_val; 
+             sd[threadIdx.x + i].idx = m_reduced_idx; 
+          } 
+      }
+      __syncthreads();
+
+      sd[threadIdx.x].val = val;
+      sd[threadIdx.x].idx = idx; // need to reconcile loc vs idx naming
+      __syncthreads();
+
+      for (int i = BLOCK_SIZE / 2; i >= WARP_SIZE; i /= 2) {
+          if (threadIdx.x < i) {
+              sd[threadIdx.x] = RAJA_MINLOC(sd[threadIdx.x],sd[threadIdx.x + i]);
+          }
+          __syncthreads();
+      }
+
+      if (threadIdx.x < 16) {
+          sd[threadIdx.x] = RAJA_MINLOC(sd[threadIdx.x],sd[threadIdx.x+16]);
+      }
+      __syncthreads();
+
+      if (threadIdx.x < 8) {
+          sd[threadIdx.x] = RAJA_MINLOC(sd[threadIdx.x],sd[threadIdx.x+8]);
+      }
+      __syncthreads();
+
+      if (threadIdx.x < 4) {
+          sd[threadIdx.x] = RAJA_MINLOC(sd[threadIdx.x],sd[threadIdx.x+4]);
+      }
+      __syncthreads();
+
+      if (threadIdx.x < 2) {
+          sd[threadIdx.x] = RAJA_MINLOC(sd[threadIdx.x],sd[threadIdx.x+2]);
+      }
+      __syncthreads();
+
+      if (threadIdx.x < 1) {
+          lastBlock = false;
+          sd[threadIdx.x] = RAJA_MINLOC(sd[threadIdx.x],sd[threadIdx.x+1]);
+          m_blockdata[m_blockoffset + blockIdx.x+1]  = 
+              RAJA_MINLOC( sd[threadIdx.x], 
+                        m_blockdata[m_blockoffset + blockIdx.x+1] );
+          unsigned int oldBlockCount = atomicAdd(&retiredBlocks[m_myID],1);
+          lastBlock = (oldBlockCount == (gridDim.x-1));
+
+      }
+      __syncthreads();
+
+      if(lastBlock) {
+        if(threadIdx.x == 0) {
+          retiredBlocks[m_myID] = 0;
+        }
+
+        CudaReductionLocBlockDataType lmin;
+        lmin.val = m_reduced_val;
+        lmin.idx = m_reduced_idx;
+        for (int i = threadIdx.x; i < gridDim.x; i += BLOCK_SIZE) {
+            lmin = RAJA_MINLOC(lmin,m_blockdata[m_blockoffset+i+1]);
+        }
+        sd[threadIdx.x] = lmin;
+        __syncthreads();
+
+        for (int i = BLOCK_SIZE / 2; i >= WARP_SIZE; i /= 2) {
+          if (threadIdx.x < i) {
+              sd[threadIdx.x] = RAJA_MINLOC(sd[threadIdx.x],sd[threadIdx.x + i]);
+          }
+          __syncthreads();
+        }
+
+        if (threadIdx.x < 16) {
+          sd[threadIdx.x] = RAJA_MINLOC(sd[threadIdx.x],sd[threadIdx.x+16]);
+        }
+        __syncthreads();
+
+        if (threadIdx.x < 8) {
+          sd[threadIdx.x] = RAJA_MINLOC(sd[threadIdx.x],sd[threadIdx.x+8]);
+        }
+        __syncthreads();
+
+        if (threadIdx.x < 4) {
+          sd[threadIdx.x] = RAJA_MINLOC(sd[threadIdx.x],sd[threadIdx.x+4]);
+        }
+        __syncthreads();
+
+        if (threadIdx.x < 2) {
+          sd[threadIdx.x] = RAJA_MINLOC(sd[threadIdx.x],sd[threadIdx.x+2]);
+        }
+        __syncthreads();
+
+        if (threadIdx.x < 1) {
+          sd[threadIdx.x] = RAJA_MINLOC(sd[threadIdx.x],sd[threadIdx.x+1]);
+          m_blockdata[m_blockoffset] = RAJA_MINLOC(m_blockdata[m_blockoffset],sd[threadIdx.x]);
+        }
+      }
+      return *this ;
+   }
+
+private:
+   //
+   // Default ctor is declared private and not implemented.
+   //
+   ReduceMinLoc< cuda_reduce<BLOCK_SIZE>, T >();
+
+   bool m_is_copy;
+
+   int m_myID;
+   int m_blockoffset;
+
+   T m_reduced_val;
+
+   Index_type m_reduced_idx;
+
+   CudaReductionLocBlockDataType* m_blockdata;
+} ;
+
+
+template <size_t BLOCK_SIZE, typename T>
+class ReduceMaxLoc< cuda_reduce<BLOCK_SIZE>, T > 
+{
+public:
+   //
+   // Constructor takes default value (default ctor is disabled).
+   //
+   explicit ReduceMaxLoc(T init_val, Index_type init_loc)
+   {
+      m_is_copy = false;
+      m_reduced_val = init_val;
+      m_reduced_idx = init_loc;
+      m_myID = getCudaReductionId();
+      retiredBlocks[m_myID] = 0;
+      m_blockdata = getCudaReductionLocMemBlock(m_myID) ;
+      m_blockoffset = 1;
+      m_blockdata[m_blockoffset].val = init_val;
+      m_blockdata[m_blockoffset].idx = init_loc;
+
+      for (int j = 1; j <= RAJA_CUDA_REDUCE_BLOCK_LENGTH; ++j) {
+         m_blockdata[m_blockoffset+j].val = init_val;
+         m_blockdata[m_blockoffset+j].idx = init_loc;
+
+      }
+      cudaErrchk(cudaDeviceSynchronize());
+   }
+
+
+   //
+   // Copy ctor executes on both host and device.
+   //
+   __host__ __device__ 
+   ReduceMaxLoc( const ReduceMaxLoc< cuda_reduce<BLOCK_SIZE> , T >& other )
+   {
+      *this = other;
+      m_is_copy = true;
+   }
+
+   //
+   // Destructor executes on both host and device.
+   // Destruction on host releases the unique id for others to use. 
+   //
+   __host__ __device__ 
+   ~ReduceMaxLoc< cuda_reduce<BLOCK_SIZE> , T >()
+   {
+      if (!m_is_copy) {
+#if defined( __CUDA_ARCH__ ) 
+#else
+         releaseCudaReductionId(m_myID); 
+#endif
+         // OK to perform cudaFree of cudaMalloc vars if needed...
+      }
+   }
+
+   //
+   // Operator to retrieve reduced min value (before object is destroyed).
+   // Accessor only operates on host.
+   //
+   operator T()
+   {
+      cudaErrchk(cudaDeviceSynchronize()) ;
+      m_reduced_val = static_cast<T>(m_blockdata[m_blockoffset].val);
+      return m_reduced_val;
+   }
+
+   //
+   // Operator to retrieve index value of min (before object is destroyed).
+   //
+   Index_type getMaxLoc()
+   {
+      cudaErrchk(cudaDeviceSynchronize()) ; //it would be good not to call this
+      m_reduced_idx = m_blockdata[m_blockoffset].idx;
+      return m_reduced_idx;
+   }
+
+   //
+   // Max-loc function 
+   //
+   __device__
+   ReduceMaxLoc< cuda_reduce<BLOCK_SIZE>, T> maxloc(T val, Index_type idx) const 
+   {
+
+      __shared__ CudaReductionLocBlockDataType sd[BLOCK_SIZE];
+      __shared__ bool lastBlock;
+
+      // initialize shared memory
+      for ( int i = BLOCK_SIZE / 2; i > 0; i /=2 ) {     
+          // this descends all the way to 1
+          if ( threadIdx.x < i ) {                                
+             // no need for __syncthreads()
+             sd[threadIdx.x + i].val = m_reduced_val; 
+             sd[threadIdx.x + i].idx = m_reduced_idx; 
+          } 
+      }
+      __syncthreads();
+
+      sd[threadIdx.x].val = val;
+      sd[threadIdx.x].idx = idx; // need to reconcile loc vs idx naming
+      __syncthreads();
+
+      for (int i = BLOCK_SIZE / 2; i >= WARP_SIZE; i /= 2) {
+          if (threadIdx.x < i) {
+              sd[threadIdx.x] = RAJA_MAXLOC(sd[threadIdx.x],sd[threadIdx.x + i]);
+          }
+          __syncthreads();
+      }
+
+      if (threadIdx.x < 16) {
+          sd[threadIdx.x] = RAJA_MAXLOC(sd[threadIdx.x],sd[threadIdx.x+16]);
+      }
+      __syncthreads();
+
+      if (threadIdx.x < 8) {
+          sd[threadIdx.x] = RAJA_MAXLOC(sd[threadIdx.x],sd[threadIdx.x+8]);
+      }
+      __syncthreads();
+
+      if (threadIdx.x < 4) {
+          sd[threadIdx.x] = RAJA_MAXLOC(sd[threadIdx.x],sd[threadIdx.x+4]);
+      }
+      __syncthreads();
+
+      if (threadIdx.x < 2) {
+          sd[threadIdx.x] = RAJA_MAXLOC(sd[threadIdx.x],sd[threadIdx.x+2]);
+      }
+      __syncthreads();
+
+      if (threadIdx.x < 1) {
+          lastBlock = false;
+          sd[threadIdx.x] = RAJA_MAXLOC(sd[threadIdx.x],sd[threadIdx.x+1]);
+          m_blockdata[m_blockoffset + blockIdx.x+1]  = 
+              RAJA_MAXLOC( sd[threadIdx.x], 
+                        m_blockdata[m_blockoffset + blockIdx.x+1] );
+          unsigned int oldBlockCount = atomicAdd(&retiredBlocks[m_myID],1);
+          lastBlock = (oldBlockCount == (gridDim.x-1));
+
+      }
+      __syncthreads();
+
+      if(lastBlock) {
+        if(threadIdx.x == 0) {
+          retiredBlocks[m_myID] = 0;
+        }
+
+        CudaReductionLocBlockDataType lmin;
+        lmin.val = m_reduced_val;
+        lmin.idx = m_reduced_idx;
+        for (int i = threadIdx.x; i < gridDim.x; i += BLOCK_SIZE) {
+            lmin = RAJA_MAXLOC(lmin,m_blockdata[m_blockoffset+i+1]);
+        }
+        sd[threadIdx.x] = lmin;
+        __syncthreads();
+
+        for (int i = BLOCK_SIZE / 2; i >= WARP_SIZE; i /= 2) {
+          if (threadIdx.x < i) {
+              sd[threadIdx.x] = RAJA_MAXLOC(sd[threadIdx.x],sd[threadIdx.x + i]);
+          }
+          __syncthreads();
+        }
+
+        if (threadIdx.x < 16) {
+          sd[threadIdx.x] = RAJA_MAXLOC(sd[threadIdx.x],sd[threadIdx.x+16]);
+        }
+        __syncthreads();
+
+        if (threadIdx.x < 8) {
+          sd[threadIdx.x] = RAJA_MAXLOC(sd[threadIdx.x],sd[threadIdx.x+8]);
+        }
+        __syncthreads();
+
+        if (threadIdx.x < 4) {
+          sd[threadIdx.x] = RAJA_MAXLOC(sd[threadIdx.x],sd[threadIdx.x+4]);
+        }
+        __syncthreads();
+
+        if (threadIdx.x < 2) {
+          sd[threadIdx.x] = RAJA_MAXLOC(sd[threadIdx.x],sd[threadIdx.x+2]);
+        }
+        __syncthreads();
+
+        if (threadIdx.x < 1) {
+          sd[threadIdx.x] = RAJA_MAXLOC(sd[threadIdx.x],sd[threadIdx.x+1]);
+          m_blockdata[m_blockoffset] = RAJA_MAXLOC(m_blockdata[m_blockoffset],sd[threadIdx.x]);
+        }
+      }
+      return *this ;
+   }
+
+private:
+   //
+   // Default ctor is declared private and not implemented.
+   //
+   ReduceMaxLoc< cuda_reduce<BLOCK_SIZE>, T >();
+
+   bool m_is_copy;
+
+   int m_myID;
+   int m_blockoffset;
+
+   T m_reduced_val;
+
+   Index_type m_reduced_idx;
+
+   CudaReductionLocBlockDataType* m_blockdata;
+} ;
+
 }  // closing brace for RAJA namespace
 
 

--- a/include/RAJA/reducers.hxx
+++ b/include/RAJA/reducers.hxx
@@ -71,7 +71,11 @@ namespace RAJA {
 ///
 #define RAJA_MAX(a, b) (((b) > (a)) ? (b) : (a))
 
-
+///
+/// Macros to support structs used in minmaxloc operations
+#define RAJA_MINLOC(a,b) (((b.val) < (a.val)) ? (b) : (a))
+///
+#define RAJA_MAXLOC(a,b) (((b.val) > (a.val)) ? (b) : (a))
 //
 // Forward declarations for reduction templates. 
 // Actual classes appear in forall_*.hxx header files. 

--- a/test/unit-tests/GPUtests/CMakeLists.txt
+++ b/test/unit-tests/GPUtests/CMakeLists.txt
@@ -60,8 +60,16 @@ cuda_add_executable(traversal.exe
 cuda_add_executable(nested.exe
   Nested.cxx)
 
+cuda_add_executable(reduceminloc.exe
+  ReduceMinLoc.cxx)
+
+cuda_add_executable(reducemaxloc.exe
+  ReduceMaxLoc.cxx)
+
 target_link_libraries(reducemin.exe RAJA)
 target_link_libraries(reducemax.exe RAJA)
 target_link_libraries(reducesum.exe RAJA)
 target_link_libraries(traversal.exe RAJA)
 target_link_libraries(nested.exe RAJA)
+target_link_libraries(reduceminloc.exe RAJA)
+target_link_libraries(reducemaxloc.exe RAJA)

--- a/test/unit-tests/GPUtests/ReduceMaxLoc.cxx
+++ b/test/unit-tests/GPUtests/ReduceMaxLoc.cxx
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+ *
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * All rights reserved.
+ *
+ * For release details and restrictions, please see raja/README-license.txt
+ */
+
+#include<string>
+#include<iostream>
+#include <cstdio>
+#include <cfloat>
+#include <random>
+
+#include "RAJA/RAJA.hxx"
+
+#define TEST_VEC_LEN  1024 * 1024
+
+typedef struct{double val; int idx;} maxloc_t;
+
+
+using namespace RAJA;
+using namespace std;
+//
+// Global variables for counting tests executed/passed.
+//
+unsigned s_ntests_run = 0;
+unsigned s_ntests_passed = 0;
+
+int main(int argc, char *argv[])
+{
+   cout << "\n Begin RAJA GPU ReduceMaxLoc tests!!! " << endl;
+
+   const int test_repeat = 10;
+
+   //
+   // Allocate and initialize managed data array
+   //
+   double *dvalue ;
+
+   cudaMallocManaged((void **)&dvalue, sizeof(double)*TEST_VEC_LEN,
+                     cudaMemAttachGlobal) ;
+   for (int i=0; i<TEST_VEC_LEN; ++i) {
+      dvalue[i] = -DBL_MAX ;
+   }
+
+
+   ///
+   /// Define thread block size for CUDA exec policy
+   ///
+   const size_t block_size = 256;
+
+////////////////////////////////////////////////////////////////////////////
+// Run 3 different max reduction tests in a loop
+////////////////////////////////////////////////////////////////////////////
+
+   // current running max value
+   maxloc_t dcurrentMax;
+   dcurrentMax.val = -DBL_MAX;
+   dcurrentMax.idx = -1; 
+
+   // for setting random values in arrays
+   random_device rd;
+   mt19937 mt(rd());
+   uniform_real_distribution<double> dist(-10, 10);
+   uniform_real_distribution<double> dist2(0, TEST_VEC_LEN-1);
+
+   for (int tcount = 0; tcount < test_repeat; ++tcount) {
+
+      cout << "\t tcount = " << tcount << endl;
+
+      //
+      // test 1 runs 3 reductions over a range multiple times to check
+      //        that reduction value can be retrieved and then subsequent
+      //        reductions can be run with the same reduction objects.
+      //
+      { // begin test 1
+
+         double BIG_MAX = 500.0;
+         ReduceMaxLoc< cuda_reduce<block_size>, double> dmax0(-DBL_MAX,-1);
+         ReduceMaxLoc< cuda_reduce<block_size>, double> dmax1(-DBL_MAX,-1);
+         ReduceMaxLoc< cuda_reduce<block_size>, double> dmax2(BIG_MAX,-1);
+
+         int loops = 16;
+         for(int k=0; k < loops ; k++) {
+
+            s_ntests_run++;
+
+            double droll = dist(mt) ; 
+            int index = int(dist2(mt));
+            maxloc_t lmax = {droll,index};
+            dvalue[index] = droll;
+            dcurrentMax = RAJA_MAXLOC(dcurrentMax, lmax); 
+
+            //printf("droll[%d] =  %lf : dcurrentMax[%d] = %lf\n",lmax.idx,lmax.val,dcurrentMax.idx,dcurrentMax.val);
+            forall< cuda_exec<block_size> >(0, TEST_VEC_LEN, 
+               [=] __device__ (int i) {
+                  dmax0.maxloc(dvalue[i],i) ;
+                  dmax1.maxloc(2*dvalue[i],i) ;
+                  dmax2.maxloc(dvalue[i],i) ;
+            } ) ;
+
+            if ( double(dmax0) != dcurrentMax.val ||
+                 double(dmax1) != 2*dcurrentMax.val ||
+                 double(dmax2) != BIG_MAX ||
+                 dmax0.getMaxLoc() != dcurrentMax.idx ||
+                 dmax1.getMaxLoc() != dcurrentMax.idx ) {
+               cout << "\n TEST 1 FAILURE: tcount, k = "
+                    << tcount << " , " << k << endl;
+               cout << "  droll = " << droll << endl;
+               cout << "\tdmax0 = " << static_cast<double>(dmax0) << " ("
+                                    << dcurrentMax.val << ") " << endl;
+               cout << "\tdmax1 = " << static_cast<double>(dmax1) << " ("
+                                    << 2*dcurrentMax.val << ") " << endl;
+               cout << "\tdmax2 = " << static_cast<double>(dmax2) << " ("
+                                    << BIG_MAX << ") " << endl;
+            } else {
+               s_ntests_passed++;
+            }
+         }
+
+      }  // end test 1
+
+////////////////////////////////////////////////////////////////////////////
+
+      //
+      // test 2 runs 2 reductions over complete array using an indexset
+      //        with two range segments to check reduction object state
+      //        is maintained properly across kernel invocations.
+      //
+      { // begin test 2
+
+         s_ntests_run++;
+
+         RangeSegment seg0(0, TEST_VEC_LEN/2);
+         RangeSegment seg1(TEST_VEC_LEN/2 + 1, TEST_VEC_LEN);
+
+         IndexSet iset;
+         iset.push_back(seg0);
+         iset.push_back(seg1);
+
+         ReduceMaxLoc< cuda_reduce<block_size>, double> dmax0(-DBL_MAX,-1);
+         ReduceMaxLoc< cuda_reduce<block_size>, double> dmax1(-DBL_MAX,-1);
+
+         int index = int(dist2(mt));
+
+         double droll = dist(mt) ;
+         dvalue[index] = droll;
+         maxloc_t lmax = {droll,index};
+         dvalue[index] = droll;
+         dcurrentMax = RAJA_MAXLOC(dcurrentMax, lmax); 
+
+         forall< IndexSet::ExecPolicy<seq_segit, cuda_exec<block_size> > >(iset,
+            [=] __device__ (int i) {
+               dmax0.maxloc(dvalue[i],i) ;
+               dmax1.maxloc(2*dvalue[i],i) ;
+         } ) ;
+
+         if ( double(dmax0) != dcurrentMax.val ||
+              double(dmax1) != 2*dcurrentMax.val ||
+              dmax0.getMaxLoc() != dcurrentMax.idx ||
+              dmax1.getMaxLoc() != dcurrentMax.idx ) {
+            cout << "\n TEST 2 FAILURE: tcount = " << tcount << endl;
+            cout << "  droll = " << droll << endl;
+            cout << "\tdmax0 = " << static_cast<double>(dmax0) << " ("
+                                 << dcurrentMax.val << ") " << endl;
+            cout << "\tdmax1 = " << static_cast<double>(dmax1) << " ("
+                                 << 2*dcurrentMax.val << ") " << endl;
+         } else {
+            s_ntests_passed++;
+         }
+
+      } // end test 2
+
+////////////////////////////////////////////////////////////////////////////
+
+      //
+      // test 3 runs 2 reductions over disjoint chunks of the array using
+      //        an indexset with four range segments not aligned with
+      //        warp boundaries to check that reduction mechanics don't
+      //        depend on any sort of special indexing.
+      //
+      { // begin test 3
+
+         s_ntests_run++;
+
+         for (int i=0; i<TEST_VEC_LEN; ++i) {
+            dvalue[i] = -DBL_MAX ;
+         }
+         dcurrentMax.val = -DBL_MAX;
+         dcurrentMax.idx = -1; 
+         RangeSegment seg0(1, 1230);
+         RangeSegment seg1(1237, 3385);
+         RangeSegment seg2(4860, 10110);
+         RangeSegment seg3(20490, 32003);
+
+         IndexSet iset;
+         iset.push_back(seg0);
+         iset.push_back(seg1);
+         iset.push_back(seg2);
+         iset.push_back(seg3);
+
+         ReduceMaxLoc< cuda_reduce<block_size>, double> dmax0(-DBL_MAX,-1);
+         ReduceMaxLoc< cuda_reduce<block_size>, double> dmax1(-DBL_MAX,-1);
+
+         // pick an index in one of the segments
+         int index = 897;                      // seg 0
+         if ( tcount % 2 == 0 ) index = 1297;  // seg 1
+         if ( tcount % 3 == 0 ) index = 7853;  // seg 2
+         if ( tcount % 4 == 0 ) index = 29457; // seg 3
+
+         double droll = dist(mt) ;
+         dvalue[index] = droll;
+
+         maxloc_t lmax = {droll,index};
+         dvalue[index] = droll;
+         dcurrentMax = RAJA_MAXLOC(dcurrentMax, lmax); 
+
+         forall< IndexSet::ExecPolicy<seq_segit, cuda_exec<block_size> > >(iset,
+            [=] __device__ (int i) {
+               dmax0.maxloc(dvalue[i],i) ;
+               dmax1.maxloc(2*dvalue[i],i) ;
+         } ) ;
+
+         if ( double(dmax0) != dcurrentMax.val ||
+              double(dmax1) != 2*dcurrentMax.val || 
+              dmax0.getMaxLoc() != dcurrentMax.idx ||
+              dmax1.getMaxLoc() != dcurrentMax.idx ) {
+            cout << "\n TEST 3 FAILURE: tcount = " << tcount << endl;
+            cout << "  droll = " << droll << endl;
+            cout << "\tdmax0 = " << static_cast<double>(dmax0) << " ("
+                                 << dcurrentMax.val << ") " << endl;
+            cout << "\tdmax1 = " << static_cast<double>(dmax1) << " ("
+                                 << 2*dcurrentMax.val << ") " << endl;
+         } else {
+            s_ntests_passed++;
+         }
+
+      } // end test 3
+
+   } // end test repeat loop
+
+   ///
+   /// Print total number of tests passed/run.
+   ///
+   cout << "\n Tests Passed / Tests Run = "
+        << s_ntests_passed << " / " << s_ntests_run << endl;
+
+   cudaFree(dvalue); 
+
+   cout << "\n RAJA GPU ReduceMaxLoc tests DONE!!! " << endl;
+   
+   return 0 ;
+}
+

--- a/test/unit-tests/GPUtests/ReduceMinLoc.cxx
+++ b/test/unit-tests/GPUtests/ReduceMinLoc.cxx
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+ *
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * All rights reserved.
+ *
+ * For release details and restrictions, please see raja/README-license.txt
+ */
+
+#include<string>
+#include<iostream>
+#include <cstdio>
+#include <cfloat>
+#include <random>
+
+#include "RAJA/RAJA.hxx"
+
+#define TEST_VEC_LEN  1024 * 1024
+
+typedef struct{double val; int idx;} minloc_t;
+
+
+using namespace RAJA;
+using namespace std;
+
+//
+// Global variables for counting tests executed/passed.
+//
+unsigned s_ntests_run = 0;
+unsigned s_ntests_passed = 0;
+
+int main(int argc, char *argv[])
+{
+   cout << "\n Begin RAJA GPU ReduceMinLoc tests!!! " << endl; 
+
+   const int test_repeat = 10;
+
+   //
+   // Allocate and initialize managed data array
+   //
+   double *dvalue ;
+
+   cudaMallocManaged((void **)&dvalue, sizeof(double)*TEST_VEC_LEN,
+                     cudaMemAttachGlobal) ;
+   for (int i=0; i<TEST_VEC_LEN; ++i) {
+      dvalue[i] = DBL_MAX ;
+   }
+
+   ///
+   /// Define thread block size for CUDA exec policy
+   ///
+   const size_t block_size = 256;
+
+////////////////////////////////////////////////////////////////////////////
+// Run 3 different min reduction tests in a loop
+////////////////////////////////////////////////////////////////////////////
+
+   // current running min value
+
+   minloc_t dcurrentMin;
+   dcurrentMin.val = DBL_MAX;
+   dcurrentMin.idx = -1; 
+
+   // for setting random min values in arrays
+   random_device rd;
+   mt19937 mt(rd());
+   uniform_real_distribution<double> dist(-10, 10);
+   uniform_real_distribution<double> dist2(0, TEST_VEC_LEN-1);
+
+   for (int tcount = 0; tcount < test_repeat; ++tcount) {
+
+      cout << "\t tcount = " << tcount << endl;
+
+      //
+      // test 1 runs 3 reductions over a range multiple times to check
+      //        that reduction value can be retrieved and then subsequent
+      //        reductions can be run with the same reduction objects.
+      //
+      { // begin test 1 
+
+         double BIG_MIN = -500.0;
+         ReduceMinLoc< cuda_reduce<block_size>, double> dmin0(DBL_MAX,-1);
+         ReduceMinLoc< cuda_reduce<block_size>, double> dmin1(DBL_MAX,1);
+         ReduceMinLoc< cuda_reduce<block_size>, double> dmin2(BIG_MIN,-1);
+
+         int loops = 16;
+         for(int k=0; k < loops ; k++) {
+
+            s_ntests_run++;
+
+            double droll = dist(mt) ; 
+            int index = int(dist2(mt));
+            dvalue[index] = droll;
+
+            minloc_t lmin = {droll,index};
+            dvalue[index] = droll;
+            dcurrentMin = RAJA_MINLOC(dcurrentMin, lmin); 
+            //printf("droll %lf : dcurrentMin %lf : index %d\n",droll,dcurrentMin,index);
+            forall< cuda_exec<block_size> >(0, TEST_VEC_LEN, 
+               [=] __device__ (int i) {
+                 dmin0.minloc(dvalue[i],i) ;
+                 dmin1.minloc(2*dvalue[i],i) ;
+                 dmin2.minloc(dvalue[i],i) ;
+            } ) ;
+
+            if ( double(dmin0) != dcurrentMin.val || 
+                 double(dmin1) != 2*dcurrentMin.val ||
+                 double(dmin2) != BIG_MIN ||
+                 dmin0.getMinLoc() != dcurrentMin.idx ||
+                 dmin1.getMinLoc() != dcurrentMin.idx ) {
+               cout << "\n TEST 1 FAILURE: tcount, k = " 
+                    << tcount << " , " << k << endl;
+               cout << "  droll = " << droll << endl; 
+               cout << "\tdmin0 = " << static_cast<double>(dmin0) << " ("
+                                    << dcurrentMin.val << ") " << endl;
+               cout << "\tdmin1 = " << static_cast<double>(dmin1) << " ("
+                                    << 2*dcurrentMin.val << ") " << endl;
+               cout << "\tdmin2 = " << static_cast<double>(dmin2) << " ("
+                                    << BIG_MIN << ") " << endl;
+            } else {
+               s_ntests_passed++;
+            }
+         }
+
+      }  // end test 1
+////////////////////////////////////////////////////////////////////////////
+
+      //
+      // test 2 runs 2 reductions over complete array using an indexset 
+      //        with two range segments to check reduction object state 
+      //        is maintained properly across kernel invocations.
+      //
+      { // begin test 2
+
+         s_ntests_run++;
+
+         RangeSegment seg0(0, TEST_VEC_LEN/2);
+         RangeSegment seg1(TEST_VEC_LEN/2 + 1, TEST_VEC_LEN);
+
+         IndexSet iset;
+         iset.push_back(seg0);
+         iset.push_back(seg1);
+
+         ReduceMinLoc< cuda_reduce<block_size>, double> dmin0(DBL_MAX,-1);
+         ReduceMinLoc< cuda_reduce<block_size>, double> dmin1(DBL_MAX,-1);
+
+         int index = int(dist2(mt));
+
+         double droll = dist(mt) ;
+         dvalue[index] = droll;
+
+         minloc_t lmin = {droll,index};
+         dvalue[index] = droll;
+         dcurrentMin = RAJA_MINLOC(dcurrentMin, lmin); 
+
+         forall< IndexSet::ExecPolicy<seq_segit, cuda_exec<block_size> > >(iset,
+            [=] __device__ (int i) {
+               dmin0.minloc(dvalue[i],i) ;
+               dmin1.minloc(2*dvalue[i],i) ;
+         } ) ;
+
+         if ( double(dmin0) != dcurrentMin.val || 
+              double(dmin1) != 2*dcurrentMin.val ||
+              dmin0.getMinLoc() != dcurrentMin.idx ||
+              dmin1.getMinLoc() != dcurrentMin.idx ) {
+            cout << "\n TEST 2 FAILURE: tcount = " << tcount << endl;
+            cout << "   droll = " << droll << endl; 
+            cout << "\tdmin0 = " << static_cast<double>(dmin0) << " ("
+                                 << dcurrentMin.val << ") " << endl;
+            cout << "\tdmin1 = " << static_cast<double>(dmin1) << " ("
+                                    << 2*dcurrentMin.val << ") " << endl;
+         } else {
+            s_ntests_passed++;
+         }
+
+      } // end test 2
+
+///////////////////////////////////////////////////////////////////////
+
+      //
+      // test 3 runs 2 reductions over disjoint chunks of the array using 
+      //        an indexset with four range segments not aligned with 
+      //        warp boundaries to check that reduction mechanics don't 
+      //        depend on any sort of special indexing.
+      //
+      { // begin test 3
+
+         s_ntests_run++;
+
+         for (int i=0; i<TEST_VEC_LEN; ++i) {
+            dvalue[i] = DBL_MAX ;
+         }
+
+
+         dcurrentMin.val = DBL_MAX ;
+         dcurrentMin.idx = -1;
+
+         RangeSegment seg0(1, 1230);
+         RangeSegment seg1(1237, 3385);
+         RangeSegment seg2(4860, 10110);
+         RangeSegment seg3(20490, 32003);
+
+         IndexSet iset;
+         iset.push_back(seg0);
+         iset.push_back(seg1);
+         iset.push_back(seg2);
+         iset.push_back(seg3);
+
+         ReduceMinLoc< cuda_reduce<block_size>, double> dmin0(DBL_MAX,-1);
+         ReduceMinLoc< cuda_reduce<block_size>, double> dmin1(DBL_MAX,-1);
+
+         // pick an index in one of the segments
+         int index = 897;                      // seg 0
+         if ( tcount % 2 == 0 ) index = 1297;  // seg 1
+         if ( tcount % 3 == 0 ) index = 7853;  // seg 2
+         if ( tcount % 4 == 0 ) index = 29457; // seg 3
+
+         double droll = dist(mt) ;
+         dvalue[index] = droll;
+
+         minloc_t lmin = {droll,index};
+         dvalue[index] = droll;
+         dcurrentMin = RAJA_MINLOC(dcurrentMin, lmin); 
+
+         forall< IndexSet::ExecPolicy<seq_segit, cuda_exec<block_size> > >(iset,
+            [=] __device__ (int i) {
+               dmin0.minloc(dvalue[i],i) ;
+               dmin1.minloc(2*dvalue[i],i) ;
+         } ) ;
+
+         if ( double(dmin0) != dcurrentMin.val || 
+              double(dmin1) != 2*dcurrentMin.val ||
+              dmin0.getMinLoc() != dcurrentMin.idx ||
+              dmin1.getMinLoc() != dcurrentMin.idx ) {
+            cout << "\n TEST 3 FAILURE: tcount = " << tcount << endl;
+            cout << "   droll = " << droll << endl; 
+            cout << "\tdmin0 = " << static_cast<double>(dmin0) << " ("
+                                 << dcurrentMin.val << ") " << endl;
+            cout << "\tdmin1 = " << static_cast<double>(dmin1) << " ("
+                                 << 2*dcurrentMin.val << ") " << endl;
+         } else {
+            s_ntests_passed++;
+         }
+
+      } // end test 3
+   } // end test repeat loop
+
+   ///
+   /// Print total number of tests passed/run.
+   ///
+   cout << "\n Tests Passed / Tests Run = "
+        << s_ntests_passed << " / " << s_ntests_run << endl;
+
+   cudaFree(dvalue);
+  
+   cout << "\n RAJA GPU ReduceMinLoc tests DONE!!! " << endl; 
+
+   return 0 ;
+}


### PR DESCRIPTION
Single-pass CUDA reductions for min/maxloc. Algorithm uses the fast hardware atomicAdd(int) to keep track of blocks retired; last block finishes the reduction. Atomic updates are not used for the actual values or indices. GPU Unit tests ReduceMinLoc.cxx and ReduceMaxLoc.cxx show usage example. 