### PR TITLE
Feature/trws/bgq testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@
 # 
 ###############################################################################
 
-cmake_minimum_required (VERSION 3.1)
+cmake_minimum_required (VERSION 3.0)
 
 project(RAJA LANGUAGES CXX C)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ option(RAJA_ENABLE_TESTS "Build tests" On)
 option(RAJA_ENABLE_EXAMPLES "Build simple examples" On)
 option(RAJA_ENABLE_NESTED "Enable nested loop support" Off)
 
+set(TEST_DRIVER "" CACHE STRING "driver used to wrap test commands")
+
 # Setup basic CMake options
 include(cmake/SetupBasics.cmake)
 # Setup vendor-specific compiler flags

--- a/host-configs/bgqos/clang_3_9_0.cmake
+++ b/host-configs/bgqos/clang_3_9_0.cmake
@@ -12,6 +12,8 @@ set(RAJA_COMPILER "RAJA_COMPILER_CLANG" CACHE STRING "")
 
 set(CMAKE_CXX_COMPILER "/usr/apps/gnu/clang/r266865-stable/bin/bgclang++" CACHE PATH "")
 
+set(TEST_DRIVER srun -N 1 -ppsmall CACHE STRING "use slurm to launch on BGQ")
+
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -ffast-math -std=c++11 -stdlib=libc++" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O3 -ffast-math -std=c++11 -stdlib=libc++" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -std=c++11 -stdlib=libc++" CACHE STRING "")

--- a/host-configs/bgqos/gcc_4_8_4.cmake
+++ b/host-configs/bgqos/gcc_4_8_4.cmake
@@ -12,6 +12,8 @@ set(RAJA_COMPILER "RAJA_COMPILER_GNU" CACHE STRING "")
 
 set(CMAKE_CXX_COMPILER "/usr/local/tools/compilers/ibm/mpicxx-4.8.4" CACHE PATH "")
 
+set(TEST_DRIVER srun -N 1 -ppsmall CACHE STRING "use slurm to launch on BGQ")
+
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Ofast -mcpu=a2 -mtune=a2 -finline-functions -finline-limit=20000 -std=c++11" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -Ofast -mcpu=a2 -mtune=a2 -finline-functions -finline-limit=20000 -std=c++11" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -std=c++11" CACHE STRING "")

--- a/test/unit/cpu/CMakeLists.txt
+++ b/test/unit/cpu/CMakeLists.txt
@@ -95,27 +95,33 @@ else()
 
 endif()
 
-add_test(CPUtraversal
-  CPUtraversal-test.exe)
+add_test(
+  NAME CPUtraversal
+  COMMAND ${TEST_DRIVER} $<TARGET_FILE:CPUtraversal-test.exe>)
 
-add_test(CPUreduce
-  CPUreduce-test.exe)
+add_test(
+  NAME CPUreduce
+  COMMAND ${TEST_DRIVER} $<TARGET_FILE:CPUreduce-test.exe>)
 
-add_test(CPUnested
-  CPUnested-test.exe)
+add_test(
+  NAME CPUnested
+  COMMAND ${TEST_DRIVER} $<TARGET_FILE:CPUnested-test.exe>)
 
 if(RAJA_ENABLE_OPENMP)
-  add_test(CPUnested-reduce
-      CPUnested_reduce-test.exe)
+    add_test(
+      NAME CPUnested-reduce
+      COMMAND ${TEST_DRIVER} $<TARGET_FILE:CPUnested_reduce-test.exe>)
 endif()
 
-add_test(indexset-test
-  indexset-tests)
+add_test(
+    NAME indexset-test
+    COMMAND ${TEST_DRIVER} $<TARGET_FILE:indexset-tests>)
 
 target_link_libraries(indexset-tests RAJA gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
 
-add_test(traversal-test
-  traversal-tests)
+add_test(
+    NAME traversal-test
+    COMMAND ${TEST_DRIVER} $<TARGET_FILE:traversal-tests>)
 
 target_link_libraries(traversal-tests RAJA gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
 

--- a/test/unit/gpu/CMakeLists.txt
+++ b/test/unit/gpu/CMakeLists.txt
@@ -48,38 +48,45 @@ SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)
 cuda_add_executable(reducemin.exe
   ReduceMin.cxx)
 
-add_test(reducemin
-    reducemin.exe)
+add_test(
+    NAME reducemin
+    COMMAND ${TEST_DRIVER} $<TARGET_FILE:reducemin.exe>)
 
 cuda_add_executable(reducemax.exe
   ReduceMax.cxx)
-add_test(reducemax
-    reducemax.exe)
+add_test(
+    NAME reducemax
+    COMMAND ${TEST_DRIVER} $<TARGET_FILE:reducemax.exe>)
 
 cuda_add_executable(reducesum.exe
   ReduceSum.cxx)
-add_test(reducesum
-    reducesum.exe)
+add_test(
+    NAME reducesum
+    COMMAND ${TEST_DRIVER} $<TARGET_FILE:reducesum.exe>)
 
 cuda_add_executable(traversal.exe
   Traversal.cxx)
-add_test(traversal
-    traversal.exe)
+add_test(
+    NAME traversal
+    COMMAND ${TEST_DRIVER} $<TARGET_FILE:traversal.exe>)
 
 cuda_add_executable(nested.exe
   Nested.cxx)
-add_test(nested
-    nested.exe)
+add_test(
+    NAME nested
+    COMMAND ${TEST_DRIVER} $<TARGET_FILE:nested.exe>)
 
 cuda_add_executable(reduceminloc.exe
   ReduceMinLoc.cxx)
-add_test(reduceminloc
-    reduceminloc.exe)
+add_test(
+    NAME reduceminloc
+    COMMAND ${TEST_DRIVER} $<TARGET_FILE:reduceminloc.exe>)
 
 cuda_add_executable(reducemaxloc.exe
   ReduceMaxLoc.cxx)
-add_test(reducemaxloc
-    reducemaxloc.exe)
+add_test(
+    NAME reducemaxloc
+    COMMAND ${TEST_DRIVER} $<TARGET_FILE:reducemaxloc.exe>)
 
 target_link_libraries(reducemin.exe RAJA)
 target_link_libraries(reducemax.exe RAJA)


### PR DESCRIPTION
This PR injects a TEST_DRIVER into each unit test's command, so we can launch tests onto the compute nodes on BGQ.  Because of the current state of cmake on BGQ, that 3.1 is available but has a broken ctest, the minimum required version needed to be decremented.  With this PR in, the gcc 4.8.4 version is auto-tested, and passes, on BGQ running all unit tests on the compute nodes.

@davidbeckingsale, is the 3.1 requirement hard for some feature?