### PR TITLE
adding a clang-format file to help style code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,7 +17,7 @@ PenaltyBreakString : 10
 
 # These improve formatting results but require clang 3.6/7 or higher
 BreakBeforeBinaryOperators : NonAssignment
-AlignAfterOpenBracket: Align
+AlignAfterOpenBracket: true
 BinPackArguments : false
 AlignOperands : true
 AlwaysBreakTemplateDeclarations : true

--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
 BasedOnStyle : google
-IndentWidth : 3
+IndentWidth : 2
 BreakBeforeBraces : Linux
 UseTab: Never
 AllowShortIfStatementsOnASingleLine : true
@@ -21,3 +21,4 @@ BinPackArguments : false
 AlignOperands : true
 AlwaysBreakTemplateDeclarations : true
 Cpp11BracedListStyle : true
+

--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,7 @@
 BasedOnStyle : google
 IndentWidth : 2
-BreakBeforeBraces : Linux
+# BreakBeforeBraces : Linux
+BreakBeforeBraces : Attach
 UseTab: Never
 AllowShortIfStatementsOnASingleLine : true
 ConstructorInitializerAllOnOneLineOrOnePerLine : true

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,23 @@
+BasedOnStyle : google
+IndentWidth : 3
+BreakBeforeBraces : Linux
+UseTab: Never
+AllowShortIfStatementsOnASingleLine : true
+ConstructorInitializerAllOnOneLineOrOnePerLine : true
+AllowShortFunctionsOnASingleLine : true
+AllowShortLoopsOnASingleLine : false
+BinPackParameters : false
+AllowAllParametersOfDeclarationOnNextLine : false
+AlignTrailingComments : true
+ColumnLimit : 80
+PenaltyBreakBeforeFirstCallParameter : 100
+PenaltyReturnTypeOnItsOwnLine : 65000
+PenaltyBreakString : 10
+
+# These improve formatting results but require clang 3.6/7 or higher
+BreakBeforeBinaryOperators : NonAssignment
+AlignAfterOpenBracket: Align
+BinPackArguments : false
+AlignOperands : true
+AlwaysBreakTemplateDeclarations : true
+Cpp11BracedListStyle : true

--- a/scripts/clang-format-all.py
+++ b/scripts/clang-format-all.py
@@ -1,5 +1,14 @@
 #! /usr/bin/env python
 
+##
+## Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+## 
+## Produced at the Lawrence Livermore National Laboratory.
+## 
+## All rights reserved.
+## 
+## For release details and restrictions, please see raja/README-license.txt
+##
 import os, sys, argparse, glob, time
 import fnmatch
 

--- a/scripts/clang-format-all.py
+++ b/scripts/clang-format-all.py
@@ -1,0 +1,73 @@
+#! /usr/bin/env python
+
+import os, sys, argparse, glob, time
+import fnmatch
+
+from subprocess import call
+
+#if using pypar run this command as mpirun -np 16 --hostfile hostfile.txt -mca btl tcp,sm,self python  script.py
+
+class ClangFormat :
+  cmd = "clang-format"  # assumes you've done a use clang-3.8.0 or equivalent which has clang-format built/installed
+  pypar_avail = False
+  pypar = None
+    
+  def __init__(self):
+    try:
+      #import pypar as pypar
+      self.pypar_avail = True
+      #self.pypar = pypar
+    except:
+      pass
+
+  def getScriptPath(self):
+    return os.path.dirname(os.path.realpath(sys.argv[0]))
+
+  def process(self,input_directory,cmd_prefix):
+    files = []
+    self.pypar_avail = False # Turn off mpi processing for now
+    self.cmd = cmd_prefix + self.cmd
+    print self.cmd + " is processing " + input_directory
+    for root, dirs, ff in os.walk(input_directory):
+      for name in ff:
+        #print name
+        if name.endswith(('.hxx','.cxx','.cpp','.cc','.c','.h')):
+          files.append(os.path.join(root,name))
+
+    print "Num to Process = " + str(len(files))
+    numToProcess = len(files)
+    if numToProcess > 0:
+      if self.pypar_avail == True:
+        proc = self.pypar.size()                                # Number of processes as specified by mpirun
+        myid = self.pypar.rank()                                # Id of this process (myid in [0, proc-1]) 
+        for ii in range(0,fpas):
+          if ii % proc == myid:
+            fname = files[ii]
+            print "node " + str(myid) + " is processing " + fname
+            call([self.cmd,"-i",fname])
+            self.pypar.barrier()
+            self.pypar.finalize() 
+      else:
+        for ii in range(0,numToProcess):
+          fname = files[ii]
+          print "Processing " + fname
+          call([self.cmd,"-i",fname])
+
+def main():
+  parser = argparse.ArgumentParser(description='clang-format directory tree [.hxx,.cxx] : default search path is scriptdirectory/..')
+  parser.add_argument('--input_directory',default="",help='Input Directory to start recursive auto-format')
+  parser.add_argument('--cmdpath',default="",help='Path to clang-format')
+  args = parser.parse_args()
+  cf = ClangFormat()
+  input_directory = args.input_directory
+  if input_directory == "":
+    input_directory = cf.getScriptPath()
+    input_directory += '/..'
+  cmd_prefix = args.cmdpath
+  if cmd_prefix != "":
+    cmd_prefix += '/'
+  cf.process(input_directory,cmd_prefix)
+
+if __name__ == '__main__':
+  main()
+

