### PR TITLE
foralln: fixed implementations of convertIndex and Layout::toIndicies

### DIFF
--- a/include/RAJA/foralln/Layout.hxx
+++ b/include/RAJA/foralln/Layout.hxx
@@ -126,7 +126,9 @@ struct Layout_impl<VarOps::index_sequence<RangeInts...>,
   RAJA_INLINE RAJA_HOST_DEVICE void toIndices(IdxLin linear_index,
                                               IDs &... indices) const
   {
-    VarOps::assign_args(linear_index, IndexRange{}, indices...);
+
+    VarOps::ignore_args( (indices = (linear_index / strides[RangeInts]) % sizes[RangeInts])... );
+
   }
 };
 


### PR DESCRIPTION
Fixed IndexValue convertIndex function to correctly work using SFINAE

Fixed Layout::toIndices implementation... i think this got messed up during a refactor