### PR TITLE
Add guards for RAJA_ENABLE_NESTED to tests

### DIFF
--- a/test/unit/cpu/CMakeLists.txt
+++ b/test/unit/cpu/CMakeLists.txt
@@ -41,7 +41,6 @@
 #
 ###############################################################################
 
-add_definitions(-DRAJA_ENABLE_NESTED)
 
 if (RAJA_ENABLE_CUDA)
   cuda_add_library(bis buildIndexSet.cxx)
@@ -51,8 +50,10 @@ if (RAJA_ENABLE_CUDA)
   cuda_add_executable(CPUreduce-test.exe
     main-reduce.cxx)
 
-  cuda_add_executable(CPUnested-test.exe
-    main-nested.cxx)
+  if(RAJA_ENABLE_NESTED)
+    cuda_add_executable(CPUnested-test.exe
+      main-nested.cxx)
+  endif()
 
   if(RAJA_ENABLE_OPENMP)
       cuda_add_executable(CPUnested_reduce-test.exe
@@ -73,8 +74,11 @@ else()
   add_executable(CPUreduce-test.exe
     main-reduce.cxx)
   
-  add_executable(CPUnested-test.exe
-    main-nested.cxx)
+  if(RAJA_ENABLE_NESTED)
+    add_executable(CPUnested-test.exe
+      main-nested.cxx)
+
+  endif()
 
   if(RAJA_ENABLE_OPENMP)
     add_executable(CPUnested_reduce-test.exe
@@ -97,9 +101,11 @@ add_test(
   NAME CPUreduce
   COMMAND ${TEST_DRIVER} $<TARGET_FILE:CPUreduce-test.exe>)
 
-add_test(
-  NAME CPUnested
-  COMMAND ${TEST_DRIVER} $<TARGET_FILE:CPUnested-test.exe>)
+if(RAJA_ENABLE_NESTED)
+  add_test(
+    NAME CPUnested
+    COMMAND ${TEST_DRIVER} $<TARGET_FILE:CPUnested-test.exe>)
+endif()
 
 if(RAJA_ENABLE_OPENMP)
     add_test(
@@ -121,7 +127,9 @@ target_link_libraries(traversal-tests RAJA bis gtest gtest_main ${CMAKE_THREAD_L
 
 target_link_libraries(CPUtraversal-test.exe RAJA bis)
 target_link_libraries(CPUreduce-test.exe RAJA bis)
-target_link_libraries(CPUnested-test.exe RAJA)
+if(RAJA_ENABLE_NESTED)
+  target_link_libraries(CPUnested-test.exe RAJA)
+endif()
 if(RAJA_ENABLE_OPENMP)
   target_link_libraries(CPUnested_reduce-test.exe RAJA)
 endif()

--- a/test/unit/cpu/CMakeLists.txt
+++ b/test/unit/cpu/CMakeLists.txt
@@ -41,7 +41,9 @@
 #
 ###############################################################################
 
-add_definitions(-DRAJA_ENABLE_NESTED)
+if (NOT RAJA_ENABLE_NESTED)
+  add_definitions(-DRAJA_ENABLE_NESTED)
+endif()
 
 if (RAJA_ENABLE_CUDA)
   cuda_add_library(bis buildIndexSet.cxx)

--- a/test/unit/cpu/CMakeLists.txt
+++ b/test/unit/cpu/CMakeLists.txt
@@ -41,6 +41,7 @@
 #
 ###############################################################################
 
+add_definitions(-DRAJA_ENABLE_NESTED)
 
 if (RAJA_ENABLE_CUDA)
   cuda_add_library(bis buildIndexSet.cxx)
@@ -50,10 +51,8 @@ if (RAJA_ENABLE_CUDA)
   cuda_add_executable(CPUreduce-test.exe
     main-reduce.cxx)
 
-  if(RAJA_ENABLE_NESTED)
-    cuda_add_executable(CPUnested-test.exe
-      main-nested.cxx)
-  endif()
+  cuda_add_executable(CPUnested-test.exe
+    main-nested.cxx)
 
   if(RAJA_ENABLE_OPENMP)
       cuda_add_executable(CPUnested_reduce-test.exe
@@ -74,11 +73,8 @@ else()
   add_executable(CPUreduce-test.exe
     main-reduce.cxx)
   
-  if(RAJA_ENABLE_NESTED)
-    add_executable(CPUnested-test.exe
-      main-nested.cxx)
-
-  endif()
+  add_executable(CPUnested-test.exe
+    main-nested.cxx)
 
   if(RAJA_ENABLE_OPENMP)
     add_executable(CPUnested_reduce-test.exe
@@ -101,11 +97,9 @@ add_test(
   NAME CPUreduce
   COMMAND ${TEST_DRIVER} $<TARGET_FILE:CPUreduce-test.exe>)
 
-if(RAJA_ENABLE_NESTED)
-  add_test(
-    NAME CPUnested
-    COMMAND ${TEST_DRIVER} $<TARGET_FILE:CPUnested-test.exe>)
-endif()
+add_test(
+  NAME CPUnested
+  COMMAND ${TEST_DRIVER} $<TARGET_FILE:CPUnested-test.exe>)
 
 if(RAJA_ENABLE_OPENMP)
     add_test(
@@ -127,9 +121,7 @@ target_link_libraries(traversal-tests RAJA bis gtest gtest_main ${CMAKE_THREAD_L
 
 target_link_libraries(CPUtraversal-test.exe RAJA bis)
 target_link_libraries(CPUreduce-test.exe RAJA bis)
-if(RAJA_ENABLE_NESTED)
-  target_link_libraries(CPUnested-test.exe RAJA)
-endif()
+target_link_libraries(CPUnested-test.exe RAJA)
 if(RAJA_ENABLE_OPENMP)
   target_link_libraries(CPUnested_reduce-test.exe RAJA)
 endif()

--- a/test/unit/gpu/CMakeLists.txt
+++ b/test/unit/gpu/CMakeLists.txt
@@ -41,7 +41,9 @@
 #
 ###############################################################################
 
-add_definitions(-DRAJA_ENABLE_NESTED)
+if (NOT RAJA_ENABLE_NESTED)
+  add_definitions(-DRAJA_ENABLE_NESTED)
+endif()
 
 SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)
 

--- a/test/unit/gpu/CMakeLists.txt
+++ b/test/unit/gpu/CMakeLists.txt
@@ -41,6 +41,8 @@
 #
 ###############################################################################
 
+add_definitions(-DRAJA_ENABLE_NESTED)
+
 SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)
 
 cuda_add_executable(reducemin.exe
@@ -68,15 +70,13 @@ add_test(
     NAME traversal
     COMMAND ${TEST_DRIVER} $<TARGET_FILE:traversal.exe>)
 
-if (RAJA_ENABLE_NESTED)
-  if(RAJA_ENABLE_OPENMP)
-      cuda_add_executable(nested.exe
-        Nested.cxx)
-      add_test(
-          NAME nested
-          COMMAND ${TEST_DRIVER} $<TARGET_FILE:nested.exe>)
-      target_link_libraries(nested.exe RAJA)
-  endif()
+if(RAJA_ENABLE_OPENMP)
+    cuda_add_executable(nested.exe
+      Nested.cxx)
+    add_test(
+        NAME nested
+        COMMAND ${TEST_DRIVER} $<TARGET_FILE:nested.exe>)
+    target_link_libraries(nested.exe RAJA)
 endif()
 
 cuda_add_executable(reduceminloc.exe

--- a/test/unit/gpu/CMakeLists.txt
+++ b/test/unit/gpu/CMakeLists.txt
@@ -41,8 +41,6 @@
 #
 ###############################################################################
 
-add_definitions(-DRAJA_ENABLE_NESTED)
-
 SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)
 
 cuda_add_executable(reducemin.exe
@@ -70,13 +68,15 @@ add_test(
     NAME traversal
     COMMAND ${TEST_DRIVER} $<TARGET_FILE:traversal.exe>)
 
-if(RAJA_ENABLE_OPENMP)
-    cuda_add_executable(nested.exe
-      Nested.cxx)
-    add_test(
-        NAME nested
-        COMMAND ${TEST_DRIVER} $<TARGET_FILE:nested.exe>)
-    target_link_libraries(nested.exe RAJA)
+if (RAJA_ENABLE_NESTED)
+  if(RAJA_ENABLE_OPENMP)
+      cuda_add_executable(nested.exe
+        Nested.cxx)
+      add_test(
+          NAME nested
+          COMMAND ${TEST_DRIVER} $<TARGET_FILE:nested.exe>)
+      target_link_libraries(nested.exe RAJA)
+  endif()
 endif()
 
 cuda_add_executable(reduceminloc.exe


### PR DESCRIPTION
This address compiler warnings mentioned in #125 
Tests requiring nested functionality are only build when `-DRAJA_ENABLE_NESTED=On`