### PR TITLE
Setup compiler-specific defines in CMake, remove macro switch

### DIFF
--- a/cmake/SetupCompilers.cmake
+++ b/cmake/SetupCompilers.cmake
@@ -48,16 +48,41 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0" CACHE STRING "")
 
 if (CMAKE_CXX_COMPILER_ID MATCHES Clang)
   set(RAJA_COMPILER "RAJA_COMPILER_CLANG")
+
+  set(RAJA_ALIGNED_ATTR "alignas(N)")
+  set(RAJA_INLINE "inline  __attribute__((always_inline))")
+  set(RAJA_SIMD "")
+  set(RAJA_ALIGN_DATA "")
+
 elseif (CMAKE_CXX_COMPILER_ID MATCHES GNU)
   set(RAJA_COMPILER "RAJA_COMPILER_GNU")
+
+  set(RAJA_ALIGNED_ATTR "__attribute__((aligned(N)))")
+  set(RAJA_INLINE "inline  __attribute__((always_inline))")
+  set(RAJA_ALIGN_DATA "__builtin_assume_aligned(d, DATA_ALIGN)")
+  set(RAJA_SIMD "")
+
 elseif (CMAKE_CXX_COMPILER_ID MATCHES Intel)
   set(RAJA_COMPILER "RAJA_COMPILER_ICC")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+  set(RAJA_ALIGNED_ATTR "alignas(N)")
+  set(RAJA_INLINE "inline  __attribute__((always_inline))")
+  set(RAJA_SIMD "")
+  set(RAJA_ALIGN_DATA "")
+
 else()
   set(RAJA_COMPILER "RAJA_COMPILER_${CMAKE_CXX_COMPILER_ID}")
+
+  set(RAJA_ALIGNED_ATTR "alignas(N)")
+  set(RAJA_INLINE "inline")
+  set(RAJA_ALIGN_DATA "")
+  set(RAJA_SIMD "")
 endif()
 
 if (RAJA_ENABLE_CUDA)
+  set(RAJA_ALIGN_DATA "")
+
   if(CMAKE_BUILD_TYPE MATCHES Release)
     set(RAJA_NVCC_FLAGS -O2; -restrict; -arch compute_35; -std c++11; --expt-extended-lambda; -x cu; -ccbin; ${CMAKE_CXX_COMPILER})
   elseif(CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
@@ -71,3 +96,18 @@ set(RAJA_RANGE_ALIGN 4 CACHE INT "")
 set(RAJA_RANGE_MIN_LENGTH 32 CACHE INT "")
 set(RAJA_DATA_ALIGN 64 CACHE INT "")
 set(RAJA_COHERENCE_BLOCK_SIZE 64 CACHE INT "")
+
+# INTEL
+#if __ICC < 1300  // use alignment intrinsic
+#define RAJA_ALIGN_DATA(d) __assume_aligned(d, DATA_ALIGN)
+#else
+#define RAJA_ALIGN_DATA(d)  // TODO: Define this...
+#endif
+#endif
+#define RAJA_SIMD  // TODO: Define this...
+
+# XLC 12
+#define RAJA_INLINE inline  __attribute__((always_inline))
+#define RAJA_ALIGN_DATA(d) __alignx(DATA_ALIGN, d)
+#define RAJA_SIMD  _Pragma("simd_level(10)")
+#define RAJA_SIMD   // TODO: Define this... 

--- a/include/RAJA/config.hxx.in
+++ b/include/RAJA/config.hxx.in
@@ -154,94 +154,11 @@ const int COHERENCE_BLOCK_SIZE = @RAJA_COHERENCE_BLOCK_SIZE@;
 //                 loop vectorization
 //
 //     RAJA_ALIGNED_ATTR(<alignment>) - macro to express type or variable alignments
-//
 
-#if defined(RAJA_COMPILER_GNU)
-#define RAJA_ALIGNED_ATTR(N) __attribute__((aligned(N)))
-#else
-#define RAJA_ALIGNED_ATTR(N) alignas(N)
-#endif
-
-
-#if defined(RAJA_COMPILER_ICC)
-//
-// Configuration options for Intel compilers
-//
-
-#define RAJA_INLINE inline  __attribute__((always_inline))
-
-#if defined(RAJA_ENABLE_CUDA)
-#define RAJA_ALIGN_DATA(d)
-#else
-
-#if __ICC < 1300  // use alignment intrinsic
-#define RAJA_ALIGN_DATA(d) __assume_aligned(d, DATA_ALIGN)
-#else
-#define RAJA_ALIGN_DATA(d)  // TODO: Define this...
-#endif
-
-#endif
-
-#define RAJA_SIMD  // TODO: Define this...
-
-
-#elif defined(RAJA_COMPILER_GNU) 
-//
-// Configuration options for GNU compilers
-//
-
-#define RAJA_INLINE inline  __attribute__((always_inline))
-
-#if defined(RAJA_ENABLE_CUDA)
-#define RAJA_ALIGN_DATA(d)
-#else
-
-#define RAJA_ALIGN_DATA(d) __builtin_assume_aligned(d, DATA_ALIGN)
-
-#endif
-
-#define RAJA_SIMD  // TODO: Define this...
-
-
-#elif defined(RAJA_COMPILER_XLC12)
-//
-// Configuration options for xlc v12 compiler (i.e., bgq/sequoia).
-//
-
-#define RAJA_INLINE inline  __attribute__((always_inline))
-
-#define RAJA_ALIGN_DATA(d) __alignx(DATA_ALIGN, d)
-
-//#define RAJA_SIMD  _Pragma("simd_level(10)")
-#define RAJA_SIMD   // TODO: Define this... 
-
-
-#elif defined(RAJA_COMPILER_CLANG)
-//
-// Configuration options for clang compilers
-//
-
-#define RAJA_INLINE inline  __attribute__((always_inline))
-
-#if defined(RAJA_ENABLE_CUDA)
-#define RAJA_ALIGN_DATA(d)
-#else
-
-#define RAJA_ALIGN_DATA(d) // TODO: Define this...
-
-#endif
-
-#define RAJA_SIMD  // TODO: Define this...
-
-#else
-
-#pragma message("RAJA_COMPILER unknown, using default empty macros.")
-
-#define RAJA_INLINE inline
-#define RAJA_ALIGN_DATA(d)
-#define RAJA_SIMD
-
-#endif
+#define RAJA_ALIGNED_ATTR(N) @RAJA_ALIGNED_ATTR@
+#define RAJA_ALIGN_DATA(N) @RAJA_ALIGN_DATA@
+#define RAJA_INLINE @RAJA_INLINE@
+#define RAJA_SIMD @RAJA_SIMD@
 
 }  // closing brace for RAJA namespace
 


### PR DESCRIPTION
This branch moves the if-else macro checks in `config.hxx` to the CMake compiler setup file.
This will make it easier to handle unknown compilers and specify default defines.

Additionally, in future we could write compiler checks to test for specific align/simd and use whichever ones work, regardless of compiler.