### PR TITLE
Allow negative indices in RangeSegment

### DIFF
--- a/include/RAJA/exec-cuda/forallN_cuda.hxx
+++ b/include/RAJA/exec-cuda/forallN_cuda.hxx
@@ -59,6 +59,8 @@
 #include<RAJA/config.hxx>
 #include<RAJA/int_datatypes.hxx>
 
+#include <climits>
+
 namespace RAJA {
 
 
@@ -136,7 +138,7 @@ struct CudaThreadBlock {
 
     int idx = begin + view(blockIdx) * threads_per_block + view(threadIdx);
     if(idx >= end){
-      idx = -1;
+      idx = INT_MIN;
     }
     return idx;
   }
@@ -194,7 +196,7 @@ struct CudaThread {
     
     int idx = begin + view(threadIdx);
     if(idx >= end){
-      idx = -1;
+      idx = INT_MIN;
     }
     return idx;
   }
@@ -235,7 +237,7 @@ struct CudaBlock {
     
     int idx = begin + view(blockIdx);
     if(idx >= end){
-      idx = -1;
+      idx = INT_MIN;
     }
     return idx;
   }
@@ -264,7 +266,7 @@ using cuda_block_z_exec = CudaPolicy<CudaBlock<Dim3z>>;
 template <typename BODY, typename ... ARGS>
 RAJA_INLINE
 __device__ void cudaCheckBounds(BODY body, int i, ARGS ... args){
-  if(i >= 0){
+  if(i >= INT_MIN){
     ForallN_BindFirstArg_Device<BODY> bound(body, i);
     cudaCheckBounds(bound, args...);
   }  
@@ -273,7 +275,7 @@ __device__ void cudaCheckBounds(BODY body, int i, ARGS ... args){
 template <typename BODY>
 RAJA_INLINE
 __device__ void cudaCheckBounds(BODY body, int i){
-  if(i >= 0){
+  if(i >= INT_MIN){
     body(i);
   }  
 }

--- a/include/RAJA/exec-cuda/forallN_cuda.hxx
+++ b/include/RAJA/exec-cuda/forallN_cuda.hxx
@@ -266,7 +266,7 @@ using cuda_block_z_exec = CudaPolicy<CudaBlock<Dim3z>>;
 template <typename BODY, typename ... ARGS>
 RAJA_INLINE
 __device__ void cudaCheckBounds(BODY body, int i, ARGS ... args){
-  if(i >= INT_MIN){
+  if(i > INT_MIN){
     ForallN_BindFirstArg_Device<BODY> bound(body, i);
     cudaCheckBounds(bound, args...);
   }  
@@ -275,7 +275,7 @@ __device__ void cudaCheckBounds(BODY body, int i, ARGS ... args){
 template <typename BODY>
 RAJA_INLINE
 __device__ void cudaCheckBounds(BODY body, int i){
-  if(i >= INT_MIN){
+  if(i > INT_MIN){
     body(i);
   }  
 }


### PR DESCRIPTION
Uses INT_MIN rather than -1 to represent out-of-bounds indices when
launching the CUDA forallN