### PR TITLE
Fix missing include stdlib.h

### DIFF
--- a/include/RAJA/internal/defines.hxx
+++ b/include/RAJA/internal/defines.hxx
@@ -1,6 +1,7 @@
 #ifndef RAJA_INTERNAL_DEFINES_HXX
 #define RAJA_INTERNAL_DEFINES_HXX
 
+#include <stdlib.h>
 #include <stdexcept>
 
 //


### PR DESCRIPTION
Add include stdlib.h to fix compile issues. (abort, getenv)