### PR TITLE
Remove confusing sphinx paragraph from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Mailing List
 Interested in RAJA? Want to contribute? The first thing to do is join our mailing list, over at Google Groups:
 - [RAJA Google Group](https://groups.google.com/forum/#!forum/raja-users)
 
+If you have questions, find a bug, or have ideas about expanding the
+functionality or applicability of RAJA and are interested in contributing
+to its development, please do not hesitate to contact us. We are always
+interested in improving RAJA and exploring new ways to use it.
+
 Authors
 -----------
 
@@ -61,16 +66,7 @@ Other contributors include:
   * Olga Pearce (pearce8@llnl.gov)
   * Tom Scogland (scogland1@llnl.gov)
 
-Useful information about the RAJA source code, how to compile it,
-run tests and examples, etc. can be seen by opening the file
-raja/docs/sphinx/html/index.html in the RAJA repo in your web browser. The
-HTML files are generated from the *.rst files in the directory raja/docs/sphinx.
-You can also look at those text files if you find this more convenient.
 
-If you have questions, find a bug, or have ideas about expanding the
-functionality or applicability of RAJA and are interested in contributing
-to its development, please do not hesitate to contact us. We are always
-interested in improving RAJA and exploring new ways to use it.
 
 Release
 -----------


### PR DESCRIPTION
We only want to point people at the hosted documentation at software.llnl.gov