### PR TITLE
[Bugfix] Repair additional headers

### DIFF
--- a/include/RAJA/index/IndexSet.hpp
+++ b/include/RAJA/index/IndexSet.hpp
@@ -55,7 +55,7 @@
 
 #include "RAJA/config.hpp"
 
-#include "IndexSetSegInfo.hpp"
+#include "RAJA/index/IndexSetSegInfo.hpp"
 #include "RAJA/internal/RAJAVec.hpp"
 
 #include <iosfwd>

--- a/include/RAJA/index/ListSegment.hpp
+++ b/include/RAJA/index/ListSegment.hpp
@@ -55,9 +55,11 @@
 
 #include "RAJA/config.hpp"
 
-#include "BaseSegment.hpp"
+#include "RAJA/index/BaseSegment.hpp"
 
+#if defined(RAJA_ENABLE_CUDA)
 #include "RAJA/policy/cuda/raja_cudaerrchk.hpp"
+#endif
 
 #include <algorithm>
 #include <iosfwd>

--- a/include/RAJA/index/RangeSegment.hpp
+++ b/include/RAJA/index/RangeSegment.hpp
@@ -55,7 +55,7 @@
 
 #include "RAJA/config.hpp"
 
-#include "BaseSegment.hpp"
+#include "RAJA/index/BaseSegment.hpp"
 #include "RAJA/internal/Iterators.hpp"
 
 #include <algorithm>

--- a/include/RAJA/pattern/scan.hpp
+++ b/include/RAJA/pattern/scan.hpp
@@ -54,6 +54,7 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "RAJA/config.hpp"
+#include "RAJA/util/Operators.hpp"
 
 #include <iterator>
 #include <type_traits>

--- a/include/RAJA/policy/cilk/forall.hpp
+++ b/include/RAJA/policy/cilk/forall.hpp
@@ -61,9 +61,9 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "RAJA/util/Types.hxx"
+#include "RAJA/util/Types.hpp"
 
-#include "RAJA/internal/fault_tolerance.hxx"
+#include "RAJA/internal/fault_tolerance.hpp"
 
 #include <cilk/cilk.h>
 #include <cilk/cilk_api.h>

--- a/include/RAJA/policy/cilk/forall.hpp
+++ b/include/RAJA/policy/cilk/forall.hpp
@@ -61,7 +61,7 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "RAJA/util/Types.hpp"
+#include "RAJA/util/types.hpp"
 
 #include "RAJA/internal/fault_tolerance.hpp"
 

--- a/include/RAJA/policy/cilk/reduce.hpp
+++ b/include/RAJA/policy/cilk/reduce.hpp
@@ -61,11 +61,11 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "RAJA/util/Types.hxx"
+#include "RAJA/util/types.hpp"
 
-#include "RAJA/pattern/Reduce.hxx"
+#include "RAJA/pattern/reduce.hpp"
 
-#include "RAJA/internal/MemUtils_CPU.hxx"
+#include "RAJA/internal/MemUtils_CPU.hpp"
 
 #include <cilk/cilk.h>
 #include <cilk/cilk_api.h>

--- a/include/RAJA/util/Layout.hpp
+++ b/include/RAJA/util/Layout.hpp
@@ -57,7 +57,7 @@
 #include <limits>
 #include "RAJA/index/IndexValue.hpp"
 #include "RAJA/internal/LegacyCompatibility.hpp"
-#include "Permutations.hpp"
+#include "RAJA/util/Permutations.hpp"
 
 namespace RAJA
 {

--- a/include/RAJA/util/OffsetLayout.hpp
+++ b/include/RAJA/util/OffsetLayout.hpp
@@ -58,8 +58,8 @@
 
 #include "RAJA/index/IndexValue.hpp"
 #include "RAJA/internal/LegacyCompatibility.hpp"
-#include "Permutations.hpp"
-#include "PermutedLayout.hpp"
+#include "RAJA/util/Permutations.hpp"
+#include "RAJA/util/PermutedLayout.hpp"
 
 namespace RAJA
 {

--- a/include/RAJA/util/Operators.hpp
+++ b/include/RAJA/util/Operators.hpp
@@ -57,7 +57,7 @@
 
 #include "RAJA/config.hpp"
 
-#include "defines.hpp"
+#include "RAJA/util/defines.hpp"
 
 #include <cfloat>
 #include <cstdint>

--- a/include/RAJA/util/PermutedLayout.hpp
+++ b/include/RAJA/util/PermutedLayout.hpp
@@ -58,8 +58,8 @@
 
 #include "RAJA/index/IndexValue.hpp"
 #include "RAJA/internal/LegacyCompatibility.hpp"
-#include "Layout.hpp"
-#include "Permutations.hpp"
+#include "RAJA/util/Layout.hpp"
+#include "RAJA/util/Permutations.hpp"
 
 namespace RAJA
 {

--- a/include/RAJA/util/View.hpp
+++ b/include/RAJA/util/View.hpp
@@ -53,7 +53,7 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "Layout.hpp"
+#include "RAJA/util/Layout.hpp"
 
 namespace RAJA
 {


### PR DESCRIPTION
In addition to resolving the last `hxx` headers, this PR switches all instances of relative includes (e.g. within the same directory) to absolute path includes.

RFC: there is `"cycles.h"` defined under fault_tolerance which no longer exists -- what should we do about this?