### PR TITLE
adding pullapprove configuration

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,13 @@
+approve_by_comment: true
+approve_regex: '^([Aa]pproved|:shipit:|:\+1:|I [Aa]pprove)'
+reject_regex: ^Rejected
+reset_on_push: false
+author_approval: ignored
+reviewers:
+  members:
+  - ajkunen
+  - keasler
+  - rhornung67
+  - trws
+  name: pullapprove
+  required: 2

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -4,10 +4,17 @@ reject_regex: ^Rejected
 reset_on_push: false
 author_approval: ignored
 reviewers:
-  members:
-  - ajkunen
-  - keasler
-  - rhornung67
-  - trws
-  name: pullapprove
-  required: 2
+  - name: czars
+    members:
+      - keasler
+      - rhornung67
+    required: 1
+  - name: everyone
+    members:
+    - ajkunen
+    - trws
+    - davidbeckingsale
+    - DavidPoliakoff
+    - keasler
+    - rhornung67
+    required: 1


### PR DESCRIPTION
This adds a pullapprove configuration.  You can read the YAML for full details, but PRs will require two approvals from the group @ajkunen, @keasler, @rhornung67, and @trws (this is arbitrary and temporary, let me know who all should be on the list).  This system can also let us say one reviewer from a given group and one review from another to merge, so I'll be happy to set that up but I need to know what the preference is.

To use it, you can link through to pullapprove to approve or reject, or you can use a github comment to get the same effect.  I adjusted the approval regex to hit the common items, but you will need to have a line that starts with one of:

*  `:+1:` or `:thumbsup:` or the unicode equivalent thereto (:+1:)
*  `:shipit:` (:shipit:)
* Approved
* I approve

To reject, it needs a line starting with "Rejected" currently.

I would appreciate feedback and preferences from folks on how they would like this to work.  It's already enabled with a default non-yaml config so we can actually try it out on this PR.

CC: @DavidPoliakoff, @davidbeckingsale, @jonesholger 