### PR TITLE
[Enhancement] PolicyBase well-defined and corresponding type_traits

### DIFF
--- a/include/RAJA/internal/type_traits.hpp
+++ b/include/RAJA/internal/type_traits.hpp
@@ -97,12 +97,38 @@ struct function_traits<R (T::*)(Args...) const> {
 
 // extract 0-based argument type
 template <size_t I, typename Fn>
-using extract_arg = std::tuple_element<I, typename function_traits<Fn>::argument_types>;
+using extract_arg =
+    std::tuple_element<I, typename function_traits<Fn>::argument_types>;
 
-template <size_t I, typename Fn>
-using extract_arg_t = typename extract_arg<I, Fn>::type;
+template <typename Pol, typename CheckWith>
+struct is_policy_of {
+  static constexpr const bool value =
+      std::is_base_of<CheckWith,
+                      std::conditional<is_wrap_policy<Pol>, Pol::inner, Pol>>;
+};
 
 }  // closing brace for detail namespace
+
+template <size_t I, typename Fn>
+using extract_arg_t = typename detail::extract_arg<I, Fn>::type;
+
+template <typename Pol>
+struct is_policy {
+  static constexpr const bool value = std::is_base_of<PolicyBase, Pol>;
+};
+
+template <typename Pol>
+struct is_forall_policy : public detail::is_policy_of<Pol, forall_policy> {
+};
+
+template <typename Pol>
+struct is_reduce_policy : public detail::is_policy_of<Pol, reduce_policy> {
+};
+
+template <typename Pol>
+struct is_taskgraph_policy
+    : public detail::is_policy_of<Pol, taskgraph_policy> {
+};
 
 }  // closing brace for RAJA namespace
 

--- a/include/RAJA/policy/PolicyBase.hpp
+++ b/include/RAJA/policy/PolicyBase.hpp
@@ -1,10 +1,31 @@
 #ifndef RAJA_POLICYBASE_HXX
 #define RAJA_POLICYBASE_HXX
 
