### PR TITLE
hotfix for compilation issues with nvcc and the new test integration

### DIFF
--- a/cmake/SetupPackages.cmake
+++ b/cmake/SetupPackages.cmake
@@ -91,6 +91,11 @@ if (RAJA_ENABLE_TESTS)
       googletest
       GIT_REPOSITORY https://github.com/google/googletest.git
       GIT_TAG release-1.7.0
+      CMAKE_ARGS                
+          -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+          -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+          -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+          -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
       INSTALL_COMMAND ""
       LOG_DOWNLOAD ON
       LOG_CONFIGURE ON

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -42,7 +42,12 @@
 ###############################################################################
 
 
-add_executable(raja-pi
-  pi.cxx)
+if (RAJA_ENABLE_CUDA)
+    cuda_add_executable(raja-pi
+      pi.cxx)
+else ()
+    add_executable(raja-pi
+      pi.cxx)
+endif ()
 
 target_link_libraries(raja-pi RAJA)

--- a/examples/pi.cxx
+++ b/examples/pi.cxx
@@ -10,7 +10,7 @@ int main(int argc, char* argv[]) {
 
   RAJA::ReduceSum<reduce_policy, double> piSum(0.0) ;
 
-  RAJA::forall<execute_policy>( 0, numBins, [=] RAJA_DEVICE (int i) {
+  RAJA::forall<execute_policy>( 0, numBins, [=] (int i) {
       double x = (double(i) + 0.5)/numBins ;
       piSum += 4.0/(1.0 + x*x) ;
   } ) ;

--- a/test/unit/cpu/CMakeLists.txt
+++ b/test/unit/cpu/CMakeLists.txt
@@ -60,6 +60,14 @@ if (RAJA_ENABLE_CUDA)
         main-nested-reduce.cxx)
   endif()
 
+  cuda_add_executable(indexset-tests
+    test-indexsets.cxx
+    buildIndexSet.cxx)
+
+  cuda_add_executable(traversal-tests
+    test-traversals.cxx
+    buildIndexSet.cxx)
+
 else()
   add_executable(CPUtraversal-test.exe
     main-traversal.cxx
@@ -77,6 +85,14 @@ else()
       main-nested-reduce.cxx)
   endif()
 
+  add_executable(indexset-tests
+    test-indexsets.cxx
+    buildIndexSet.cxx)
+
+  add_executable(traversal-tests
+    test-traversals.cxx
+    buildIndexSet.cxx)
+
 endif()
 
 add_test(CPUtraversal
@@ -93,18 +109,10 @@ if(RAJA_ENABLE_OPENMP)
       CPUnested_reduce-test.exe)
 endif()
 
-add_executable(indexset-tests
-  test-indexsets.cxx
-  buildIndexSet.cxx)
-
 add_test(indexset-test
   indexset-tests)
 
 target_link_libraries(indexset-tests RAJA gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
-
-add_executable(traversal-tests
-  test-traversals.cxx
-  buildIndexSet.cxx)
 
 add_test(traversal-test
   traversal-tests)


### PR DESCRIPTION
This is a set of hotfixes for build issues with the gtest integration that only showed up on odd environments.  Since a build with enable_cuda forces all including files to include cuda constructs, they only build with NVCC.  We really need to fix that.  Also, the gtest library needs to be built with the same ABI as the rest of raja, so it must be built with the same compilers. This version passes all CPU and GPU tests on rzhas.