### PR TITLE
[WIP] Iterables/Containers support for scan; Create segmented scan

### DIFF
--- a/include/RAJA/exec-cuda/scan_cuda.hxx
+++ b/include/RAJA/exec-cuda/scan_cuda.hxx
@@ -71,6 +71,8 @@ namespace detail
 {
 namespace scan
 {
+namespace iterators
+{
 
 /*!
         \brief explicit inclusive inplace scan given range, function, and
@@ -140,6 +142,8 @@ void exclusive(const ::RAJA::cuda_exec_base&,
   ::thrust::exclusive_scan(::thrust::device, begin, end, out, init, binary_op);
   cudaDeviceSynchronize();
 }
+
+}  // closing brace for iterators namespace
 
 }  // closing brace for scan namespace
 

--- a/include/RAJA/exec-openmp/scan_openmp.hxx
+++ b/include/RAJA/exec-openmp/scan_openmp.hxx
@@ -54,6 +54,7 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "RAJA/config.hxx"
+#include "RAJA/type_traits.hxx"
 
 #include "RAJA/exec-sequential/scan_sequential.hxx"
 
@@ -189,7 +190,11 @@ namespace iterable
    and
    initial value
 */
-template <typename Iterable, typename BinFn, typename T>
+template <typename Iterable,
+          typename BinFn,
+          typename T,
+          typename = typename std::
+              enable_if<::RAJA::is_range_segment<Iterable>::value>::type>
 void inclusive_inplace(const ::RAJA::omp_parallel_for_exec&,
                        const Iterable range,
                        T* in,
@@ -226,7 +231,11 @@ void inclusive_inplace(const ::RAJA::omp_parallel_for_exec&,
    and
    initial value
 */
-template <typename Iterable, typename BinFn, typename T>
+template <typename Iterable,
+          typename BinFn,
+          typename T,
+          typename = typename std::
+              enable_if<::RAJA::is_range_segment<Iterable>::value>::type>
 void exclusive_inplace(const ::RAJA::omp_parallel_for_exec&,
                        const Iterable range,
                        T* in,
@@ -270,7 +279,9 @@ template <typename Iterable,
           typename TOut,
           typename BinFn,
           typename T = typename std::remove_pointer<
-              typename std::decay<TOut>::type>::type>
+              typename std::decay<TOut>::type>::type,
+          typename = typename std::
+              enable_if<::RAJA::is_range_segment<Iterable>::value>::type>
 void inclusive(const ::RAJA::omp_parallel_for_exec& exec,
                const Iterable range,
                const TIn* in,
@@ -293,7 +304,9 @@ template <typename Iterable,
           typename TOut,
           typename BinFn,
           typename T = typename std::remove_pointer<
-              typename std::decay<TOut>::type>::type>
+              typename std::decay<TOut>::type>::type,
+          typename = typename std::
+              enable_if<::RAJA::is_range_segment<Iterable>::value>::type>
 void exclusive(const ::RAJA::omp_parallel_for_exec& exec,
                const Iterable range,
                const TIn* in,

--- a/include/RAJA/exec-openmp/scan_openmp.hxx
+++ b/include/RAJA/exec-openmp/scan_openmp.hxx
@@ -78,6 +78,9 @@ int firstIndex(int n, int p, int pid)
   return static_cast<size_t>(n * pid) / p;
 }
 
+namespace iterators
+{
+
 /*!
         \brief explicit inclusive inplace scan given range, function, and
    initial value
@@ -175,6 +178,8 @@ void exclusive(const ::RAJA::omp_parallel_for_exec& exec,
   ::std::copy(begin, end, out);
   exclusive_inplace(exec, out, out + (end - begin), f, v);
 }
+
+}  // namespace iterators
 
 }  // namespace scan
 

--- a/include/RAJA/exec-openmp/scan_openmp.hxx
+++ b/include/RAJA/exec-openmp/scan_openmp.hxx
@@ -181,6 +181,204 @@ void exclusive(const ::RAJA::omp_parallel_for_exec& exec,
 
 }  // namespace iterators
 
+namespace iterable
+{
+
+/*!
+        \brief explicit inclusive inplace scan given range, pointer, function,
+   and
+   initial value
+*/
+template <typename Iterable, typename BinFn, typename T>
+void inclusive_inplace(const ::RAJA::omp_parallel_for_exec&,
+                       const Iterable range,
+                       T* in,
+                       BinFn f,
+                       T v)
+{
+  auto begin = range.begin();
+  auto end = range.end();
+  const int n = end - begin;
+  const int p = omp_get_max_threads();
+  ::std::vector<T> sums(p, v);
+#pragma omp parallel
+  {
+    const int pid = omp_get_thread_num();
+    const int i0 = firstIndex(n, p, pid);
+    const int i1 = firstIndex(n, p, pid + 1);
+    Iterable local = range;
+    local.setBegin(*begin + i0);
+    local.setEnd(*begin + i1);
+    inclusive_inplace(::RAJA::seq_exec{}, local, in, f, v);
+    sums[pid] = *(in + *begin + i1 - 1);
+#pragma omp barrier
+#pragma omp single
+    ::RAJA::detail::scan::iterators::exclusive_inplace(
+        seq_exec{}, sums.data(), sums.data() + p, f, BinFn::identity);
+    for (int i = i0; i < i1; ++i) {
+      *(in + *begin + i) = f(*(in + *begin + i), sums[pid]);
+    }
+  }
+}
+
+/*!
+        \brief explicit exclusive inplace scan given range, pointer, function,
+   and
+   initial value
+*/
+template <typename Iterable, typename BinFn, typename T>
+void exclusive_inplace(const ::RAJA::omp_parallel_for_exec&,
+                       const Iterable range,
+                       T* in,
+                       BinFn f,
+                       T v)
+{
+  auto begin = range.begin();
+  auto end = range.end();
+  const int n = end - begin;
+  const int p = omp_get_max_threads();
+  ::std::vector<T> sums(p, v);
+#pragma omp parallel
+  {
+    const int pid = omp_get_thread_num();
+    const int i0 = firstIndex(n, p, pid);
+    const int i1 = firstIndex(n, p, pid + 1);
+    const T init = ((pid == 0) ? v : in[*begin + i0 - 1]);
+    Iterable local = range;
+    local.setBegin(*begin + i0);
+    local.setEnd(*begin + i1);
+#pragma omp barrier
+    exclusive_inplace(::RAJA::seq_exec{}, local, in, f, init);
+    sums[pid] = in[*begin + i1 - 1];
+#pragma omp barrier
+#pragma omp single
+    ::RAJA::detail::scan::iterators::exclusive_inplace(
+        seq_exec{}, sums.data(), sums.data() + p, f, BinFn::identity);
+    for (int i = i0; i < i1; ++i) {
+      in[*begin + i] = f(in[*begin + i], sums[pid]);
+    }
+  }
+}
+
+/*!
+        \brief explicit inclusive scan given range, input, output, function, and
+   initial value
+*/
+
+template <typename Iterable,
+          typename TIn,
+          typename TOut,
+          typename BinFn,
+          typename T = typename std::remove_pointer<
+              typename std::decay<TOut>::type>::type>
+void inclusive(const ::RAJA::omp_parallel_for_exec& exec,
+               const Iterable range,
+               const TIn* in,
+               TOut* out,
+               BinFn f,
+               T v)
+{
+  for (const auto index : range) {
+    out[index] = in[index];
+  }
+  inclusive_inplace(exec, range, out, f, v);
+}
+
+/*!
+        \brief explicit exclusive scan given range, input, output, function, and
+   initial value
+*/
+template <typename Iterable,
+          typename TIn,
+          typename TOut,
+          typename BinFn,
+          typename T = typename std::remove_pointer<
+              typename std::decay<TOut>::type>::type>
+void exclusive(const ::RAJA::omp_parallel_for_exec& exec,
+               const Iterable range,
+               const TIn* in,
+               TOut* out,
+               BinFn f,
+               T v)
+{
+  for (const auto index : range) {
+    out[index] = in[index];
+  }
+  exclusive_inplace(exec, range, out, f, v);
+}
+
+}  // namespace iterable
+
+namespace container
+{
+/*!
+        \brief explicit in-place inclusive scan given container, function, and
+   initial value
+*/
+template <typename Container, typename BinFn, typename T>
+void inclusive_inplace(const ::RAJA::omp_parallel_for_exec& exec,
+                       Container& c,
+                       BinFn f,
+                       T v)
+{
+  ::RAJA::detail::scan::iterators::inclusive_inplace(
+      exec, c.begin(), c.end(), f, v);
+}
+
+/*!
+        \brief explicit in-place exclusive scan given container, function, and
+   initial value
+*/
+template <typename Container, typename BinFn, typename T>
+void exclusive_inplace(const ::RAJA::omp_parallel_for_exec& exec,
+                       Container& c,
+                       BinFn f,
+                       T v)
+{
+  ::RAJA::detail::scan::iterators::exclusive_inplace(
+      exec, c.begin(), c.end(), f, v);
+}
+
+/*!
+\brief explicit inclusive scan given input container, output container,
+function, and
+initial value
+*/
+template <typename ContainerIn,
+          typename ContainerOut,
+          typename BinFn,
+          typename T>
+void inclusive(const ::RAJA::omp_parallel_for_exec& e,
+               const ContainerIn& in,
+               ContainerOut& out,
+               BinFn f,
+               T v)
+{
+  ::RAJA::detail::scan::iterators::inclusive(
+      e, in.begin(), in.end(), out.begin(), f, v);
+}
+
+/*!
+\brief explicit exclusive scan given input container, output container,
+function, and
+initial value
+*/
+template <typename ContainerIn,
+          typename ContainerOut,
+          typename BinFn,
+          typename T>
+void exclusive(const ::RAJA::omp_parallel_for_exec& e,
+               const ContainerIn& in,
+               ContainerOut& out,
+               BinFn f,
+               T v)
+{
+  ::RAJA::detail::scan::iterators::exclusive(
+      e, in.begin(), in.end(), out.begin(), f, v);
+}
+
+}  // namespace container
+
 }  // namespace scan
 
 }  // namespace detail

--- a/include/RAJA/exec-sequential/scan_sequential.hxx
+++ b/include/RAJA/exec-sequential/scan_sequential.hxx
@@ -110,7 +110,7 @@ void exclusive_inplace(const ::RAJA::seq_exec&,
 }
 
 /*!
-        \brief explicit inclusive scan given input range, output, function, and
+        \brief explicit inclusive scan given range, input, output, function, and
    initial value
 */
 template <typename Iter, typename OutIter, typename BinFn, typename T>
@@ -153,6 +153,163 @@ void exclusive(const ::RAJA::seq_exec&,
 }
 
 }  // namespace iterators
+
+namespace iterable
+{
+
+/*!
+        \brief explicit inclusive inplace scan given range, pointer, function,
+   and
+   initial value
+*/
+template <typename Iterable, typename BinFn, typename T>
+void inclusive_inplace(const ::RAJA::seq_exec&,
+                       Iterable range,
+                       T* in,
+                       BinFn f,
+                       T v)
+{
+  auto begin = range.begin();
+  auto end = range.end();
+  T agg = in[*begin];
+  while (++begin != end) {
+    agg = f(in[*begin], agg);
+    in[*begin] = agg;
+  }
+}
+
+/*!
+        \brief explicit exclusive inplace scan given range, pointer, function,
+   and
+   initial value
+*/
+template <typename Iterable, typename BinFn, typename T>
+void exclusive_inplace(const ::RAJA::seq_exec&,
+                       Iterable range,
+                       T* in,
+                       BinFn f,
+                       T v)
+{
+  auto begin = range.begin();
+  auto end = range.end();
+  T agg = v;
+  while (begin != end) {
+    T t = in[*begin];
+    in[*begin] = agg;
+    agg = f(agg, t);
+    ++begin;
+  }
+}
+
+/*!
+        \brief explicit inclusive scan given range, input, output, function, and
+   initial value
+*/
+template <typename Iterable, typename TIn, typename TOut, typename BinFn>
+void inclusive(const ::RAJA::seq_exec&,
+               Iterable range,
+               TIn* in,
+               TOut* out,
+               BinFn f,
+               TOut v)
+{
+  auto begin = range.begin();
+  auto end = range.end();
+  TOut agg = in[*begin];
+  out[*begin] = agg;
+  while (++begin != end) {
+    agg = f(agg, in[*begin]);
+    out[*begin] = agg;
+  }
+}
+
+/*!
+        \brief explicit exclusive scan given range, input, output, function, and
+   initial value
+*/
+template <typename Iterable, typename TIn, typename TOut, typename BinFn>
+void exclusive(const ::RAJA::seq_exec&,
+               Iterable range,
+               TIn* in,
+               TOut* out,
+               BinFn f,
+               TOut v)
+{
+  auto begin = range.begin();
+  auto end = range.end();
+  TOut agg = v;
+  out[*begin] = agg;
+  while (++begin != end) {
+    agg = f(agg, in[*(begin - 1)]);
+    out[*begin] = agg;
+  }
+}
+
+}  // namespace iterable
+
+namespace container
+{
+/*!
+        \brief explicit in-place inclusive scan given container, function, and
+   initial value
+*/
+template <typename Container, typename BinFn, typename T>
+void inclusive_inplace(const ::RAJA::seq_exec& exec, Container& c, BinFn f, T v)
+{
+  ::RAJA::detail::scan::iterators::inclusive_inplace(
+      exec, c.begin(), c.end(), f, v);
+}
+
+/*!
+        \brief explicit in-place exclusive scan given container, function, and
+   initial value
+*/
+template <typename Container, typename BinFn, typename T>
+void exclusive_inplace(const ::RAJA::seq_exec& exec, Container& c, BinFn f, T v)
+{
+  ::RAJA::detail::scan::iterators::exclusive_inplace(
+      exec, c.begin(), c.end(), f, v);
+}
+
+/*!
+\brief explicit inclusive scan given input container, output container,
+function, and
+initial value
+*/
+template <typename ContainerIn,
+          typename ContainerOut,
+          typename BinFn,
+          typename T>
+void inclusive(const ::RAJA::seq_exec& e,
+               const ContainerIn& in,
+               ContainerOut& out,
+               BinFn f,
+               T v)
+{
+  ::RAJA::detail::scan::iterators::inclusive(
+      e, in.begin(), in.end(), out.begin(), f, v);
+}
+
+/*!
+\brief explicit exclusive scan given input container, output container,
+function, and
+initial value
+*/
+template <typename ContainerIn,
+          typename ContainerOut,
+          typename BinFn,
+          typename T>
+void exclusive(const ::RAJA::seq_exec& e,
+               const ContainerIn& in,
+               ContainerOut& out,
+               BinFn f,
+               T v)
+{
+  ::RAJA::detail::scan::iterators::exclusive(
+      e, in.begin(), in.end(), out.begin(), f, v);
+}
+
+}  // namespace container
 
 }  // namespace scan
 

--- a/include/RAJA/exec-sequential/scan_sequential.hxx
+++ b/include/RAJA/exec-sequential/scan_sequential.hxx
@@ -66,6 +66,8 @@ namespace detail
 {
 namespace scan
 {
+namespace iterators
+{
 
 /*!
         \brief explicit inclusive inplace scan given range, function, and
@@ -149,6 +151,8 @@ void exclusive(const ::RAJA::seq_exec&,
     *o = agg;
   }
 }
+
+}  // namespace iterators
 
 }  // namespace scan
 

--- a/include/RAJA/exec-sequential/scan_sequential.hxx
+++ b/include/RAJA/exec-sequential/scan_sequential.hxx
@@ -115,8 +115,8 @@ void exclusive_inplace(const ::RAJA::seq_exec&,
 */
 template <typename Iter, typename OutIter, typename BinFn, typename T>
 void inclusive(const ::RAJA::seq_exec&,
-               Iter begin,
-               Iter end,
+               const Iter begin,
+               const Iter end,
                OutIter out,
                BinFn f,
                T v)
@@ -136,8 +136,8 @@ void inclusive(const ::RAJA::seq_exec&,
 */
 template <typename Iter, typename OutIter, typename BinFn, typename T>
 void exclusive(const ::RAJA::seq_exec&,
-               Iter begin,
-               Iter end,
+               const Iter begin,
+               const Iter end,
                OutIter out,
                BinFn f,
                T v)
@@ -164,7 +164,7 @@ namespace iterable
 */
 template <typename Iterable, typename BinFn, typename T>
 void inclusive_inplace(const ::RAJA::seq_exec&,
-                       Iterable range,
+                       const Iterable range,
                        T* in,
                        BinFn f,
                        T v)
@@ -185,7 +185,7 @@ void inclusive_inplace(const ::RAJA::seq_exec&,
 */
 template <typename Iterable, typename BinFn, typename T>
 void exclusive_inplace(const ::RAJA::seq_exec&,
-                       Iterable range,
+                       const Iterable range,
                        T* in,
                        BinFn f,
                        T v)
@@ -205,21 +205,27 @@ void exclusive_inplace(const ::RAJA::seq_exec&,
         \brief explicit inclusive scan given range, input, output, function, and
    initial value
 */
-template <typename Iterable, typename TIn, typename TOut, typename BinFn>
+
+template <typename Iterable,
+          typename TIn,
+          typename TOut,
+          typename BinFn,
+          typename T = typename std::remove_pointer<
+              typename std::decay<TOut>::type>::type>
 void inclusive(const ::RAJA::seq_exec&,
-               Iterable range,
-               TIn* in,
+               const Iterable range,
+               const TIn* in,
                TOut* out,
                BinFn f,
-               TOut v)
+               T v)
 {
   auto begin = range.begin();
   auto end = range.end();
-  TOut agg = in[*begin];
-  out[*begin] = agg;
+  T agg = *(in + *begin);
+  *(out + *begin) = agg;
   while (++begin != end) {
-    agg = f(agg, in[*begin]);
-    out[*begin] = agg;
+    agg = f(agg, *(in + *begin));
+    *(out + *begin) = agg;
   }
 }
 
@@ -227,20 +233,26 @@ void inclusive(const ::RAJA::seq_exec&,
         \brief explicit exclusive scan given range, input, output, function, and
    initial value
 */
-template <typename Iterable, typename TIn, typename TOut, typename BinFn>
+template <typename Iterable,
+          typename TIn,
+          typename TOut,
+          typename BinFn,
+          typename T = typename std::remove_pointer<
+              typename std::decay<TOut>::type>::type>
 void exclusive(const ::RAJA::seq_exec&,
-               Iterable range,
-               TIn* in,
+               const Iterable range,
+               const TIn* in,
                TOut* out,
                BinFn f,
-               TOut v)
+               T v)
 {
   auto begin = range.begin();
   auto end = range.end();
-  TOut agg = v;
+  T agg = v;
   out[*begin] = agg;
-  while (++begin != end) {
-    agg = f(agg, in[*(begin - 1)]);
+  while ((begin + 1) != end) {
+    agg = f(agg, in[*begin]);
+    ++begin;
     out[*begin] = agg;
   }
 }

--- a/include/RAJA/scan.hxx
+++ b/include/RAJA/scan.hxx
@@ -58,6 +58,8 @@
 #include <iterator>
 #include <type_traits>
 
+#include "RAJA/type_traits.hxx"
+
 namespace RAJA
 {
 
@@ -76,14 +78,16 @@ namespace RAJA
 */
 template <typename ExecPolicy,
           typename Iter,
-          typename T = typename std::iterator_traits<Iter>::value_type,
-          typename BinaryFunction = ::RAJA::operators::plus<T>>
-void inclusive_scan_inplace(Iter begin,
-                            Iter end,
-                            BinaryFunction binop = BinaryFunction{},
-                            T value = BinaryFunction::identity)
+          typename T = typename value_of<Iter>::type,
+          typename BinaryFunction = operators::plus<T>>
+typename std::enable_if<is_random_access_iterator<Iter>::value>::type
+inclusive_scan_inplace(Iter begin,
+                       Iter end,
+                       BinaryFunction binop = BinaryFunction{},
+                       T value = BinaryFunction::identity)
 {
-  detail::scan::inclusive_inplace(ExecPolicy{}, begin, end, binop, value);
+  detail::scan::iterators::inclusive_inplace(
+      ExecPolicy{}, begin, end, binop, value);
 }
 
 /*!
@@ -101,14 +105,16 @@ void inclusive_scan_inplace(Iter begin,
 */
 template <typename ExecPolicy,
           typename Iter,
-          typename T = typename std::iterator_traits<Iter>::value_type,
-          typename BinaryFunction = ::RAJA::operators::plus<T>>
-void exclusive_scan_inplace(Iter begin,
-                            Iter end,
-                            BinaryFunction binop = BinaryFunction{},
-                            T value = BinaryFunction::identity)
+          typename T = typename value_of<Iter>::type,
+          typename BinaryFunction = operators::plus<T>>
+typename std::enable_if<is_random_access_iterator<Iter>::value>::type
+exclusive_scan_inplace(Iter begin,
+                       Iter end,
+                       BinaryFunction binop = BinaryFunction{},
+                       T value = BinaryFunction::identity)
 {
-  detail::scan::exclusive_inplace(ExecPolicy{}, begin, end, binop, value);
+  detail::scan::iterators::exclusive_inplace(
+      ExecPolicy{}, begin, end, binop, value);
 }
 
 /*!
@@ -131,15 +137,18 @@ void exclusive_scan_inplace(Iter begin,
 template <typename ExecPolicy,
           typename Iter,
           typename IterOut,
-          typename T = typename std::iterator_traits<Iter>::value_type,
-          typename BinaryFunction = ::RAJA::operators::plus<T>>
-void inclusive_scan(Iter begin,
-                    Iter end,
-                    IterOut out,
-                    BinaryFunction binop = BinaryFunction{},
-                    T value = BinaryFunction::identity)
+          typename T = typename value_of<IterOut>::type,
+          typename BinaryFunction = operators::plus<T>>
+typename std::enable_if<is_random_access_iterator<Iter>::value
+                        && is_random_access_iterator<IterOut>::value>::type
+inclusive_scan(Iter begin,
+               Iter end,
+               IterOut out,
+               BinaryFunction binop = BinaryFunction{},
+               T value = BinaryFunction::identity)
 {
-  detail::scan::inclusive(ExecPolicy{}, begin, end, out, binop, value);
+  detail::scan::iterators::inclusive(
+      ExecPolicy{}, begin, end, out, binop, value);
 }
 
 /*!
@@ -162,15 +171,136 @@ void inclusive_scan(Iter begin,
 template <typename ExecPolicy,
           typename Iter,
           typename IterOut,
-          typename T = typename std::iterator_traits<Iter>::value_type,
-          typename BinaryFunction = ::RAJA::operators::plus<T>>
-void exclusive_scan(Iter begin,
-                    Iter end,
-                    IterOut out,
-                    BinaryFunction binop = BinaryFunction{},
-                    T value = BinaryFunction::identity)
+          typename T = typename value_of<IterOut>::type,
+          typename BinaryFunction = operators::plus<T>>
+typename std::enable_if<is_random_access_iterator<Iter>::value
+                        && is_random_access_iterator<IterOut>::value>::type
+exclusive_scan(Iter begin,
+               Iter end,
+               IterOut out,
+               BinaryFunction binop = BinaryFunction{},
+               T value = BinaryFunction::identity)
 {
-  detail::scan::exclusive(ExecPolicy{}, begin, end, out, binop, value);
+  detail::scan::iterators::exclusive(
+      ExecPolicy{}, begin, end, out, binop, value);
+}
+
+
+/******************************************************************************/
+
+template <typename ExecPolicy,
+          typename Iterable,
+          typename T,
+          typename BinaryFunction = operators::plus<T>>
+typename std::enable_if<is_iterable<Iterable>::value>::type
+inclusive_scan_inplace(Iterable range,
+                       T* in,
+                       BinaryFunction binop = BinaryFunction{},
+                       T value = BinaryFunction::identity)
+{
+  detail::scan::iterable::inclusive_inplace(
+      ExecPolicy{}, range, in, binop, value);
+}
+
+template <typename ExecPolicy,
+          typename Iterable,
+          typename T,
+          typename BinaryFunction = operators::plus<T>>
+typename std::enable_if<is_iterable<Iterable>::value>::type
+exclusive_scan_inplace(Iterable range,
+                       T* in,
+                       BinaryFunction binop = BinaryFunction{},
+                       T value = BinaryFunction::identity)
+{
+  detail::scan::iterable::exclusive_inplace(
+      ExecPolicy{}, range, in, binop, value);
+}
+
+template <typename ExecPolicy,
+          typename Iterable,
+          typename TIn,
+          typename TOut,
+          typename BinaryFunction = operators::plus<TOut>>
+typename std::enable_if<is_iterable<Iterable>::value>::type inclusive_scan(
+    Iterable range,
+    const TIn* in,
+    TOut out,
+    BinaryFunction binop = BinaryFunction{},
+    TOut value = BinaryFunction::identity)
+{
+  detail::scan::iterable::inclusive(ExecPolicy{}, range, in, out, binop, value);
+}
+
+template <typename ExecPolicy,
+          typename Iterable,
+          typename TIn,
+          typename TOut,
+          typename BinaryFunction = operators::plus<TOut>>
+typename std::enable_if<is_iterable<Iterable>::value>::type exclusive_scan(
+    Iterable range,
+    const TIn* in,
+    TOut* out,
+    BinaryFunction binop = BinaryFunction{},
+    TOut value = BinaryFunction::identity)
+{
+  detail::scan::iterable::exclusive(ExecPolicy{}, range, in, out, binop, value);
+}
+
+/******************************************************************************/
+
+template <typename ExecPolicy,
+          typename Container,
+          typename T = typename value_of<Container>::type,
+          typename BinaryFunction = operators::plus<T>>
+typename std::enable_if<Iterators::OffersRAI<Container>::value>::type
+inclusive_scan_inplace(Container& con,
+                       BinaryFunction binop = BinaryFunction{},
+                       T value = BinaryFunction::identity)
+{
+  detail::scan::container::inclusive_inplace(ExecPolicy{}, con, binop, value);
+}
+
+
+template <typename ExecPolicy,
+          typename Container,
+          typename T = typename value_of<Container>::type,
+          typename BinaryFunction = operators::plus<T>>
+typename std::enable_if<Iterators::OffersRAI<Container>::value>::type
+exclusive_scan_inplace(Container& con,
+                       BinaryFunction binop = BinaryFunction{},
+                       T value = BinaryFunction::identity)
+{
+  detail::scan::container::exclusive_inplace(ExecPolicy{}, con, binop, value);
+}
+
+template <typename ExecPolicy,
+          typename InContainer,
+          typename OutContainer,
+          typename T = typename value_of<OutContainer>::type,
+          typename BinaryFunction = operators::plus<TOut>>
+typename std::enable_if<Iterators::OffersRAI<Container>::value>::type
+inclusive_scan_inplace(const InContainer& in,
+                       OutContainer& out,
+                       BinaryFunction binop = BinaryFunction{},
+                       TOut value = BinaryFunction::identity)
+{
+  detail::scan::container::inclusive_inplace(
+      ExecPolicy{}, in, out, binop, value);
+}
+
+template <typename ExecPolicy,
+          typename InContainer,
+          typename OutContainer,
+          typename T = typename value_of<OutContainer>::type,
+          typename BinaryFunction = operators::plus<TOut>>
+typename std::enable_if<Iterators::OffersRAI<Container>::value>::type
+exclusive_scan_inplace(const InContainer& in,
+                       OutContainer& out,
+                       BinaryFunction binop = BinaryFunction{},
+                       TOut value = BinaryFunction::identity)
+{
+  detail::scan::container::exclusive_inplace(
+      ExecPolicy{}, in, out, binop, value);
 }
 
 }  // closing brace for RAJA namespace

--- a/include/RAJA/scan.hxx
+++ b/include/RAJA/scan.hxx
@@ -78,7 +78,7 @@ namespace RAJA
 */
 template <typename ExecPolicy,
           typename Iter,
-          typename T = typename value_of<Iter>::type,
+          typename T = typename std::iterator_traits<Iter>::value_type,
           typename BinaryFunction = operators::plus<T>>
 typename std::enable_if<is_random_access_iterator<Iter>::value>::type
 inclusive_scan_inplace(Iter begin,
@@ -105,7 +105,7 @@ inclusive_scan_inplace(Iter begin,
 */
 template <typename ExecPolicy,
           typename Iter,
-          typename T = typename value_of<Iter>::type,
+          typename T = typename std::iterator_traits<Iter>::value_type,
           typename BinaryFunction = operators::plus<T>>
 typename std::enable_if<is_random_access_iterator<Iter>::value>::type
 exclusive_scan_inplace(Iter begin,
@@ -137,7 +137,7 @@ exclusive_scan_inplace(Iter begin,
 template <typename ExecPolicy,
           typename Iter,
           typename IterOut,
-          typename T = typename value_of<IterOut>::type,
+          typename T = typename std::iterator_traits<IterOut>::value_type,
           typename BinaryFunction = operators::plus<T>>
 typename std::enable_if<is_random_access_iterator<Iter>::value
                         && is_random_access_iterator<IterOut>::value>::type
@@ -171,7 +171,7 @@ inclusive_scan(Iter begin,
 template <typename ExecPolicy,
           typename Iter,
           typename IterOut,
-          typename T = typename value_of<IterOut>::type,
+          typename T = typename std::iterator_traits<IterOut>::value_type,
           typename BinaryFunction = operators::plus<T>>
 typename std::enable_if<is_random_access_iterator<Iter>::value
                         && is_random_access_iterator<IterOut>::value>::type
@@ -252,7 +252,7 @@ template <typename ExecPolicy,
           typename Container,
           typename T = typename value_of<Container>::type,
           typename BinaryFunction = operators::plus<T>>
-typename std::enable_if<Iterators::OffersRAI<Container>::value>::type
+typename std::enable_if<has_iterator<Container>::value>::type
 inclusive_scan_inplace(Container& con,
                        BinaryFunction binop = BinaryFunction{},
                        T value = BinaryFunction::identity)
@@ -265,7 +265,7 @@ template <typename ExecPolicy,
           typename Container,
           typename T = typename value_of<Container>::type,
           typename BinaryFunction = operators::plus<T>>
-typename std::enable_if<Iterators::OffersRAI<Container>::value>::type
+typename std::enable_if<has_iterator<Container>::value>::type
 exclusive_scan_inplace(Container& con,
                        BinaryFunction binop = BinaryFunction{},
                        T value = BinaryFunction::identity)
@@ -278,7 +278,7 @@ template <typename ExecPolicy,
           typename OutContainer,
           typename T = typename value_of<OutContainer>::type,
           typename BinaryFunction = operators::plus<T>>
-typename std::enable_if<Iterators::OffersRAI<Container>::value>::type
+typename std::enable_if<has_iterator<InContainer>::value>::type
 inclusive_scan_inplace(const InContainer& in,
                        OutContainer& out,
                        BinaryFunction binop = BinaryFunction{},
@@ -293,7 +293,7 @@ template <typename ExecPolicy,
           typename OutContainer,
           typename T = typename value_of<OutContainer>::type,
           typename BinaryFunction = operators::plus<T>>
-typename std::enable_if<Iterators::OffersRAI<Container>::value>::type
+typename std::enable_if<has_iterator<InContainer>::value>::type
 exclusive_scan_inplace(const InContainer& in,
                        OutContainer& out,
                        BinaryFunction binop = BinaryFunction{},

--- a/include/RAJA/scan.hxx
+++ b/include/RAJA/scan.hxx
@@ -141,8 +141,8 @@ template <typename ExecPolicy,
           typename BinaryFunction = operators::plus<T>>
 typename std::enable_if<is_random_access_iterator<Iter>::value
                         && is_random_access_iterator<IterOut>::value>::type
-inclusive_scan(Iter begin,
-               Iter end,
+inclusive_scan(const Iter begin,
+               const Iter end,
                IterOut out,
                BinaryFunction binop = BinaryFunction{},
                T value = BinaryFunction::identity)
@@ -175,8 +175,8 @@ template <typename ExecPolicy,
           typename BinaryFunction = operators::plus<T>>
 typename std::enable_if<is_random_access_iterator<Iter>::value
                         && is_random_access_iterator<IterOut>::value>::type
-exclusive_scan(Iter begin,
-               Iter end,
+exclusive_scan(const Iter begin,
+               const Iter end,
                IterOut out,
                BinaryFunction binop = BinaryFunction{},
                T value = BinaryFunction::identity)
@@ -193,7 +193,7 @@ template <typename ExecPolicy,
           typename T,
           typename BinaryFunction = operators::plus<T>>
 typename std::enable_if<is_iterable<Iterable>::value>::type
-inclusive_scan_inplace(Iterable range,
+inclusive_scan_inplace(const Iterable range,
                        T* in,
                        BinaryFunction binop = BinaryFunction{},
                        T value = BinaryFunction::identity)
@@ -207,7 +207,7 @@ template <typename ExecPolicy,
           typename T,
           typename BinaryFunction = operators::plus<T>>
 typename std::enable_if<is_iterable<Iterable>::value>::type
-exclusive_scan_inplace(Iterable range,
+exclusive_scan_inplace(const Iterable range,
                        T* in,
                        BinaryFunction binop = BinaryFunction{},
                        T value = BinaryFunction::identity)
@@ -222,9 +222,9 @@ template <typename ExecPolicy,
           typename TOut,
           typename BinaryFunction = operators::plus<TOut>>
 typename std::enable_if<is_iterable<Iterable>::value>::type inclusive_scan(
-    Iterable range,
+    const Iterable range,
     const TIn* in,
-    TOut out,
+    TOut* out,
     BinaryFunction binop = BinaryFunction{},
     TOut value = BinaryFunction::identity)
 {
@@ -237,7 +237,7 @@ template <typename ExecPolicy,
           typename TOut,
           typename BinaryFunction = operators::plus<TOut>>
 typename std::enable_if<is_iterable<Iterable>::value>::type exclusive_scan(
-    Iterable range,
+    const Iterable range,
     const TIn* in,
     TOut* out,
     BinaryFunction binop = BinaryFunction{},
@@ -278,14 +278,13 @@ template <typename ExecPolicy,
           typename OutContainer,
           typename T = typename value_of<OutContainer>::type,
           typename BinaryFunction = operators::plus<T>>
-typename std::enable_if<has_iterator<InContainer>::value>::type
-inclusive_scan_inplace(const InContainer& in,
-                       OutContainer& out,
-                       BinaryFunction binop = BinaryFunction{},
-                       T value = BinaryFunction::identity)
+typename std::enable_if<has_iterator<InContainer>::value>::type inclusive_scan(
+    const InContainer& in,
+    OutContainer& out,
+    BinaryFunction binop = BinaryFunction{},
+    T value = BinaryFunction::identity)
 {
-  detail::scan::container::inclusive_inplace(
-      ExecPolicy{}, in, out, binop, value);
+  detail::scan::container::inclusive(ExecPolicy{}, in, out, binop, value);
 }
 
 template <typename ExecPolicy,
@@ -293,14 +292,13 @@ template <typename ExecPolicy,
           typename OutContainer,
           typename T = typename value_of<OutContainer>::type,
           typename BinaryFunction = operators::plus<T>>
-typename std::enable_if<has_iterator<InContainer>::value>::type
-exclusive_scan_inplace(const InContainer& in,
-                       OutContainer& out,
-                       BinaryFunction binop = BinaryFunction{},
-                       T value = BinaryFunction::identity)
+typename std::enable_if<has_iterator<InContainer>::value>::type exclusive_scan(
+    const InContainer& in,
+    OutContainer& out,
+    BinaryFunction binop = BinaryFunction{},
+    T value = BinaryFunction::identity)
 {
-  detail::scan::container::exclusive_inplace(
-      ExecPolicy{}, in, out, binop, value);
+  detail::scan::container::exclusive(ExecPolicy{}, in, out, binop, value);
 }
 
 }  // closing brace for RAJA namespace

--- a/include/RAJA/scan.hxx
+++ b/include/RAJA/scan.hxx
@@ -277,12 +277,12 @@ template <typename ExecPolicy,
           typename InContainer,
           typename OutContainer,
           typename T = typename value_of<OutContainer>::type,
-          typename BinaryFunction = operators::plus<TOut>>
+          typename BinaryFunction = operators::plus<T>>
 typename std::enable_if<Iterators::OffersRAI<Container>::value>::type
 inclusive_scan_inplace(const InContainer& in,
                        OutContainer& out,
                        BinaryFunction binop = BinaryFunction{},
-                       TOut value = BinaryFunction::identity)
+                       T value = BinaryFunction::identity)
 {
   detail::scan::container::inclusive_inplace(
       ExecPolicy{}, in, out, binop, value);
@@ -292,12 +292,12 @@ template <typename ExecPolicy,
           typename InContainer,
           typename OutContainer,
           typename T = typename value_of<OutContainer>::type,
-          typename BinaryFunction = operators::plus<TOut>>
+          typename BinaryFunction = operators::plus<T>>
 typename std::enable_if<Iterators::OffersRAI<Container>::value>::type
 exclusive_scan_inplace(const InContainer& in,
                        OutContainer& out,
                        BinaryFunction binop = BinaryFunction{},
-                       TOut value = BinaryFunction::identity)
+                       T value = BinaryFunction::identity)
 {
   detail::scan::container::exclusive_inplace(
       ExecPolicy{}, in, out, binop, value);

--- a/include/RAJA/type_traits.hxx
+++ b/include/RAJA/type_traits.hxx
@@ -1,0 +1,123 @@
+/*!
+ ******************************************************************************
+ *
+ * \file
+ *
+ * \brief   RAJA type traits header file.
+ */
+
+#ifndef RAJA_type_traits_HXX
+#define RAJA_type_traits_HXX
+
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-689114
+//
+// All rights reserved.
+//
+// This file is part of RAJA.
+//
+// For additional details, please also read raja/README-license.txt.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the disclaimer below.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the disclaimer (as noted below) in the
+//   documentation and/or other materials provided with the distribution.
+//
+// * Neither the name of the LLNS/LLNL nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+// LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "RAJA/config.hxx"
+
+#include "RAJA/Iterator.hxx"
+
+#include "RAJA/ListSegment.hxx"
+#include "RAJA/RangeSegment.hxx"
+
+namespace RAJA
+{
+
+template <typename Iter>
+struct is_random_access_iterator {
+  static const bool value = std::
+      is_same<std::random_access_iterator_tag,
+              typename std::iterator_traits<Iter>::iterator_category>::value;
+};
+
+template <typename Iter,
+          typename = typename std::enable_if<is_random_access_iterator<Iter>>>
+struct value_of {
+  using type = std::iterator_traits<Iter>::value_type;
+};
+
+template <typename Container,
+          typename =
+              typename std::enable_if<Iterators::OffersRAI<Container>::value>>
+struct value_of {
+  using type = typename value_of<typename OutContainer::iterator>::type;
+};
+
+template <typename T>
+struct is_iterable {
+  template <class, class>
+  class checker;
+  template <typename C>
+  static std::true_type test_begin(checker<C, decltype(&C::begin)> *);
+  template <typename C>
+  static std::true_type test_end(checker<C, decltype(&C::end)> *);
+  template <typename C>
+  static std::false_type test_begin(...);
+  template <typename C>
+  static std::false_type test_end(...);
+  using begin_type = decltype(test_begin<T>(nullptr));
+  using end_type = decltype(test_end<T>(nullptr));
+        static const bool value =
+		std::is_same<std::true_type, begin_type)>::value &&
+		std::is_same<std::true_type, end_type)>::value;
+};
+
+template <typename SegmentT>
+struct is_segment {
+  constexpr static const bool value =
+      std::is_base_of<RAJA::BaseSegment, SegmentT>::value;
+};
+
+template <typename SegmentT>
+struct is_range_segment {
+  constexpr static const bool value =
+      std::is_base_of<RAJA::RangeSegment, SegmentT>::value
+      || std::is_base_of<RAJA::RangeStrideSegment, SegmentT>::value;
+};
+
+tempate<typename SegmentT> struct is_list_segment {
+  constexpr static const bool value =
+      std::is_base_of<RAJA::ListSegment, SegmentT>::value;
+};
+
+}  // closing bracket for RAJA namespace
+
+#endif  // closing endif for header file include guard

--- a/include/RAJA/type_traits.hxx
+++ b/include/RAJA/type_traits.hxx
@@ -112,7 +112,10 @@ struct is_random_access_iterator {
               typename std::iterator_traits<Iter>::iterator_category>::value;
 };
 
-template <typename Container, typename = meta::void_t<>>
+template <typename Container,
+          typename = meta::void_t<>,
+          typename = typename std::enable_if<is_random_access_iterator<
+              typename Container::iterator>::value>>
 struct has_iterator : std::false_type {
 };
 
@@ -139,14 +142,14 @@ struct is_segment {
 template <typename SegmentT>
 struct is_range_segment {
   constexpr static const bool value =
-      std::is_base_of<RAJA::RangeSegment, SegmentT>::value
-      || std::is_base_of<RAJA::RangeStrideSegment, SegmentT>::value;
+      std::is_same<RAJA::RangeSegment, SegmentT>::value
+      || std::is_same<RAJA::RangeStrideSegment, SegmentT>::value;
 };
 
 template <typename SegmentT>
 struct is_list_segment {
   constexpr static const bool value =
-      std::is_base_of<RAJA::ListSegment, SegmentT>::value;
+      std::is_same<RAJA::ListSegment, SegmentT>::value;
 };
 
 }  // closing bracket for RAJA namespace

--- a/include/RAJA/type_traits.hxx
+++ b/include/RAJA/type_traits.hxx
@@ -63,6 +63,7 @@ namespace RAJA
 
 namespace meta
 {
+
 template <class...>
 struct voider {
   using type = void;
@@ -86,6 +87,16 @@ struct if_<false, WhenTrue, WhenFalse> {
 template <bool Statement, typename WhenTrue, typename WhenFalse>
 using if_t = typename if_<Statement, WhenTrue, WhenFalse>::type;
 }
+
+template <typename value_type, bool is_pointer>
+struct add_const_pointer {
+  typedef const value_type type;
+};
+
+template <typename value_type>
+struct add_const_pointer<value_type, true> {
+  typedef const value_type *type;
+};
 
 template <typename T>
 struct is_iterable {

--- a/test/unit/cpu/test-scan.cxx
+++ b/test/unit/cpu/test-scan.cxx
@@ -18,8 +18,7 @@ const int N = 1024;
 
 // Unit Test Space Exploration
 
-//#ifdef RAJA_ENABLE_OPENMP
-#if 0
+#ifdef RAJA_ENABLE_OPENMP
 using ExecTypes = std::tuple<RAJA::seq_exec, RAJA::omp_parallel_for_exec>;
 #else
 using ExecTypes = std::tuple<RAJA::seq_exec>;

--- a/test/unit/cpu/test-scan.cxx
+++ b/test/unit/cpu/test-scan.cxx
@@ -9,6 +9,7 @@
 #include <cstdlib>
 
 #include <gtest/gtest.h>
+#include <RAJA/LegacyCompatibility.hxx>
 #include <RAJA/RAJA.hxx>
 
 #include "data_storage.hxx"
@@ -18,13 +19,28 @@ const int N = 1024;
 
 // Unit Test Space Exploration
 
-#ifdef RAJA_ENABLE_OPENMP
+#if 0
+//#ifdef RAJA_ENABLE_OPENMP
 using ExecTypes = std::tuple<RAJA::seq_exec, RAJA::omp_parallel_for_exec>;
 #else
 using ExecTypes = std::tuple<RAJA::seq_exec>;
 #endif
+namespace API
+{
+struct type {
+};
+struct Iterators : type {
+};
+struct Iterables : type {
+};
+struct Containers : type {
+};
+}
 
-using ReduceTypes = std::tuple<RAJA::operators::safe_plus<int>,
+using APITypes = std::tuple<API::Iterators, API::Iterables, API::Containers>;
+
+/*
+        using ReduceTypes = std::tuple<RAJA::operators::safe_plus<int>,
                                RAJA::operators::safe_plus<float>,
                                RAJA::operators::safe_plus<double>,
                                RAJA::operators::minimum<int>,
@@ -33,13 +49,17 @@ using ReduceTypes = std::tuple<RAJA::operators::safe_plus<int>,
                                RAJA::operators::maximum<int>,
                                RAJA::operators::maximum<float>,
                                RAJA::operators::maximum<double>>;
+*/
+using ReduceTypes = std::tuple<RAJA::operators::safe_plus<float>,
+                               RAJA::operators::maximum<int>>;
 
 using InPlaceTypes = std::tuple<std::false_type, std::true_type>;
 
 template <typename T1, typename T2>
-using Cross = typename types::product<T1, T2>;
+using Cross = typename types::product<T1, T2>::type;
 
-using Types = Cross<Cross<ExecTypes, ReduceTypes>::type, InPlaceTypes>::type;
+using Types =
+    Cross<Cross<Cross<ExecTypes, ReduceTypes>, InPlaceTypes>, APITypes>;
 
 template <typename T>
 struct ForTesting {
@@ -52,34 +72,157 @@ struct ForTesting<std::tuple<Ts...>> {
 
 using CrossTypes = ForTesting<Types>::type;
 
+template <typename APIType, bool inPlace>
+struct Params {
+};
+template <>
+struct Params<API::Iterators, true> {
+  template <typename Fn, typename Storage>
+  static auto get(Storage* data)
+      -> decltype(std::make_tuple(data->in.begin(), data->in.end(), Fn{}))
+  {
+    return std::make_tuple(data->in.begin(), data->in.end(), Fn{});
+  }
+};
+template <>
+struct Params<API::Iterators, false> {
+  template <typename Fn, typename Storage>
+  static auto get(Storage* data) -> decltype(std::make_tuple(data->in.begin(),
+                                                             data->in.end(),
+                                                             data->out.begin(),
+                                                             Fn{}))
+  {
+    return std::make_tuple(data->in.begin(),
+                           data->in.end(),
+                           data->out.begin(),
+                           Fn{});
+  }
+};
+template <>
+struct Params<API::Iterables, true> {
+  template <typename Fn, typename Storage>
+  static auto get(Storage* data)
+      -> decltype(std::make_tuple(RAJA::RangeSegment{0, data->in.size()},
+                                  data->in.begin(),
+                                  Fn{},
+                                  Fn::identity))
+  {
+    return std::make_tuple(RAJA::RangeSegment{0, data->in.size()},
+                           data->in.begin(),
+                           Fn{},
+                           Fn::identity);
+  }
+};
 
-// dispatchers
+template <>
+struct Params<API::Iterables, false> {
+  template <typename Fn, typename Storage>
+  static auto get(Storage* data)
+      -> decltype(std::make_tuple(RAJA::RangeSegment{0, data->in.size()},
+                                  data->in.begin(),
+                                  data->out.begin(),
+                                  Fn{},
+                                  Fn::identity))
+  {
+    return std::make_tuple(RAJA::RangeSegment{0, data->in.size()},
+                           data->in.begin(),
+                           data->out.begin(),
+                           Fn{},
+                           Fn::identity);
+  }
+};
+template <>
+struct Params<API::Containers, true> {
+  template <typename Fn, typename Storage>
+  static auto get(Storage* data)
+      -> decltype(std::make_tuple(data->in, Fn{}, Fn::identity))
+  {
+    return std::make_tuple(data->in, Fn{}, Fn::identity);
+  }
+};
 
-template <typename Exec, typename Fn, typename Storage>
-void inclusive(Storage* data, bool inPlace = false)
+template <>
+struct Params<API::Containers, false> {
+  template <typename Fn, typename Storage>
+  static auto get(Storage* data)
+      -> decltype(std::make_tuple(data->in, data->out, Fn{}, Fn::identity))
+  {
+    return std::make_tuple(data->in, data->out, Fn{}, Fn::identity);
+  }
+};
+
+template <typename Fn, typename... Args>
+void dispatch(Fn&& f, std::tuple<Args...>&& t)
 {
-  if (inPlace)
-    RAJA::inclusive_scan_inplace<Exec>(data->ibegin(), data->iend(), Fn{});
-  else
-    RAJA::inclusive_scan<Exec>(data->ibegin(),
-                               data->iend(),
-                               data->obegin(),
-                               Fn{});
-}
+  VarOps::invoke(t, f);
+};
 
-template <typename Exec, typename Fn, typename Storage>
-void exclusive(Storage* data, bool inPlace = false)
-{
-  if (inPlace)
-    RAJA::exclusive_scan_inplace<Exec>(data->ibegin(), data->iend(), Fn{});
-  else
-    RAJA::exclusive_scan<Exec>(data->ibegin(),
-                               data->iend(),
-                               data->obegin(),
-                               Fn{});
-}
+template <typename T>
+struct getFunType {
+};
 
-// comparators
+template <typename... Args>
+struct getFunType<std::tuple<Args...>> {
+  using type = void(Args...);
+};
+
+template <bool inPlace>
+struct inclusive {
+};
+
+template <>
+struct inclusive<true> {
+  template <typename Exec, typename Fn, typename APIType, typename Storage>
+  static void exec(Storage* data)
+  {
+    auto&& args = Params<APIType, true>::template get<Fn>(data);
+    using Args = typename std::decay<decltype(args)>::type;
+    using FnType = typename getFunType<Args>::type;
+    dispatch((FnType*)RAJA::inclusive_scan_inplace<Exec>,
+             std::forward<Args>(args));
+  }
+};
+
+template <>
+struct inclusive<false> {
+  template <typename Exec, typename Fn, typename APIType, typename Storage>
+  static void exec(Storage* data)
+  {
+    auto&& args = Params<APIType, true>::template get<Fn>(data);
+    using Args = typename std::decay<decltype(args)>::type;
+    using FnType = typename getFunType<Args>::type;
+    dispatch((FnType*)RAJA::inclusive_scan<Exec>, std::forward<Args>(args));
+  }
+};
+
+template <bool inPlace>
+struct exclusive {
+};
+
+template <>
+struct exclusive<true> {
+  template <typename Exec, typename Fn, typename APIType, typename Storage>
+  static void exec(Storage* data)
+  {
+    auto&& args = Params<APIType, true>::template get<Fn>(data);
+    using Args = typename std::decay<decltype(args)>::type;
+    using FnType = typename getFunType<Args>::type;
+    dispatch((FnType*)RAJA::exclusive_scan_inplace<Exec>,
+             std::forward<Args>(args));
+  }
+};
+
+template <>
+struct exclusive<false> {
+  template <typename Exec, typename Fn, typename APIType, typename Storage>
+  static void exec(Storage* data)
+  {
+    auto&& args = Params<APIType, true>::template get<Fn>(data);
+    using Args = typename std::decay<decltype(args)>::type;
+    using FnType = typename getFunType<Args>::type;
+    dispatch((FnType*)RAJA::exclusive_scan<Exec>, std::forward<Args>(args));
+  }
+};
 
 template <typename Data,
           typename Storage,
@@ -87,11 +230,11 @@ template <typename Data,
           typename T = typename std::remove_pointer<Data>::type::type>
 void compareInclusive(Data original, Storage data, Fn function, T init)
 {
-  auto in = original->ibegin();
-  auto out = data->obegin();
+  auto in = original->in.begin();
+  auto out = data->out.begin();
   T sum = *in;
   int index = 0;
-  while ((out + index) != data->oend()) {
+  while ((out + index) != data->out.end()) {
     ASSERT_EQ(sum, *(out + index)) << "Expected value differs at index "
                                    << index;
     ++index;
@@ -105,11 +248,11 @@ template <typename Data,
           typename T = typename std::remove_pointer<Data>::type::type>
 void compareExclusive(Data original, Storage data, Fn function, T init)
 {
-  auto in = original->ibegin();
-  auto out = data->obegin();
+  auto in = original->in.begin();
+  auto out = data->out.begin();
   T sum = init;
   int index = 0;
-  while ((out + index) != data->oend()) {
+  while ((out + index) != data->out.end()) {
     ASSERT_EQ(sum, *(out + index)) << "Expected value differs at index "
                                    << index;
     sum = function(sum, *(in + index));
@@ -126,6 +269,7 @@ public:
   using Exec = typename std::tuple_element<0, Tuple>::type;
   using Fn = typename std::tuple_element<1, Tuple>::type;
   using Bool = typename std::tuple_element<2, Tuple>::type;
+  using API = typename std::tuple_element<3, Tuple>::type;
   constexpr const static bool InPlace = Bool::value;
   using T = typename Fn::result_type;
   using Storage = storage<Exec, T, InPlace>;
@@ -133,13 +277,13 @@ public:
 protected:
   virtual void SetUp()
   {
-    std::iota(data->ibegin(), data->iend(), 1);
-    std::shuffle(data->ibegin(),
-                 data->iend(),
+    std::iota(data->in.begin(), data->in.end(), 1);
+    std::shuffle(data->in.begin(),
+                 data->in.end(),
                  std::mt19937{std::random_device{}()});
-    std::copy(data->ibegin(), data->iend(), original->ibegin());
+    std::copy(data->in.begin(), data->in.end(), original->in.begin());
   }
-
+  // eventually replace with std::make_unique<Storage>(N)
   std::unique_ptr<Storage> data = std::unique_ptr<Storage>(new Storage{N});
   std::unique_ptr<Storage> original = std::unique_ptr<Storage>(new Storage{N});
   Fn function = Fn{};
@@ -148,24 +292,32 @@ protected:
 template <typename Tuple>
 class InclusiveScanTest : public ScanTest<Tuple>
 {
+  using Parent = ScanTest<Tuple>;
+
 protected:
   virtual void SetUp()
   {
-    ScanTest<Tuple>::SetUp();
-    inclusive<typename ScanTest<Tuple>::Exec, typename ScanTest<Tuple>::Fn>(
-        this->data.get(), ScanTest<Tuple>::InPlace);
+    Parent::SetUp();
+    ::inclusive<Parent::InPlace>::template exec<typename Parent::Exec,
+                                                typename Parent::Fn,
+                                                typename Parent::API>(
+        this->data.get());
   }
 };
 
 template <typename Tuple>
 class ExclusiveScanTest : public ScanTest<Tuple>
 {
+  using Parent = ScanTest<Tuple>;
+
 protected:
   virtual void SetUp()
   {
-    ScanTest<Tuple>::SetUp();
-    exclusive<typename ScanTest<Tuple>::Exec, typename ScanTest<Tuple>::Fn>(
-        this->data.get(), ScanTest<Tuple>::InPlace);
+    Parent::SetUp();
+    exclusive<Parent::InPlace>::template exec<typename Parent::Exec,
+                                              typename Parent::Fn,
+                                              typename Parent::API>(
+        this->data.get());
   }
 };
 


### PR DESCRIPTION
The current API is relatively limited:

`${type}_scan_inplace<Exec>(begin, end [,AssocFn=plus] [,Value init=0]);`
`${type}_scan<Exec>(const begin, const end, out [,AssocFn=plus] [,Value init=0]);`

This branch proposes API extensions for Iterables e.g. `RangeSegment`,`RangeStridedSegment`,`BoxSegment` (future), `ListSegment` (sequential only)

`${type}_scan_inplace<Exec>(Iterable, inPtr [,AssocFn=plus] [,Value init=0]);`
`${type}_scan<Exec>(Iterable, const inPtr, outPtr [,AssocFn=plus] [,Value init=0]);`

As well as containers (those with data elements and satisfying RAI + begin() + end())

`${type}_scan_inplace<Exec>(Container in [,AssocFn=plus] [,Value init=0]);`
`${type}_scan<Exec>(const Container in, Container out, [,AssocFn=plus] [,Value init=0]);`

Also, this branch will introduce segmented scans using `IndexSets` with the restrictions specified above.

`${type}_segmented_scan_inplace<OuterExec, InnerExec> (IndexSet, inPtr [,AssocFn=plus] [,Value init=0]);`
`${type}_segmented_scan<OuterExec, InnerExec> (IndexSet, const inPtr, outPtr [,AssocFn=plus] [,Value init=0]);`

Tasks:
- [x] public API
- [x] internal API - Iterables
- [x] internal API - Containers
- [ ] internal API - segmented_scan
- [x] `RangeSegment` support (Sequential + OpenMP)
- [x] `RangeStrideSegment` support (Sequential + OpenMP)
- [x] `ListSegment` support (Sequential)
- [ ] CUDA/Thrust support for `RangeSegment` and `RangeStrideSegment` (iterator facade)
- [ ] `segmented_scan` support (Sequential + OpenMP - inner/outer parallelization)
- [ ] `segmented_scan` support (CUDA/Thrust) -- iterator facades/interfacing
