### PR TITLE
Rename template parameters to avoid name collision

### DIFF
--- a/include/RAJA/foralln/Generic.hxx
+++ b/include/RAJA/foralln/Generic.hxx
@@ -182,7 +182,7 @@ struct ForallN_PeelOuter {
   }
 };
 
-template <typename... PREST>
+template <typename... POLICY_REST>
 struct ForallN_Executor {
 };
 
@@ -192,18 +192,18 @@ struct ForallN_Executor {
  *  The default action is to call RAJA::forall to peel off outer loop nest.
  */
 
-template <typename PI, typename... PREST>
-struct ForallN_Executor<PI, PREST...> {
-  typedef typename PI::ISET TI;
-  typedef typename PI::POLICY POLICY_I;
+template <typename POLICY_INIT, typename... POLICY_REST>
+struct ForallN_Executor<POLICY_INIT, POLICY_REST...> {
+  typedef typename POLICY_INIT::ISET TYPE_I;
+  typedef typename POLICY_INIT::POLICY POLICY_I;
 
-  typedef ForallN_Executor<PREST...> NextExec;
+  typedef ForallN_Executor<POLICY_REST...> NextExec;
 
-  PI const is_i;
+  POLICY_INIT const is_i;
   NextExec const next_exec;
 
-  template <typename... TREST>
-  constexpr ForallN_Executor(PI const &is_i0, TREST const &... is_rest)
+  template <typename... TYPE_REST>
+  constexpr ForallN_Executor(POLICY_INIT const &is_i0, TYPE_REST const &... is_rest)
       : is_i(is_i0), next_exec(is_rest...)
   {
   }

--- a/include/RAJA/foralln/Tile.hxx
+++ b/include/RAJA/foralln/Tile.hxx
@@ -100,10 +100,10 @@ struct Tile {
  ******************************************************************/
 
 // Forward declaration so the apply_tile's can recurse into peel_tile
-template <typename BODY, int TIDX, typename... PREST, typename TilePolicy>
+template <typename BODY, int TIDX, typename... POLICY_REST, typename TilePolicy>
 RAJA_INLINE void forallN_peel_tile(TilePolicy,
                                    BODY body,
-                                   PREST const &... prest);
+                                   POLICY_REST const &... prest);
 
 /*!
  * \brief Applys the tile_none policy
@@ -111,17 +111,17 @@ RAJA_INLINE void forallN_peel_tile(TilePolicy,
 template <typename BODY,
           typename TilePolicy,
           int TIDX,
-          typename PI,
-          typename... PREST>
+          typename POLICY_INIT,
+          typename... POLICY_REST>
 RAJA_INLINE void forallN_apply_tile(tile_none,
                                     BODY body,
-                                    PI const &pi,
-                                    PREST const &... prest)
+                                    POLICY_INIT const &pi,
+                                    POLICY_REST const &... prest)
 {
   // printf("TIDX=%d: policy=tile_none\n", (int)TIDX);
 
   // Pass thru, so just bind the index set
-  typedef ForallN_BindFirstArg_Host<BODY, PI> BOUND;
+  typedef ForallN_BindFirstArg_Host<BODY, POLICY_INIT> BOUND;
   BOUND new_body(body, pi);
 
   // Recurse to the next policy
@@ -135,16 +135,16 @@ template <typename BODY,
           typename TilePolicy,
           int TIDX,
           int TileSize,
-          typename PI,
-          typename... PREST>
+          typename POLICY_INIT,
+          typename... POLICY_REST>
 RAJA_INLINE void forallN_apply_tile(tile_fixed<TileSize>,
                                     BODY body,
-                                    PI const &pi,
-                                    PREST const &... prest)
+                                    POLICY_INIT const &pi,
+                                    POLICY_REST const &... prest)
 {
   // printf("TIDX=%d: policy=tile_fixed<%d>\n", TIDX, TileSize);
 
-  typedef ForallN_BindFirstArg_Host<BODY, PI> BOUND;
+  typedef ForallN_BindFirstArg_Host<BODY, POLICY_INIT> BOUND;
 
   // tile loop
   Index_type i_begin = pi.getBegin();
@@ -152,7 +152,7 @@ RAJA_INLINE void forallN_apply_tile(tile_fixed<TileSize>,
   for (Index_type i0 = i_begin; i0 < i_end; i0 += TileSize) {
     // Create a new tile
     Index_type i1 = std::min(i0 + TileSize, i_end);
-    PI pi_tile(RangeSegment(i0, i1));
+    POLICY_INIT pi_tile(RangeSegment(i0, i1));
 
     // Pass thru, so just bind the index set
     BOUND new_body(body, pi_tile);
@@ -203,13 +203,13 @@ RAJA_INLINE void forallN_peel_tile(TilePolicy, BODY body)
  */
 template <typename BODY,
           int TIDX,
-          typename PI,
-          typename... PREST,
+          typename POLICY_INIT,
+          typename... POLICY_REST,
           typename... TilePolicies>
 RAJA_INLINE void forallN_peel_tile(TileList<TilePolicies...>,
                                    BODY body,
-                                   PI const &pi,
-                                   PREST const &... prest)
+                                   POLICY_INIT const &pi,
+                                   POLICY_REST const &... prest)
 {
   using TilePolicy = TileList<TilePolicies...>;
 


### PR DESCRIPTION
Template argument name PI may collide with common macro PI.