### PR TITLE
Scripts to support git-clang-format

### DIFF
--- a/scripts/check_formatting.py
+++ b/scripts/check_formatting.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+import subprocess
+output = subprocess.check_output(["git", "format", "--diff"])
+
+if output not in ['no modified files to format\n', 'clang-format did not modify any files\n']:
+  print "Run git format, then commit.\n"
+  exit(1)
+else:
+  exit(0)

--- a/scripts/git-format
+++ b/scripts/git-format
@@ -1,0 +1,2 @@
+#!/bin/bash
+git-clang-format --extensions cxx,cpp,cc,c,hxx,hpp,h $@


### PR DESCRIPTION
LLVM's git-clang-format is already setup for git integration; but the only problem is that git-clang-format out of the box does not recognize the .hxx extension.

The easiest way to remedy this is to: 
git config --global clangFormat.extensions cxx,cpp,cc,c,hxx,hpp,h

and then you can run the following after staging your files
git clang-format 

Note that their documentation specifies clangFormat.extension which is incorrect

Another way is to use scripts/git-format (added in this PR) which is a wrapper around git-clang-format but adds the --extensions flag; so if scripts is in your path git will automatically pick it up and allow you to run

git format

In addition I've added scripts/check_formatting.py which you can copy as a pre-commit hook. It won't let you commit unless you've run git format, or clang-format first.  To do this

 cp scripts/check_formatting.py .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit

BTW, check_formatting.py is setup to call git format  --diff;  so edit this file if you are going to add the global clangFormat.extensions property and want to use git clang-format instead.

Comments?
