### PR TITLE
[enhancement] Fix operator limits by removing `std::numeric_limits`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,8 @@ include(cmake/SetupPackages.cmake)
 include(cmake/SetupRajaConfig.cmake)
 # Macros for building executables and libraries
 include (cmake/RAJAMacros.cmake)
+# Sanity check for compiler compatibility
+include (cmake/CompilerCompatibility.cmake)
 
 include_directories(${PROJECT_BINARY_DIR}/include/RAJA)
 include_directories(${PROJECT_BINARY_DIR}/include)

--- a/cmake/CompilerCompatibility.cmake
+++ b/cmake/CompilerCompatibility.cmake
@@ -1,7 +1,9 @@
 include(CheckCXXSourceCompiles)
 
 set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
-set(CMAKE_REQUIRED_FLAGS ${CMAKE_CXX_FLAGS})
+if (NOT MSVC)
+  set(CMAKE_REQUIRED_FLAGS "-std=c++11")
+endif()
 
 CHECK_CXX_SOURCE_COMPILES(
 "#include <type_traits>

--- a/cmake/CompilerCompatibility.cmake
+++ b/cmake/CompilerCompatibility.cmake
@@ -1,0 +1,66 @@
+include(CheckCXXSourceCompiles)
+
+set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+set(CMAKE_REQUIRED_FLAGS ${CMAKE_CXX_FLAGS})
+
+CHECK_CXX_SOURCE_COMPILES(
+"#include <type_traits>
+#include <limits>
+
+template <typename T>
+struct signed_limits {
+  static constexpr T min()
+  {
+    return static_cast<T>(1llu << ((8llu * sizeof(T)) - 1llu));
+  }
+  static constexpr T max()
+  {
+    return static_cast<T>(~(1llu << ((8llu * sizeof(T)) - 1llu)));
+  }
+};
+
+template <typename T>
+struct unsigned_limits {
+  static constexpr T min()
+  {
+    return static_cast<T>(0);
+  }
+  static constexpr T max()
+  {
+    return static_cast<T>(0xFFFFFFFFFFFFFFFF);
+  }
+};
+
+template <typename T>
+struct limits : public std::conditional<
+  std::is_signed<T>::value,
+  signed_limits<T>,
+  unsigned_limits<T>>::type {
+};
+
+template <typename T>
+void check() {
+  static_assert(limits<T>::min() == std::numeric_limits<T>::min(), \"min failed\");
+  static_assert(limits<T>::max() == std::numeric_limits<T>::max(), \"max failed\");
+}
+
+int main() {
+  check<char>();
+  check<unsigned char>();
+  check<short>();
+  check<unsigned short>();
+  check<int>();
+  check<unsigned int>();
+  check<long>();
+  check<unsigned long>();
+  check<long int>();
+  check<unsigned long int>();
+  check<long long>();
+  check<unsigned long long>();
+}" check_power_of_two_integral_types)
+
+set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
+
+if(NOT check_power_of_two_integral_types)
+  message(FATAL_ERROR "RAJA fast limits are unsupported for your compiler/architecture")
+endif()

--- a/cmake/SetupCompilers.cmake
+++ b/cmake/SetupCompilers.cmake
@@ -1,43 +1,43 @@
 ###############################################################################
 # Copyright (c) 2016, Lawrence Livermore National Security, LLC.
-# 
+#
 # Produced at the Lawrence Livermore National Laboratory
-# 
+#
 # LLNL-CODE-689114
-# 
+#
 # All rights reserved.
-# 
-# This file is part of RAJA. 
-# 
+#
+# This file is part of RAJA.
+#
 # For additional details, please also read raja/README-license.txt.
-# 
-# Redistribution and use in source and binary forms, with or without 
+#
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
-# * Redistributions of source code must retain the above copyright notice, 
+#
+# * Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the disclaimer below.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the disclaimer (as noted below) in the
 #   documentation and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 #   be used to endorse or promote products derived from this software without
 #   specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 ###############################################################################
 
 if (NOT RAJA_ENABLE_CLANG_CUDA)
@@ -56,6 +56,10 @@ if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
   if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
     message(FATAL_ERROR "RAJA requires GCC 4.9 or greater!")
   endif ()
+elseif (CMAKE_CXX_COMPILER_ID MATCHES AppleClang)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+elseif (CMAKE_CXX_COMPILER_ID MATCHES Clang)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 elseif (CMAKE_CXX_COMPILER_ID MATCHES Intel)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES XL)

--- a/include/RAJA/internal/ForallNPolicy.hpp
+++ b/include/RAJA/internal/ForallNPolicy.hpp
@@ -101,7 +101,6 @@ struct ForallN_PeelOuter {
   {
   }
 
-  RAJA_SUPPRESS_HD_WARN
   RAJA_INLINE
   RAJA_HOST_DEVICE
   void operator()(Index_type i) const
@@ -110,7 +109,6 @@ struct ForallN_PeelOuter {
     next_exec(inner);
   }
 
-  RAJA_SUPPRESS_HD_WARN
   RAJA_INLINE
   RAJA_HOST_DEVICE
   void operator()(Index_type i, Index_type j) const
@@ -120,7 +118,6 @@ struct ForallN_PeelOuter {
     next_exec(inner_j);
   }
 
-  RAJA_SUPPRESS_HD_WARN
   RAJA_INLINE
   RAJA_HOST_DEVICE
   void operator()(Index_type i, Index_type j, Index_type k) const

--- a/include/RAJA/internal/ForallNPolicy.hpp
+++ b/include/RAJA/internal/ForallNPolicy.hpp
@@ -1,13 +1,14 @@
 #ifndef RAJA_internal_ForallNPolicy_HXX_
 #define RAJA_internal_ForallNPolicy_HXX_
 
-namespace RAJA {
+namespace RAJA
+{
 
 /******************************************************************
  *  ForallN generic policies
  ******************************************************************/
 
-template<typename P, typename I>
+template <typename P, typename I>
 struct ForallN_PolicyPair : public I {
   typedef P POLICY;
   typedef I ISET;
@@ -16,7 +17,7 @@ struct ForallN_PolicyPair : public I {
   explicit constexpr ForallN_PolicyPair(ISET const &i) : ISET(i) {}
 };
 
-template<typename... PLIST>
+template <typename... PLIST>
 struct ExecList {
   constexpr const static size_t num_loops = sizeof...(PLIST);
   typedef std::tuple<PLIST...> tuple;
@@ -30,7 +31,7 @@ struct Execute {
   typedef ForallN_Execute_Tag PolicyTag;
 };
 
-template<typename EXEC, typename NEXT = Execute>
+template <typename EXEC, typename NEXT = Execute>
 struct NestedPolicy {
   typedef NEXT NextPolicy;
   typedef EXEC ExecPolicies;
@@ -100,16 +101,18 @@ struct ForallN_PeelOuter {
   {
   }
 
+  RAJA_SUPPRESS_HD_WARN
   RAJA_INLINE
-      RAJA_HOST_DEVICE
+  RAJA_HOST_DEVICE
   void operator()(Index_type i) const
   {
     ForallN_BindFirstArg_HostDevice<BODY> inner(body, i);
     next_exec(inner);
   }
 
+  RAJA_SUPPRESS_HD_WARN
   RAJA_INLINE
-      RAJA_HOST_DEVICE
+  RAJA_HOST_DEVICE
   void operator()(Index_type i, Index_type j) const
   {
     ForallN_BindFirstArg_HostDevice<BODY> inner_i(body, i);
@@ -117,8 +120,9 @@ struct ForallN_PeelOuter {
     next_exec(inner_j);
   }
 
+  RAJA_SUPPRESS_HD_WARN
   RAJA_INLINE
-      RAJA_HOST_DEVICE
+  RAJA_HOST_DEVICE
   void operator()(Index_type i, Index_type j, Index_type k) const
   {
     ForallN_BindFirstArg_HostDevice<BODY> inner_i(body, i);
@@ -128,6 +132,6 @@ struct ForallN_PeelOuter {
   }
 };
 
-} // end of RAJA namespace
+}  // end of RAJA namespace
 
 #endif

--- a/include/RAJA/util/Layout.hpp
+++ b/include/RAJA/util/Layout.hpp
@@ -74,7 +74,7 @@ public:
   typedef VarOps::make_index_sequence<sizeof...(RangeInts)> IndexRange;
 
   static constexpr size_t n_dims = sizeof...(RangeInts);
-  static constexpr size_t limit = std::numeric_limits<IdxLin>::max();
+  static constexpr size_t limit = RAJA::operators::limits<IdxLin>::max();
 
   // const char *index_types[sizeof...(RangeInts)];
 

--- a/include/RAJA/util/Operators.hpp
+++ b/include/RAJA/util/Operators.hpp
@@ -231,88 +231,101 @@ struct larger_of<T, U, false> {
 
 template <typename T, typename U>
 struct larger_of {
-  using type =
-      typename detail::larger_of<T,
-                                 U,
-                                 (size_of<T>::value > size_of<U>::value)>::type;
+  using type = typename detail::
+      larger_of<T, U, (size_of<T>::value > size_of<U>::value)>::type;
 };
 
 }  // closing brace for types namespace
 
-namespace detail {
+namespace detail
+{
 template <typename T>
 struct signed_limits {
-RAJA_INLINE RAJA_HOST_DEVICE
-static constexpr T min() {
-   return static_cast<T>(1llu << ((8llu * sizeof(T)) - 1llu));
-}
-RAJA_INLINE RAJA_HOST_DEVICE
-static constexpr T max() {
-  return static_cast<T>(~(1llu << ((8llu * sizeof(T)) - 1llu)));
-}
+  RAJA_INLINE RAJA_HOST_DEVICE static constexpr T min()
+  {
+    return static_cast<T>(1llu << ((8llu * sizeof(T)) - 1llu));
+  }
+  RAJA_INLINE RAJA_HOST_DEVICE static constexpr T max()
+  {
+    return static_cast<T>(~(1llu << ((8llu * sizeof(T)) - 1llu)));
+  }
 };
 
 template <typename T>
 struct unsigned_limits {
-RAJA_INLINE RAJA_HOST_DEVICE
-static constexpr T min() {
-   return static_cast<T>(0);
-}
-RAJA_INLINE RAJA_HOST_DEVICE
-static constexpr T max() {
-  return static_cast<T>(0xFFFFFFFFFFFFFFFF);
-}
+  RAJA_INLINE RAJA_HOST_DEVICE static constexpr T min()
+  {
+    return static_cast<T>(0);
+  }
+  RAJA_INLINE RAJA_HOST_DEVICE static constexpr T max()
+  {
+    return static_cast<T>(0xFFFFFFFFFFFFFFFF);
+  }
 };
 
 template <typename T>
 struct floating_point_limits {
 };
 
-template<>
+template <>
 struct floating_point_limits<float> {
-RAJA_INLINE RAJA_HOST_DEVICE
-static constexpr float min() {
-   return -FLT_MAX;
-}
-RAJA_INLINE RAJA_HOST_DEVICE
-static constexpr float max() {
-   return FLT_MAX;
-}
+  RAJA_INLINE RAJA_HOST_DEVICE static constexpr float min() { return -FLT_MAX; }
+  RAJA_INLINE RAJA_HOST_DEVICE static constexpr float max() { return FLT_MAX; }
 };
 
-template<>
+template <>
 struct floating_point_limits<double> {
-RAJA_INLINE RAJA_HOST_DEVICE
-static constexpr double min() {
-   return -DBL_MAX;
-}
-RAJA_INLINE RAJA_HOST_DEVICE
-static constexpr double max() {
-   return DBL_MAX;
-}
+  RAJA_INLINE RAJA_HOST_DEVICE static constexpr double min()
+  {
+    return -DBL_MAX;
+  }
+  RAJA_INLINE RAJA_HOST_DEVICE static constexpr double max() { return DBL_MAX; }
 };
 
-template<>
+template <>
 struct floating_point_limits<long double> {
-RAJA_INLINE RAJA_HOST_DEVICE
-static constexpr long double min() {
-   return -LDBL_MAX;
-}
-RAJA_INLINE RAJA_HOST_DEVICE
-static constexpr long double max() {
-   return LDBL_MAX;
-}
+  RAJA_INLINE RAJA_HOST_DEVICE static constexpr long double min()
+  {
+    return -LDBL_MAX;
+  }
+  RAJA_INLINE RAJA_HOST_DEVICE static constexpr long double max()
+  {
+    return LDBL_MAX;
+  }
 };
-} // end namespace detail
+}  // end namespace detail
 
 template <typename T>
-struct limits : public std::conditional<
-  std::is_integral<T>::value,
-  typename std::conditional<
-    std::is_unsigned<T>::value,
-    detail::unsigned_limits<T>,
-    detail::signed_limits<T>>::type,
-  detail::floating_point_limits<T>>::type {};
+struct limits
+  : public std::conditional<
+      std::is_integral<T>::value,
+      typename std::conditional<
+        std::is_unsigned<T>::value,
+        detail::unsigned_limits<T>,
+        detail::signed_limits<T>>::type,
+      detail::floating_point_limits<T>>::type {
+};
+
+#ifdef RAJA_CHECK_LIMITS
+template <typename T>
+constexpr bool check()
+{
+  return limits<T>::min() == std::numeric_limits<T>::min()
+         && limits<T>::max() == std::numeric_limits<T>::max();
+}
+static_assert(check<char>(), "limits for char is broken");
+static_assert(check<unsigned char>(), "limits for unsigned char is broken");
+static_assert(check<short>(), "limits for short is broken");
+static_assert(check<unsigned short>(), "limits for unsigned short is broken");
+static_assert(check<int>(), "limits for int is broken");
+static_assert(check<unsigned int>(), "limits for unsigned int is broken");
+static_assert(check<long>(), "limits for long is broken");
+static_assert(check<unsigned long>(), "limits for unsigned long is broken");
+static_assert(check<long int>(), "limits for long int is broken");
+static_assert(check<unsigned long int>(), "limits for unsigned long int is broken");
+static_assert(check<long long>(), "limits for long long is broken");
+static_assert(check<unsigned long long>(), "limits for unsigned long long is broken");
+#endif
 
 namespace constants
 {
@@ -511,12 +524,18 @@ struct identity : public detail::unary_function<Orig, Ret> {
 
 template <typename T, typename U>
 struct project1st : public detail::binary_function<T, U, T> {
-  RAJA_HOST_DEVICE T operator()(const T& lhs, const U& RAJA_UNUSED_ARG(rhs)) { return lhs; }
+  RAJA_HOST_DEVICE T operator()(const T& lhs, const U& RAJA_UNUSED_ARG(rhs))
+  {
+    return lhs;
+  }
 };
 
 template <typename T, typename U = T>
 struct project2nd : public detail::binary_function<T, U, U> {
-  RAJA_HOST_DEVICE U operator()(const T& RAJA_UNUSED_ARG(lhs), const U& rhs) { return rhs; }
+  RAJA_HOST_DEVICE U operator()(const T& RAJA_UNUSED_ARG(lhs), const U& rhs)
+  {
+    return rhs;
+  }
 };
 
 // Type Traits

--- a/include/RAJA/util/Operators.hpp
+++ b/include/RAJA/util/Operators.hpp
@@ -61,7 +61,6 @@
 
 #include <cfloat>
 #include <cstdint>
-#include <limits>
 #include <type_traits>
 
 namespace RAJA
@@ -307,6 +306,7 @@ struct limits
 };
 
 #ifdef RAJA_CHECK_LIMITS
+#include <limits>
 template <typename T>
 constexpr bool check()
 {
@@ -326,22 +326,6 @@ static_assert(check<unsigned long int>(), "limits for unsigned long int is broke
 static_assert(check<long long>(), "limits for long long is broken");
 static_assert(check<unsigned long long>(), "limits for unsigned long long is broken");
 #endif
-
-namespace constants
-{
-
-template <typename T>
-RAJA_HOST_DEVICE constexpr T min()
-{
-  return limits<T>::min();
-}
-template <typename T>
-RAJA_HOST_DEVICE constexpr T max()
-{
-  return limits<T>::max();
-}
-
-}  // closing brace for constants namespace
 
 // Arithmetic
 
@@ -451,7 +435,7 @@ struct minimum : public detail::binary_function<Arg1, Arg2, Ret>,
   {
     return (lhs < rhs) ? lhs : rhs;
   }
-  static constexpr const Ret identity = constants::max<Ret>();
+  static constexpr const Ret identity = limits<Ret>::max();
 };
 
 template <typename Ret, typename Arg1 = Ret, typename Arg2 = Arg1>
@@ -461,7 +445,7 @@ struct maximum : public detail::binary_function<Arg1, Arg2, Ret>,
   {
     return (lhs < rhs) ? rhs : lhs;
   }
-  static constexpr const Ret identity = constants::min<Ret>();
+  static constexpr const Ret identity = limits<Ret>::min();
 };
 
 // Logical Comparison

--- a/include/RAJA/util/PermutedLayout.hpp
+++ b/include/RAJA/util/PermutedLayout.hpp
@@ -54,12 +54,12 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include <iostream>
-#include <limits>
 
 #include "RAJA/index/IndexValue.hpp"
 #include "RAJA/internal/LegacyCompatibility.hpp"
 #include "RAJA/util/Layout.hpp"
 #include "RAJA/util/Permutations.hpp"
+#include "RAJA/util/Operators.hpp"
 
 namespace RAJA
 {
@@ -85,7 +85,7 @@ Layout<Rank, IdxLin>
   for (size_t i = 1; i < Rank; i++) {
     lmods[i] = folded_strides[i - 1];
   }
-  lmods[0] = std::numeric_limits<IdxLin>::max();
+  lmods[0] = RAJA::operators::limits<IdxLin>::max();
 
   for (size_t i = 0; i < Rank; ++i) {
     mods[permutation[i]] = lmods[i];

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -59,6 +59,11 @@ if (NOT MSVC)
             DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT}
     )
   endif(RAJA_ENABLE_OPENMP)
+  raja_add_test(
+    NAME integral-limits
+    SOURCES test-integral-limits.cxx
+    DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT}
+  )
 endif()
 
 add_subdirectory(cpu)

--- a/test/unit/test-integral-limits.cxx
+++ b/test/unit/test-integral-limits.cxx
@@ -1,0 +1,79 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-689114
+//
+// All rights reserved.
+//
+// This file is part of RAJA.
+//
+// For additional details, please also read raja/README-license.txt.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the disclaimer below.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the disclaimer (as noted below) in the
+//   documentation and/or other materials provided with the distribution.
+//
+// * Neither the name of the LLNS/LLNL nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+// LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "gtest/gtest.h"
+
+#define RAJA_CHECK_LIMITS
+#include "RAJA/util/Operators.hpp"
+
+#include <limits>
+
+template <typename T>
+class IntegralLimitsTest : public ::testing::Test
+{
+};
+
+TYPED_TEST_CASE_P(IntegralLimitsTest);
+
+TYPED_TEST_P(IntegralLimitsTest, IntegralLimits)
+{
+  ASSERT_EQ(RAJA::operators::limits<TypeParam>::min(), std::numeric_limits<TypeParam>::min());
+  ASSERT_EQ(RAJA::operators::limits<TypeParam>::max(), std::numeric_limits<TypeParam>::max());
+}
+
+REGISTER_TYPED_TEST_CASE_P(IntegralLimitsTest, IntegralLimits);
+
+using integer_types = ::testing::Types<
+  char,
+  unsigned char,
+  short,
+  unsigned short,
+  int,
+  unsigned int,
+  long,
+  unsigned long,
+  long int,
+  unsigned long int,
+  long long,
+  unsigned long long>;
+
+INSTANTIATE_TYPED_TEST_CASE_P(IntegralLimitsTests, IntegralLimitsTest, integer_types);


### PR DESCRIPTION
`numeric_limits` is great with host-only code, but breaks with GPU code. I hand-rolled limits for all integral types and floating-point types.

* Unsigned Integral types rely on the compiler masking appropriately
* Signed integral types use some bit hack magic -- I tested with numeric_limits before committing
* Floating-point types rely on `cfloat` and `{FLT,DBL,LDBL}_MAX`

I also threw in a fix for a massive warning dump with CUDA 8 on my arch box -- `operator()` within `ForallNPolicy` was not marked `RAJA_SUPPRESS_HD_WARN` (but is now). If this is intentional, I can revert it back.