### PR TITLE
Issue186 install on windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,7 @@ raja_add_library(
 install(TARGETS RAJA EXPORT RAJA
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib
 )
 
 install(EXPORT RAJA DESTINATION share/raja/cmake/)


### PR DESCRIPTION
Windows needs RUNTIME DESTINATION for .dll libraries to be installed.