### PR TITLE
partial rework to move multipolicy

### DIFF
--- a/include/RAJA/internal/ForallNPolicy.hpp
+++ b/include/RAJA/internal/ForallNPolicy.hpp
@@ -101,6 +101,7 @@ struct ForallN_PeelOuter {
   {
   }
 
+  RAJA_SUPPRESS_HD_WARN
   RAJA_INLINE
   RAJA_HOST_DEVICE
   void operator()(Index_type i) const
@@ -109,6 +110,7 @@ struct ForallN_PeelOuter {
     next_exec(inner);
   }
 
+  RAJA_SUPPRESS_HD_WARN
   RAJA_INLINE
   RAJA_HOST_DEVICE
   void operator()(Index_type i, Index_type j) const
@@ -118,6 +120,7 @@ struct ForallN_PeelOuter {
     next_exec(inner_j);
   }
 
+  RAJA_SUPPRESS_HD_WARN
   RAJA_INLINE
   RAJA_HOST_DEVICE
   void operator()(Index_type i, Index_type j, Index_type k) const

--- a/include/RAJA/pattern/forall.hpp
+++ b/include/RAJA/pattern/forall.hpp
@@ -119,6 +119,67 @@ namespace RAJA
 /*!
  ******************************************************************************
  *
+ * \brief The RAJA::wrap layer unwraps dynamic policies before dispatch
+ *
+ ******************************************************************************
+ */
+namespace wrap {
+
+/*!
+ ******************************************************************************
+ *
+ * \brief Generic dispatch over containers with a value-based policy
+ *
+ ******************************************************************************
+ */
+template <typename EXEC_POLICY_T, typename Container, typename LOOP_BODY>
+RAJA_INLINE void forall(EXEC_POLICY_T&& p, Container&& c, LOOP_BODY loop_body)
+{
+  impl::forall(std::forward<EXEC_POLICY_T>(p), std::forward<Container>(c), loop_body);
+}
+
+/*!
+ ******************************************************************************
+ *
+ * \brief Generic dispatch over containers with icount
+ *
+ ******************************************************************************
+ */
+template <typename EXEC_POLICY_T, typename LOOP_BODY>
+RAJA_INLINE void forall_Icount(EXEC_POLICY_T&&p, const IndexSet& c, LOOP_BODY loop_body)
+{
+
+  impl::forall_Icount(p, c, loop_body);
+}
+
+/*!
+ ******************************************************************************
+ *
+ * \brief Generic dispatch over containers with icount
+ *
+ ******************************************************************************
+ */
+template <typename EXEC_POLICY_T, typename Container, typename LOOP_BODY>
+RAJA_INLINE void forall_Icount(EXEC_POLICY_T&& p,
+                               Container&& c,
+                               Index_type icount,
+                               LOOP_BODY loop_body)
+{
+  using Iterator = decltype(std::begin(c));
+  using category = typename std::iterator_traits<Iterator>::iterator_category;
+  static_assert(
+      std::is_base_of<std::random_access_iterator_tag, category>::value,
+      "Iterators passed to RAJA must be Random Access or Contiguous iterators");
+
+  impl::forall_Icount(p, std::forward<Container>(c), icount,
+                 loop_body);
+}
+
+}
+
+/*!
+ ******************************************************************************
+ *
  * \brief Generic dispatch over containers with icount
  *
  ******************************************************************************
@@ -127,7 +188,7 @@ template <typename EXEC_POLICY_T, typename LOOP_BODY>
 RAJA_INLINE void forall_Icount(const IndexSet& c, LOOP_BODY loop_body)
 {
 
-  impl::forall_Icount(EXEC_POLICY_T(), c, loop_body);
+    wrap::forall_Icount(EXEC_POLICY_T(), c, loop_body);
 }
 
 /*!
@@ -148,26 +209,10 @@ RAJA_INLINE void forall_Icount(Container&& c,
       std::is_base_of<std::random_access_iterator_tag, category>::value,
       "Iterators passed to RAJA must be Random Access or Contiguous iterators");
 
-  impl::forall_Icount(EXEC_POLICY_T(), std::forward<Container>(c), icount,
+  wrap::forall_Icount(EXEC_POLICY_T(), std::forward<Container>(c), icount,
                  loop_body);
 }
 
-namespace wrap {
-
-/*!
- ******************************************************************************
- *
- * \brief Generic dispatch over containers with a value-based policy
- *
- ******************************************************************************
- */
-template <typename EXEC_POLICY_T, typename Container, typename LOOP_BODY>
-RAJA_INLINE void forall(EXEC_POLICY_T&& p, Container&& c, LOOP_BODY loop_body)
-{
-  impl::forall(std::forward<EXEC_POLICY_T>(p), std::forward<Container>(c), loop_body);
-}
-
-}
 
 
 /*!
@@ -248,7 +293,7 @@ RAJA_INLINE void forall_Icount(Index_type begin,
                                Index_type icount,
                                LOOP_BODY loop_body)
 {
-  impl::forall_Icount(EXEC_POLICY_T(), RangeSegment(begin, end), icount,
+    wrap::forall_Icount(EXEC_POLICY_T(), RangeSegment(begin, end), icount,
                    loop_body);
 }
 
@@ -293,7 +338,7 @@ RAJA_INLINE void forall_Icount(Index_type begin,
                                Index_type icount,
                                LOOP_BODY loop_body)
 {
-  impl::forall_Icount(EXEC_POLICY_T(),
+    wrap::forall_Icount(EXEC_POLICY_T(),
                 RangeStrideSegment(begin, end, stride),
                 icount,
                 loop_body);

--- a/include/RAJA/pattern/forall.hpp
+++ b/include/RAJA/pattern/forall.hpp
@@ -152,6 +152,24 @@ RAJA_INLINE void forall_Icount(Container&& c,
                  loop_body);
 }
 
+namespace wrap {
+
+/*!
+ ******************************************************************************
+ *
+ * \brief Generic dispatch over containers with a value-based policy
+ *
+ ******************************************************************************
+ */
+template <typename EXEC_POLICY_T, typename Container, typename LOOP_BODY>
+RAJA_INLINE void forall(EXEC_POLICY_T&& p, Container&& c, LOOP_BODY loop_body)
+{
+  impl::forall(std::forward<EXEC_POLICY_T>(p), std::forward<Container>(c), loop_body);
+}
+
+}
+
+
 /*!
  ******************************************************************************
  *
@@ -170,7 +188,7 @@ RAJA_INLINE void forall(EXEC_POLICY_T&& p, Container&& c, LOOP_BODY loop_body)
 
   // printf("running container\n");
 
-  impl::forall(std::forward<EXEC_POLICY_T>(p), std::forward<Container>(c), loop_body);
+  wrap::forall(std::forward<EXEC_POLICY_T>(p), std::forward<Container>(c), loop_body);
 }
 
 /*!
@@ -191,7 +209,7 @@ RAJA_INLINE void forall(Container&& c, LOOP_BODY loop_body)
 
   // printf("running container\n");
 
-  impl::forall(EXEC_POLICY_T(), std::forward<Container>(c), loop_body);
+  wrap::forall(EXEC_POLICY_T(), std::forward<Container>(c), loop_body);
 }
 
 //
@@ -212,7 +230,7 @@ RAJA_INLINE void forall(Container&& c, LOOP_BODY loop_body)
 template <typename EXEC_POLICY_T, typename LOOP_BODY>
 RAJA_INLINE void forall(Index_type begin, Index_type end, LOOP_BODY loop_body)
 {
-  forall<EXEC_POLICY_T>(RangeSegment(begin, end), loop_body);
+    wrap::forall(EXEC_POLICY_T{}, RangeSegment(begin, end), loop_body);
 }
 
 /*!
@@ -255,7 +273,7 @@ RAJA_INLINE void forall(Index_type begin,
                         Index_type stride,
                         LOOP_BODY loop_body)
 {
-  impl::forall(EXEC_POLICY_T(), RangeStrideSegment(begin, end, stride),
+  wrap::forall(EXEC_POLICY_T(), RangeStrideSegment(begin, end, stride),
              loop_body);
 }
 
@@ -302,7 +320,7 @@ RAJA_INLINE void forall(const Index_type* idx,
                         LOOP_BODY loop_body)
 {
   // turn into an iterator
-  forall<EXEC_POLICY_T>(ListSegment(idx, len, Unowned), loop_body);
+    wrap::forall(EXEC_POLICY_T{}, ListSegment(idx, len, Unowned), loop_body);
 }
 
 /*!

--- a/include/RAJA/policy/MultiPolicy.hpp
+++ b/include/RAJA/policy/MultiPolicy.hpp
@@ -144,7 +144,9 @@ auto make_multi_policy(std::tuple<Policies...> policies, Selector s)
       VarOps::make_index_sequence<sizeof... (Policies)>{}, s, policies);
 }
 
-namespace impl {
+namespace wrap {
+template <typename EXEC_POLICY_T, typename Container, typename LOOP_BODY>
+RAJA_INLINE void forall(EXEC_POLICY_T&& p, Container&& c, LOOP_BODY loop_body);
 
 /// forall - MultiPolicy specialization, select at runtime from a
 /// compile-time list of policies, build with make_multi_policy()
@@ -179,7 +181,7 @@ struct policy_invoker : public policy_invoker<index - 1, size, rest...> {
   void invoke(int offset, Iterable &&iter, Body &&body)
   {
     if (offset == size - index - 1) {
-      RAJA::impl::forall(_p, iter, body);
+      RAJA::wrap::forall(_p, iter, body);
     } else {
       NextInvoker::invoke(offset, iter, body);
     }
@@ -194,7 +196,7 @@ struct policy_invoker<0, size, Policy, rest...> {
   void invoke(int offset, Iterable &&iter, Body &&body)
   {
     if (offset == size - 1) {
-      RAJA::impl::forall(_p, iter, body);
+      RAJA::wrap::forall(_p, iter, body);
     } else {
       throw std::runtime_error("unknown offset invoked");
     }

--- a/include/RAJA/policy/PolicyBase.hpp
+++ b/include/RAJA/policy/PolicyBase.hpp
@@ -37,7 +37,7 @@ struct WrapperPolicy : public Inner {
 // "makers"
 
 template <typename Inner, typename... T>
-struct wrap : public WrapperPolicy<Inner, T...> {
+struct wrapper : public WrapperPolicy<Inner, T...> {
 };
 
 template <Policy Pol, Launch L, Pattern P>

--- a/include/RAJA/policy/openmp/policy.hpp
+++ b/include/RAJA/policy/openmp/policy.hpp
@@ -18,7 +18,7 @@ namespace RAJA
 /// Segment execution policies
 ///
 template <typename InnerPolicy>
-struct omp_parallel_exec : public RAJA::wrap<InnerPolicy> {
+struct omp_parallel_exec : public RAJA::wrapper<InnerPolicy> {
 };
 
 struct omp_for_exec : public RAJA::make_policy_pattern<RAJA::Policy::openmp,


### PR DESCRIPTION
This is a partial rework adding a layer to allow things like the chai integration to operate after all wrapper policies have been resolved.  I'm not sure I love the way it works, but it adds another layer between the user interface layer and impl such that wrapper policies live in the RAJA::wrap namespace, and are all resolved by the time RAJA::wrap::forall generic is invoked.  If this solution is selected, there's more to do, but since I did this much to see if it was going to be feasible at all it seemed worth putting it up.