### PR TITLE
fix nvcc test build

### DIFF
--- a/host-configs/bgqos/clang_3_9_0.cmake
+++ b/host-configs/bgqos/clang_3_9_0.cmake
@@ -12,7 +12,7 @@ set(RAJA_COMPILER "RAJA_COMPILER_CLANG" CACHE STRING "")
 
 set(CMAKE_CXX_COMPILER "/usr/apps/gnu/clang/r266865-stable/bin/bgclang++" CACHE PATH "")
 
-set(TEST_DRIVER srun -N 1 -ppsmall CACHE STRING "use slurm to launch on BGQ")
+set(TEST_DRIVER srun CACHE STRING "use slurm to launch on BGQ")
 
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -ffast-math -std=c++11 -stdlib=libc++" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O3 -ffast-math -std=c++11 -stdlib=libc++" CACHE STRING "")

--- a/host-configs/bgqos/gcc_4_8_4.cmake
+++ b/host-configs/bgqos/gcc_4_8_4.cmake
@@ -12,7 +12,7 @@ set(RAJA_COMPILER "RAJA_COMPILER_GNU" CACHE STRING "")
 
 set(CMAKE_CXX_COMPILER "/usr/local/tools/compilers/ibm/mpicxx-4.8.4" CACHE PATH "")
 
-set(TEST_DRIVER srun -N 1 -ppsmall CACHE STRING "use slurm to launch on BGQ")
+set(TEST_DRIVER srun CACHE STRING "use slurm to launch on BGQ")
 
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Ofast -mcpu=a2 -mtune=a2 -finline-functions -finline-limit=20000 -std=c++11" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -Ofast -mcpu=a2 -mtune=a2 -finline-functions -finline-limit=20000 -std=c++11" CACHE STRING "")

--- a/test/unit/cpu/CMakeLists.txt
+++ b/test/unit/cpu/CMakeLists.txt
@@ -66,7 +66,7 @@ if (RAJA_ENABLE_CUDA)
     test-traversals.cxx)
 
 else()
-  cuda_add_library(bis buildIndexSet.cxx)
+  add_library(bis buildIndexSet.cxx)
   add_executable(CPUtraversal-test.exe
     main-traversal.cxx)
 

--- a/test/unit/cpu/CMakeLists.txt
+++ b/test/unit/cpu/CMakeLists.txt
@@ -44,13 +44,12 @@
 add_definitions(-DRAJA_ENABLE_NESTED)
 
 if (RAJA_ENABLE_CUDA)
+  cuda_add_library(bis buildIndexSet.cxx)
   cuda_add_executable(CPUtraversal-test.exe
-    main-traversal.cxx
-    buildIndexSet.cxx)
+    main-traversal.cxx)
 
   cuda_add_executable(CPUreduce-test.exe
-    main-reduce.cxx
-    buildIndexSet.cxx)
+    main-reduce.cxx)
 
   cuda_add_executable(CPUnested-test.exe
     main-nested.cxx)
@@ -61,21 +60,18 @@ if (RAJA_ENABLE_CUDA)
   endif()
 
   cuda_add_executable(indexset-tests
-    test-indexsets.cxx
-    buildIndexSet.cxx)
+    test-indexsets.cxx)
 
   cuda_add_executable(traversal-tests
-    test-traversals.cxx
-    buildIndexSet.cxx)
+    test-traversals.cxx)
 
 else()
+  cuda_add_library(bis buildIndexSet.cxx)
   add_executable(CPUtraversal-test.exe
-    main-traversal.cxx
-    buildIndexSet.cxx)
+    main-traversal.cxx)
 
   add_executable(CPUreduce-test.exe
-    main-reduce.cxx
-    buildIndexSet.cxx)
+    main-reduce.cxx)
   
   add_executable(CPUnested-test.exe
     main-nested.cxx)
@@ -86,12 +82,10 @@ else()
   endif()
 
   add_executable(indexset-tests
-    test-indexsets.cxx
-    buildIndexSet.cxx)
+    test-indexsets.cxx)
 
   add_executable(traversal-tests
-    test-traversals.cxx
-    buildIndexSet.cxx)
+    test-traversals.cxx)
 
 endif()
 
@@ -117,16 +111,16 @@ add_test(
     NAME indexset-test
     COMMAND ${TEST_DRIVER} $<TARGET_FILE:indexset-tests>)
 
-target_link_libraries(indexset-tests RAJA gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(indexset-tests RAJA bis gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
 
 add_test(
     NAME traversal-test
     COMMAND ${TEST_DRIVER} $<TARGET_FILE:traversal-tests>)
 
-target_link_libraries(traversal-tests RAJA gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(traversal-tests RAJA bis gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
 
-target_link_libraries(CPUtraversal-test.exe RAJA)
-target_link_libraries(CPUreduce-test.exe RAJA)
+target_link_libraries(CPUtraversal-test.exe RAJA bis)
+target_link_libraries(CPUreduce-test.exe RAJA bis)
 target_link_libraries(CPUnested-test.exe RAJA)
 if(RAJA_ENABLE_OPENMP)
   target_link_libraries(CPUnested_reduce-test.exe RAJA)

--- a/test/unit/gpu/CMakeLists.txt
+++ b/test/unit/gpu/CMakeLists.txt
@@ -70,11 +70,14 @@ add_test(
     NAME traversal
     COMMAND ${TEST_DRIVER} $<TARGET_FILE:traversal.exe>)
 
-cuda_add_executable(nested.exe
-  Nested.cxx)
-add_test(
-    NAME nested
-    COMMAND ${TEST_DRIVER} $<TARGET_FILE:nested.exe>)
+if(RAJA_ENABLE_OPENMP)
+    cuda_add_executable(nested.exe
+      Nested.cxx)
+    add_test(
+        NAME nested
+        COMMAND ${TEST_DRIVER} $<TARGET_FILE:nested.exe>)
+    target_link_libraries(nested.exe RAJA)
+endif()
 
 cuda_add_executable(reduceminloc.exe
   ReduceMinLoc.cxx)
@@ -92,6 +95,5 @@ target_link_libraries(reducemin.exe RAJA)
 target_link_libraries(reducemax.exe RAJA)
 target_link_libraries(reducesum.exe RAJA)
 target_link_libraries(traversal.exe RAJA)
-target_link_libraries(nested.exe RAJA)
 target_link_libraries(reduceminloc.exe RAJA)
 target_link_libraries(reducemaxloc.exe RAJA)


### PR DESCRIPTION
Switch to compiling each object only once, and only compile gpu Nested test when OpenMP is available.