### PR TITLE
[DNM] Policy performance test

### DIFF
--- a/include/RAJA/BaseSegment.hxx
+++ b/include/RAJA/BaseSegment.hxx
@@ -67,8 +67,7 @@ namespace RAJA {
  *
  ******************************************************************************
  */
-class BaseSegment
-{
+class BaseSegment {
 public:
 
    ///

--- a/include/RAJA/IndexSet.hxx
+++ b/include/RAJA/IndexSet.hxx
@@ -86,9 +86,11 @@ public:
    template< typename SEG_ITER_POLICY_T,
              typename SEG_EXEC_POLICY_T > struct ExecPolicy
    {
-      typedef SEG_ITER_POLICY_T seg_it;
-      typedef SEG_EXEC_POLICY_T seg_exec;
+       typedef SEG_ITER_POLICY_T seg_it;
+       typedef SEG_EXEC_POLICY_T seg_exec;
    };
+
+   using SegVecT = RAJAVec<IndexSetSegInfo>;
 
 
 //@{
@@ -222,6 +224,29 @@ public:
    ///
    IndexSetSegInfo* getSegmentInfo(unsigned i) {
       return &(m_segments[i]);
+   }
+
+   using iterator = SegVecT::iterator;
+
+   ///
+   /// Get an iterator to the end.
+   ///
+   iterator end() const {
+       return m_segments.end();
+   }
+
+   ///
+   /// Get an iterator to the beginning.
+   ///
+   iterator begin() const {
+       return m_segments.begin();
+   }
+
+   ///
+   /// Return the number of elements in the range.
+   ///
+   size_t size() const {
+       return m_segments.size();
    }
 
 //@}
@@ -403,7 +428,7 @@ private:
    ///
    /// Collection of IndexSet segment info objects.
    ///
-   RAJAVec<IndexSetSegInfo> m_segments;
+   SegVecT m_segments;
 
    ///
    /// Vectors holding user defined segment intervals; each is [begin, end).

--- a/include/RAJA/ListSegment.hxx
+++ b/include/RAJA/ListSegment.hxx
@@ -133,6 +133,29 @@ public:
    ///
    Index_type getLength() const { return m_len; }
 
+   using iterator = Index_type *;
+
+   ///
+   /// Get an iterator to the end.
+   ///
+   iterator end() const {
+       return m_indx + m_len;
+   }
+
+   ///
+   /// Get an iterator to the beginning.
+   ///
+   Index_type* begin() const {
+       return m_indx;
+   }
+
+   ///
+   /// Return the number of elements in the range.
+   ///
+   Index_type size() const {
+       return m_len;
+   }
+
    ///
    /// Return enum value indicating whether segment object owns the data
    /// representing its indices.

--- a/include/RAJA/RAJAVec.hxx
+++ b/include/RAJA/RAJAVec.hxx
@@ -131,20 +131,27 @@ public:
       if (m_capacity > 0) delete [] m_data;  
    }
 
-   using iterator = Iterators::pointer_iterator<T*>;
+   using iterator = T*;
+
+   ///
+   /// Get a pointer to the beginning of the contiguous vector
+   ///
+   T* data() const {
+       return m_data;
+   }
 
    ///
    /// Get an iterator to the end.
    ///
    iterator end() const {
-       return iterator(m_data);
+       return m_data+m_size;
    }
 
    ///
    /// Get an iterator to the beginning.
    ///
    iterator begin() const {
-       return iterator(m_data + m_size);
+       return m_data;
    }
 
    ///

--- a/include/RAJA/RAJAVec.hxx
+++ b/include/RAJA/RAJAVec.hxx
@@ -55,6 +55,7 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "RAJA/config.hxx"
+#include "RAJA/Iterators.hxx"
 
 #include <algorithm>
 
@@ -128,6 +129,22 @@ public:
    ~RAJAVec()
    {
       if (m_capacity > 0) delete [] m_data;  
+   }
+
+   using iterator = Iterators::pointer_iterator<T*>;
+
+   ///
+   /// Get an iterator to the end.
+   ///
+   iterator end() const {
+       return iterator(m_data);
+   }
+
+   ///
+   /// Get an iterator to the beginning.
+   ///
+   iterator begin() const {
+       return iterator(m_data + m_size);
    }
 
    ///

--- a/include/RAJA/RangeSegment.hxx
+++ b/include/RAJA/RangeSegment.hxx
@@ -215,18 +215,20 @@ public:
    ///
    void print(std::ostream& os) const;
 
+   using iterator = Iterators::numeric_iterator<Index_type>;
+
    ///
    /// Get an iterator to the end.
    ///
-   Iterators::numeric_iterator<Index_type> end() const {
-       return Iterators::numeric_iterator<Index_type>(m_end);
+   iterator end() const {
+       return iterator(m_end);
    }
 
    ///
    /// Get an iterator to the beginning.
    ///
-   Iterators::numeric_iterator<Index_type> begin() const {
-       return Iterators::numeric_iterator<Index_type>(m_begin);
+   iterator begin() const {
+       return iterator(m_begin);
    }
 
    ///

--- a/include/RAJA/RangeSegment.hxx
+++ b/include/RAJA/RangeSegment.hxx
@@ -56,12 +56,14 @@
 #include "RAJA/config.hxx"
 
 #include "RAJA/BaseSegment.hxx"
+#include "RAJA/Iterators.hxx"
 
 #include <algorithm>
 #include <iosfwd>
 
 
 namespace RAJA {
+
 
 
 /*!
@@ -212,6 +214,28 @@ public:
    /// Print segment data to given output stream.
    ///
    void print(std::ostream& os) const;
+
+   ///
+   /// Get an iterator to the end.
+   ///
+   Iterators::numeric_iterator<Index_type> end() const {
+       return Iterators::numeric_iterator<Index_type>(m_end);
+   }
+
+   ///
+   /// Get an iterator to the beginning.
+   ///
+   Iterators::numeric_iterator<Index_type> begin() const {
+       return Iterators::numeric_iterator<Index_type>(m_begin);
+   }
+
+   ///
+   /// Return the number of elements in the range.
+   ///
+   Index_type size() const {
+       return m_end - m_begin;
+   }
+
 
 private:
    Index_type m_begin;

--- a/include/RAJA/exec-openmp/forall_openmp.hxx
+++ b/include/RAJA/exec-openmp/forall_openmp.hxx
@@ -1195,6 +1195,32 @@ void forall_segments(omp_taskgraph_interval_segit,
    } // end omp parallel region
 }
 
+/*!
+ ******************************************************************************
+ *
+ * \brief  omp parallel for iteration over random access iterators.
+ *
+ ******************************************************************************
+ */
+template <typename Iterator,
+         typename LOOP_BODY>
+RAJA_INLINE
+void forall(omp_parallel_for_exec,
+            std::random_access_iterator_tag,
+            Iterator begin,
+            Iterator end,
+            LOOP_BODY loop_body)
+{
+   RAJA_FT_BEGIN ;
+
+#pragma omp parallel for schedule(static)
+   for ( auto ii = begin ; ii < end ; ++ii ) {
+      loop_body( *ii );
+   }
+
+   RAJA_FT_END ;
+}
+
 
 }  // closing brace for RAJA namespace
 

--- a/include/RAJA/exec-openmp/forall_openmp.hxx
+++ b/include/RAJA/exec-openmp/forall_openmp.hxx
@@ -204,24 +204,24 @@ void forall_Icount(omp_for_nowait_exec,
  *
  ******************************************************************************
  */
-template <typename LOOP_BODY>
-RAJA_INLINE
-void forall(omp_parallel_for_exec,
-            const RangeSegment& iseg,
-            LOOP_BODY loop_body)
-{
-   Index_type begin = iseg.getBegin();
-   Index_type end   = iseg.getEnd();
-
-   RAJA_FT_BEGIN ;
-
-#pragma omp parallel for schedule(static)
-   for ( Index_type ii = begin ; ii < end ; ++ii ) {
-      loop_body( ii );
-   }
-
-   RAJA_FT_END ;
-}
+// template <typename LOOP_BODY>
+// RAJA_INLINE
+// void forall(omp_parallel_for_exec,
+//             const RangeSegment& iseg,
+//             LOOP_BODY loop_body)
+// {
+//    Index_type begin = iseg.getBegin();
+//    Index_type end   = iseg.getEnd();
+//
+//    RAJA_FT_BEGIN ;
+//
+// #pragma omp parallel for schedule(static)
+//    for ( Index_type ii = begin ; ii < end ; ++ii ) {
+//       loop_body( ii );
+//    }
+//
+//    RAJA_FT_END ;
+// }
 
 
 /*!
@@ -231,24 +231,24 @@ void forall(omp_parallel_for_exec,
  *
  ******************************************************************************
  */
-template <typename LOOP_BODY>
-RAJA_INLINE
-void forall(omp_for_nowait_exec,
-            const RangeSegment& iseg,
-            LOOP_BODY loop_body)
-{
-   Index_type begin = iseg.getBegin();
-   Index_type end   = iseg.getEnd();
-
-   RAJA_FT_BEGIN ;
-
-#pragma omp for schedule(static) nowait
-   for ( Index_type ii = begin ; ii < end ; ++ii ) {
-      loop_body( ii );
-   }
-
-   RAJA_FT_END ;
-}
+// template <typename LOOP_BODY>
+// RAJA_INLINE
+// void forall(omp_for_nowait_exec,
+//             const RangeSegment& iseg,
+//             LOOP_BODY loop_body)
+// {
+//    Index_type begin = iseg.getBegin();
+//    Index_type end   = iseg.getEnd();
+//
+//    RAJA_FT_BEGIN ;
+//
+// #pragma omp for schedule(static) nowait
+//    for ( Index_type ii = begin ; ii < end ; ++ii ) {
+//       loop_body( ii );
+//    }
+//
+//    RAJA_FT_END ;
+// }
 
 
 /*!
@@ -691,25 +691,25 @@ void forall_Icount(omp_for_nowait_exec,
  *
  ******************************************************************************
  */
-template <typename LOOP_BODY>
-RAJA_INLINE
-void forall(omp_parallel_for_exec,
-            const ListSegment& iseg,
-            LOOP_BODY loop_body)
-{
-   const Index_type* __restrict__ idx = iseg.getIndex();
-   Index_type len = iseg.getLength();
-
-   RAJA_FT_BEGIN ;
-
-#pragma novector
-#pragma omp parallel for schedule(static)
-   for ( Index_type k = 0 ; k < len ; ++k ) {
-      loop_body( idx[k] );
-   }
-
-   RAJA_FT_END ;
-}
+// template <typename LOOP_BODY>
+// RAJA_INLINE
+// void forall(omp_parallel_for_exec,
+//             const ListSegment& iseg,
+//             LOOP_BODY loop_body)
+// {
+//    const Index_type* __restrict__ idx = iseg.getIndex();
+//    Index_type len = iseg.getLength();
+//
+//    RAJA_FT_BEGIN ;
+//
+// #pragma novector
+// #pragma omp parallel for schedule(static)
+//    for ( Index_type k = 0 ; k < len ; ++k ) {
+//       loop_body( idx[k] );
+//    }
+//
+//    RAJA_FT_END ;
+// }
 
 /*!
  ******************************************************************************
@@ -718,25 +718,25 @@ void forall(omp_parallel_for_exec,
  *
  ******************************************************************************
  */
-template <typename LOOP_BODY>
-RAJA_INLINE
-void forall(omp_for_nowait_exec,
-            const ListSegment& iseg,
-            LOOP_BODY loop_body)
-{
-   const Index_type* __restrict__ idx = iseg.getIndex();
-   Index_type len = iseg.getLength();
-
-   RAJA_FT_BEGIN ;
-
-#pragma novector
-#pragma omp for schedule(static) nowait
-   for ( Index_type k = 0 ; k < len ; ++k ) {
-      loop_body( idx[k] );
-   }
-
-   RAJA_FT_END ;
-}
+// template <typename LOOP_BODY>
+// RAJA_INLINE
+// void forall(omp_for_nowait_exec,
+//             const ListSegment& iseg,
+//             LOOP_BODY loop_body)
+// {
+//    const Index_type* __restrict__ idx = iseg.getIndex();
+//    Index_type len = iseg.getLength();
+//
+//    RAJA_FT_BEGIN ;
+//
+// #pragma novector
+// #pragma omp for schedule(static) nowait
+//    for ( Index_type k = 0 ; k < len ; ++k ) {
+//       loop_body( idx[k] );
+//    }
+//
+//    RAJA_FT_END ;
+// }
 
 
 /*!
@@ -1193,32 +1193,6 @@ void forall_segments(omp_taskgraph_interval_segit,
       } // loop over interval segments
 
    } // end omp parallel region
-}
-
-/*!
- ******************************************************************************
- *
- * \brief  omp parallel for iteration over random access iterators.
- *
- ******************************************************************************
- */
-template <typename Iterator,
-         typename LOOP_BODY>
-RAJA_INLINE
-void forall(omp_parallel_for_exec,
-            std::random_access_iterator_tag,
-            Iterator begin,
-            Iterator end,
-            LOOP_BODY loop_body)
-{
-   RAJA_FT_BEGIN ;
-
-#pragma omp parallel for schedule(static)
-   for ( auto ii = begin ; ii < end ; ++ii ) {
-      loop_body( *ii );
-   }
-
-   RAJA_FT_END ;
 }
 
 

--- a/include/RAJA/exec-openmp/raja_openmp.hxx
+++ b/include/RAJA/exec-openmp/raja_openmp.hxx
@@ -59,6 +59,8 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+#include "RAJA/PolicyBase.hxx"
+
 namespace RAJA {
 
 //
@@ -72,17 +74,55 @@ namespace RAJA {
 ///
 /// Segment execution policies
 ///
-struct omp_parallel_for_exec {};
+struct omp_parallel_for_exec : public PolicyBase {
+    template<typename IndexT = Index_type,
+             typename Func>
+    void range(IndexT begin, IndexT end, Func &&f) const {
+        // printf("yup omp pfor1...\n");
+#pragma omp parallel for schedule(static)
+        for ( auto ii = begin ; ii < end ; ++ii ) {
+            loop_body( ii );
+        }
+    }
+
+    template<typename Iterator,
+             typename Func>
+    void iterator(Iterator &&begin, Iterator &&end, Func &&loop_body) const {
+        // printf("yup omp pfor2...\n");
+#pragma omp parallel for schedule(static)
+        for ( auto &ii = begin ; ii < end ; ++ii ) {
+            loop_body( *ii );
+        }
+    }
+};
 //struct omp_parallel_for_nowait_exec {};
-struct omp_for_nowait_exec {};
+struct omp_for_nowait_exec : public PolicyBase {
+    template<typename IndexT = Index_type,
+             typename Func>
+    void range(IndexT begin, IndexT end, Func &&f) const {
+#pragma omp for schedule(static) nowait
+        for ( auto ii = begin ; ii < end ; ++ii ) {
+            loop_body( ii );
+        }
+    }
+
+    template<typename Iterator,
+             typename Func>
+    void iterator(Iterator &&begin, Iterator &&end, Func &&loop_body) const {
+#pragma omp for schedule(static) nowait
+        for ( auto &ii = begin ; ii < end ; ++ii ) {
+            loop_body( *ii );
+        }
+    }
+};
 
 ///
 /// Index set segment iteration policies
 ///
-struct omp_parallel_for_segit {};
-struct omp_parallel_segit {};
-struct omp_taskgraph_segit {};
-struct omp_taskgraph_interval_segit {};
+struct omp_parallel_for_segit : public PolicyBase {};
+struct omp_parallel_segit : public PolicyBase {};
+struct omp_taskgraph_segit : public PolicyBase {};
+struct omp_taskgraph_interval_segit : public PolicyBase {};
 
 ///
 ///////////////////////////////////////////////////////////////////////

--- a/include/RAJA/exec-sequential/forall_sequential.hxx
+++ b/include/RAJA/exec-sequential/forall_sequential.hxx
@@ -468,7 +468,7 @@ template <typename SEG_EXEC_POLICY_T,
           typename LOOP_BODY>
 RAJA_INLINE
 void forall( IndexSet::ExecPolicy<seq_segit, SEG_EXEC_POLICY_T>,
-             const IndexSet& iset, 
+             const IndexSet& iset,
              LOOP_BODY loop_body )
 {
    int num_seg = iset.getNumSegments();
@@ -520,34 +520,34 @@ void forall_Icount( IndexSet::ExecPolicy<seq_segit, SEG_EXEC_POLICY_T>,
  *
  ******************************************************************************
  */
-template <typename LOOP_BODY>
-RAJA_INLINE
-void forall_segments(seq_segit,
-                     const IndexSet& iset,
-                     LOOP_BODY loop_body)
-{
-   IndexSet& ncis = (*const_cast<IndexSet *>(&iset)) ;
-   int num_seg = ncis.getNumSegments();
-
-   /* Create a temporary IndexSet with one Segment */
-   IndexSet is_tmp;
-   is_tmp.push_back( RangeSegment(0, 0) ) ; // create a dummy range segment
-
-   RangeSegment* segTmp = static_cast<RangeSegment*>(is_tmp.getSegment(0));
-
-   for ( int isi = 0; isi < num_seg; ++isi ) {
-
-      RangeSegment* isetSeg = 
-         static_cast<RangeSegment*>(ncis.getSegment(isi));
-
-      segTmp->setBegin(isetSeg->getBegin()) ;
-      segTmp->setEnd(isetSeg->getEnd()) ;
-      segTmp->setPrivate(isetSeg->getPrivate()) ;
-
-      loop_body(&is_tmp) ;
-
-   } // loop over index set segments
-}
+// template <typename LOOP_BODY>
+// RAJA_INLINE
+// void forall_segments(seq_segit,
+//                      const IndexSet& iset,
+//                      LOOP_BODY loop_body)
+// {
+//    IndexSet& ncis = (*const_cast<IndexSet *>(&iset)) ;
+//    int num_seg = ncis.getNumSegments();
+//
+//    #<{(| Create a temporary IndexSet with one Segment |)}>#
+//    IndexSet is_tmp;
+//    is_tmp.push_back( RangeSegment(0, 0) ) ; // create a dummy range segment
+//
+//    RangeSegment* segTmp = static_cast<RangeSegment*>(is_tmp.getSegment(0));
+//
+//    for ( int isi = 0; isi < num_seg; ++isi ) {
+//
+//       RangeSegment* isetSeg =
+//          static_cast<RangeSegment*>(ncis.getSegment(isi));
+//
+//       segTmp->setBegin(isetSeg->getBegin()) ;
+//       segTmp->setEnd(isetSeg->getEnd()) ;
+//       segTmp->setPrivate(isetSeg->getPrivate()) ;
+//
+//       loop_body(&is_tmp) ;
+//
+//    } // loop over index set segments
+// }
 
 
 }  // closing brace for RAJA namespace

--- a/include/RAJA/exec-sequential/raja_sequential.hxx
+++ b/include/RAJA/exec-sequential/raja_sequential.hxx
@@ -55,6 +55,8 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+#include "RAJA/PolicyBase.hxx"
+
 namespace RAJA {
 
 //
@@ -68,12 +70,12 @@ namespace RAJA {
 ///
 /// Segment execution policies
 ///
-struct seq_exec {};
+struct seq_exec : public PolicyBase {};
 
 ///
 /// Index set segment iteration policies
 ///
-struct seq_segit {};
+struct seq_segit : public PolicyBase {};
 
 ///
 ///////////////////////////////////////////////////////////////////////

--- a/include/RAJA/exec-sequential/raja_sequential.hxx
+++ b/include/RAJA/exec-sequential/raja_sequential.hxx
@@ -75,7 +75,7 @@ struct seq_exec : public PolicyBase {};
 ///
 /// Index set segment iteration policies
 ///
-struct seq_segit : public PolicyBase {};
+struct seq_segit : public SegmentPolicyBase {};
 
 ///
 ///////////////////////////////////////////////////////////////////////

--- a/include/RAJA/exec-simd/forall_simd.hxx
+++ b/include/RAJA/exec-simd/forall_simd.hxx
@@ -142,24 +142,24 @@ RAJA_SIMD
  *
  ******************************************************************************
  */
-template <typename LOOP_BODY>
-RAJA_INLINE
-void forall(simd_exec,
-            const RangeSegment& iseg,
-            LOOP_BODY loop_body)
-{
-   Index_type begin = iseg.getBegin();
-   Index_type end   = iseg.getEnd();
-
-   RAJA_FT_BEGIN ;
-
-RAJA_SIMD
-   for ( Index_type ii = begin ; ii < end ; ++ii ) {
-      loop_body( ii );
-   }
-
-   RAJA_FT_END ;
-}
+// template <typename LOOP_BODY>
+// RAJA_INLINE
+// void forall(simd_exec,
+//             const RangeSegment& iseg,
+//             LOOP_BODY loop_body)
+// {
+//    Index_type begin = iseg.getBegin();
+//    Index_type end   = iseg.getEnd();
+//
+//    RAJA_FT_BEGIN ;
+//
+// RAJA_SIMD
+//    for ( Index_type ii = begin ; ii < end ; ++ii ) {
+//       loop_body( ii );
+//    }
+//
+//    RAJA_FT_END ;
+// }
 
 /*!
  ******************************************************************************

--- a/include/RAJA/exec-simd/raja_simd.hxx
+++ b/include/RAJA/exec-simd/raja_simd.hxx
@@ -63,13 +63,34 @@
 //////////////////////////////////////////////////////////////////////
 //
 
+#include "RAJA/PolicyBase.hxx"
 
 ///
 /// Segment execution policies
 ///
 namespace RAJA {
 
-struct simd_exec {};
+struct simd_exec : public PolicyBase {
+    template<typename IndexT = Index_type,
+             typename Func>
+    void range(IndexT begin, IndexT end, Func &&f) const {
+        // printf("yup...\n");
+        RAJA_SIMD
+        for ( auto ii = begin ; ii < end ; ++ii ) {
+            loop_body( ii );
+        }
+    }
+
+    template<typename Iterator,
+             typename Func>
+    void iterator(Iterator &&begin, Iterator &&end, Func &&loop_body) const {
+        // printf("yup2...\n");
+        RAJA_SIMD
+        for ( auto &ii = begin ; ii < end ; ++ii ) {
+            loop_body( *ii );
+        }
+    }
+};
 
 }
 

--- a/include/RAJA/forall_generic.hxx
+++ b/include/RAJA/forall_generic.hxx
@@ -91,6 +91,7 @@
 
 #include "RAJA/int_datatypes.hxx"
 #include "RAJA/Iterators.hxx"
+#include "RAJA/fault_tolerance.hxx"
 
 #include <type_traits>
 
@@ -161,16 +162,16 @@ void forall_Icount(Index_type begin, Index_type end,
  *
  ******************************************************************************
  */
-template <typename EXEC_POLICY_T,
-          typename LOOP_BODY>
-RAJA_INLINE
-void forall(const RangeSegment& iseg,
-            LOOP_BODY loop_body)
-{
-   forall( EXEC_POLICY_T(),
-           iseg.getBegin(), iseg.getEnd(),
-           loop_body );
-}
+// template <typename EXEC_POLICY_T,
+//           typename LOOP_BODY>
+// RAJA_INLINE
+// void forall(const RangeSegment& iseg,
+//             LOOP_BODY loop_body)
+// {
+//    forall( EXEC_POLICY_T(),
+//            iseg.getBegin(), iseg.getEnd(),
+//            loop_body );
+// }
 
 /*!
  ******************************************************************************
@@ -359,16 +360,16 @@ void forall_Icount(const Index_type* idx, Index_type len,
  *
  ******************************************************************************
  */
-template <typename EXEC_POLICY_T, 
-          typename LOOP_BODY>
-RAJA_INLINE
-void forall(const ListSegment& iseg, 
-            LOOP_BODY loop_body)
-{
-   forall( EXEC_POLICY_T(),
-           iseg.getIndex(), iseg.getLength(), 
-           loop_body );
-}
+// template <typename EXEC_POLICY_T,
+//           typename LOOP_BODY>
+// RAJA_INLINE
+// void forall(const ListSegment& iseg,
+//             LOOP_BODY loop_body)
+// {
+//    forall( EXEC_POLICY_T(),
+//            iseg.getIndex(), iseg.getLength(),
+//            loop_body );
+// }
 
 /*!
  ******************************************************************************
@@ -477,7 +478,7 @@ void forall_Icount(const INDEXSET_T& iset,
  ******************************************************************************
  */
 template <typename EXEC_POLICY_T,
-          typename LOOP_BODY,
+          typename LOOP_BODY
           >
 RAJA_INLINE
 void forall_segments(const IndexSet& iset,
@@ -486,6 +487,31 @@ void forall_segments(const IndexSet& iset,
    forall_segments(EXEC_POLICY_T(),
                    iset,
                    loop_body);
+}
+
+/*!
+ ******************************************************************************
+ *
+ * \brief  omp parallel for iteration over random access iterators.
+ *
+ ******************************************************************************
+ */
+template <
+         typename Policy,
+         typename Iterator,
+         typename LOOP_BODY>
+RAJA_INLINE
+void forall(const Policy &p,
+            std::random_access_iterator_tag,
+            Iterator begin,
+            Iterator end,
+            LOOP_BODY loop_body)
+{
+   RAJA_FT_BEGIN ;
+
+   p.iterator(begin, end, loop_body);
+
+   RAJA_FT_END ;
 }
 
 
@@ -531,6 +557,8 @@ void forall(Container c,
    auto begin = std::begin(c);
    auto end = std::end(c);
    using category = typename std::iterator_traits<decltype(std::begin(c))>::iterator_category;
+
+   // printf("running container\n");
 
    forall(EXEC_POLICY_T(),
           category(),

--- a/include/RAJA/forall_generic.hxx
+++ b/include/RAJA/forall_generic.hxx
@@ -92,6 +92,7 @@
 #include "RAJA/int_datatypes.hxx"
 #include "RAJA/Iterators.hxx"
 #include "RAJA/fault_tolerance.hxx"
+#include "RAJA/PolicyBase.hxx"
 
 #include <type_traits>
 
@@ -413,13 +414,15 @@ void forall_Icount(const ListSegment& iseg,
 template <typename EXEC_POLICY_T,
           typename INDEXSET_T, 
           typename LOOP_BODY,
-          typename std::enable_if<std::is_base_of<IndexSet, INDEXSET_T>::value>::type * = nullptr
+          typename std::enable_if<std::is_base_of<IndexSet, INDEXSET_T>::value &&
+          std::is_base_of<SegmentPolicyBase, typename EXEC_POLICY_T::seg_it>::value>::type * = nullptr
           >
 RAJA_INLINE
 void forall(const INDEXSET_T& iset, LOOP_BODY loop_body)
 {
    forall(EXEC_POLICY_T(),
-          iset, loop_body);
+          iset,
+          loop_body );
 }
 
 /*!
@@ -578,8 +581,8 @@ void forall_Icount(Iterator begin,
 template <typename EXEC_POLICY_T,
           typename Container,
           typename LOOP_BODY,
-          typename std::enable_if<Iterators::OffersRAI<Container>::value>::type * = nullptr,
-          typename std::enable_if<!std::is_base_of<IndexSet, Container>::value>::type * = nullptr
+          typename std::enable_if<Iterators::OffersRAI<Container>::value>::type * = nullptr
+          , typename std::enable_if<!std::is_base_of<IndexSet, Container>::value>::type * = nullptr
           >
 RAJA_INLINE
 void forall(Container c,

--- a/include/RAJA/forall_generic.hxx
+++ b/include/RAJA/forall_generic.hxx
@@ -492,14 +492,13 @@ void forall_segments(const IndexSet& iset,
 /*!
  ******************************************************************************
  *
- * \brief  omp parallel for iteration over random access iterators.
+ * \brief  Generic iteration over random access iterators.
  *
  ******************************************************************************
  */
-template <
-         typename Policy,
-         typename Iterator,
-         typename LOOP_BODY>
+template <typename Policy,
+          typename Iterator,
+          typename LOOP_BODY>
 RAJA_INLINE
 void forall(const Policy &p,
             std::random_access_iterator_tag,
@@ -538,6 +537,37 @@ void forall(Iterator begin,
           loop_body );
 }
 
+template<typename Iterator,
+         typename Body>
+struct IcountWrapper {
+    IcountWrapper(Body && body) : m_body(body) {}
+    private:
+        Body m_body;
+};
+/*!
+ ******************************************************************************
+ *
+ * \brief Generic dispatch over iterators with count.
+ *
+ ******************************************************************************
+ */
+template <typename EXEC_POLICY_T,
+          typename Iterator,
+          typename LOOP_BODY>
+RAJA_INLINE
+void forall_Icount(Iterator begin,
+                   Iterator end,
+                   Index_type icount,
+                   LOOP_BODY loop_body)
+{
+   using category = typename std::iterator_traits<Iterator>::iterator_category;
+
+   forall(EXEC_POLICY_T(),
+          category(),
+          begin, end,
+          loop_body );
+}
+
 /*!
  ******************************************************************************
  *
@@ -548,7 +578,8 @@ void forall(Iterator begin,
 template <typename EXEC_POLICY_T,
           typename Container,
           typename LOOP_BODY,
-          typename std::enable_if<Iterators::OffersRAI<Container>::value>::type * = nullptr
+          typename std::enable_if<Iterators::OffersRAI<Container>::value>::type * = nullptr,
+          typename std::enable_if<!std::is_base_of<IndexSet, Container>::value>::type * = nullptr
           >
 RAJA_INLINE
 void forall(Container c,

--- a/include/RAJA/segment_exec.hxx
+++ b/include/RAJA/segment_exec.hxx
@@ -58,6 +58,10 @@
 
 #include "RAJA/config.hxx"
 
+#include "RAJA/IndexSetSegInfo.hxx"
+#include "RAJA/BaseSegment.hxx"
+#include "RAJA/RangeSegment.hxx"
+#include "RAJA/ListSegment.hxx"
 
 namespace RAJA {
 
@@ -187,6 +191,38 @@ void executeRangeList_forall_Icount(const IndexSetSegInfo* seg_info,
 
    }  // switch on segment type
 }
+
+//TODO: TRWS, this does not belong here, but the current include snarl
+//prevents it from being elsewhere
+/*!
+ ******************************************************************************
+ *
+ * \brief Generic iteration over IndexSet ExecPolicy policies
+ *
+ ******************************************************************************
+ */
+template <typename SEG_ITER_POLICY_T,
+          typename SEG_EXEC_POLICY_T,
+          typename Iterator,
+          typename LOOP_BODY>
+RAJA_INLINE
+void forall(IndexSet::ExecPolicy<SEG_ITER_POLICY_T, SEG_EXEC_POLICY_T>,
+            std::random_access_iterator_tag,
+            Iterator begin, Iterator end,
+            LOOP_BODY&& loop_body)
+{
+   RAJA_FT_BEGIN ;
+
+    SEG_ITER_POLICY_T first_policy;
+    // TODO: convert lambda to functor
+    auto wrapped = [loop_body](const IndexSetSegInfo & seg_info) {
+        executeRangeList_forall<SEG_EXEC_POLICY_T>(&seg_info, loop_body);
+    };
+    first_policy.iterator(begin, end, wrapped);
+
+   RAJA_FT_END ;
+}
+
 
 
 }  // closing brace for RAJA namespace

--- a/include/RAJA/segment_exec.hxx
+++ b/include/RAJA/segment_exec.hxx
@@ -203,12 +203,11 @@ void executeRangeList_forall_Icount(const IndexSetSegInfo* seg_info,
  */
 template <typename SEG_ITER_POLICY_T,
           typename SEG_EXEC_POLICY_T,
-          typename Iterator,
+          typename INDEXSET_T,
           typename LOOP_BODY>
 RAJA_INLINE
 void forall(IndexSet::ExecPolicy<SEG_ITER_POLICY_T, SEG_EXEC_POLICY_T>,
-            std::random_access_iterator_tag,
-            Iterator begin, Iterator end,
+            INDEXSET_T && iset,
             LOOP_BODY&& loop_body)
 {
    RAJA_FT_BEGIN ;
@@ -218,7 +217,7 @@ void forall(IndexSet::ExecPolicy<SEG_ITER_POLICY_T, SEG_EXEC_POLICY_T>,
     auto wrapped = [loop_body](const IndexSetSegInfo & seg_info) {
         executeRangeList_forall<SEG_EXEC_POLICY_T>(&seg_info, loop_body);
     };
-    first_policy.iterator(begin, end, wrapped);
+    first_policy.indexset(iset, wrapped);
 
    RAJA_FT_END ;
 }

--- a/include/RAJA/segment_exec.hxx
+++ b/include/RAJA/segment_exec.hxx
@@ -85,9 +85,8 @@ void executeRangeList_forall(const IndexSetSegInfo* seg_info,
       case _RangeSeg_ : {
          const RangeSegment* tseg =
             static_cast<const RangeSegment*>(iseg);
-         forall(
-            SEG_EXEC_POLICY_T(),
-            tseg->getBegin(), tseg->getEnd(),
+         forall<SEG_EXEC_POLICY_T>(
+            *tseg,
             loop_body
          );
          break;
@@ -109,9 +108,8 @@ void executeRangeList_forall(const IndexSetSegInfo* seg_info,
       case _ListSeg_ : {
          const ListSegment* tseg =
             static_cast<const ListSegment*>(iseg);
-         forall(
-            SEG_EXEC_POLICY_T(),
-            tseg->getIndex(), tseg->getLength(),
+         forall<SEG_EXEC_POLICY_T>(
+            *tseg,
             loop_body
          );
          break;

--- a/src/LockFreeIndexSetBuilders.cxx
+++ b/src/LockFreeIndexSetBuilders.cxx
@@ -82,7 +82,8 @@ namespace RAJA {
 void buildLockFreeBlockIndexset(RAJA::IndexSet& iset,
                                 int fastDim, int midDim, int slowDim)
 {
-   int numThreads = getMaxOMPThreadsCPU();
+   // int numThreads = getMaxOMPThreadsCPU();
+   int numThreads = 8;
 
    // printf("Lock-free created\n") ;
 

--- a/test/Kripke-v1.1/Kripke-v1.1-RAJA/Kripke.cpp
+++ b/test/Kripke-v1.1/Kripke-v1.1-RAJA/Kripke.cpp
@@ -252,8 +252,10 @@ int main(int argc, char **argv) {
       int tid = omp_get_thread_num();
 #ifdef __bgq__
       int core = Kernel_ProcessorCoreID();
-#else
+#elif defined(__LINUX__)
       int core = sched_getcpu();
+#else
+      int core = 0;
 #endif
       printf("Rank: %d Thread %d: Core %d\n", myid, tid, core);
     }

--- a/test/Kripke-v1.1/Kripke-v1.1-baseline/Kripke.cpp
+++ b/test/Kripke-v1.1/Kripke-v1.1-baseline/Kripke.cpp
@@ -252,8 +252,10 @@ int main(int argc, char **argv) {
       int tid = omp_get_thread_num();
 #ifdef __bgq__
       int core = Kernel_ProcessorCoreID();
-#else
+#elif defined(__LINUX__)
       int core = sched_getcpu();
+#else
+      int core = 0;
 #endif
       printf("Rank: %d Thread %d: Core %d\n", myid, tid, core);
     }


### PR DESCRIPTION
This implements iterators for range and list segments, adds policy implementations that take advantage of this, removes the otherwise more specific overloads, and adjusts IndexSet's implementation to call the correct overloads.  I haven't had time to do a thorough performance eval yet, but for clang-omp 3.5 on a mac, kripke performance does not change (or if it changes the change is within the error of the measurements).  More to come, but if anyone wants to play with it, let me know how it comes out.