-namespace RAJA {
+namespace RAJA
+{
 
-struct PolicyBase { };
+namespace detail
+{
+struct wrap_policy {
+};
+}
 
+struct PolicyBase {
+};
+
+struct reduce_policy : public PolicyBase {
+};
+
+struct forall_policy : public PolicyBase {
+};
+
+template <typename Inner>
+struct wrap_policy : public PolicyBase, public detail::wrap_policy {
+  using inner_policy = Inner;
+};
+
+struct taskgraph_policy : public PolicyBase {
+};
 }
 
 #endif /* RAJA_POLICYBASE_HXX */

--- a/include/RAJA/policy/PolicyBase.hpp
+++ b/include/RAJA/policy/PolicyBase.hpp
@@ -4,12 +4,6 @@
 namespace RAJA
 {
 
-namespace detail
-{
-struct wrap_policy {
-};
-}
-
 struct PolicyBase {
 };
 
@@ -19,13 +13,20 @@ struct reduce_policy : public PolicyBase {
 struct forall_policy : public PolicyBase {
 };
 
+struct taskgraph_policy : public PolicyBase {
+};
+
+namespace detail
+{
+  struct wrap_policy : public PolicyBase {
+};
+} // end namespace detail
+
 template <typename Inner>
-struct wrap_policy : public PolicyBase, public detail::wrap_policy {
+struct wrap_policy : public detail::wrap_policy {
   using inner_policy = Inner;
 };
 
-struct taskgraph_policy : public PolicyBase {
-};
-}
+} // end namespace RAJA
 
 #endif /* RAJA_POLICYBASE_HXX */

--- a/include/RAJA/policy/PolicyBase.hpp
+++ b/include/RAJA/policy/PolicyBase.hpp
@@ -1,32 +1,76 @@
 #ifndef RAJA_POLICYBASE_HXX
 #define RAJA_POLICYBASE_HXX
 
+#include <stddef.h>
+
 namespace RAJA
 {
+
+enum class Policy { undefined, sequential, simd, openmp, cuda, cilk };
+
+enum class Launch { undefined, sync, async };
+
+enum class Pattern {
+  undefined,
+  forall,
+  reduce,
+  taskgraph,
+};
 
 struct PolicyBase {
 };
 
-struct reduce_policy : public PolicyBase {
+template <Policy P = Policy::undefined,
+          Launch L = Launch::undefined,
+          Pattern Pat = Pattern::undefined>
+struct PolicyBaseT : public PolicyBase {
+  static constexpr Policy policy = P;
+  static constexpr Launch launch = L;
+  static constexpr Pattern pattern = Pat;
 };
 
-struct forall_policy : public PolicyBase {
+template <typename Inner, typename... T>
+struct WrapperPolicy : public Inner {
+  using inner = Inner;
 };
 
-struct taskgraph_policy : public PolicyBase {
+// "makers"
+
+template <typename Inner, typename... T>
+struct wrap : public WrapperPolicy<Inner, T...> {
 };
 
-namespace detail
-{
-  struct wrap_policy : public PolicyBase {
-};
-} // end namespace detail
-
-template <typename Inner>
-struct wrap_policy : public detail::wrap_policy {
-  using inner_policy = Inner;
+template <Policy Pol, Launch L, Pattern P>
+struct make_policy_launch_pattern : public PolicyBaseT<Pol, L, P> {
 };
 
-} // end namespace RAJA
+template <Policy P>
+struct make_policy
+    : public PolicyBaseT<P, Launch::undefined, Pattern::undefined> {
+};
+
+template <Launch L>
+struct make_launch
+    : public PolicyBaseT<Policy::undefined, L, Pattern::undefined> {
+};
+
+template <Pattern P>
+struct make_pattern
+    : public PolicyBaseT<Policy::undefined, Launch::undefined, P> {
+};
+
+template <Policy Pol, Launch L>
+struct make_policy_launch : public PolicyBaseT<Pol, L, Pattern::undefined> {
+};
+
+template <Policy Pol, Pattern P>
+struct make_policy_pattern : public PolicyBaseT<Pol, Launch::undefined, P> {
+};
+
+template <Launch L, Pattern P>
+struct make_launch_pattern : public PolicyBaseT<Policy::undefined, L, P> {
+};
+
+}  // end namespace RAJA
 
 #endif /* RAJA_POLICYBASE_HXX */

--- a/include/RAJA/policy/cilk/policy.hpp
+++ b/include/RAJA/policy/cilk/policy.hpp
@@ -17,7 +17,8 @@ namespace RAJA
 ///
 /// Segment execution policies
 ///
-struct cilk_for_exec : public forall_policy {
+struct cilk_for_exec : public RAJA::make_policy_pattern<RAJA::Policy::cilk,
+                                                        RAJA::Pattern::forall> {
 };
 
 ///
@@ -33,7 +34,8 @@ struct cilk_for_segit : public cilk_for_exec {
 ///
 ///////////////////////////////////////////////////////////////////////
 ///
-struct cilk_reduce : public reduce_policy {
+struct cilk_reduce : public RAJA::make_policy_pattern<RAJA::Policy::cilk,
+                                                      RAJA::Pattern::reduce> {
 };
 
 }  // closing brace for RAJA namespace

--- a/include/RAJA/policy/cilk/policy.hpp
+++ b/include/RAJA/policy/cilk/policy.hpp
@@ -33,7 +33,7 @@ struct cilk_for_segit : public cilk_for_exec {
 ///
 ///////////////////////////////////////////////////////////////////////
 ///
-  struct cilk_reduce : public reduce_policy {
+struct cilk_reduce : public reduce_policy {
 };
 
 }  // closing brace for RAJA namespace

--- a/include/RAJA/policy/cilk/policy.hpp
+++ b/include/RAJA/policy/cilk/policy.hpp
@@ -1,6 +1,8 @@
 #ifndef policy_cilk_HXX_
 #define policy_cilk_HXX_
 
+#include "RAJA/policy/PolicyBase.hpp"
+
 namespace RAJA
 {
 
@@ -15,7 +17,7 @@ namespace RAJA
 ///
 /// Segment execution policies
 ///
-struct cilk_for_exec {
+struct cilk_for_exec : public forall_policy {
 };
 
 ///
@@ -31,7 +33,7 @@ struct cilk_for_segit : public cilk_for_exec {
 ///
 ///////////////////////////////////////////////////////////////////////
 ///
-struct cilk_reduce {
+  struct cilk_reduce : public reduce_policy {
 };
 
 }  // closing brace for RAJA namespace

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -68,16 +68,23 @@ struct Dim3z {
 /// Segment execution policies
 ///
 
-struct cuda_exec_base : public forall_policy {
-};
+template <size_t BLOCK_SIZE, bool Async>
+struct cuda_exec;
 
-template <size_t BLOCK_SIZE, bool Async = false>
-struct cuda_exec : public cuda_exec_base {
+template <size_t BLOCK_SIZE>
+struct cuda_exec<BLOCK_SIZE, true>
+    : public RAJA::make_policy_launch_pattern<RAJA::Policy::cuda,
+                                              RAJA::Launch::async,
+                                              RAJA::Pattern::forall> {
 };
 
 ///
 template <size_t BLOCK_SIZE>
-using cuda_exec_async = cuda_exec<BLOCK_SIZE, true>;
+struct cuda_exec<BLOCK_SIZE, false>
+    : public RAJA::make_policy_launch_pattern<RAJA::Policy::cuda,
+                                              RAJA::Launch::sync,
+                                              RAJA::Pattern::forall> {
+};
 
 //
 // NOTE: There is no Index set segment iteration policy for CUDA
@@ -90,14 +97,38 @@ using cuda_exec_async = cuda_exec<BLOCK_SIZE, true>;
 ///
 ///////////////////////////////////////////////////////////////////////
 ///
-template <size_t BLOCK_SIZE, bool Async = false>
-struct cuda_reduce : public reduce_policy {
+template <size_t BLOCK_SIZE, bool Async>
+struct cuda_reduce;
+
+template <size_t BLOCK_SIZE>
+struct cuda_reduce<BLOCK_SIZE, true>
+    : public RAJA::make_policy_launch_pattern<RAJA::Policy::cuda,
+                                              RAJA::Launch::async,
+                                              RAJA::Pattern::reduce> {
 };
-///
-template <size_t BLOCK_SIZE, bool Async = false>
-struct cuda_reduce_atomic : public reduce_policy  {
+template <size_t BLOCK_SIZE>
+struct cuda_reduce<BLOCK_SIZE, false>
+    : public RAJA::make_policy_launch_pattern<RAJA::Policy::cuda,
+                                              RAJA::Launch::sync,
+                                              RAJA::Pattern::reduce> {
 };
-///
+
+template <size_t BLOCK_SIZE, bool Async>
+struct cuda_reduce_atomic;
+
+template <size_t BLOCK_SIZE>
+struct cuda_reduce_atomic<BLOCK_SIZE, true>
+    : public RAJA::make_policy_launch_pattern<RAJA::Policy::cuda,
+                                              RAJA::Launch::async,
+                                              RAJA::Pattern::reduce> {
+};
+template <size_t BLOCK_SIZE>
+struct cuda_reduce_atomic<BLOCK_SIZE, false>
+    : public RAJA::make_policy_launch_pattern<RAJA::Policy::cuda,
+                                              RAJA::Launch::sync,
+                                              RAJA::Pattern::reduce> {
+};
+
 template <size_t BLOCK_SIZE>
 using cuda_reduce_async = cuda_reduce<BLOCK_SIZE, true>;
 ///
@@ -143,19 +174,19 @@ const int RAJA_CUDA_MAX_BLOCK_SIZE = 2048;
 template <typename T>
 __device__ inline T _atomicMin(T *address, T value)
 {
-return atomicMin(address, value);
+  return atomicMin(address, value);
 }
 ///
 template <typename T>
 __device__ inline T _atomicMax(T *address, T value)
 {
-return atomicMax(address, value);
+  return atomicMax(address, value);
 }
 ///
 template <typename T>
 __device__ inline T _atomicAdd(T *address, T value)
 {
-return atomicAdd(address, value);
+  return atomicAdd(address, value);
 }
 
 //

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -1,6 +1,8 @@
 #ifndef RAJA_policy_cuda_HPP
 #define RAJA_policy_cuda_HPP
 
+#include "RAJA/policy/PolicyBase.hpp"
+
 namespace RAJA
 {
 
@@ -66,7 +68,7 @@ struct Dim3z {
 /// Segment execution policies
 ///
 
-struct cuda_exec_base {
+struct cuda_exec_base : public forall_policy {
 };
 
 template <size_t BLOCK_SIZE, bool Async = false>
@@ -89,11 +91,11 @@ using cuda_exec_async = cuda_exec<BLOCK_SIZE, true>;
 ///////////////////////////////////////////////////////////////////////
 ///
 template <size_t BLOCK_SIZE, bool Async = false>
-struct cuda_reduce {
+struct cuda_reduce : public reduce_policy {
 };
 ///
 template <size_t BLOCK_SIZE, bool Async = false>
-struct cuda_reduce_atomic {
+struct cuda_reduce_atomic : public reduce_policy  {
 };
 ///
 template <size_t BLOCK_SIZE>
@@ -125,16 +127,8 @@ const int RAJA_CUDA_MAX_BLOCK_SIZE = 2048;
 #define RAJA_USE_ATOMIC_TWO
 //#define RAJA_USE_NO_ATOMICS
 
-#if 0
-#define ull_to_double(x) __longlong_as_double(reinterpret_cast<long long>(x))
-
-#define double_to_ull(x) \
-  reinterpret_cast<unsigned long long>(__double_as_longlong(x))
-#else
 #define ull_to_double(x) __longlong_as_double(x)
-
 #define double_to_ull(x) __double_as_longlong(x)
-#endif
 
 /*!
  ******************************************************************************
@@ -491,11 +485,7 @@ __device__ inline double _atomicAdd(double *address, double value)
 }
 #endif
 
-#elif defined(RAJA_USE_NO_ATOMICS)
-
-// Noting to do here...
-
-#else
+#elif !defined(RAJA_USE_NO_ATOMICS)
 
 #error one of the options for using/not using atomics must be specified
 

--- a/include/RAJA/policy/openmp/policy.hpp
+++ b/include/RAJA/policy/openmp/policy.hpp
@@ -18,20 +18,30 @@ namespace RAJA
 /// Segment execution policies
 ///
 template <typename InnerPolicy>
-struct omp_parallel_exec : public wrap_policy<InnerPolicy> {
+struct omp_parallel_exec : public RAJA::wrap<InnerPolicy> {
 };
-struct omp_for_exec : public forall_policy {
+
+struct omp_for_exec : public RAJA::make_policy_pattern<RAJA::Policy::openmp,
+                                                       RAJA::Pattern::forall> {
 };
+
 struct omp_parallel_for_exec : public omp_parallel_exec<omp_for_exec> {
 };
+
 template <size_t ChunkSize>
-struct omp_for_static : public forall_policy {
+struct omp_for_static
+    : public RAJA::make_policy_pattern<RAJA::Policy::openmp,
+                                       RAJA::Pattern::forall> {
 };
+
 template <size_t ChunkSize>
 struct omp_parallel_for_static
     : public omp_parallel_exec<omp_for_static<ChunkSize>> {
 };
-struct omp_for_nowait_exec : public forall_policy {
+
+struct omp_for_nowait_exec
+    : public RAJA::make_policy_pattern<RAJA::Policy::openmp,
+                                       RAJA::Pattern::forall> {
 };
 
 ///
@@ -41,9 +51,13 @@ struct omp_parallel_for_segit : public omp_parallel_for_exec {
 };
 struct omp_parallel_segit : public omp_parallel_for_segit {
 };
-struct omp_taskgraph_segit : public taskgraph_policy {
+struct omp_taskgraph_segit
+    : public RAJA::make_policy_pattern<RAJA::Policy::openmp,
+                                       RAJA::Pattern::taskgraph> {
 };
-struct omp_taskgraph_interval_segit : public taskgraph_policy {
+struct omp_taskgraph_interval_segit
+    : public RAJA::make_policy_pattern<RAJA::Policy::openmp,
+                                       RAJA::Pattern::taskgraph> {
 };
 
 ///
@@ -53,10 +67,11 @@ struct omp_taskgraph_interval_segit : public taskgraph_policy {
 ///
 ///////////////////////////////////////////////////////////////////////
 ///
-struct omp_reduce : public reduce_policy {
+struct omp_reduce : public RAJA::make_policy_pattern<RAJA::Policy::openmp,
+                                                     RAJA::Pattern::reduce> {
 };
 
-struct omp_reduce_ordered : public reduce_policy {
+struct omp_reduce_ordered : public omp_reduce {
 };
 
 }  // closing brace for RAJA namespace

--- a/include/RAJA/policy/openmp/policy.hpp
+++ b/include/RAJA/policy/openmp/policy.hpp
@@ -1,6 +1,8 @@
 #ifndef policy_openmp_HXX_
 #define policy_openmp_HXX_
 
+#include "RAJA/policy/PolicyBase.hpp"
+
 namespace RAJA
 {
 
@@ -16,20 +18,20 @@ namespace RAJA
 /// Segment execution policies
 ///
 template <typename InnerPolicy>
-struct omp_parallel_exec {
+struct omp_parallel_exec : public wrap_policy<InnerPolicy> {
 };
-struct omp_for_exec {
+struct omp_for_exec : public forall_policy {
 };
 struct omp_parallel_for_exec : public omp_parallel_exec<omp_for_exec> {
 };
 template <size_t ChunkSize>
-struct omp_for_static {
+struct omp_for_static : public forall_policy {
 };
 template <size_t ChunkSize>
 struct omp_parallel_for_static
     : public omp_parallel_exec<omp_for_static<ChunkSize>> {
 };
-struct omp_for_nowait_exec {
+struct omp_for_nowait_exec : public forall_policy {
 };
 
 ///
@@ -39,9 +41,9 @@ struct omp_parallel_for_segit : public omp_parallel_for_exec {
 };
 struct omp_parallel_segit : public omp_parallel_for_segit {
 };
-struct omp_taskgraph_segit {
+struct omp_taskgraph_segit : public taskgraph_policy {
 };
-struct omp_taskgraph_interval_segit {
+struct omp_taskgraph_interval_segit : public taskgraph_policy {
 };
 
 ///
@@ -51,10 +53,10 @@ struct omp_taskgraph_interval_segit {
 ///
 ///////////////////////////////////////////////////////////////////////
 ///
-struct omp_reduce {
+struct omp_reduce : public reduce_policy {
 };
 
-struct omp_reduce_ordered {
+struct omp_reduce_ordered : public reduce_policy {
 };
 
 }  // closing brace for RAJA namespace

--- a/include/RAJA/policy/sequential/policy.hpp
+++ b/include/RAJA/policy/sequential/policy.hpp
@@ -17,7 +17,8 @@ namespace RAJA
 ///
 /// Segment execution policies
 ///
-struct seq_exec : public forall_policy {
+struct seq_exec
+    : public RAJA::make_policy_pattern<Policy::sequential, Pattern::forall> {
 };
 
 ///
@@ -33,7 +34,8 @@ struct seq_segit : public seq_exec {
 ///
 ///////////////////////////////////////////////////////////////////////
 ///
-struct seq_reduce : public reduce_policy {
+struct seq_reduce
+    : public make_policy_pattern<Policy::sequential, Pattern::reduce> {
 };
 
 }  // closing brace for RAJA namespace

--- a/include/RAJA/policy/sequential/policy.hpp
+++ b/include/RAJA/policy/sequential/policy.hpp
@@ -33,7 +33,7 @@ struct seq_segit : public seq_exec {
 ///
 ///////////////////////////////////////////////////////////////////////
 ///
-  struct seq_reduce : public reduce_policy {
+struct seq_reduce : public reduce_policy {
 };
 
 }  // closing brace for RAJA namespace

--- a/include/RAJA/policy/sequential/policy.hpp
+++ b/include/RAJA/policy/sequential/policy.hpp
@@ -17,7 +17,7 @@ namespace RAJA
 ///
 /// Segment execution policies
 ///
-struct seq_exec : public PolicyBase {
+struct seq_exec : public forall_policy {
 };
 
 ///
@@ -33,7 +33,7 @@ struct seq_segit : public seq_exec {
 ///
 ///////////////////////////////////////////////////////////////////////
 ///
-struct seq_reduce {
+  struct seq_reduce : public reduce_policy {
 };
 
 }  // closing brace for RAJA namespace

--- a/include/RAJA/policy/simd/policy.hpp
+++ b/include/RAJA/policy/simd/policy.hpp
@@ -20,6 +20,6 @@ namespace RAJA
 struct simd_exec : forall_policy {
 };
 
-} // end of namespace RAJA
+}  // end of namespace RAJA
 
 #endif

--- a/include/RAJA/policy/simd/policy.hpp
+++ b/include/RAJA/policy/simd/policy.hpp
@@ -1,6 +1,8 @@
 #ifndef policy_simd_HXX_
 #define policy_simd_HXX_
 
+#include "RAJA/policy/PolicyBase.hpp"
+
 //
 //////////////////////////////////////////////////////////////////////
 //
@@ -15,7 +17,7 @@
 namespace RAJA
 {
 
-struct simd_exec {
+struct simd_exec : forall_policy {
 };
 
 } // end of namespace RAJA

--- a/include/RAJA/policy/simd/policy.hpp
+++ b/include/RAJA/policy/simd/policy.hpp
@@ -17,7 +17,8 @@
 namespace RAJA
 {
 
-struct simd_exec : forall_policy {
+struct simd_exec : public RAJA::make_policy_pattern<RAJA::Policy::simd,
+                                                    RAJA::Pattern::forall> {
 };
 
 }  // end of namespace RAJA

--- a/test/include/data_storage.hxx
+++ b/test/include/data_storage.hxx
@@ -5,6 +5,7 @@
 
 #include "RAJA/RAJA.hpp"
 #include "RAJA/util/defines.hpp"
+#include "RAJA/internal/type_traits.hpp"
 
 namespace internal
 {
@@ -59,8 +60,7 @@ struct storage<ExecPolicy, T, true> : public storage_base {
   using StorageType =
       typename internal::storage<ExecPolicy,
                                  T,
-                                 std::is_base_of<RAJA::cuda_exec_base,
-                                                 ExecPolicy>::value>;
+                                 RAJA::is_cuda_policy<ExecPolicy>::value>;
 #else
   using StorageType = typename internal::storage<ExecPolicy, T>;
 #endif


### PR DESCRIPTION
**NOTE** this has been heavily updated and the text at the top is the most recent implementation

`PolicyBase` now defines different types of policies and types:

here's a proposed change that explicitly breaks apart policy, launch, and pattern. This would also make `Pattern`, `Policy` and `Launch` more friendly for user-facing logic :)

```cpp
enum class Policy {
  undefined,
  sequential,
  simd,
  openmp,
  cuda,
  cilk
};

enum class Launch {
  undefined,
  sync,
  async
};

enum class Pattern {
  undefined,
  forall,
  reduce,
  taskgraph,
};

template <
  Policy P = Policy::undefined,
  Launch L = Launch::undefined,
  Pattern Pat = Pattern::undefined>
struct PolicyBase {
  static constexpr Policy policy = P;
  static constexpr Launch launch = L;
  static constexpr Pattern pattern = Pat;
};

template <typename Inner, typename ... T>
struct WrapperPolicy : public Inner {
  using inner = Inner;
};
```

type traits exist for:

```cpp
is_<POLICY>_policy
is_<LAUNCH>_launch
is_<PATTERN>_pattern
```

creating templated policies and patterns are also easy:

```cpp
{POLICY}_for< Pattern > // openmp_for<Pattern::forall>
{PATTERN}_for< Policy > // reduce_for<Policy::cuda>
```

extracting policy/launch/patterns are now trivial:

```cpp
using Pol = RAJA::omp_parallel_for_exec;
RAJA::Policy policy = Pol::policy;
RAJA::Pattern pattern = Pol::pattern;
```

Definitions in each *policy* header file now properly extend from a corresponding policy