### PR TITLE
Delete unnecessary return statement

### DIFF
--- a/test/unit-tests/CPUtests/main-traversal.cxx
+++ b/test/unit-tests/CPUtests/main-traversal.cxx
@@ -572,8 +572,6 @@ int main(int argc, char *argv[])
 
    cout << "\n DONE!!! " << endl;
 
-   return 0 ;
-
    if (s_ntests_passed_total == s_ntests_run_total) {
      return 0 ;
    } else {


### PR DESCRIPTION
I think I missed this during rebase - we don't want to return 0 before checking how many tests pass.