### PR TITLE
Added assertions to protect correct block sizes in CUDA reductions

### DIFF
--- a/include/RAJA/exec-cuda/raja_cuda.hxx
+++ b/include/RAJA/exec-cuda/raja_cuda.hxx
@@ -145,6 +145,7 @@ struct cuda_reduce_atomic {};
 // values.
 //
 const int WARP_SIZE = 32;
+const int RAJA_CUDA_MAX_BLOCK_SIZE = 2048;
 
 }  // closing brace for RAJA namespace
 

--- a/include/RAJA/exec-cuda/reduce_cuda.hxx
+++ b/include/RAJA/exec-cuda/reduce_cuda.hxx
@@ -568,7 +568,6 @@ class ReduceSum<cuda_reduce<BLOCK_SIZE>, T> {
   // Constructor takes initial reduction value (default ctor is disabled).
   // Ctor only executes on the host.
   //
-  static_assert(BLOCK_SIZE!=0);
   static constexpr bool powerOfTwoCheck = (!(BLOCK_SIZE&(BLOCK_SIZE-1))); 
   static constexpr bool reasonableRangeCheck = ((BLOCK_SIZE>=32) && (BLOCK_SIZE<=2048));
   static_assert(powerOfTwoCheck,"Error: block sizes must be a power of 2");

--- a/include/RAJA/exec-cuda/reduce_cuda.hxx
+++ b/include/RAJA/exec-cuda/reduce_cuda.hxx
@@ -568,7 +568,13 @@ class ReduceSum<cuda_reduce<BLOCK_SIZE>, T> {
   // Constructor takes initial reduction value (default ctor is disabled).
   // Ctor only executes on the host.
   //
+  static_assert(BLOCK_SIZE!=0);
+  static constexpr bool powerOfTwoCheck = (!(BLOCK_SIZE&(BLOCK_SIZE-1))); 
+  static constexpr bool reasonableRangeCheck = ((BLOCK_SIZE>=32) && (BLOCK_SIZE<=2048));
+  static_assert(powerOfTwoCheck,"Error: block sizes must be a power of 2");
+  static_assert(reasonableRangeCheck,"Error: block sizes must be between 32 and 2048");
   explicit ReduceSum(T init_val) {
+   
     m_is_copy = false;
 
     m_init_val = init_val;

--- a/include/RAJA/exec-cuda/reduce_cuda.hxx
+++ b/include/RAJA/exec-cuda/reduce_cuda.hxx
@@ -423,6 +423,12 @@ class ReduceMin<cuda_reduce<BLOCK_SIZE>, T> {
   T m_reduced_val;
 
   CudaReductionBlockTallyType *m_tallydata;
+  
+  // Sanity checks for block size
+  static constexpr bool powerOfTwoCheck = (!(BLOCK_SIZE&(BLOCK_SIZE-1))); 
+  static constexpr bool reasonableRangeCheck = ((BLOCK_SIZE>=32) && (BLOCK_SIZE<=2048));
+  static_assert(powerOfTwoCheck,"Error: block sizes must be a power of 2");
+  static_assert(reasonableRangeCheck,"Error: block sizes must be between 32 and 2048");
 };
 
 /*!
@@ -550,6 +556,12 @@ class ReduceMax<cuda_reduce<BLOCK_SIZE>, T> {
   T m_reduced_val;
 
   CudaReductionBlockTallyType *m_tallydata;
+  
+  // Sanity checks for block size
+  static constexpr bool powerOfTwoCheck = (!(BLOCK_SIZE&(BLOCK_SIZE-1))); 
+  static constexpr bool reasonableRangeCheck = ((BLOCK_SIZE>=32) && (BLOCK_SIZE<=2048));
+  static_assert(powerOfTwoCheck,"Error: block sizes must be a power of 2");
+  static_assert(reasonableRangeCheck,"Error: block sizes must be between 32 and 2048");
 };
 
 /*!
@@ -568,10 +580,6 @@ class ReduceSum<cuda_reduce<BLOCK_SIZE>, T> {
   // Constructor takes initial reduction value (default ctor is disabled).
   // Ctor only executes on the host.
   //
-  static constexpr bool powerOfTwoCheck = (!(BLOCK_SIZE&(BLOCK_SIZE-1))); 
-  static constexpr bool reasonableRangeCheck = ((BLOCK_SIZE>=32) && (BLOCK_SIZE<=2048));
-  static_assert(powerOfTwoCheck,"Error: block sizes must be a power of 2");
-  static_assert(reasonableRangeCheck,"Error: block sizes must be between 32 and 2048");
   explicit ReduceSum(T init_val) {
    
     m_is_copy = false;
@@ -704,6 +712,12 @@ class ReduceSum<cuda_reduce<BLOCK_SIZE>, T> {
   int m_blockoffset;
 
   CudaReductionBlockDataType *m_max_grid_size;
+
+  // Sanity checks for block size
+  static constexpr bool powerOfTwoCheck = (!(BLOCK_SIZE&(BLOCK_SIZE-1))); 
+  static constexpr bool reasonableRangeCheck = ((BLOCK_SIZE>=32) && (BLOCK_SIZE<=2048));
+  static_assert(powerOfTwoCheck,"Error: block sizes must be a power of 2");
+  static_assert(reasonableRangeCheck,"Error: block sizes must be between 32 and 2048");
 };
 
 /*!
@@ -825,6 +839,12 @@ class ReduceSum<cuda_reduce_atomic<BLOCK_SIZE>, T> {
   T m_reduced_val;
 
   CudaReductionBlockTallyType *m_tallydata;
+
+  // Sanity checks for block size
+  static constexpr bool powerOfTwoCheck = (!(BLOCK_SIZE&(BLOCK_SIZE-1))); 
+  static constexpr bool reasonableRangeCheck = ((BLOCK_SIZE>=32) && (BLOCK_SIZE<=2048));
+  static_assert(powerOfTwoCheck,"Error: block sizes must be a power of 2");
+  static_assert(reasonableRangeCheck,"Error: block sizes must be between 32 and 2048");
 };
 
 ///
@@ -1030,6 +1050,12 @@ class ReduceMinLoc<cuda_reduce<BLOCK_SIZE>, T> {
   Index_type m_reduced_idx;
 
   CudaReductionLocBlockDataType *m_blockdata;
+
+  // Sanity checks for block size
+  static constexpr bool powerOfTwoCheck = (!(BLOCK_SIZE&(BLOCK_SIZE-1))); 
+  static constexpr bool reasonableRangeCheck = ((BLOCK_SIZE>=32) && (BLOCK_SIZE<=2048));
+  static_assert(powerOfTwoCheck,"Error: block sizes must be a power of 2");
+  static_assert(reasonableRangeCheck,"Error: block sizes must be between 32 and 2048");
 };
 
 template <size_t BLOCK_SIZE, typename T>
@@ -1226,6 +1252,12 @@ class ReduceMaxLoc<cuda_reduce<BLOCK_SIZE>, T> {
   Index_type m_reduced_idx;
 
   CudaReductionLocBlockDataType *m_blockdata;
+
+  // Sanity checks for block size
+  static constexpr bool powerOfTwoCheck = (!(BLOCK_SIZE&(BLOCK_SIZE-1))); 
+  static constexpr bool reasonableRangeCheck = ((BLOCK_SIZE>=32) && (BLOCK_SIZE<=2048));
+  static_assert(powerOfTwoCheck,"Error: block sizes must be a power of 2");
+  static_assert(reasonableRangeCheck,"Error: block sizes must be between 32 and 2048");
 };
 
 }  // closing brace for RAJA namespace


### PR DESCRIPTION
Small code change, added static asserts testing 

1) That the block size is a power of two
2) That the block size is between 32 and 2048. 2048 is chosen randomly, feel free to propose changes

Reviews from either of @jonesholger or @davidbeckingsale ? You'll need to build CUDA, do a correctly sized reduction, and an incorrectly sized reduction to test. To remove the WIP tag we need to settle on a max block size

Note: code contributed by @trws