--- a/scripts/clang-format-all.py
+++ b/scripts/clang-format-all.py
@@ -23,43 +23,63 @@ class ClangFormat :
   def getScriptPath(self):
     return os.path.dirname(os.path.realpath(sys.argv[0]))
 
+  def which(self,program):
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, fname = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            path = path.strip('"')
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+
+    return None
+
   def process(self,input_directory,cmd_prefix):
     files = []
     self.pypar_avail = False # Turn off mpi processing for now
-    self.cmd = cmd_prefix + self.cmd
-    print self.cmd + " is processing " + input_directory
-    for root, dirs, ff in os.walk(input_directory):
-      for name in ff:
-        #print name
-        if name.endswith(('.hxx','.cxx','.cpp','.cc','.c','.h')):
-          files.append(os.path.join(root,name))
+    self.cmd = self.which(cmd_prefix + self.cmd)
+    if self.cmd is None:
+      print "Error could not find clang-format"
+    else:
+      print self.cmd + " is processing " + input_directory
+      for root, dirs, ff in os.walk(input_directory):
+        for name in ff:
+          #print name
+          if name.endswith(('.cxx','.cpp','.cc','.c','.hxx','.hpp','.h')):
+            files.append(os.path.join(root,name))
 
-    print "Num to Process = " + str(len(files))
-    numToProcess = len(files)
-    if numToProcess > 0:
-      if self.pypar_avail == True:
-        proc = self.pypar.size()                                # Number of processes as specified by mpirun
-        myid = self.pypar.rank()                                # Id of this process (myid in [0, proc-1]) 
-        for ii in range(0,fpas):
-          if ii % proc == myid:
+      print "Num to Process = " + str(len(files))
+      numToProcess = len(files)
+      if numToProcess > 0:
+        if self.pypar_avail == True:
+          proc = self.pypar.size()                                # Number of processes as specified by mpirun
+          myid = self.pypar.rank()                                # Id of this process (myid in [0, proc-1]) 
+          for ii in range(0,fpas):
+            if ii % proc == myid:
+              fname = files[ii]
+              print "node " + str(myid) + " is processing " + fname
+              call([self.cmd,"-i",fname])
+              self.pypar.barrier()
+              self.pypar.finalize() 
+        else:
+          for ii in range(0,numToProcess):
             fname = files[ii]
-            print "node " + str(myid) + " is processing " + fname
+            print "Processing " + fname
             call([self.cmd,"-i",fname])
-            self.pypar.barrier()
-            self.pypar.finalize() 
-      else:
-        for ii in range(0,numToProcess):
-          fname = files[ii]
-          print "Processing " + fname
-          call([self.cmd,"-i",fname])
 
 def main():
-  parser = argparse.ArgumentParser(description='clang-format directory tree [.hxx,.cxx] : default search path is scriptdirectory/..')
+  parser = argparse.ArgumentParser(description='clang-format directory tree  : default search path is scriptdirectory/..')
   parser.add_argument('--input_directory',default="",help='Input Directory to start recursive auto-format')
   parser.add_argument('--cmdpath',default="",help='Path to clang-format')
   args = parser.parse_args()
   cf = ClangFormat()
-  input_directory = args.input_directory
+  input_directory = os.path.abspath(args.input_directory)
   if input_directory == "":
     input_directory = cf.getScriptPath()
     input_directory += '/..'


### PR DESCRIPTION
This encodes a format that is as similar as I could seem to get clang-format to go to the style used in RAJA overall.  The only real difference is that it is more likely to pull template parameters and function arguments onto a single line when they fit in the 80-column limit than the manual style.

I suggest folks give this a try, and see if it's close enough to be made a standard tool for styling.  If there are any particular complaints, it's entirely possible they can be fixed.