### PR TITLE
Feature/rhornung67/header moves

### DIFF
--- a/include/RAJA/RAJA.hpp
+++ b/include/RAJA/RAJA.hpp
@@ -108,8 +108,8 @@
 // Multidimensional layouts and views.
 //
 #include "RAJA/util/Layout.hpp"
-#include "RAJA/util/PermutedLayout.hpp"
 #include "RAJA/util/OffsetLayout.hpp"
+#include "RAJA/util/PermutedLayout.hpp"
 #include "RAJA/util/View.hpp"
 
 //

--- a/include/RAJA/index/IndexValue.hpp
+++ b/include/RAJA/index/IndexValue.hpp
@@ -288,7 +288,8 @@ RAJA_HOST_DEVICE RAJA_INLINE TO convertIndex_helper(FROM val)
   return TO{val};
 }
 template <typename TO, typename FROM>
-RAJA_HOST_DEVICE RAJA_INLINE TO convertIndex_helper(typename FROM::IndexValueType val)
+RAJA_HOST_DEVICE RAJA_INLINE TO
+convertIndex_helper(typename FROM::IndexValueType val)
 {
   return static_cast<TO>(*val);
 }
@@ -300,7 +301,6 @@ RAJA_HOST_DEVICE RAJA_INLINE TO convertIndex(FROM val)
 }
 
 
-
 }  // namespace RAJA
 
 /*!
@@ -310,7 +310,7 @@ RAJA_HOST_DEVICE RAJA_INLINE TO convertIndex(FROM val)
   class TYPE : public RAJA::IndexValue<TYPE>                                   \
   {                                                                            \
   public:                                                                      \
-    typedef TYPE IndexValueType; \
+    typedef TYPE IndexValueType;                                               \
     RAJA_HOST_DEVICE RAJA_INLINE TYPE() : RAJA::IndexValue<TYPE>::IndexValue() \
     {                                                                          \
     }                                                                          \

--- a/include/RAJA/index/ListSegment.hpp
+++ b/include/RAJA/index/ListSegment.hpp
@@ -120,10 +120,10 @@ public:
   /// Move-constructor for list segment.
   ///
   ListSegment(ListSegment&& other)
-    : BaseSegment(std::move(other)),
-      m_indx(other.m_indx),
-      m_len(other.m_len),
-      m_indx_own(other.m_indx_own)
+      : BaseSegment(std::move(other)),
+        m_indx(other.m_indx),
+        m_len(other.m_len),
+        m_indx_own(other.m_indx_own)
   {
     other.m_indx = nullptr;
   }
@@ -273,9 +273,11 @@ ListSegment::ListSegment(const T& indx)
                                  cudaMemAttachGlobal));
     using T_TYPE = typename std::remove_reference<decltype(indx[0])>::type;
     if (sizeof(T_TYPE) == sizeof(Index_type) && std::is_integral<T_TYPE>::value
-        && std::is_same<std::vector<T_TYPE>, typename std::decay<T>::type>::value) {
+        && std::is_same<std::vector<T_TYPE>,
+                        typename std::decay<T>::type>::value) {
       // this will bitwise copy signed or unsigned integral types
-      cudaErrchk(cudaMemcpy(m_indx, &indx[0], m_len * sizeof(Index_type), cudaMemcpyDefault));
+      cudaErrchk(cudaMemcpy(
+          m_indx, &indx[0], m_len * sizeof(Index_type), cudaMemcpyDefault));
     } else {
       cudaErrchk(cudaDeviceSynchronize());
       std::copy(indx.begin(), indx.end(), m_indx);

--- a/include/RAJA/internal/ForallNPolicy.hpp
+++ b/include/RAJA/internal/ForallNPolicy.hpp
@@ -69,24 +69,12 @@ struct ForallN_PolicyPair : public I {
   explicit constexpr ForallN_PolicyPair(ISET const &i) : ISET(i) {}
 };
 
-template <typename... PLIST>
-struct ExecList {
-  constexpr const static size_t num_loops = sizeof...(PLIST);
-  typedef std::tuple<PLIST...> tuple;
-};
-
 // Execute (Termination default)
 struct ForallN_Execute_Tag {
 };
 
 struct Execute {
   typedef ForallN_Execute_Tag PolicyTag;
-};
-
-template <typename EXEC, typename NEXT = Execute>
-struct NestedPolicy {
-  typedef NEXT NextPolicy;
-  typedef EXEC ExecPolicies;
 };
 
 

--- a/include/RAJA/internal/Iterators.hpp
+++ b/include/RAJA/internal/Iterators.hpp
@@ -54,184 +54,334 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "RAJA/util/types.hpp"
 #include "RAJA/util/defines.hpp"
+#include "RAJA/util/types.hpp"
 
-#include <type_traits>
 #include <iterator>
+#include <type_traits>
 #include <utility>
 
-namespace RAJA {
-    namespace Iterators {
+namespace RAJA
+{
+namespace Iterators
+{
 
 
 // Helpers
 
 
-template<typename Container>
-using IteratorCategoryOf = typename std::iterator_traits<typename std::remove_reference<Container>::type::iterator>::iterator_category;
+template <typename Container>
+using IteratorCategoryOf =
+    typename std::iterator_traits<typename std::remove_reference<Container>::
+                                      type::iterator>::iterator_category;
 
-template<typename Container>
-using OffersRAI =
-    std::is_base_of<
-        std::random_access_iterator_tag,
-        IteratorCategoryOf<Container>>;
+template <typename Container>
+using OffersRAI = std::is_base_of<std::random_access_iterator_tag,
+                                  IteratorCategoryOf<Container>>;
 
 // Containers
 
-template<typename Type,
-         typename DifferenceType = std::ptrdiff_t,
-         typename PointerType = Type *>
+template <typename Type,
+          typename DifferenceType = std::ptrdiff_t,
+          typename PointerType = Type*>
 class base_iterator : public std::iterator<std::random_access_iterator_tag,
-                                                Type,
-                                                DifferenceType>
+                                           Type,
+                                           DifferenceType>
 {
 public:
-    using difference_type = typename std::iterator<std::random_access_iterator_tag, Type>::difference_type;
+  using difference_type =
+      typename std::iterator<std::random_access_iterator_tag,
+                             Type>::difference_type;
 
-    RAJA_HOST_DEVICE constexpr base_iterator() : val(0) {}
-    RAJA_HOST_DEVICE constexpr base_iterator(Type rhs) : val(rhs) {}
-    RAJA_HOST_DEVICE constexpr base_iterator(const base_iterator &rhs) : val(rhs.val) {}
+  RAJA_HOST_DEVICE constexpr base_iterator() : val(0) {}
+  RAJA_HOST_DEVICE constexpr base_iterator(Type rhs) : val(rhs) {}
+  RAJA_HOST_DEVICE constexpr base_iterator(const base_iterator& rhs)
+      : val(rhs.val)
+  {
+  }
 
-    RAJA_HOST_DEVICE inline bool operator==(const base_iterator& rhs) const {return val == rhs.val;}
-    RAJA_HOST_DEVICE inline bool operator!=(const base_iterator& rhs) const {return val != rhs.val;}
-    RAJA_HOST_DEVICE inline bool operator>(const base_iterator& rhs) const {return val > rhs.val;}
-    RAJA_HOST_DEVICE inline bool operator<(const base_iterator& rhs) const {return val < rhs.val;}
-    RAJA_HOST_DEVICE inline bool operator>=(const base_iterator& rhs) const {return val >= rhs.val;}
-    RAJA_HOST_DEVICE inline bool operator<=(const base_iterator& rhs) const {return val <= rhs.val;}
+  RAJA_HOST_DEVICE inline bool operator==(const base_iterator& rhs) const
+  {
+    return val == rhs.val;
+  }
+  RAJA_HOST_DEVICE inline bool operator!=(const base_iterator& rhs) const
+  {
+    return val != rhs.val;
+  }
+  RAJA_HOST_DEVICE inline bool operator>(const base_iterator& rhs) const
+  {
+    return val > rhs.val;
+  }
+  RAJA_HOST_DEVICE inline bool operator<(const base_iterator& rhs) const
+  {
+    return val < rhs.val;
+  }
+  RAJA_HOST_DEVICE inline bool operator>=(const base_iterator& rhs) const
+  {
+    return val >= rhs.val;
+  }
+  RAJA_HOST_DEVICE inline bool operator<=(const base_iterator& rhs) const
+  {
+    return val <= rhs.val;
+  }
+
 protected:
-    Type val;
+  Type val;
 };
 
-template<typename Type = Index_type,
-         typename DifferenceType = Index_type,
-         typename PointerType = Type *>
-class numeric_iterator : public base_iterator< Type,
-                                               DifferenceType>
+template <typename Type = Index_type,
+          typename DifferenceType = Index_type,
+          typename PointerType = Type*>
+class numeric_iterator : public base_iterator<Type, DifferenceType>
 {
 public:
-    using difference_type = typename std::iterator<std::random_access_iterator_tag, Type>::difference_type;
-    using base = base_iterator<Type, DifferenceType>;
+  using difference_type =
+      typename std::iterator<std::random_access_iterator_tag,
+                             Type>::difference_type;
+  using base = base_iterator<Type, DifferenceType>;
 
-    RAJA_HOST_DEVICE constexpr numeric_iterator() : base(0) {}
-    RAJA_HOST_DEVICE constexpr numeric_iterator(const Type& rhs) : base(rhs) {}
-    RAJA_HOST_DEVICE constexpr numeric_iterator(const numeric_iterator& rhs) : base(rhs.val) {}
+  RAJA_HOST_DEVICE constexpr numeric_iterator() : base(0) {}
+  RAJA_HOST_DEVICE constexpr numeric_iterator(const Type& rhs) : base(rhs) {}
+  RAJA_HOST_DEVICE constexpr numeric_iterator(const numeric_iterator& rhs)
+      : base(rhs.val)
+  {
+  }
 
-    RAJA_HOST_DEVICE inline numeric_iterator& operator++() {++base::val; return *this;}
-    RAJA_HOST_DEVICE inline numeric_iterator& operator--() {--base::val; return *this;}
-    RAJA_HOST_DEVICE inline numeric_iterator operator++(int) {numeric_iterator tmp(*this); ++base::val; return tmp;}
-    RAJA_HOST_DEVICE inline numeric_iterator operator--(int) {numeric_iterator tmp(*this); --base::val; return tmp;}
+  RAJA_HOST_DEVICE inline numeric_iterator& operator++()
+  {
+    ++base::val;
+    return *this;
+  }
+  RAJA_HOST_DEVICE inline numeric_iterator& operator--()
+  {
+    --base::val;
+    return *this;
+  }
+  RAJA_HOST_DEVICE inline numeric_iterator operator++(int)
+  {
+    numeric_iterator tmp(*this);
+    ++base::val;
+    return tmp;
+  }
+  RAJA_HOST_DEVICE inline numeric_iterator operator--(int)
+  {
+    numeric_iterator tmp(*this);
+    --base::val;
+    return tmp;
+  }
 
-    RAJA_HOST_DEVICE inline numeric_iterator& operator+=(const difference_type& rhs) {base::val+=rhs; return *this;}
-    RAJA_HOST_DEVICE inline numeric_iterator& operator-=(const difference_type& rhs) {base::val-=rhs; return *this;}
-    RAJA_HOST_DEVICE inline numeric_iterator& operator+=(const numeric_iterator& rhs) {base::val+=rhs.val; return *this;}
-    RAJA_HOST_DEVICE inline numeric_iterator& operator-=(const numeric_iterator& rhs) {base::val-=rhs.val; return *this;}
+  RAJA_HOST_DEVICE inline numeric_iterator& operator+=(
+      const difference_type& rhs)
+  {
+    base::val += rhs;
+    return *this;
+  }
+  RAJA_HOST_DEVICE inline numeric_iterator& operator-=(
+      const difference_type& rhs)
+  {
+    base::val -= rhs;
+    return *this;
+  }
+  RAJA_HOST_DEVICE inline numeric_iterator& operator+=(
+      const numeric_iterator& rhs)
+  {
+    base::val += rhs.val;
+    return *this;
+  }
+  RAJA_HOST_DEVICE inline numeric_iterator& operator-=(
+      const numeric_iterator& rhs)
+  {
+    base::val -= rhs.val;
+    return *this;
+  }
 
-    RAJA_HOST_DEVICE inline difference_type operator+(const numeric_iterator& rhs) const {return static_cast<difference_type>(base::val)+static_cast<difference_type>(rhs.val);}
-    RAJA_HOST_DEVICE inline difference_type operator-(const numeric_iterator& rhs) const {return static_cast<difference_type>(base::val)-static_cast<difference_type>(rhs.val);}
-    RAJA_HOST_DEVICE inline numeric_iterator operator+(const difference_type& rhs) const {return numeric_iterator(base::val+rhs);}
-    RAJA_HOST_DEVICE inline numeric_iterator operator-(const difference_type& rhs) const {return numeric_iterator(base::val-rhs);}
-    RAJA_HOST_DEVICE friend constexpr numeric_iterator operator+(difference_type lhs, const numeric_iterator& rhs) {return numeric_iterator(lhs+rhs.val);}
-    RAJA_HOST_DEVICE friend constexpr numeric_iterator operator-(difference_type lhs, const numeric_iterator& rhs) {return numeric_iterator(lhs-rhs.val);}
+  RAJA_HOST_DEVICE inline difference_type operator+(
+      const numeric_iterator& rhs) const
+  {
+    return static_cast<difference_type>(base::val)
+           + static_cast<difference_type>(rhs.val);
+  }
+  RAJA_HOST_DEVICE inline difference_type operator-(
+      const numeric_iterator& rhs) const
+  {
+    return static_cast<difference_type>(base::val)
+           - static_cast<difference_type>(rhs.val);
+  }
+  RAJA_HOST_DEVICE inline numeric_iterator operator+(
+      const difference_type& rhs) const
+  {
+    return numeric_iterator(base::val + rhs);
+  }
+  RAJA_HOST_DEVICE inline numeric_iterator operator-(
+      const difference_type& rhs) const
+  {
+    return numeric_iterator(base::val - rhs);
+  }
+  RAJA_HOST_DEVICE friend constexpr numeric_iterator operator+(
+      difference_type lhs,
+      const numeric_iterator& rhs)
+  {
+    return numeric_iterator(lhs + rhs.val);
+  }
+  RAJA_HOST_DEVICE friend constexpr numeric_iterator operator-(
+      difference_type lhs,
+      const numeric_iterator& rhs)
+  {
+    return numeric_iterator(lhs - rhs.val);
+  }
 
-    RAJA_HOST_DEVICE inline Type operator*() const {return base::val;}
-    RAJA_HOST_DEVICE inline Type operator->() const {return base::val;}
-    RAJA_HOST_DEVICE constexpr Type operator[](difference_type rhs) const {return base::val + rhs;}
-
+  RAJA_HOST_DEVICE inline Type operator*() const { return base::val; }
+  RAJA_HOST_DEVICE inline Type operator->() const { return base::val; }
+  RAJA_HOST_DEVICE constexpr Type operator[](difference_type rhs) const
+  {
+    return base::val + rhs;
+  }
 };
 
-template<typename Type = Index_type,
-         typename DifferenceType = Index_type,
-         typename PointerType = Type *>
-class strided_numeric_iterator : public base_iterator< Type,
-                                               DifferenceType>
+template <typename Type = Index_type,
+          typename DifferenceType = Index_type,
+          typename PointerType = Type*>
+class strided_numeric_iterator : public base_iterator<Type, DifferenceType>
 {
 public:
-    using difference_type = typename std::iterator<std::random_access_iterator_tag, Type>::difference_type;
-    using base = base_iterator<Type, DifferenceType>;
+  using difference_type =
+      typename std::iterator<std::random_access_iterator_tag,
+                             Type>::difference_type;
+  using base = base_iterator<Type, DifferenceType>;
 
-    RAJA_HOST_DEVICE constexpr strided_numeric_iterator() : base(0), stride(1) {}
-    RAJA_HOST_DEVICE constexpr strided_numeric_iterator(const Type& rhs, DifferenceType stride = 1) : base(rhs), stride(stride) {}
-    RAJA_HOST_DEVICE constexpr strided_numeric_iterator(const strided_numeric_iterator& rhs) : base(rhs.val), stride(rhs.stride) {}
+  RAJA_HOST_DEVICE constexpr strided_numeric_iterator() : base(0), stride(1) {}
+  RAJA_HOST_DEVICE constexpr strided_numeric_iterator(const Type& rhs,
+                                                      DifferenceType stride = 1)
+      : base(rhs), stride(stride)
+  {
+  }
+  RAJA_HOST_DEVICE constexpr strided_numeric_iterator(
+      const strided_numeric_iterator& rhs)
+      : base(rhs.val), stride(rhs.stride)
+  {
+  }
 
-    RAJA_HOST_DEVICE inline strided_numeric_iterator& operator++() {base::val += stride; return *this;}
-    RAJA_HOST_DEVICE inline strided_numeric_iterator& operator--() {base::val -= stride; return *this;}
+  RAJA_HOST_DEVICE inline strided_numeric_iterator& operator++()
+  {
+    base::val += stride;
+    return *this;
+  }
+  RAJA_HOST_DEVICE inline strided_numeric_iterator& operator--()
+  {
+    base::val -= stride;
+    return *this;
+  }
 
-    RAJA_HOST_DEVICE inline strided_numeric_iterator& operator+=(const difference_type& rhs) {base::val+=rhs * stride; return *this;}
-    RAJA_HOST_DEVICE inline strided_numeric_iterator& operator-=(const difference_type& rhs) {base::val-=rhs * stride; return *this;}
+  RAJA_HOST_DEVICE inline strided_numeric_iterator& operator+=(
+      const difference_type& rhs)
+  {
+    base::val += rhs * stride;
+    return *this;
+  }
+  RAJA_HOST_DEVICE inline strided_numeric_iterator& operator-=(
+      const difference_type& rhs)
+  {
+    base::val -= rhs * stride;
+    return *this;
+  }
 
-    RAJA_HOST_DEVICE inline difference_type operator+(const strided_numeric_iterator& rhs) const {
-        return static_cast<difference_type>(base::val)
-            + (static_cast<difference_type>(rhs.val * stride));}
-    RAJA_HOST_DEVICE inline difference_type operator-(const strided_numeric_iterator& rhs) const {
-        auto diff = static_cast<difference_type>(base::val)
-            - (static_cast<difference_type>(rhs.val));
-        if (diff < stride)
-            return 0;
-        if (diff % stride) // check for off-stride endpoint
-            return diff/stride + 1;
-        return diff/stride;
-    }
-    RAJA_HOST_DEVICE inline strided_numeric_iterator operator+(const difference_type& rhs) const {return strided_numeric_iterator(base::val+rhs * stride);}
-    RAJA_HOST_DEVICE inline strided_numeric_iterator operator-(const difference_type& rhs) const {return strided_numeric_iterator(base::val-rhs * stride);}
+  RAJA_HOST_DEVICE inline difference_type operator+(
+      const strided_numeric_iterator& rhs) const
+  {
+    return static_cast<difference_type>(base::val)
+           + (static_cast<difference_type>(rhs.val * stride));
+  }
+  RAJA_HOST_DEVICE inline difference_type operator-(
+      const strided_numeric_iterator& rhs) const
+  {
+    auto diff = static_cast<difference_type>(base::val)
+                - (static_cast<difference_type>(rhs.val));
+    if (diff < stride) return 0;
+    if (diff % stride)  // check for off-stride endpoint
+      return diff / stride + 1;
+    return diff / stride;
+  }
+  RAJA_HOST_DEVICE inline strided_numeric_iterator operator+(
+      const difference_type& rhs) const
+  {
+    return strided_numeric_iterator(base::val + rhs * stride);
+  }
+  RAJA_HOST_DEVICE inline strided_numeric_iterator operator-(
+      const difference_type& rhs) const
+  {
+    return strided_numeric_iterator(base::val - rhs * stride);
+  }
 
-    // Specialized comparison to allow normal iteration to work on off-stride
-    // multiples by adjusting rhs to the nearest *higher* multiple of stride
-    RAJA_HOST_DEVICE inline bool operator!=(const strided_numeric_iterator& rhs) const {
-        if (base::val == rhs.val) return false;
-        auto rem = rhs.val % stride;
-        return base::val != rhs.val + rem;
-    }
+  // Specialized comparison to allow normal iteration to work on off-stride
+  // multiples by adjusting rhs to the nearest *higher* multiple of stride
+  RAJA_HOST_DEVICE inline bool operator!=(
+      const strided_numeric_iterator& rhs) const
+  {
+    if (base::val == rhs.val) return false;
+    auto rem = rhs.val % stride;
+    return base::val != rhs.val + rem;
+  }
 
-    RAJA_HOST_DEVICE inline Type operator*() const {return base::val;}
-    RAJA_HOST_DEVICE inline Type operator->() const {return base::val;}
-    RAJA_HOST_DEVICE inline Type operator[](difference_type rhs) const {return base::val + rhs * stride;}
+  RAJA_HOST_DEVICE inline Type operator*() const { return base::val; }
+  RAJA_HOST_DEVICE inline Type operator->() const { return base::val; }
+  RAJA_HOST_DEVICE inline Type operator[](difference_type rhs) const
+  {
+    return base::val + rhs * stride;
+  }
 
 private:
-    DifferenceType stride;
-
+  DifferenceType stride;
 };
 
 // TODO: this should really be a generic Zip, then using Enumerator =
 // Zip<numeric_iterator, Iterator>
-template<typename Iterator>
-class Enumerater : public numeric_iterator<> {
+template <typename Iterator>
+class Enumerater : public numeric_iterator<>
+{
 public:
-    template<typename First,
-             typename Second>
-    class InnerPair {
-        public:
-        InnerPair() = delete;
-        RAJA_HOST_DEVICE constexpr InnerPair(First && f, Second && s) : first(f), second(s) {};
-        First first;
-        Second second;
-    };
-    using base = numeric_iterator<>;
+  template <typename First, typename Second>
+  class InnerPair
+  {
+  public:
+    InnerPair() = delete;
+    RAJA_HOST_DEVICE constexpr InnerPair(First&& f, Second&& s)
+        : first(f), second(s){};
+    First first;
+    Second second;
+  };
+  using base = numeric_iterator<>;
 
-    using pair = InnerPair<std::ptrdiff_t,
-                           Iterator>;
-    using value_type = pair;
-    using pointer_type = pair*;
-    using reference = pair&;
+  using pair = InnerPair<std::ptrdiff_t, Iterator>;
+  using value_type = pair;
+  using pointer_type = pair*;
+  using reference = pair&;
 
-    Enumerater() = delete;
-    RAJA_HOST_DEVICE constexpr Enumerater(const Iterator& rhs,
-                         std::ptrdiff_t val = 0,
-                         std::ptrdiff_t offset = 0)
-        : base(val), offset(offset), wrapped(rhs) {}
-    RAJA_HOST_DEVICE constexpr Enumerater(const Enumerater &rhs)
-        : base(rhs.val), offset(rhs.offset), wrapped(rhs.wrapped) {}
+  Enumerater() = delete;
+  RAJA_HOST_DEVICE constexpr Enumerater(const Iterator& rhs,
+                                        std::ptrdiff_t val = 0,
+                                        std::ptrdiff_t offset = 0)
+      : base(val), offset(offset), wrapped(rhs)
+  {
+  }
+  RAJA_HOST_DEVICE constexpr Enumerater(const Enumerater& rhs)
+      : base(rhs.val), offset(rhs.offset), wrapped(rhs.wrapped)
+  {
+  }
 
-    RAJA_HOST_DEVICE inline pair operator*() const {return pair(offset+val, wrapped+val);}
-    RAJA_HOST_DEVICE constexpr pair operator[](typename base::difference_type rhs) const {
-        return pair(val+offset+rhs, wrapped+val+rhs);
-    }
+  RAJA_HOST_DEVICE inline pair operator*() const
+  {
+    return pair(offset + val, wrapped + val);
+  }
+  RAJA_HOST_DEVICE constexpr pair operator[](
+      typename base::difference_type rhs) const
+  {
+    return pair(val + offset + rhs, wrapped + val + rhs);
+  }
 
 private:
-    std::ptrdiff_t offset;
-    Iterator wrapped;
+  std::ptrdiff_t offset;
+  Iterator wrapped;
 };
-
 }
 }
 

--- a/include/RAJA/internal/LegacyCompatibility.hpp
+++ b/include/RAJA/internal/LegacyCompatibility.hpp
@@ -58,9 +58,9 @@
 #include "RAJA/util/defines.hpp"
 
 #if (!defined(__INTEL_COMPILER)) && (!defined(RAJA_COMPILER_MSVC))
-static_assert(
-    __cplusplus >= 201103L,
-    "C++ standards below 2011 are not supported" RAJA_STRINGIFY_HELPER(__cplusplus));
+static_assert(__cplusplus >= 201103L,
+              "C++ standards below 2011 are not "
+              "supported" RAJA_STRINGIFY_HELPER(__cplusplus));
 #endif
 
 #include <cstdint>
@@ -85,8 +85,8 @@ static_assert(
 //     using thrust::make_tuple;
 // }
 // #else
-#include <tuple>
 #include <array>
+#include <tuple>
 namespace VarOps
 {
 using std::tuple;
@@ -158,8 +158,9 @@ struct foldl_impl<Op, Arg1, Arg2, Arg3, Rest...> {
 };
 
 template <typename Op, typename Arg1>
-RAJA_HOST_DEVICE RAJA_INLINE constexpr auto foldl(Op&& RAJA_UNUSED_ARG(operation), Arg1&& arg) ->
-    typename foldl_impl<Op, Arg1>::Ret
+RAJA_HOST_DEVICE RAJA_INLINE constexpr auto foldl(
+    Op&& RAJA_UNUSED_ARG(operation),
+    Arg1&& arg) -> typename foldl_impl<Op, Arg1>::Ret
 {
   return forward<Arg1&&>(arg);
 }
@@ -195,8 +196,9 @@ RAJA_HOST_DEVICE RAJA_INLINE constexpr auto foldl(Op&& operation,
 
 struct adder {
   template <typename Result>
-  RAJA_HOST_DEVICE RAJA_INLINE constexpr Result operator()(const Result& l,
-                                                           const Result& r) const
+  RAJA_HOST_DEVICE RAJA_INLINE constexpr Result operator()(
+      const Result& l,
+      const Result& r) const
   {
     return l + r;
   }
@@ -246,7 +248,7 @@ RAJA_HOST_DEVICE RAJA_INLINE constexpr auto rotate_left_one(
 template <size_t... Ints>
 constexpr size_t integer_sequence<Ints...>::size;
 template <size_t... Ints>
-constexpr  std::array<size_t, sizeof...(Ints)> integer_sequence<Ints...>::value;
+constexpr std::array<size_t, sizeof...(Ints)> integer_sequence<Ints...>::value;
 
 namespace integer_sequence_detail
 {
@@ -385,8 +387,9 @@ struct get_offset
 template <size_t index>
 struct get_arg_at {
   template <typename First, typename... Rest>
-  RAJA_HOST_DEVICE RAJA_INLINE static constexpr auto value(First&& RAJA_UNUSED_ARG(first),
-                                                           Rest&&... rest)
+  RAJA_HOST_DEVICE RAJA_INLINE static constexpr auto value(
+      First&& RAJA_UNUSED_ARG(first),
+      Rest&&... rest)
       -> decltype(VarOps::forward<
                   typename VarOps::get_type_at<index - 1, Rest...>::type>(
           get_arg_at<index - 1>::value(VarOps::forward<Rest>(rest)...)))
@@ -401,8 +404,9 @@ struct get_arg_at {
 template <>
 struct get_arg_at<0> {
   template <typename First, typename... Rest>
-  RAJA_HOST_DEVICE RAJA_INLINE static constexpr auto value(First&& first,
-                                                           Rest&&... RAJA_UNUSED_ARG(rest))
+  RAJA_HOST_DEVICE RAJA_INLINE static constexpr auto value(
+      First&& first,
+      Rest&&... RAJA_UNUSED_ARG(rest))
       -> decltype(VarOps::forward<First>(first))
   {
     return VarOps::forward<First>(first);

--- a/include/RAJA/internal/MemUtils_CPU.hpp
+++ b/include/RAJA/internal/MemUtils_CPU.hpp
@@ -66,14 +66,15 @@ namespace RAJA
 ///
 /// Portable aligned memory allocation
 ///
-void * allocate_aligned(size_t alignment, size_t size);
+void* allocate_aligned(size_t alignment, size_t size);
 
 ///
 /// Portable aligned memory allocation
 ///
-template<typename T>
-T * allocate_aligned_type(size_t alignment, size_t size) {
-    return reinterpret_cast<T*>(allocate_aligned(alignment, size));
+template <typename T>
+T* allocate_aligned_type(size_t alignment, size_t size)
+{
+  return reinterpret_cast<T*>(allocate_aligned(alignment, size));
 }
 
 

--- a/include/RAJA/internal/rangelist_forall.hpp
+++ b/include/RAJA/internal/rangelist_forall.hpp
@@ -54,8 +54,10 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-namespace RAJA {
-namespace impl {
+namespace RAJA
+{
+namespace impl
+{
 
 /*!
  ******************************************************************************
@@ -166,68 +168,76 @@ RAJA_INLINE void executeRangeList_forall_Icount(const IndexSetSegInfo* seg_info,
  */
 // TODO: this should be with the IndexSet class, really it should be part of
 // its built-in iterator, but we need to address the include snarl first
-template<typename SEG_EXEC_POLICY_T, typename LOOP_BODY>
+template <typename SEG_EXEC_POLICY_T, typename LOOP_BODY>
 struct rangeListExecutor {
-  constexpr rangeListExecutor(LOOP_BODY &&body) : body(body) {}
+  constexpr rangeListExecutor(LOOP_BODY&& body) : body(body) {}
   RAJA_INLINE
-  void operator()(const IndexSetSegInfo &seg_info) {
+  void operator()(const IndexSetSegInfo& seg_info)
+  {
     executeRangeList_forall<SEG_EXEC_POLICY_T>(&seg_info, body);
   }
 
- private:
+private:
   // LOOP_BODY body;
   typename std::remove_reference<LOOP_BODY>::type body;
 };
 
-template<typename SEG_EXEC_POLICY_T, typename LOOP_BODY>
+template <typename SEG_EXEC_POLICY_T, typename LOOP_BODY>
 constexpr RAJA_INLINE rangeListExecutor<SEG_EXEC_POLICY_T, LOOP_BODY>
-makeRangeListExecutor(LOOP_BODY &&body) {
+makeRangeListExecutor(LOOP_BODY&& body)
+{
   return rangeListExecutor<SEG_EXEC_POLICY_T, LOOP_BODY>(body);
 }
 
-template<typename SEG_IT_POLICY_T,
-    typename SEG_EXEC_POLICY_T,
-    typename LOOP_BODY>
+template <typename SEG_IT_POLICY_T,
+          typename SEG_EXEC_POLICY_T,
+          typename LOOP_BODY>
 RAJA_INLINE void forall(
-    IndexSet::ExecPolicy <SEG_IT_POLICY_T, SEG_EXEC_POLICY_T>,
-    const IndexSet &iset,
-    LOOP_BODY loop_body) {
+    IndexSet::ExecPolicy<SEG_IT_POLICY_T, SEG_EXEC_POLICY_T>,
+    const IndexSet& iset,
+    LOOP_BODY loop_body)
+{
   impl::forall(SEG_IT_POLICY_T(),
-               iset, makeRangeListExecutor<SEG_EXEC_POLICY_T>(loop_body));
+               iset,
+               makeRangeListExecutor<SEG_EXEC_POLICY_T>(loop_body));
 }
 
-template<typename SEG_EXEC_POLICY_T, typename LOOP_BODY>
+template <typename SEG_EXEC_POLICY_T, typename LOOP_BODY>
 struct rangeListIcountExecutor {
-  constexpr rangeListIcountExecutor(LOOP_BODY &&body) : body(body) {}
+  constexpr rangeListIcountExecutor(LOOP_BODY&& body) : body(body) {}
   RAJA_INLINE
-  void operator()(const IndexSetSegInfo &seg_info) {
+  void operator()(const IndexSetSegInfo& seg_info)
+  {
     executeRangeList_forall_Icount<SEG_EXEC_POLICY_T>(&seg_info, body);
   }
 
- private:
+private:
   typename std::remove_reference<LOOP_BODY>::type body;
   // LOOP_BODY body;
 };
 
-template<typename SEG_EXEC_POLICY_T, typename LOOP_BODY>
+template <typename SEG_EXEC_POLICY_T, typename LOOP_BODY>
 constexpr RAJA_INLINE rangeListIcountExecutor<SEG_EXEC_POLICY_T, LOOP_BODY>
-makeRangeListIcountExecutor(LOOP_BODY &&body) {
+makeRangeListIcountExecutor(LOOP_BODY&& body)
+{
   return rangeListIcountExecutor<SEG_EXEC_POLICY_T, LOOP_BODY>(body);
 }
 
-template<typename SEG_IT_POLICY_T,
-    typename SEG_EXEC_POLICY_T,
-    typename LOOP_BODY>
+template <typename SEG_IT_POLICY_T,
+          typename SEG_EXEC_POLICY_T,
+          typename LOOP_BODY>
 RAJA_INLINE void forall_Icount(
-    IndexSet::ExecPolicy <SEG_IT_POLICY_T, SEG_EXEC_POLICY_T>,
-    const IndexSet &iset,
-    LOOP_BODY loop_body) {
+    IndexSet::ExecPolicy<SEG_IT_POLICY_T, SEG_EXEC_POLICY_T>,
+    const IndexSet& iset,
+    LOOP_BODY loop_body)
+{
   // no need for icount variant here
   impl::forall(SEG_IT_POLICY_T(),
-               iset, makeRangeListIcountExecutor<SEG_EXEC_POLICY_T>(loop_body));
+               iset,
+               makeRangeListIcountExecutor<SEG_EXEC_POLICY_T>(loop_body));
 }
 
-} // end of namespace impl
-} // end of namespace RAJA
+}  // end of namespace impl
+}  // end of namespace RAJA
 
-#endif // RAJA_rangelist_forall_HPP
+#endif  // RAJA_rangelist_forall_HPP

--- a/include/RAJA/internal/type_traits.hpp
+++ b/include/RAJA/internal/type_traits.hpp
@@ -135,15 +135,22 @@ struct is_enum_same<T, A, A> : public std::true_type {
 };
 
 template <typename P_, Policy P>
-struct models_policy : public std::integral_constant<bool, is_enum_same<Policy, P_::policy, P>::value> {
+struct models_policy
+    : public std::
+          integral_constant<bool, is_enum_same<Policy, P_::policy, P>::value> {
 };
 
 template <typename P_, Launch L>
-struct models_launch : public std::integral_constant<bool, is_enum_same<Launch, P_::launch, L>::value> {
+struct models_launch
+    : public std::
+          integral_constant<bool, is_enum_same<Launch, P_::launch, L>::value> {
 };
 
 template <typename P_, Pattern P>
-struct models_pattern : public std::integral_constant<bool, is_enum_same<Pattern, P_::pattern, P>::value> {
+struct models_pattern
+    : public std::
+          integral_constant<bool,
+                            is_enum_same<Pattern, P_::pattern, P>::value> {
 };
 }
 

--- a/include/RAJA/pattern/forall.hpp
+++ b/include/RAJA/pattern/forall.hpp
@@ -93,8 +93,8 @@
 #include "RAJA/policy/PolicyBase.hpp"
 
 #include "RAJA/index/IndexSet.hpp"
-#include "RAJA/index/RangeSegment.hpp"
 #include "RAJA/index/ListSegment.hpp"
+#include "RAJA/index/RangeSegment.hpp"
 
 #include "RAJA/internal/fault_tolerance.hpp"
 #include "RAJA/util/types.hpp"
@@ -148,8 +148,10 @@ RAJA_INLINE void forall_Icount(Container&& c,
       std::is_base_of<std::random_access_iterator_tag, category>::value,
       "Iterators passed to RAJA must be Random Access or Contiguous iterators");
 
-  impl::forall_Icount(EXEC_POLICY_T(), std::forward<Container>(c), icount,
-                 loop_body);
+  impl::forall_Icount(EXEC_POLICY_T(),
+                      std::forward<Container>(c),
+                      icount,
+                      loop_body);
 }
 
 /*!
@@ -170,7 +172,9 @@ RAJA_INLINE void forall(EXEC_POLICY_T&& p, Container&& c, LOOP_BODY loop_body)
 
   // printf("running container\n");
 
-  impl::forall(std::forward<EXEC_POLICY_T>(p), std::forward<Container>(c), loop_body);
+  impl::forall(std::forward<EXEC_POLICY_T>(p),
+               std::forward<Container>(c),
+               loop_body);
 }
 
 /*!
@@ -230,8 +234,10 @@ RAJA_INLINE void forall_Icount(Index_type begin,
                                Index_type icount,
                                LOOP_BODY loop_body)
 {
-  impl::forall_Icount(EXEC_POLICY_T(), RangeSegment(begin, end), icount,
-                   loop_body);
+  impl::forall_Icount(EXEC_POLICY_T(),
+                      RangeSegment(begin, end),
+                      icount,
+                      loop_body);
 }
 
 //
@@ -255,8 +261,9 @@ RAJA_INLINE void forall(Index_type begin,
                         Index_type stride,
                         LOOP_BODY loop_body)
 {
-  impl::forall(EXEC_POLICY_T(), RangeStrideSegment(begin, end, stride),
-             loop_body);
+  impl::forall(EXEC_POLICY_T(),
+               RangeStrideSegment(begin, end, stride),
+               loop_body);
 }
 
 /*!
@@ -276,9 +283,9 @@ RAJA_INLINE void forall_Icount(Index_type begin,
                                LOOP_BODY loop_body)
 {
   impl::forall_Icount(EXEC_POLICY_T(),
-                RangeStrideSegment(begin, end, stride),
-                icount,
-                loop_body);
+                      RangeStrideSegment(begin, end, stride),
+                      icount,
+                      loop_body);
 }
 
 //
@@ -321,7 +328,9 @@ RAJA_INLINE void forall_Icount(const Index_type* idx,
                                LOOP_BODY loop_body)
 {
   // turn into an iterator
-  forall_Icount<EXEC_POLICY_T>(ListSegment(idx, len, Unowned), icount, loop_body);
+  forall_Icount<EXEC_POLICY_T>(ListSegment(idx, len, Unowned),
+                               icount,
+                               loop_body);
 }
 
 

--- a/include/RAJA/pattern/forallN.hpp
+++ b/include/RAJA/pattern/forallN.hpp
@@ -66,6 +66,31 @@
 namespace RAJA
 {
 
+/*!
+ * \brief Struct used to define forallN nested policies.
+ *
+ *  Typically, passed as first template argument to forallN templates.
+ */
+template <typename EXEC, typename NEXT = Execute>
+struct NestedPolicy {
+  typedef NEXT NextPolicy;
+  typedef EXEC ExecPolicies;
+};
+
+/*!
+ * \brief Struct that contains a policy for each loop nest in a forallN
+ *        construct. 
+ *
+ *  Typically, passed as first template argument to NestedPolicy template,
+ *  followed by permutation, etc.
+ */
+template <typename... PLIST>
+struct ExecList {
+  constexpr const static size_t num_loops = sizeof...(PLIST);
+  typedef std::tuple<PLIST...> tuple;
+};
+
+
 /******************************************************************
  *  ForallN_Executor(): Default Executor for loops
  ******************************************************************/
@@ -75,7 +100,6 @@ namespace RAJA
  *
  *  The default action is to call RAJA::forall to peel off outer loop nest.
  */
-
 template <typename POLICY_INIT, typename... POLICY_REST>
 struct ForallN_Executor<POLICY_INIT, POLICY_REST...> {
   typedef typename POLICY_INIT::ISET TYPE_I;

--- a/include/RAJA/pattern/forallN.hpp
+++ b/include/RAJA/pattern/forallN.hpp
@@ -79,7 +79,7 @@ struct NestedPolicy {
 
 /*!
  * \brief Struct that contains a policy for each loop nest in a forallN
- *        construct. 
+ *        construct.
  *
  *  Typically, passed as first template argument to NestedPolicy template,
  *  followed by permutation, etc.
@@ -111,7 +111,8 @@ struct ForallN_Executor<POLICY_INIT, POLICY_REST...> {
   NextExec const next_exec;
 
   template <typename... TYPE_REST>
-  constexpr ForallN_Executor(POLICY_INIT const &is_i0, TYPE_REST const &... is_rest)
+  constexpr ForallN_Executor(POLICY_INIT const &is_i0,
+                             TYPE_REST const &... is_rest)
       : is_i(is_i0), next_exec(is_rest...)
   {
   }
@@ -216,13 +217,13 @@ RAJA_INLINE void forallN_impl_extract(RAJA::ExecList<ExecPolicies...>,
                                            args)...);
 }
 
-namespace detail {
+namespace detail
+{
 
-template<typename T, size_t Unused>
+template <typename T, size_t Unused>
 struct type_repeater {
-    using type=T;
+  using type = T;
 };
-
 }
 
 template <typename POLICY,
@@ -242,7 +243,8 @@ RAJA_INLINE void forallN_impl(VarOps::index_sequence<Range...>,
   // Make it look like variadics can have defaults
   forallN_impl_extract<POLICY,
                        Indices...,
-                       typename detail::type_repeater<Index_type, Unspecified>::type...>(
+                       typename detail::type_repeater<Index_type,
+                                                      Unspecified>::type...>(
       typename POLICY::ExecPolicies(), body, args...);
 }
 

--- a/include/RAJA/pattern/reduce.hpp
+++ b/include/RAJA/pattern/reduce.hpp
@@ -78,13 +78,13 @@ namespace RAJA
 #define RAJA_MAXLOC(a, b) (((b.val) > (a.val)) ? (b) : (a))
 
 ///
-///Macros to support unstructured minmaxloc operations
+/// Macros to support unstructured minmaxloc operations
 #define RAJA_MINLOC_UNSTRUCTURED(set_val, set_idx, a_val, a_idx, b_val, b_idx) \
-  set_idx = ((b_val) < (a_val) ? (b_idx) : (a_idx)); \
+  set_idx = ((b_val) < (a_val) ? (b_idx) : (a_idx));                           \
   set_val = ((b_val) < (a_val) ? (b_val) : (a_val));
 ///
 #define RAJA_MAXLOC_UNSTRUCTURED(set_val, set_idx, a_val, a_idx, b_val, b_idx) \
-  set_idx = ((b_val) > (a_val) ? (b_idx) : (a_idx)); \
+  set_idx = ((b_val) > (a_val) ? (b_idx) : (a_idx));                           \
   set_val = ((b_val) > (a_val) ? (b_val) : (a_val));
 
 //

--- a/include/RAJA/policy/MultiPolicy.hpp
+++ b/include/RAJA/policy/MultiPolicy.hpp
@@ -63,9 +63,10 @@ namespace RAJA
 template <typename Selector, typename... Policies>
 class MultiPolicy;
 
-namespace detail {
-    template <size_t index, size_t size, typename Policy, typename... rest>
-    struct policy_invoker;
+namespace detail
+{
+template <size_t index, size_t size, typename Policy, typename... rest>
+struct policy_invoker;
 }
 
 
@@ -96,9 +97,10 @@ public:
     return s(i);
   }
 
-  detail::
-      policy_invoker<sizeof...(Policies) - 1, sizeof...(Policies), Policies...>
-          _policies;
+  detail::policy_invoker<sizeof...(Policies)-1,
+                         sizeof...(Policies),
+                         Policies...>
+      _policies;
 };
 
 namespace detail
@@ -141,10 +143,11 @@ auto make_multi_policy(std::tuple<Policies...> policies, Selector s)
     -> MultiPolicy<Selector, Policies...>
 {
   return detail::make_multi_policy(
-      VarOps::make_index_sequence<sizeof... (Policies)>{}, s, policies);
+      VarOps::make_index_sequence<sizeof...(Policies)>{}, s, policies);
 }
 
-namespace impl {
+namespace impl
+{
 
 /// forall - MultiPolicy specialization, select at runtime from a
 /// compile-time list of policies, build with make_multi_policy()
@@ -161,7 +164,6 @@ RAJA_INLINE void forall(MultiPolicy<Selector, Policies...> p,
 {
   p.invoke(iter, body);
 }
-
 }
 
 namespace detail
@@ -201,7 +203,6 @@ struct policy_invoker<0, size, Policy, rest...> {
   }
 };
 }
-
 }
 
 #endif

--- a/include/RAJA/policy/cilk.hpp
+++ b/include/RAJA/policy/cilk.hpp
@@ -60,8 +60,8 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 
-#include "RAJA/policy/cilk/policy.hpp"
 #include "RAJA/policy/cilk/forall.hpp"
+#include "RAJA/policy/cilk/policy.hpp"
 #include "RAJA/policy/cilk/reduce.hpp"
 
 #endif  // closing endif for if defined(RAJA_ENABLE_CILK)

--- a/include/RAJA/policy/cuda.hpp
+++ b/include/RAJA/policy/cuda.hpp
@@ -62,8 +62,8 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
-#include "RAJA/policy/cuda/policy.hpp"
 #include "RAJA/policy/cuda/forall.hpp"
+#include "RAJA/policy/cuda/policy.hpp"
 #include "RAJA/policy/cuda/reduce.hpp"
 #if defined(__NVCC__)
 #include "RAJA/policy/cuda/scan.hpp"

--- a/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
+++ b/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
@@ -65,7 +65,7 @@ namespace RAJA
 /*!
  * \def RAJA_CUDA_MAX_NUM_BLOCKS
  * Maximum number of blocks that RAJA will launch
- */ 
+ */
 #define RAJA_CUDA_MAX_NUM_BLOCKS (1024 * 16)
 
 /*!
@@ -84,9 +84,9 @@ namespace RAJA
 
 /*!
  * \def RAJA_CUDA_REDUCE_VAR_MAXSIZE
- * Size in bytes used in CudaReductionDummyDataType for array allocation to 
+ * Size in bytes used in CudaReductionDummyDataType for array allocation to
  * accommodate the template type used in reductions.
- * 
+ *
  * Note: Includes the size of the index variable for Loc reductions.
  */
 #define RAJA_CUDA_REDUCE_VAR_MAXSIZE 16
@@ -106,7 +106,7 @@ typedef unsigned int GridSizeType;
  ******************************************************************************
  */
 struct RAJA_ALIGNED_ATTR(RAJA_CUDA_REDUCE_VAR_MAXSIZE)
-CudaReductionDummyDataType {
+    CudaReductionDummyDataType {
   unsigned char data[RAJA_CUDA_REDUCE_VAR_MAXSIZE];
 };
 
@@ -174,7 +174,7 @@ struct CudaReductionLocBlockType {
  *
  ******************************************************************************
  */
-template  <typename T>
+template <typename T>
 struct CudaReductionLocType {
   T val;
   Index_type idx;
@@ -261,7 +261,7 @@ int getCudaMemblockUsedCount();
 /*!
  ******************************************************************************
  *
- * \brief Get a valid reduction id, or complain and exit if no valid id is 
+ * \brief Get a valid reduction id, or complain and exit if no valid id is
  *        available.
  *
  * \return int the next available valid reduction id.
@@ -302,7 +302,7 @@ void getCudaReductionTallyBlock(int id, void** host_tally, void** device_tally);
  ******************************************************************************
  *
  * \brief Release tally block for reducer object with given id.
- * 
+ *
  ******************************************************************************
  */
 void releaseCudaReductionTallyBlock(int id);
@@ -323,13 +323,13 @@ void beforeCudaKernelLaunch();
  * \brief Resets state variables after kernel launch.
  *
  ******************************************************************************
- */ 
+ */
 void afterCudaKernelLaunch();
 
 /*!
  ******************************************************************************
  *
- * \brief Updates host tally cache for read by reduction variable with id and 
+ * \brief Updates host tally cache for read by reduction variable with id and
  * an asynchronous reduction policy.
  *
  ******************************************************************************
@@ -339,7 +339,7 @@ void beforeCudaReadTallyBlockAsync(int id);
 /*!
  ******************************************************************************
  *
- * \brief Updates host tally cache for read by reduction variable with id and 
+ * \brief Updates host tally cache for read by reduction variable with id and
  * a synchronous reduction policy.
  *
  ******************************************************************************
@@ -349,12 +349,12 @@ void beforeCudaReadTallyBlockSync(int id);
 /*!
  ******************************************************************************
  *
- * \brief Updates host tally cache for read by reduction variable with id and 
+ * \brief Updates host tally cache for read by reduction variable with id and
  * templated on Async from the reduction policy.
  *
  ******************************************************************************
  */
-template<bool Async>
+template <bool Async>
 void beforeCudaReadTallyBlock(int id)
 {
   if (Async) {

--- a/include/RAJA/policy/cuda/forall.hpp
+++ b/include/RAJA/policy/cuda/forall.hpp
@@ -61,14 +61,14 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "RAJA/util/types.hpp"
 #include "RAJA/util/defines.hpp"
+#include "RAJA/util/types.hpp"
 
 #include "RAJA/internal/fault_tolerance.hpp"
 
-#include "RAJA/policy/cuda/raja_cudaerrchk.hpp"
 #include "RAJA/policy/cuda/MemUtils_CUDA.hpp"
 #include "RAJA/policy/cuda/policy.hpp"
+#include "RAJA/policy/cuda/raja_cudaerrchk.hpp"
 
 #include "RAJA/index/IndexSet.hpp"
 
@@ -79,10 +79,12 @@ namespace impl
 {
 
 template <typename SEG_EXEC_POLICY_T, typename LOOP_BODY>
-RAJA_INLINE void executeRangeList_forall(const IndexSetSegInfo* seg_info, LOOP_BODY&& loop_body);
+RAJA_INLINE void executeRangeList_forall(const IndexSetSegInfo* seg_info,
+                                         LOOP_BODY&& loop_body);
 
 template <typename SEG_EXEC_POLICY_T, typename LOOP_BODY>
-RAJA_INLINE void executeRangeList_forall_Icount(const IndexSetSegInfo* seg_info, LOOP_BODY&& loop_body);
+RAJA_INLINE void executeRangeList_forall_Icount(const IndexSetSegInfo* seg_info,
+                                                LOOP_BODY&& loop_body);
 
 //
 //////////////////////////////////////////////////////////////////////
@@ -105,7 +107,7 @@ namespace INTERNAL
  */
 __device__ __forceinline__ Index_type getGlobalIdx_1D_1D()
 {
-  Index_type blockId  = blockIdx.x;
+  Index_type blockId = blockIdx.x;
   Index_type threadId = blockId * blockDim.x + threadIdx.x;
   return threadId;
 }
@@ -133,12 +135,12 @@ __device__ __forceinline__ Index_type getGlobalIdx_3D_3D()
 }
 __device__ __forceinline__ Index_type getGlobalNumThreads_3D_3D()
 {
-  Index_type numThreads = blockDim.x * blockDim.y * blockDim.z *
-                          gridDim.x * gridDim.y * gridDim.z;
+  Index_type numThreads =
+      blockDim.x * blockDim.y * blockDim.z * gridDim.x * gridDim.y * gridDim.z;
   return numThreads;
 }
 
-} // end INTERNAL namespace for helper functions
+}  // end INTERNAL namespace for helper functions
 
 
 /*!
@@ -207,17 +209,16 @@ RAJA_INLINE void forall(cuda_exec<BLOCK_SIZE, Async>,
   auto final_end = std::end(iter);
   Index_type total_len = std::distance(first_begin, final_end);
 
-  Index_type max_step_size = (getCudaMemblockUsedCount() > 0) ?
-                                  BLOCK_SIZE * RAJA_CUDA_MAX_NUM_BLOCKS
-                                  : total_len;
+  Index_type max_step_size = (getCudaMemblockUsedCount() > 0)
+                                 ? BLOCK_SIZE * RAJA_CUDA_MAX_NUM_BLOCKS
+                                 : total_len;
 
   RAJA_FT_BEGIN;
 
-  for ( Index_type step_size, offset = 0;
-        offset < total_len;
-        offset += step_size ) {
+  for (Index_type step_size, offset = 0; offset < total_len;
+       offset += step_size) {
 
-    step_size = RAJA_MIN( total_len - offset, max_step_size );
+    step_size = RAJA_MIN(total_len - offset, max_step_size);
 
     auto begin = first_begin + offset;
     auto end = begin + step_size;
@@ -225,8 +226,8 @@ RAJA_INLINE void forall(cuda_exec<BLOCK_SIZE, Async>,
     Index_type len = std::distance(begin, end);
     Index_type gridSize = RAJA_DIVIDE_CEILING_INT(len, BLOCK_SIZE);
 
-    forall_cuda_kernel<<<RAJA_CUDA_LAUNCH_PARAMS(gridSize, BLOCK_SIZE)
-                      >>>(body, std::move(begin), len);
+    forall_cuda_kernel<<<RAJA_CUDA_LAUNCH_PARAMS(gridSize, BLOCK_SIZE)>>>(
+        body, std::move(begin), len);
   }
 
   RAJA_CUDA_CHECK_AND_SYNC(Async);
@@ -251,17 +252,16 @@ RAJA_INLINE void forall_Icount(cuda_exec<BLOCK_SIZE, Async>,
   auto final_end = std::end(iter);
   Index_type total_len = std::distance(first_begin, final_end);
 
-  Index_type max_step_size = (getCudaMemblockUsedCount() > 0) ?
-                                  BLOCK_SIZE * RAJA_CUDA_MAX_NUM_BLOCKS
-                                  : total_len;
+  Index_type max_step_size = (getCudaMemblockUsedCount() > 0)
+                                 ? BLOCK_SIZE * RAJA_CUDA_MAX_NUM_BLOCKS
+                                 : total_len;
 
   RAJA_FT_BEGIN;
 
-  for ( Index_type step_size, offset = 0;
-        offset < total_len;
-        offset += step_size ) {
+  for (Index_type step_size, offset = 0; offset < total_len;
+       offset += step_size) {
 
-    step_size = RAJA_MIN( total_len - offset, max_step_size );
+    step_size = RAJA_MIN(total_len - offset, max_step_size);
 
     auto begin = first_begin + offset;
     auto end = begin + step_size;
@@ -269,8 +269,8 @@ RAJA_INLINE void forall_Icount(cuda_exec<BLOCK_SIZE, Async>,
     Index_type len = std::distance(begin, end);
     Index_type gridSize = RAJA_DIVIDE_CEILING_INT(len, BLOCK_SIZE);
 
-    forall_Icount_cuda_kernel<<<RAJA_CUDA_LAUNCH_PARAMS(gridSize, BLOCK_SIZE)
-                             >>>(body, std::move(begin), len, icount + offset);
+    forall_Icount_cuda_kernel<<<RAJA_CUDA_LAUNCH_PARAMS(
+        gridSize, BLOCK_SIZE)>>>(body, std::move(begin), len, icount + offset);
   }
 
   RAJA_CUDA_CHECK_AND_SYNC(Async);
@@ -299,9 +299,10 @@ RAJA_INLINE void forall_Icount(cuda_exec<BLOCK_SIZE, Async>,
  ******************************************************************************
  */
 template <size_t BLOCK_SIZE, bool Async, typename LOOP_BODY>
-RAJA_INLINE void forall(IndexSet::ExecPolicy<seq_segit, cuda_exec<BLOCK_SIZE, Async>>,
-                        const IndexSet& iset,
-                        LOOP_BODY&& loop_body)
+RAJA_INLINE void forall(
+    IndexSet::ExecPolicy<seq_segit, cuda_exec<BLOCK_SIZE, Async>>,
+    const IndexSet& iset,
+    LOOP_BODY&& loop_body)
 {
 
   int num_seg = iset.getNumSegments();
@@ -335,7 +336,8 @@ RAJA_INLINE void forall_Icount(
   int num_seg = iset.getNumSegments();
   for (int isi = 0; isi < num_seg; ++isi) {
     const IndexSetSegInfo* seg_info = iset.getSegmentInfo(isi);
-    executeRangeList_forall_Icount<cuda_exec<BLOCK_SIZE, true>>(seg_info, loop_body);
+    executeRangeList_forall_Icount<cuda_exec<BLOCK_SIZE, true>>(seg_info,
+                                                                loop_body);
 
   }  // iterate over segments of index set
 

--- a/include/RAJA/policy/cuda/forallN.hpp
+++ b/include/RAJA/policy/cuda/forallN.hpp
@@ -116,13 +116,13 @@ struct CudaDim {
 };
 
 RAJA_INLINE
-constexpr int numBlocks(CudaDim const& dim)
+constexpr int numBlocks(CudaDim const &dim)
 {
   return dim.num_blocks.x * dim.num_blocks.y * dim.num_blocks.z;
 }
 
 RAJA_INLINE
-constexpr int numThreads(CudaDim const& dim)
+constexpr int numThreads(CudaDim const &dim)
 {
   return dim.num_threads.x * dim.num_threads.y * dim.num_threads.z;
 }
@@ -151,7 +151,7 @@ struct CudaThreadBlock {
 
   VIEWDIM view;
 
-  template<typename Iterable>
+  template <typename Iterable>
   CudaThreadBlock(CudaDim &dims, Iterable const &i)
       : distance(std::distance(std::begin(i), std::end(i)))
   {
@@ -205,7 +205,7 @@ struct CudaThread {
 
   VIEWDIM view;
 
-  template<typename Iterable>
+  template <typename Iterable>
   CudaThread(CudaDim &dims, Iterable const &i)
       : distance(std::distance(std::begin(i), std::end(i)))
   {
@@ -221,10 +221,7 @@ struct CudaThread {
     return idx;
   }
 
-  void inline setDims(CudaDim &dims)
-  {
-    view(dims.num_threads) = distance;
-  }
+  void inline setDims(CudaDim &dims) { view(dims.num_threads) = distance; }
 };
 
 /* These execution policies map the given loop nest to the threads in the
@@ -242,7 +239,7 @@ struct CudaBlock {
 
   VIEWDIM view;
 
-  template<typename Iterable>
+  template <typename Iterable>
   CudaBlock(CudaDim &dims, Iterable const &i)
       : distance(std::distance(std::begin(i), std::end(i)))
   {
@@ -258,10 +255,7 @@ struct CudaBlock {
     return idx;
   }
 
-  void inline setDims(CudaDim &dims)
-  {
-    view(dims.num_blocks) = distance;
-  }
+  void inline setDims(CudaDim &dims) { view(dims.num_blocks) = distance; }
 };
 
 /* These execution policies map the given loop nest to the blocks in the
@@ -275,21 +269,25 @@ using cuda_block_z_exec = CudaPolicy<CudaBlock<Dim3z>>;
 
 template <typename CUDA_EXEC, typename Iterator>
 struct CudaIterableWrapper {
-    CUDA_EXEC pol_;
-    Iterator i_;
-    constexpr CudaIterableWrapper (const CUDA_EXEC &pol, const Iterator &i)
-        : pol_(pol), i_(i) {
-    }
+  CUDA_EXEC pol_;
+  Iterator i_;
+  constexpr CudaIterableWrapper(const CUDA_EXEC &pol, const Iterator &i)
+      : pol_(pol), i_(i)
+  {
+  }
 
-    __device__ inline decltype(i_[0]) operator()() {
-        auto val = pol_();
-        return val > INT_MIN ? i_[pol_()] : INT_MIN;
-    }
+  __device__ inline decltype(i_[0]) operator()()
+  {
+    auto val = pol_();
+    return val > INT_MIN ? i_[pol_()] : INT_MIN;
+  }
 };
 
 template <typename CUDA_EXEC, typename Iterator>
-auto make_cuda_iter_wrapper(const CUDA_EXEC &pol, const Iterator &i) -> CudaIterableWrapper<CUDA_EXEC, Iterator> {
-    return CudaIterableWrapper<CUDA_EXEC, Iterator>(pol, i);
+auto make_cuda_iter_wrapper(const CUDA_EXEC &pol, const Iterator &i)
+    -> CudaIterableWrapper<CUDA_EXEC, Iterator>
+{
+  return CudaIterableWrapper<CUDA_EXEC, Iterator>(pol, i);
 }
 
 /*!
@@ -314,7 +312,8 @@ RAJA_INLINE __device__ void cudaCheckBounds(BODY &body, int i)
 }
 
 /*!
- * \brief Launcher that uses execution policies to map blockIdx and threadIdx to map
+ * \brief Launcher that uses execution policies to map blockIdx and threadIdx to
+ * map
  * to N-argument function
  */
 template <typename BODY, typename... CARGS>
@@ -376,7 +375,8 @@ struct ForallN_Executor<ForallN_PolicyPair<CudaPolicy<CuARG0>, ISET0>,
                  body,
                  make_cuda_iter_wrapper(CuARG0(dims, iset0), std::begin(iset0)),
                  make_cuda_iter_wrapper(CuARG1(dims, iset1), std::begin(iset1)),
-                 make_cuda_iter_wrapper(CuARGS(dims, std::get<N>(isets)), std::begin(std::get<N>(isets)))...);
+                 make_cuda_iter_wrapper(CuARGS(dims, std::get<N>(isets)),
+                                        std::begin(std::get<N>(isets)))...);
   }
 
   template <typename BODY, typename... CARGS>
@@ -385,8 +385,9 @@ struct ForallN_Executor<ForallN_PolicyPair<CudaPolicy<CuARG0>, ISET0>,
                                 CARGS const &... cargs) const
   {
     if (numBlocks(dims) > 0 && numThreads(dims) > 0) {
-      cudaLauncherN<<<RAJA_CUDA_LAUNCH_PARAMS(dims.num_blocks, dims.num_threads)
-                   >>>(body, cargs...);
+      cudaLauncherN<<<RAJA_CUDA_LAUNCH_PARAMS(dims.num_blocks,
+                                              dims.num_threads)>>>(body,
+                                                                   cargs...);
     }
 
     RAJA_CUDA_CHECK_AND_SYNC(true);
@@ -409,8 +410,8 @@ struct ForallN_Executor<ForallN_PolicyPair<CudaPolicy<CuARG0>, ISET0>> {
     auto c0 = make_cuda_iter_wrapper(CuARG0(dims, iset0), std::begin(iset0));
 
     if (numBlocks(dims) > 0 && numThreads(dims) > 0) {
-      cudaLauncherN<<<RAJA_CUDA_LAUNCH_PARAMS(dims.num_blocks, dims.num_threads)
-                   >>>(body, c0);
+      cudaLauncherN<<<RAJA_CUDA_LAUNCH_PARAMS(dims.num_blocks,
+                                              dims.num_threads)>>>(body, c0);
     }
 
     RAJA_CUDA_CHECK_AND_SYNC(true);

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -120,20 +120,25 @@ struct Dim3z {
 /// Segment execution policies
 ///
 
-namespace detail {
-  template <bool Async>
-  struct get_launch {
-    static constexpr RAJA::Launch value = RAJA::Launch::async;
-  };
+namespace detail
+{
+template <bool Async>
+struct get_launch {
+  static constexpr RAJA::Launch value = RAJA::Launch::async;
+};
 
-  template <>
-  struct get_launch<false> {
-    static constexpr RAJA::Launch value = RAJA::Launch::sync;
-  };
+template <>
+struct get_launch<false> {
+  static constexpr RAJA::Launch value = RAJA::Launch::sync;
+};
 }
 
 template <size_t BLOCK_SIZE, bool Async = false>
-struct cuda_exec : public RAJA::make_policy_launch_pattern<RAJA::Policy::cuda, detail::get_launch<Async>::value, RAJA::Pattern::forall> {};
+struct cuda_exec
+    : public RAJA::make_policy_launch_pattern<RAJA::Policy::cuda,
+                                              detail::get_launch<Async>::value,
+                                              RAJA::Pattern::forall> {
+};
 
 //
 // NOTE: There is no Index set segment iteration policy for CUDA
@@ -148,13 +153,21 @@ struct cuda_exec : public RAJA::make_policy_launch_pattern<RAJA::Policy::cuda, d
 ///
 
 template <size_t BLOCK_SIZE, bool Async = false>
-struct cuda_reduce : public RAJA::make_policy_launch_pattern<RAJA::Policy::cuda, detail::get_launch<Async>::value, RAJA::Pattern::reduce> {};
+struct cuda_reduce
+    : public RAJA::make_policy_launch_pattern<RAJA::Policy::cuda,
+                                              detail::get_launch<Async>::value,
+                                              RAJA::Pattern::reduce> {
+};
 
 template <size_t BLOCK_SIZE>
 using cuda_reduce_async = cuda_reduce<BLOCK_SIZE, true>;
 
 template <size_t BLOCK_SIZE, bool Async = false>
-struct cuda_reduce_atomic : public RAJA::make_policy_launch_pattern<RAJA::Policy::cuda, detail::get_launch<Async>::value, RAJA::Pattern::reduce> {};
+struct cuda_reduce_atomic
+    : public RAJA::make_policy_launch_pattern<RAJA::Policy::cuda,
+                                              detail::get_launch<Async>::value,
+                                              RAJA::Pattern::reduce> {
+};
 
 template <size_t BLOCK_SIZE>
 using cuda_reduce_atomic_async = cuda_reduce_atomic<BLOCK_SIZE, true>;

--- a/include/RAJA/policy/cuda/raja_cudaerrchk.hpp
+++ b/include/RAJA/policy/cuda/raja_cudaerrchk.hpp
@@ -78,8 +78,8 @@ namespace RAJA
 ///
 ///////////////////////////////////////////////////////////////////////
 ///
-#define cudaErrchk(ans)                          \
-  {                                              \
+#define cudaErrchk(ans)                            \
+  {                                                \
     ::RAJA::cudaAssert((ans), __FILE__, __LINE__); \
   }
 
@@ -98,10 +98,10 @@ inline void cudaAssert(cudaError_t code,
 /*!
  * \def RAJA_CUDA_CHECK_AND_SYNC(Async)
  * Macro that checks for errors and synchronizes based on paramater Async.
- */ 
-#define RAJA_CUDA_CHECK_AND_SYNC(Async) \
-  cudaErrchk(cudaPeekAtLastError()); \
-  if (!Async) { \
+ */
+#define RAJA_CUDA_CHECK_AND_SYNC(Async)  \
+  cudaErrchk(cudaPeekAtLastError());     \
+  if (!Async) {                          \
     cudaErrchk(cudaDeviceSynchronize()); \
   }
 

--- a/include/RAJA/policy/cuda/reduce.hpp
+++ b/include/RAJA/policy/cuda/reduce.hpp
@@ -65,8 +65,8 @@
 #include "RAJA/pattern/reduce.hpp"
 
 #include "RAJA/policy/cuda/MemUtils_CUDA.hpp"
-#include "RAJA/policy/cuda/raja_cudaerrchk.hpp"
 #include "RAJA/policy/cuda/policy.hpp"
+#include "RAJA/policy/cuda/raja_cudaerrchk.hpp"
 
 #include <cuda.h>
 
@@ -83,24 +83,23 @@ namespace HIDDEN
  *
  ******************************************************************************
  */
-template<typename T>
+template <typename T>
 __device__ __forceinline__ T shfl_xor(T var, int laneMask)
 {
-  const int int_sizeof_T =
-      (sizeof(T) + sizeof(int) - 1) / sizeof(int);
+  const int int_sizeof_T = (sizeof(T) + sizeof(int) - 1) / sizeof(int);
   union {
     T var;
     int arr[int_sizeof_T];
   } Tunion;
   Tunion.var = var;
 
-  for(int i = 0; i < int_sizeof_T; ++i) {
+  for (int i = 0; i < int_sizeof_T; ++i) {
     Tunion.arr[i] = __shfl_xor(Tunion.arr[i], laneMask);
   }
   return Tunion.var;
 }
 
-} // end HIDDEN namespace for helper functions
+}  // end HIDDEN namespace for helper functions
 
 //
 //////////////////////////////////////////////////////////////////////
@@ -248,7 +247,8 @@ public:
    *
    * Note: only operates on device.
    */
-  __device__ ReduceMin<cuda_reduce<BLOCK_SIZE, Async>, T> const &min(T val) const
+  __device__ ReduceMin<cuda_reduce<BLOCK_SIZE, Async>, T> const &min(
+      T val) const
   {
     extern __shared__ unsigned char sd_block[];
     T *sd = reinterpret_cast<T *>(&sd_block[m_smem_offset]);
@@ -309,8 +309,8 @@ private:
   static_assert(reasonableRangeCheck,
                 "Error: block sizes must be between 32 and 1024");
   static_assert(sizeofcheck,
-      "Error: type must be of size <= "
-      RAJA_STRINGIFY_MACRO(RAJA_CUDA_REDUCE_VAR_MAXSIZE));
+                "Error: type must be of size <= " RAJA_STRINGIFY_MACRO(
+                    RAJA_CUDA_REDUCE_VAR_MAXSIZE));
 };
 
 /*!
@@ -451,8 +451,8 @@ public:
    *
    * Note: only operates on device.
    */
-  __device__ ReduceMax<cuda_reduce<BLOCK_SIZE, Async>, T> const &max(T val)
-   const
+  __device__ ReduceMax<cuda_reduce<BLOCK_SIZE, Async>, T> const &max(
+      T val) const
   {
     extern __shared__ unsigned char sd_block[];
     T *sd = reinterpret_cast<T *>(&sd_block[m_smem_offset]);
@@ -513,8 +513,8 @@ private:
   static_assert(reasonableRangeCheck,
                 "Error: block sizes must be between 32 and 1024");
   static_assert(sizeofcheck,
-      "Error: type must be of size <= "
-      RAJA_STRINGIFY_MACRO(RAJA_CUDA_REDUCE_VAR_MAXSIZE));
+                "Error: type must be of size <= " RAJA_STRINGIFY_MACRO(
+                    RAJA_CUDA_REDUCE_VAR_MAXSIZE));
 };
 
 /*!
@@ -775,8 +775,8 @@ private:
   static_assert(reasonableRangeCheck,
                 "Error: block sizes must be between 32 and 1024");
   static_assert(sizeofcheck,
-      "Error: type must be of size <= "
-      RAJA_STRINGIFY_MACRO(RAJA_CUDA_REDUCE_VAR_MAXSIZE));
+                "Error: type must be of size <= " RAJA_STRINGIFY_MACRO(
+                    RAJA_CUDA_REDUCE_VAR_MAXSIZE));
 };
 
 /*!
@@ -896,8 +896,6 @@ public:
       releaseCudaReductionId(m_myID);
     }
 #endif
-
-
   }
 
   /*!
@@ -985,8 +983,8 @@ private:
   static_assert(reasonableRangeCheck,
                 "Error: block sizes must be between 32 and 1024");
   static_assert(sizeofcheck,
-      "Error: type must be of size <= "
-      RAJA_STRINGIFY_MACRO(RAJA_CUDA_REDUCE_VAR_MAXSIZE));
+                "Error: type must be of size <= " RAJA_STRINGIFY_MACRO(
+                    RAJA_CUDA_REDUCE_VAR_MAXSIZE));
 };
 
 /*!
@@ -1062,9 +1060,9 @@ public:
     __syncthreads();
 #else
     m_is_copy_host = true;
-    m_smem_offset =
-        getCudaSharedmemOffset(m_myID, BLOCK_SIZE,
-                               (sizeof(T) + sizeof(Index_type)));
+    m_smem_offset = getCudaSharedmemOffset(m_myID,
+                                           BLOCK_SIZE,
+                                           (sizeof(T) + sizeof(Index_type)));
 #endif
   }
 
@@ -1099,11 +1097,11 @@ public:
       for (int i = BLOCK_SIZE / 2; i >= WARP_SIZE; i /= 2) {
         if (threadId < i) {
           RAJA_MINLOC_UNSTRUCTURED(sd_val[threadId],
-                           sd_idx[threadId],
-                           sd_val[threadId],
-                           sd_idx[threadId],
-                           sd_val[threadId + i],
-                           sd_idx[threadId + i]);
+                                   sd_idx[threadId],
+                                   sd_val[threadId],
+                                   sd_idx[threadId],
+                                   sd_val[threadId + i],
+                                   sd_idx[threadId + i]);
         }
         __syncthreads();
       }
@@ -1111,11 +1109,11 @@ public:
       for (int i = WARP_SIZE / 2; i > 0; i /= 2) {
         if (threadId < i) {
           RAJA_MINLOC_UNSTRUCTURED(sd_val[threadId],
-                           sd_idx[threadId],
-                           sd_val[threadId],
-                           sd_idx[threadId],
-                           sd_val[threadId + i],
-                           sd_idx[threadId + i]);
+                                   sd_idx[threadId],
+                                   sd_val[threadId],
+                                   sd_idx[threadId],
+                                   sd_val[threadId + i],
+                                   sd_idx[threadId + i]);
         }
       }
 
@@ -1138,11 +1136,11 @@ public:
         int threads = blockDim.x * blockDim.y * blockDim.z;
         for (int i = threadId; i < blocks; i += threads) {
           RAJA_MINLOC_UNSTRUCTURED(lmin.val,
-                           lmin.idx,
-                           lmin.val,
-                           lmin.idx,
-                           m_blockdata->values[i],
-                           m_blockdata->indices[i]);
+                                   lmin.idx,
+                                   lmin.val,
+                                   lmin.idx,
+                                   m_blockdata->values[i],
+                                   m_blockdata->indices[i]);
         }
         sd_val[threadId] = lmin.val;
         sd_idx[threadId] = lmin.idx;
@@ -1151,11 +1149,11 @@ public:
         for (int i = BLOCK_SIZE / 2; i >= WARP_SIZE; i /= 2) {
           if (threadId < i) {
             RAJA_MINLOC_UNSTRUCTURED(sd_val[threadId],
-                             sd_idx[threadId],
-                             sd_val[threadId],
-                             sd_idx[threadId],
-                             sd_val[threadId + i],
-                             sd_idx[threadId + i]);
+                                     sd_idx[threadId],
+                                     sd_val[threadId],
+                                     sd_idx[threadId],
+                                     sd_val[threadId + i],
+                                     sd_idx[threadId + i]);
           }
           __syncthreads();
         }
@@ -1163,21 +1161,21 @@ public:
         for (int i = WARP_SIZE / 2; i > 0; i /= 2) {
           if (threadId < i) {
             RAJA_MINLOC_UNSTRUCTURED(sd_val[threadId],
-                             sd_idx[threadId],
-                             sd_val[threadId],
-                             sd_idx[threadId],
-                             sd_val[threadId + i],
-                             sd_idx[threadId + i]);
+                                     sd_idx[threadId],
+                                     sd_val[threadId],
+                                     sd_idx[threadId],
+                                     sd_val[threadId + i],
+                                     sd_idx[threadId + i]);
           }
         }
 
         if (threadId < 1) {
           RAJA_MINLOC_UNSTRUCTURED(m_tally_device->tally.val,
-                           m_tally_device->tally.idx,
-                           m_tally_device->tally.val,
-                           m_tally_device->tally.idx,
-                           sd_val[threadId],
-                           sd_idx[threadId]);
+                                   m_tally_device->tally.idx,
+                                   m_tally_device->tally.val,
+                                   m_tally_device->tally.idx,
+                                   sd_val[threadId],
+                                   sd_idx[threadId]);
         }
       }
     }
@@ -1236,11 +1234,11 @@ public:
                    + (blockDim.x * blockDim.y) * threadIdx.z;
 
     RAJA_MINLOC_UNSTRUCTURED(sd_val[threadId],
-                     sd_idx[threadId],
-                     sd_val[threadId],
-                     sd_idx[threadId],
-                     val,
-                     idx);
+                             sd_idx[threadId],
+                             sd_val[threadId],
+                             sd_idx[threadId],
+                             val,
+                             idx);
 
     return *this;
   }
@@ -1298,8 +1296,8 @@ private:
   static_assert(reasonableRangeCheck,
                 "Error: block sizes must be between 32 and 1024");
   static_assert(sizeofcheck,
-      "Error: type must be of size <= "
-      RAJA_STRINGIFY_MACRO(RAJA_CUDA_REDUCE_VAR_MAXSIZE));
+                "Error: type must be of size <= " RAJA_STRINGIFY_MACRO(
+                    RAJA_CUDA_REDUCE_VAR_MAXSIZE));
 };
 
 /*!
@@ -1375,9 +1373,9 @@ public:
     __syncthreads();
 #else
     m_is_copy_host = true;
-    m_smem_offset =
-        getCudaSharedmemOffset(m_myID, BLOCK_SIZE,
-                               (sizeof(T) + sizeof(Index_type)));
+    m_smem_offset = getCudaSharedmemOffset(m_myID,
+                                           BLOCK_SIZE,
+                                           (sizeof(T) + sizeof(Index_type)));
 #endif
   }
 
@@ -1412,11 +1410,11 @@ public:
       for (int i = BLOCK_SIZE / 2; i >= WARP_SIZE; i /= 2) {
         if (threadId < i) {
           RAJA_MAXLOC_UNSTRUCTURED(sd_val[threadId],
-                           sd_idx[threadId],
-                           sd_val[threadId],
-                           sd_idx[threadId],
-                           sd_val[threadId + i],
-                           sd_idx[threadId + i]);
+                                   sd_idx[threadId],
+                                   sd_val[threadId],
+                                   sd_idx[threadId],
+                                   sd_val[threadId + i],
+                                   sd_idx[threadId + i]);
         }
         __syncthreads();
       }
@@ -1424,11 +1422,11 @@ public:
       for (int i = WARP_SIZE / 2; i > 0; i /= 2) {
         if (threadId < i) {
           RAJA_MAXLOC_UNSTRUCTURED(sd_val[threadId],
-                           sd_idx[threadId],
-                           sd_val[threadId],
-                           sd_idx[threadId],
-                           sd_val[threadId + i],
-                           sd_idx[threadId + i]);
+                                   sd_idx[threadId],
+                                   sd_val[threadId],
+                                   sd_idx[threadId],
+                                   sd_val[threadId + i],
+                                   sd_idx[threadId + i]);
         }
       }
 
@@ -1451,11 +1449,11 @@ public:
         int threads = blockDim.x * blockDim.y * blockDim.z;
         for (int i = threadId; i < blocks; i += threads) {
           RAJA_MAXLOC_UNSTRUCTURED(lmax.val,
-                           lmax.idx,
-                           lmax.val,
-                           lmax.idx,
-                           m_blockdata->values[i],
-                           m_blockdata->indices[i]);
+                                   lmax.idx,
+                                   lmax.val,
+                                   lmax.idx,
+                                   m_blockdata->values[i],
+                                   m_blockdata->indices[i]);
         }
         sd_val[threadId] = lmax.val;
         sd_idx[threadId] = lmax.idx;
@@ -1464,11 +1462,11 @@ public:
         for (int i = BLOCK_SIZE / 2; i >= WARP_SIZE; i /= 2) {
           if (threadId < i) {
             RAJA_MAXLOC_UNSTRUCTURED(sd_val[threadId],
-                             sd_idx[threadId],
-                             sd_val[threadId],
-                             sd_idx[threadId],
-                             sd_val[threadId + i],
-                             sd_idx[threadId + i]);
+                                     sd_idx[threadId],
+                                     sd_val[threadId],
+                                     sd_idx[threadId],
+                                     sd_val[threadId + i],
+                                     sd_idx[threadId + i]);
           }
           __syncthreads();
         }
@@ -1476,21 +1474,21 @@ public:
         for (int i = WARP_SIZE / 2; i > 0; i /= 2) {
           if (threadId < i) {
             RAJA_MAXLOC_UNSTRUCTURED(sd_val[threadId],
-                             sd_idx[threadId],
-                             sd_val[threadId],
-                             sd_idx[threadId],
-                             sd_val[threadId + i],
-                             sd_idx[threadId + i]);
+                                     sd_idx[threadId],
+                                     sd_val[threadId],
+                                     sd_idx[threadId],
+                                     sd_val[threadId + i],
+                                     sd_idx[threadId + i]);
           }
         }
 
         if (threadId < 1) {
           RAJA_MAXLOC_UNSTRUCTURED(m_tally_device->tally.val,
-                           m_tally_device->tally.idx,
-                           m_tally_device->tally.val,
-                           m_tally_device->tally.idx,
-                           sd_val[threadId],
-                           sd_idx[threadId]);
+                                   m_tally_device->tally.idx,
+                                   m_tally_device->tally.val,
+                                   m_tally_device->tally.idx,
+                                   sd_val[threadId],
+                                   sd_idx[threadId]);
         }
       }
     }
@@ -1500,8 +1498,6 @@ public:
       releaseCudaReductionId(m_myID);
     }
 #endif
-
-
   }
 
   /*!
@@ -1551,11 +1547,11 @@ public:
                    + (blockDim.x * blockDim.y) * threadIdx.z;
 
     RAJA_MAXLOC_UNSTRUCTURED(sd_val[threadId],
-                     sd_idx[threadId],
-                     sd_val[threadId],
-                     sd_idx[threadId],
-                     val,
-                     idx);
+                             sd_idx[threadId],
+                             sd_val[threadId],
+                             sd_idx[threadId],
+                             val,
+                             idx);
     return *this;
   }
 
@@ -1612,8 +1608,8 @@ private:
   static_assert(reasonableRangeCheck,
                 "Error: block sizes must be between 32 and 1024");
   static_assert(sizeofcheck,
-      "Error: type must be of size <= "
-      RAJA_STRINGIFY_MACRO(RAJA_CUDA_REDUCE_VAR_MAXSIZE));
+                "Error: type must be of size <= " RAJA_STRINGIFY_MACRO(
+                    RAJA_CUDA_REDUCE_VAR_MAXSIZE));
 };
 
 }  // closing brace for RAJA namespace

--- a/include/RAJA/policy/cuda/scan.hpp
+++ b/include/RAJA/policy/cuda/scan.hpp
@@ -63,8 +63,8 @@
 #include <type_traits>
 
 #if defined(RAJA_ENABLE_CUB)
-#include "cub/util_allocator.cuh"
 #include "cub/device/device_scan.cuh"
+#include "cub/util_allocator.cuh"
 #else
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
@@ -80,7 +80,8 @@ namespace scan
 {
 
 #if defined(RAJA_ENABLE_CUB)
-RAJA_INLINE ::cub::CachingDeviceAllocator& getAllocator() {
+RAJA_INLINE::cub::CachingDeviceAllocator& getAllocator()
+{
   static ::cub::CachingDeviceAllocator allocator(true);
   return allocator;
 }
@@ -90,10 +91,7 @@ RAJA_INLINE ::cub::CachingDeviceAllocator& getAllocator() {
         \brief explicit inclusive inplace scan given range, function, and
    initial value
 */
-template <size_t BLOCK_SIZE,
-          bool Async,
-          typename InputIter,
-          typename Function>
+template <size_t BLOCK_SIZE, bool Async, typename InputIter, typename Function>
 void inclusive_inplace(const ::RAJA::cuda_exec<BLOCK_SIZE, Async>&,
                        InputIter begin,
                        InputIter end,
@@ -104,11 +102,14 @@ void inclusive_inplace(const ::RAJA::cuda_exec<BLOCK_SIZE, Async>&,
   // Determine temporary device storage requirements
   void* d_temp_storage = NULL;
   size_t temp_storage_bytes = 0;
-  cudaErrchk(::cub::DeviceScan::InclusiveScan(d_temp_storage, temp_storage_bytes, begin, begin, binary_op, len));
+  cudaErrchk(::cub::DeviceScan::InclusiveScan(
+      d_temp_storage, temp_storage_bytes, begin, begin, binary_op, len));
   // Allocate temporary storage
-  cudaErrchk(getAllocator().DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+  cudaErrchk(
+      getAllocator().DeviceAllocate(&d_temp_storage, temp_storage_bytes));
   // Run
-  cudaErrchk(::cub::DeviceScan::InclusiveScan(d_temp_storage, temp_storage_bytes, begin, begin, binary_op, len));
+  cudaErrchk(::cub::DeviceScan::InclusiveScan(
+      d_temp_storage, temp_storage_bytes, begin, begin, binary_op, len));
   // Free temporary storage
   cudaErrchk(getAllocator().DeviceFree(d_temp_storage));
 #else
@@ -137,11 +138,14 @@ void exclusive_inplace(const ::RAJA::cuda_exec<BLOCK_SIZE, Async>&,
   // Determine temporary device storage requirements
   void* d_temp_storage = NULL;
   size_t temp_storage_bytes = 0;
-  cudaErrchk(::cub::DeviceScan::ExclusiveScan(d_temp_storage, temp_storage_bytes, begin, begin, binary_op, init, len));
+  cudaErrchk(::cub::DeviceScan::ExclusiveScan(
+      d_temp_storage, temp_storage_bytes, begin, begin, binary_op, init, len));
   // Allocate temporary storage
-  cudaErrchk(getAllocator().DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+  cudaErrchk(
+      getAllocator().DeviceAllocate(&d_temp_storage, temp_storage_bytes));
   // Run
-  cudaErrchk(::cub::DeviceScan::ExclusiveScan(d_temp_storage, temp_storage_bytes, begin, begin, binary_op, init, len));
+  cudaErrchk(::cub::DeviceScan::ExclusiveScan(
+      d_temp_storage, temp_storage_bytes, begin, begin, binary_op, init, len));
   // Free temporary storage
   cudaErrchk(getAllocator().DeviceFree(d_temp_storage));
 #else
@@ -171,11 +175,14 @@ void inclusive(const ::RAJA::cuda_exec<BLOCK_SIZE, Async>&,
   // Determine temporary device storage requirements
   void* d_temp_storage = NULL;
   size_t temp_storage_bytes = 0;
-  cudaErrchk(::cub::DeviceScan::InclusiveScan(d_temp_storage, temp_storage_bytes, begin, out, binary_op, len));
+  cudaErrchk(::cub::DeviceScan::InclusiveScan(
+      d_temp_storage, temp_storage_bytes, begin, out, binary_op, len));
   // Allocate temporary storage
-  cudaErrchk(getAllocator().DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+  cudaErrchk(
+      getAllocator().DeviceAllocate(&d_temp_storage, temp_storage_bytes));
   // Run
-  cudaErrchk(::cub::DeviceScan::InclusiveScan(d_temp_storage, temp_storage_bytes, begin, out, binary_op, len));
+  cudaErrchk(::cub::DeviceScan::InclusiveScan(
+      d_temp_storage, temp_storage_bytes, begin, out, binary_op, len));
   // Free temporary storage
   cudaErrchk(getAllocator().DeviceFree(d_temp_storage));
 #else
@@ -206,11 +213,14 @@ void exclusive(const ::RAJA::cuda_exec<BLOCK_SIZE, Async>&,
   // Determine temporary device storage requirements
   void* d_temp_storage = NULL;
   size_t temp_storage_bytes = 0;
-  cudaErrchk(::cub::DeviceScan::ExclusiveScan(d_temp_storage, temp_storage_bytes, begin, out, binary_op, init, len));
+  cudaErrchk(::cub::DeviceScan::ExclusiveScan(
+      d_temp_storage, temp_storage_bytes, begin, out, binary_op, init, len));
   // Allocate temporary storage
-  cudaErrchk(getAllocator().DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+  cudaErrchk(
+      getAllocator().DeviceAllocate(&d_temp_storage, temp_storage_bytes));
   // Run
-  cudaErrchk(::cub::DeviceScan::ExclusiveScan(d_temp_storage, temp_storage_bytes, begin, out, binary_op, init, len));
+  cudaErrchk(::cub::DeviceScan::ExclusiveScan(
+      d_temp_storage, temp_storage_bytes, begin, out, binary_op, init, len));
   // Free temporary storage
   cudaErrchk(getAllocator().DeviceFree(d_temp_storage));
 #else

--- a/include/RAJA/policy/openmp.hpp
+++ b/include/RAJA/policy/openmp.hpp
@@ -64,8 +64,8 @@
 #include <iostream>
 #include <thread>
 
-#include "RAJA/policy/openmp/policy.hpp"
 #include "RAJA/policy/openmp/forall.hpp"
+#include "RAJA/policy/openmp/policy.hpp"
 #include "RAJA/policy/openmp/reduce.hpp"
 #include "RAJA/policy/openmp/scan.hpp"
 

--- a/include/RAJA/policy/openmp/forall.hpp
+++ b/include/RAJA/policy/openmp/forall.hpp
@@ -64,9 +64,9 @@
 
 #include "RAJA/internal/fault_tolerance.hpp"
 
-#include "RAJA/index/RangeSegment.hpp"
-#include "RAJA/index/ListSegment.hpp"
 #include "RAJA/index/IndexSet.hpp"
+#include "RAJA/index/ListSegment.hpp"
+#include "RAJA/index/RangeSegment.hpp"
 
 #include "RAJA/policy/openmp/policy.hpp"
 
@@ -83,7 +83,8 @@ namespace impl
 {
 
 template <typename SEG_EXEC_POLICY_T, typename LOOP_BODY>
-RAJA_INLINE void executeRangeList_forall(const IndexSetSegInfo* seg_info, LOOP_BODY&& loop_body);
+RAJA_INLINE void executeRangeList_forall(const IndexSetSegInfo* seg_info,
+                                         LOOP_BODY&& loop_body);
 
 ///
 /// OpenMP parallel for policy implementation
@@ -97,8 +98,7 @@ RAJA_INLINE void forall(const omp_parallel_exec<InnerPolicy>&,
 #pragma omp parallel
   {
     typename std::remove_reference<decltype(loop_body)>::type body = loop_body;
-    forall<InnerPolicy>(std::forward<Iterable>(iter),
-                        std::forward<Func>(body));
+    forall<InnerPolicy>(std::forward<Iterable>(iter), std::forward<Func>(body));
   }
 }
 

--- a/include/RAJA/policy/openmp/forallN.hpp
+++ b/include/RAJA/policy/openmp/forallN.hpp
@@ -57,8 +57,8 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "RAJA/util/types.hpp"
 #include "RAJA/internal/ForallNPolicy.hpp"
+#include "RAJA/util/types.hpp"
 
 #include "RAJA/policy/openmp/policy.hpp"
 
@@ -200,8 +200,10 @@ struct ForallN_Executor<ForallN_PolicyPair<omp_collapse_nowait_exec,
 
   RAJA_INLINE
   constexpr ForallN_Executor(
-      ForallN_PolicyPair<omp_collapse_nowait_exec, RangeStrideSegment> const &iseti_,
-      ForallN_PolicyPair<omp_collapse_nowait_exec, RangeStrideSegment> const &isetj_,
+      ForallN_PolicyPair<omp_collapse_nowait_exec, RangeStrideSegment> const
+          &iseti_,
+      ForallN_PolicyPair<omp_collapse_nowait_exec, RangeStrideSegment> const
+          &isetj_,
       PREST const &... prest)
       : iset_i(iseti_), iset_j(isetj_), next_exec(prest...)
   {
@@ -225,8 +227,8 @@ struct ForallN_Executor<ForallN_PolicyPair<omp_collapse_nowait_exec,
 #else
 #pragma omp for nowait
 #endif
-    for (int i = begin_i; i < end_i; i+=stride_i) {
-      for (int j = begin_j; j < end_j; j+=stride_j) {
+    for (int i = begin_i; i < end_i; i += stride_i) {
+      for (int j = begin_j; j < end_j; j += stride_j) {
         outer(i, j);
       }
     }
@@ -250,9 +252,12 @@ struct ForallN_Executor<ForallN_PolicyPair<omp_collapse_nowait_exec,
 
   RAJA_INLINE
   constexpr ForallN_Executor(
-      ForallN_PolicyPair<omp_collapse_nowait_exec, RangeStrideSegment> const &iseti_,
-      ForallN_PolicyPair<omp_collapse_nowait_exec, RangeStrideSegment> const &isetj_,
-      ForallN_PolicyPair<omp_collapse_nowait_exec, RangeStrideSegment> const &isetk_,
+      ForallN_PolicyPair<omp_collapse_nowait_exec, RangeStrideSegment> const
+          &iseti_,
+      ForallN_PolicyPair<omp_collapse_nowait_exec, RangeStrideSegment> const
+          &isetj_,
+      ForallN_PolicyPair<omp_collapse_nowait_exec, RangeStrideSegment> const
+          &isetk_,
       PREST... prest)
       : iset_i(iseti_), iset_j(isetj_), iset_k(isetk_), next_exec(prest...)
   {
@@ -278,9 +283,9 @@ struct ForallN_Executor<ForallN_PolicyPair<omp_collapse_nowait_exec,
 #else
 #pragma omp for nowait
 #endif
-    for (int i = begin_i; i < end_i; i+=stride_i) {
-      for (int j = begin_j; j < end_j; j+=stride_j) {
-        for (int k = begin_k; k < end_k; k+=stride_k) {
+    for (int i = begin_i; i < end_i; i += stride_i) {
+      for (int j = begin_j; j < end_j; j += stride_j) {
+        for (int k = begin_k; k < end_k; k += stride_k) {
           outer(i, j, k);
         }
       }

--- a/include/RAJA/policy/openmp/forallN.hpp
+++ b/include/RAJA/policy/openmp/forallN.hpp
@@ -82,12 +82,10 @@ struct OMP_Parallel {
   typedef NEXT NextPolicy;
 };
 
-/******************************************************************
- *  ForallN collapse nowait policies
- ******************************************************************/
 
-struct omp_collapse_nowait_exec {
-};
+/******************************************************************
+ *  ForallN collapse nowait execution templates
+ ******************************************************************/
 
 template <typename... PREST>
 struct ForallN_Executor<ForallN_PolicyPair<omp_collapse_nowait_exec,

--- a/include/RAJA/policy/openmp/policy.hpp
+++ b/include/RAJA/policy/openmp/policy.hpp
@@ -96,6 +96,7 @@ struct omp_for_nowait_exec
                                        RAJA::Pattern::forall> {
 };
 
+
 ///
 /// Index set segment iteration policies
 ///
@@ -110,6 +111,13 @@ struct omp_taskgraph_segit
 struct omp_taskgraph_interval_segit
     : public RAJA::make_policy_pattern<RAJA::Policy::openmp,
                                        RAJA::Pattern::taskgraph> {
+};
+
+
+///
+/// Policies for applying OpenMP clauses in forallN loop nests.
+///
+struct omp_collapse_nowait_exec {
 };
 
 ///

--- a/include/RAJA/policy/openmp/reduce.hpp
+++ b/include/RAJA/policy/openmp/reduce.hpp
@@ -91,17 +91,13 @@ public:
   //
   // Constructor takes default value (default ctor is disabled).
   //
-  explicit ReduceMin(T init_val):
-    m_parent(NULL), m_val(init_val)
-  {
-  }
+  explicit ReduceMin(T init_val) : m_parent(NULL), m_val(init_val) {}
 
   //
   // Copy ctor.
   //
-  ReduceMin(const ReduceMin<omp_reduce, T>& other):
-    m_parent(other.m_parent ? other.m_parent : &other),
-    m_val(other.m_val)
+  ReduceMin(const ReduceMin<omp_reduce, T>& other)
+      : m_parent(other.m_parent ? other.m_parent : &other), m_val(other.m_val)
   {
   }
 
@@ -121,10 +117,7 @@ public:
   //
   // Operator that returns reduced min value.
   //
-  operator T()
-  {
-    return m_val;
-  }
+  operator T() { return m_val; }
 
   //
   // Method that returns reduced min value.
@@ -141,7 +134,8 @@ public:
     return *this;
   }
 
-  ReduceMin<omp_reduce, T>& min(T rhs) {
+  ReduceMin<omp_reduce, T>& min(T rhs)
+  {
     m_val = RAJA_MIN(m_val, rhs);
     return *this;
   }
@@ -152,7 +146,7 @@ private:
   //
   ReduceMin<omp_reduce, T>();
 
-  const my_type * m_parent;
+  const my_type* m_parent;
   mutable T m_val;
 };
 
@@ -174,18 +168,18 @@ public:
   //
   // Constructor takes default value (default ctor is disabled).
   //
-  explicit ReduceMinLoc(T init_val, Index_type init_loc):
-    m_parent(NULL), m_val(init_val), m_idx(init_loc)
+  explicit ReduceMinLoc(T init_val, Index_type init_loc)
+      : m_parent(NULL), m_val(init_val), m_idx(init_loc)
   {
   }
 
   //
   // Copy ctor.
   //
-  ReduceMinLoc(const ReduceMinLoc<omp_reduce, T>& other):
-    m_parent(other.m_parent ? other.m_parent : &other),
-    m_val(other.m_val),
-    m_idx(other.m_idx)
+  ReduceMinLoc(const ReduceMinLoc<omp_reduce, T>& other)
+      : m_parent(other.m_parent ? other.m_parent : &other),
+        m_val(other.m_val),
+        m_idx(other.m_idx)
   {
   }
 
@@ -206,10 +200,7 @@ public:
   //
   // Operator that returns reduced min value.
   //
-  operator T()
-  {
-    return m_val;
-  }
+  operator T() { return m_val; }
 
   //
   // Method that returns reduced min value.
@@ -219,10 +210,7 @@ public:
   //
   // Method that returns index corresponding to reduced min value.
   //
-  Index_type getLoc()
-  {
-    return m_idx;
-  }
+  Index_type getLoc() { return m_idx; }
 
   //
   // Method that updates min and index value for current thread.
@@ -251,7 +239,7 @@ private:
   //
   ReduceMinLoc<omp_reduce, T>();
 
-  const my_type * m_parent;
+  const my_type* m_parent;
 
   mutable T m_val;
   mutable Index_type m_idx;
@@ -275,17 +263,13 @@ public:
   //
   // Constructor takes default value (default ctor is disabled).
   //
-  explicit ReduceMax(T init_val):
-    m_parent(NULL), m_val(init_val)
-  {
-  }
+  explicit ReduceMax(T init_val) : m_parent(NULL), m_val(init_val) {}
 
   //
   // Copy ctor.
   //
-  ReduceMax(const ReduceMax<omp_reduce, T>& other) :
-    m_parent(other.m_parent ? other.m_parent : &other),
-    m_val(other.m_val)
+  ReduceMax(const ReduceMax<omp_reduce, T>& other)
+      : m_parent(other.m_parent ? other.m_parent : &other), m_val(other.m_val)
   {
   }
 
@@ -306,10 +290,7 @@ public:
   //
   // Operator that returns reduced max value.
   //
-  operator T()
-  {
-    return m_val;
-  }
+  operator T() { return m_val; }
 
   //
   // Method that returns reduced max value.
@@ -337,7 +318,7 @@ private:
   //
   ReduceMax<omp_reduce, T>();
 
-  const my_type * m_parent;
+  const my_type* m_parent;
 
   mutable T m_val;
 };
@@ -360,18 +341,18 @@ public:
   //
   // Constructor takes default value (default ctor is disabled).
   //
-  explicit ReduceMaxLoc(T init_val, Index_type init_loc):
-    m_parent(NULL), m_val(init_val), m_idx(init_loc)
+  explicit ReduceMaxLoc(T init_val, Index_type init_loc)
+      : m_parent(NULL), m_val(init_val), m_idx(init_loc)
   {
   }
 
   //
   // Copy ctor.
   //
-  ReduceMaxLoc(const ReduceMaxLoc<omp_reduce, T>& other):
-    m_parent(other.m_parent ? other.m_parent : &other),
-    m_val(other.m_val),
-    m_idx(other.m_idx)
+  ReduceMaxLoc(const ReduceMaxLoc<omp_reduce, T>& other)
+      : m_parent(other.m_parent ? other.m_parent : &other),
+        m_val(other.m_val),
+        m_idx(other.m_idx)
   {
   }
 
@@ -392,10 +373,7 @@ public:
   //
   // Operator that returns reduced max value.
   //
-  operator T()
-  {
-    return m_val;
-  }
+  operator T() { return m_val; }
 
   //
   // Method that returns reduced max value.
@@ -405,10 +383,7 @@ public:
   //
   // Method that returns index corresponding to reduced max value.
   //
-  Index_type getLoc()
-  {
-    return m_idx;
-  }
+  Index_type getLoc() { return m_idx; }
 
   //
   // Method that updates max and index value for current thread.
@@ -437,7 +412,7 @@ private:
   //
   ReduceMaxLoc<omp_reduce, T>();
 
-  const my_type * m_parent;
+  const my_type* m_parent;
 
   mutable T m_val;
   mutable Index_type m_idx;
@@ -462,17 +437,17 @@ public:
   // Constructor takes default value (default ctor is disabled).
   //
   explicit ReduceSum(T init_val, T initializer = 0)
-    : m_parent(NULL), m_val(init_val), m_custom_init(initializer)
+      : m_parent(NULL), m_val(init_val), m_custom_init(initializer)
   {
   }
 
   //
   // Copy ctor.
   //
-  ReduceSum(const ReduceSum<omp_reduce, T>& other) :
-    m_parent(other.m_parent ? other.m_parent : &other),
-    m_val(other.m_custom_init),
-    m_custom_init(other.m_custom_init)
+  ReduceSum(const ReduceSum<omp_reduce, T>& other)
+      : m_parent(other.m_parent ? other.m_parent : &other),
+        m_val(other.m_custom_init),
+        m_custom_init(other.m_custom_init)
   {
   }
 
@@ -493,10 +468,7 @@ public:
   //
   // Operator that returns reduced sum value.
   //
-  operator T()
-  {
-    return m_val;
-  }
+  operator T() { return m_val; }
 
   //
   // Method that returns sum value.
@@ -524,11 +496,10 @@ private:
   //
   ReduceSum<omp_reduce, T>();
 
-  const my_type * m_parent;
+  const my_type* m_parent;
 
   mutable T m_val;
   T m_custom_init;
-
 };
 
 /*

--- a/include/RAJA/policy/openmp/scan.hpp
+++ b/include/RAJA/policy/openmp/scan.hpp
@@ -55,8 +55,8 @@
 
 #include "RAJA/config.hpp"
 
-#include "RAJA/policy/sequential/scan.hpp"
 #include "RAJA/policy/openmp/policy.hpp"
+#include "RAJA/policy/sequential/scan.hpp"
 
 #include <omp.h>
 

--- a/include/RAJA/policy/sequential.hpp
+++ b/include/RAJA/policy/sequential.hpp
@@ -56,8 +56,8 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 
-#include "RAJA/policy/sequential/policy.hpp"
 #include "RAJA/policy/sequential/forall.hpp"
+#include "RAJA/policy/sequential/policy.hpp"
 #include "RAJA/policy/sequential/reduce.hpp"
 #include "RAJA/policy/sequential/scan.hpp"
 

--- a/include/RAJA/policy/sequential/forall.hpp
+++ b/include/RAJA/policy/sequential/forall.hpp
@@ -62,8 +62,8 @@
 
 #include "RAJA/policy/sequential/policy.hpp"
 
-#include "RAJA/index/RangeSegment.hpp"
 #include "RAJA/index/ListSegment.hpp"
+#include "RAJA/index/RangeSegment.hpp"
 
 #include "RAJA/internal/fault_tolerance.hpp"
 

--- a/include/RAJA/policy/sequential/reduce.hpp
+++ b/include/RAJA/policy/sequential/reduce.hpp
@@ -87,17 +87,13 @@ public:
   //
   // Constructor takes default value (default ctor is disabled).
   //
-  explicit ReduceMin(T init_m_val) :
-    m_parent(NULL), m_val(init_m_val)
-  {
-  }
+  explicit ReduceMin(T init_m_val) : m_parent(NULL), m_val(init_m_val) {}
 
   //
   // Copy ctor.
   //
-  ReduceMin(const ReduceMin<seq_reduce, T>& other) :
-    m_parent(other.m_parent ? other.m_parent : &other),
-    m_val(other.m_val)
+  ReduceMin(const ReduceMin<seq_reduce, T>& other)
+      : m_parent(other.m_parent ? other.m_parent : &other), m_val(other.m_val)
   {
   }
 
@@ -115,10 +111,7 @@ public:
   //
   // Operator that returns reduced min value.
   //
-  operator T()
-  {
-    return m_val;
-  }
+  operator T() { return m_val; }
 
   //
   // Method that returns reduced min value.
@@ -146,7 +139,7 @@ private:
   //
   ReduceMin<seq_reduce, T>();
 
-  const my_type * m_parent;
+  const my_type* m_parent;
   mutable T m_val;
 };
 
@@ -168,18 +161,18 @@ public:
   //
   // Constructor takes default value (default ctor is disabled).
   //
-  explicit ReduceMinLoc(T init_m_val, Index_type init_loc) :
-    m_parent(NULL), m_val(init_m_val), loc(init_loc)
+  explicit ReduceMinLoc(T init_m_val, Index_type init_loc)
+      : m_parent(NULL), m_val(init_m_val), loc(init_loc)
   {
   }
 
   //
   // Copy ctor.
   //
-  ReduceMinLoc(const ReduceMinLoc<seq_reduce, T>& other) :
-    m_parent(other.m_parent ? other.m_parent : &other),
-    m_val(other.m_val),
-    loc(other.loc)
+  ReduceMinLoc(const ReduceMinLoc<seq_reduce, T>& other)
+      : m_parent(other.m_parent ? other.m_parent : &other),
+        m_val(other.m_val),
+        loc(other.loc)
   {
   }
 
@@ -197,10 +190,7 @@ public:
   //
   // Operator that returns reduced min value.
   //
-  operator T()
-  {
-    return m_val;
-  }
+  operator T() { return m_val; }
 
   //
   // Method that returns reduced min value.
@@ -210,10 +200,7 @@ public:
   //
   // Method that returns index corresponding to reduced min value.
   //
-  Index_type getLoc()
-  {
-    return loc;
-  }
+  Index_type getLoc() { return loc; }
 
   //
   // Method that updates min and index value.
@@ -242,7 +229,7 @@ private:
   //
   ReduceMinLoc<seq_reduce, T>();
 
-  const my_type * m_parent;
+  const my_type* m_parent;
 
   mutable T m_val;
   mutable Index_type loc;
@@ -266,18 +253,13 @@ public:
   //
   // Constructor takes default value (default ctor is disabled).
   //
-  explicit ReduceMax(T init_m_val) :
-    m_parent(NULL),
-    m_val(init_m_val)
-  {
-  }
+  explicit ReduceMax(T init_m_val) : m_parent(NULL), m_val(init_m_val) {}
 
   //
   // Copy ctor.
   //
-  ReduceMax(const ReduceMax<seq_reduce, T>& other) :
-    m_parent(other.m_parent ? other.m_parent : &other),
-    m_val(other.m_val)
+  ReduceMax(const ReduceMax<seq_reduce, T>& other)
+      : m_parent(other.m_parent ? other.m_parent : &other), m_val(other.m_val)
   {
   }
 
@@ -295,10 +277,7 @@ public:
   //
   // Operator that returns reduced max value.
   //
-  operator T()
-  {
-    return m_val;
-  }
+  operator T() { return m_val; }
 
   //
   // Method that returns reduced max value.
@@ -326,7 +305,7 @@ private:
   //
   ReduceMax<seq_reduce, T>();
 
-  const my_type * m_parent;
+  const my_type* m_parent;
 
   mutable T m_val;
 };
@@ -349,20 +328,18 @@ public:
   //
   // Constructor takes default value (default ctor is disabled).
   //
-  explicit ReduceMaxLoc(T init_m_val, Index_type init_loc) :
-    m_parent(NULL),
-    m_val(init_m_val),
-    loc(init_loc)
+  explicit ReduceMaxLoc(T init_m_val, Index_type init_loc)
+      : m_parent(NULL), m_val(init_m_val), loc(init_loc)
   {
   }
 
   //
   // Copy ctor.
   //
-  ReduceMaxLoc(const ReduceMaxLoc<seq_reduce, T>& other) :
-    m_parent(other.m_parent ? other.m_parent : &other),
-    m_val(other.m_val),
-    loc(other.loc)
+  ReduceMaxLoc(const ReduceMaxLoc<seq_reduce, T>& other)
+      : m_parent(other.m_parent ? other.m_parent : &other),
+        m_val(other.m_val),
+        loc(other.loc)
   {
   }
 
@@ -380,10 +357,7 @@ public:
   //
   // Operator that returns reduced max value.
   //
-  operator T()
-  {
-    return m_val;
-  }
+  operator T() { return m_val; }
 
   //
   // Method that returns reduced max value.
@@ -393,10 +367,7 @@ public:
   //
   // Method that returns index corresponding to reduced max value.
   //
-  Index_type getLoc()
-  {
-    return loc;
-  }
+  Index_type getLoc() { return loc; }
 
   //
   // Method that updates max and index value.
@@ -425,7 +396,7 @@ private:
   //
   ReduceMaxLoc<seq_reduce, T>();
 
-  const my_type * m_parent;
+  const my_type* m_parent;
 
   mutable T m_val;
   mutable Index_type loc;
@@ -449,20 +420,18 @@ public:
   //
   // Constructor takes default value (default ctor is disabled).
   //
-  explicit ReduceSum(T init_m_val, T initializer = 0) :
-    m_parent(NULL),
-    m_val(init_m_val),
-    m_custom_init(initializer)
+  explicit ReduceSum(T init_m_val, T initializer = 0)
+      : m_parent(NULL), m_val(init_m_val), m_custom_init(initializer)
   {
   }
 
   //
   // Copy ctor.
   //
-  ReduceSum(const ReduceSum<seq_reduce, T>& other) :
-    m_parent(other.m_parent ? other.m_parent : &other),
-    m_val(other.m_custom_init),
-    m_custom_init(other.m_custom_init)
+  ReduceSum(const ReduceSum<seq_reduce, T>& other)
+      : m_parent(other.m_parent ? other.m_parent : &other),
+        m_val(other.m_custom_init),
+        m_custom_init(other.m_custom_init)
   {
   }
 
@@ -480,10 +449,7 @@ public:
   //
   // Operator that returns reduced sum value.
   //
-  operator T()
-  {
-    return m_val;
-  }
+  operator T() { return m_val; }
 
   //
   // Method that returns reduced sum value.
@@ -511,7 +477,7 @@ private:
   //
   ReduceSum<seq_reduce, T>();
 
-  const my_type * m_parent;
+  const my_type* m_parent;
 
   mutable T m_val;
   T m_custom_init;

--- a/include/RAJA/policy/sequential/scan.hpp
+++ b/include/RAJA/policy/sequential/scan.hpp
@@ -76,10 +76,7 @@ namespace scan
    initial value
 */
 template <typename Iter, typename BinFn>
-void inclusive_inplace(const ::RAJA::seq_exec&,
-                       Iter begin,
-                       Iter end,
-                       BinFn f)
+void inclusive_inplace(const ::RAJA::seq_exec&, Iter begin, Iter end, BinFn f)
 {
   using Value = typename ::std::iterator_traits<Iter>::value_type;
   Value agg = *begin;

--- a/include/RAJA/policy/simd.hpp
+++ b/include/RAJA/policy/simd.hpp
@@ -56,7 +56,7 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 
-#include "RAJA/policy/simd/policy.hpp"
 #include "RAJA/policy/simd/forall.hpp"
+#include "RAJA/policy/simd/policy.hpp"
 
 #endif  // closing endif for header file include guard

--- a/include/RAJA/util/OffsetLayout.hpp
+++ b/include/RAJA/util/OffsetLayout.hpp
@@ -3,7 +3,7 @@
  *
  * \file
  *
- * \brief   RAJA header file defining offset layout operations for 
+ * \brief   RAJA header file defining offset layout operations for
  *          forallN templates.
  *
  ******************************************************************************
@@ -79,9 +79,9 @@ struct OffsetLayout_impl<VarOps::index_sequence<RangeInts...>, IdxLin> {
 
   IdxLin offsets[sizeof...(RangeInts)];
 
-  constexpr RAJA_INLINE
-  OffsetLayout_impl(std::array<IdxLin, sizeof...(RangeInts)> lower,
-                    std::array<IdxLin, sizeof...(RangeInts)> upper)
+  constexpr RAJA_INLINE OffsetLayout_impl(
+      std::array<IdxLin, sizeof...(RangeInts)> lower,
+      std::array<IdxLin, sizeof...(RangeInts)> upper)
       : base_{(upper[RangeInts] - lower[RangeInts] + 1)...},
         offsets{lower[RangeInts]...}
   {
@@ -103,9 +103,9 @@ struct OffsetLayout_impl<VarOps::index_sequence<RangeInts...>, IdxLin> {
   }
 
 private:
-  constexpr RAJA_INLINE
-  OffsetLayout_impl(const std::array<IdxLin, sizeof...(RangeInts)>& offsets_in,
-                    const Layout<sizeof...(RangeInts), IdxLin>& rhs)
+  constexpr RAJA_INLINE OffsetLayout_impl(
+      const std::array<IdxLin, sizeof...(RangeInts)>& offsets_in,
+      const Layout<sizeof...(RangeInts), IdxLin>& rhs)
       : base_{rhs}, offsets{offsets_in[RangeInts]...}
   {
   }
@@ -117,15 +117,15 @@ template <size_t n_dims = 1, typename IdxLin = Index_type>
 struct OffsetLayout
     : public internal::OffsetLayout_impl<VarOps::make_index_sequence<n_dims>,
                                          IdxLin> {
-  using parent = internal::OffsetLayout_impl<
-      VarOps::make_index_sequence<n_dims>, IdxLin>;
+  using parent =
+      internal::OffsetLayout_impl<VarOps::make_index_sequence<n_dims>, IdxLin>;
 
   using internal::OffsetLayout_impl<VarOps::make_index_sequence<n_dims>,
                                     IdxLin>::OffsetLayout_impl;
 
   constexpr RAJA_INLINE RAJA_HOST_DEVICE OffsetLayout(
       const internal::OffsetLayout_impl<VarOps::make_index_sequence<n_dims>,
-                                        IdxLin> &rhs)
+                                        IdxLin>& rhs)
       : parent{rhs}
   {
   }
@@ -140,23 +140,18 @@ auto make_offset_layout(const std::array<IdxLin, n_dims>& lower,
 }
 
 template <size_t Rank, typename IdxLin = Index_type>
-auto make_permuted_offset_layout(const std::array<IdxLin,
-                                                            Rank>&
-                                                            lower,
-                                           const std::array<IdxLin,
-                                                            Rank>&
-                                                            upper,
-                                           const std::array<size_t,
-                                                            Rank>&
-                                                            permutation)
+auto make_permuted_offset_layout(const std::array<IdxLin, Rank>& lower,
+                                 const std::array<IdxLin, Rank>& upper,
+                                 const std::array<size_t, Rank>& permutation)
     -> decltype(make_offset_layout<Rank, IdxLin>(lower, upper))
 {
   std::array<IdxLin, Rank> sizes;
-  for (size_t i=0; i < Rank; ++i) {
+  for (size_t i = 0; i < Rank; ++i) {
     sizes[i] = upper[i] - lower[i] + 1;
   }
-  return internal::OffsetLayout_impl<VarOps::make_index_sequence<Rank>, IdxLin>::from_layout_and_offsets
-      (lower, make_permuted_layout(sizes, permutation));
+  return internal::OffsetLayout_impl<VarOps::make_index_sequence<Rank>,
+                                     IdxLin>::
+      from_layout_and_offsets(lower, make_permuted_layout(sizes, permutation));
 }
 
 }  // namespace RAJA

--- a/include/RAJA/util/Operators.hpp
+++ b/include/RAJA/util/Operators.hpp
@@ -230,8 +230,10 @@ struct larger_of<T, U, false> {
 
 template <typename T, typename U>
 struct larger_of {
-  using type = typename detail::
-      larger_of<T, U, (size_of<T>::value > size_of<U>::value)>::type;
+  using type =
+      typename detail::larger_of<T,
+                                 U,
+                                 (size_of<T>::value > size_of<U>::value)>::type;
 };
 
 }  // closing brace for types namespace
@@ -296,13 +298,12 @@ struct floating_point_limits<long double> {
 
 template <typename T>
 struct limits
-  : public std::conditional<
-      std::is_integral<T>::value,
-      typename std::conditional<
-        std::is_unsigned<T>::value,
-        detail::unsigned_limits<T>,
-        detail::signed_limits<T>>::type,
-      detail::floating_point_limits<T>>::type {
+    : public std::
+          conditional<std::is_integral<T>::value,
+                      typename std::conditional<std::is_unsigned<T>::value,
+                                                detail::unsigned_limits<T>,
+                                                detail::signed_limits<T>>::type,
+                      detail::floating_point_limits<T>>::type {
 };
 
 #ifdef RAJA_CHECK_LIMITS
@@ -322,9 +323,11 @@ static_assert(check<unsigned int>(), "limits for unsigned int is broken");
 static_assert(check<long>(), "limits for long is broken");
 static_assert(check<unsigned long>(), "limits for unsigned long is broken");
 static_assert(check<long int>(), "limits for long int is broken");
-static_assert(check<unsigned long int>(), "limits for unsigned long int is broken");
+static_assert(check<unsigned long int>(),
+              "limits for unsigned long int is broken");
 static_assert(check<long long>(), "limits for long long is broken");
-static_assert(check<unsigned long long>(), "limits for unsigned long long is broken");
+static_assert(check<unsigned long long>(),
+              "limits for unsigned long long is broken");
 #endif
 
 // Arithmetic

--- a/include/RAJA/util/PermutedLayout.hpp
+++ b/include/RAJA/util/PermutedLayout.hpp
@@ -3,7 +3,7 @@
  *
  * \file
  *
- * \brief   RAJA header file defining layout permutation operations for 
+ * \brief   RAJA header file defining layout permutation operations for
  *          forallN templates.
  *
  ******************************************************************************
@@ -59,16 +59,16 @@
 #include "RAJA/index/IndexValue.hpp"
 #include "RAJA/internal/LegacyCompatibility.hpp"
 #include "RAJA/util/Layout.hpp"
-#include "RAJA/util/Permutations.hpp"
 #include "RAJA/util/Operators.hpp"
+#include "RAJA/util/Permutations.hpp"
 
 namespace RAJA
 {
 
 template <size_t Rank, typename IdxLin = Index_type>
 auto make_permuted_layout(std::array<IdxLin, Rank> sizes,
-                          std::array<size_t, Rank> permutation) ->
-Layout<Rank, IdxLin>
+                          std::array<size_t, Rank> permutation)
+    -> Layout<Rank, IdxLin>
 {
   std::array<IdxLin, Rank> strides, mods;
   std::array<IdxLin, Rank> folded_strides, lmods;
@@ -96,9 +96,9 @@ Layout<Rank, IdxLin>
 }
 
 
-template<size_t ... Ints>
+template <size_t... Ints>
 using Perm = VarOps::index_sequence<Ints...>;
-template<size_t N>
+template <size_t N>
 using MakePerm = VarOps::make_index_sequence<N>;
 
 }  // namespace RAJA

--- a/include/RAJA/util/Timer.hpp
+++ b/include/RAJA/util/Timer.hpp
@@ -143,13 +143,15 @@ private:
   using DurationType = std::chrono::duration<ElapsedType>;
 
 public:
-  ChronoTimer() : tstart(ClockType::now()), tstop(ClockType::now()), 
-                  telapsed(0) {}
+  ChronoTimer() : tstart(ClockType::now()), tstop(ClockType::now()), telapsed(0)
+  {
+  }
   void start() { tstart = ClockType::now(); }
   void stop()
   {
     tstop = ClockType::now();
-    telapsed += std::chrono::duration_cast<DurationType>(tstop - tstart).count();
+    telapsed +=
+        std::chrono::duration_cast<DurationType>(tstop - tstart).count();
   }
 
   ElapsedType elapsed() { return telapsed; }
@@ -200,7 +202,11 @@ public:
 
   ElapsedType elapsed() { return (stime_elapsed + nstime_elapsed); }
 
-  void reset() { stime_elapsed = 0; nstime_elapsed = 0; }
+  void reset()
+  {
+    stime_elapsed = 0;
+    nstime_elapsed = 0;
+  }
 
 private:
   TimeType tstart;

--- a/include/RAJA/util/View.hpp
+++ b/include/RAJA/util/View.hpp
@@ -74,9 +74,7 @@ struct View {
   {
   }
 
-  RAJA_INLINE void set_data(DataType *data_ptr) {
-      data = data_ptr;
-  }
+  RAJA_INLINE void set_data(DataType *data_ptr) { data = data_ptr; }
 
   // making this specifically typed would require unpacking the layout,
   // this is easier to maintain
@@ -104,9 +102,7 @@ struct TypedView {
   {
   }
 
-  RAJA_INLINE void set_data(DataType *data_ptr) {
-      base_.set_data(data_ptr);
-  }
+  RAJA_INLINE void set_data(DataType *data_ptr) { base_.set_data(data_ptr); }
 
   RAJA_HOST_DEVICE RAJA_INLINE DataType &operator()(IndexTypes... args) const
   {

--- a/include/RAJA/util/defines.hpp
+++ b/include/RAJA/util/defines.hpp
@@ -53,6 +53,8 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+#include "RAJA/config.hpp"
+
 #include <stdlib.h>
 #include <stdexcept>
 

--- a/include/RAJA/util/defines.hpp
+++ b/include/RAJA/util/defines.hpp
@@ -122,7 +122,7 @@
  * \endcode
  *******************************************************************************
  */
-#define RAJA_UNUSED_VAR(_x)   static_cast<void>(_x)
+#define RAJA_UNUSED_VAR(_x) static_cast<void>(_x)
 
 /*!
  * \def RAJA_STRINGIFY_HELPER(x)
@@ -133,7 +133,7 @@
 
 /*!
  * \def RAJA_STRINGIFY_MACRO(x)
- * 
+ *
  * Used in static_assert macros to print values of defines
  */
 #define RAJA_STRINGIFY_MACRO(x) RAJA_STRINGIFY_HELPER(x)
@@ -144,14 +144,15 @@
  * Macro to find ceiling (dividend / divisor) for integer types
  */
 #define RAJA_DIVIDE_CEILING_INT(dividend, divisor) \
- ( ( (dividend) + (divisor) - 1 ) / (divisor) )
+  (((dividend) + (divisor)-1) / (divisor))
 
-inline void RAJA_ABORT_OR_THROW(const char *str) {
-    if  (getenv ("RAJA_NO_EXCEPT") != NULL) {
-        abort();
-    } else {
-        throw std::runtime_error(str);
-    }
+inline void RAJA_ABORT_OR_THROW(const char *str)
+{
+  if (getenv("RAJA_NO_EXCEPT") != NULL) {
+    abort();
+  } else {
+    throw std::runtime_error(str);
+  }
 }
 
 #endif /* RAJA_INTERNAL_DEFINES_HPP */

--- a/src/ListSegment.cpp
+++ b/src/ListSegment.cpp
@@ -78,7 +78,7 @@ ListSegment::ListSegment(const Index_type* indx,
 
 ////
 ////
-ListSegment::ListSegment(const ListSegment& other) 
+ListSegment::ListSegment(const ListSegment& other)
     : BaseSegment(_ListSeg_), m_indx(0), m_len(0)
 {
   initIndexData(other.m_indx, other.getLength(), other.m_indx_own);
@@ -143,7 +143,7 @@ bool ListSegment::indicesEqual(const Index_type* indx, Index_type len) const
 void ListSegment::print(std::ostream& os) const
 {
 #if defined(RAJA_ENABLE_CUDA)
-    cudaErrchk(cudaDeviceSynchronize());
+  cudaErrchk(cudaDeviceSynchronize());
 #endif
   os << "ListSegment : length, owns index = " << getLength()
      << (m_indx_own == Owned ? " -- Owned" : " -- Unowned") << std::endl;
@@ -177,8 +177,8 @@ void ListSegment::initIndexData(const Index_type* indx,
       cudaErrchk(cudaMallocManaged((void**)&m_indx,
                                    m_len * sizeof(Index_type),
                                    cudaMemAttachGlobal));
-      cudaErrchk(cudaMemcpy(m_indx, indx,
-                            m_len * sizeof(Index_type), cudaMemcpyDefault));
+      cudaErrchk(cudaMemcpy(
+          m_indx, indx, m_len * sizeof(Index_type), cudaMemcpyDefault));
 #else
       m_indx = new Index_type[len];
       for (Index_type i = 0; i < m_len; ++i) {

--- a/src/LockFreeIndexSetBuilders.cpp
+++ b/src/LockFreeIndexSetBuilders.cpp
@@ -244,7 +244,8 @@ void buildLockFreeColorIndexset(RAJA::IndexSet& iset,
   Index_type worksetSize = 0;
   Index_type* workset = new Index_type[numEntity];
 
-  Index_type* rangeToDomain = new Index_type[numEntityRange * numRangePerDomain];
+  Index_type* rangeToDomain =
+      new Index_type[numEntityRange * numRangePerDomain];
   Index_type* rangeToDomainCount = new Index_type[numEntityRange];
 
   memset(rangeToDomainCount, 0, numEntityRange * sizeof(Index_type));

--- a/src/MemUtils_CPU.cpp
+++ b/src/MemUtils_CPU.cpp
@@ -65,7 +65,8 @@
 
 #include <stdlib.h>
 
-#if defined(_WIN32) || defined(WIN32) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__BORLANDC__)
+#if defined(_WIN32) || defined(WIN32) || defined(__CYGWIN__) \
+    || defined(__MINGW32__) || defined(__BORLANDC__)
 #include <malloc.h>
 #endif
 
@@ -89,29 +90,33 @@ CPUReductionBlockDataType* s_cpu_reduction_mem_block = 0;
 //
 Index_type* s_cpu_reduction_loc_block = 0;
 
-void * allocate_aligned(size_t alignment, size_t size) {
+void* allocate_aligned(size_t alignment, size_t size)
+{
 #if defined(HAVE_POSIX_MEMALIGN)
-    // posix_memalign available
-    void * ret = NULL;
-    int err = posix_memalign(&ret, alignment, size);
-    return err ? NULL : ret;
-#elif defined(_WIN32) || defined(WIN32) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__BORLANDC__)
-    //on windows
-    return _aligned_malloc(size, alignment);
+  // posix_memalign available
+  void* ret = NULL;
+  int err = posix_memalign(&ret, alignment, size);
+  return err ? NULL : ret;
+#elif defined(_WIN32) || defined(WIN32) || defined(__CYGWIN__) \
+    || defined(__MINGW32__) || defined(__BORLANDC__)
+  // on windows
+  return _aligned_malloc(size, alignment);
 #else
-    #error No known aligned allocator available
+#error No known aligned allocator available
 #endif
 }
 
 
-void free_aligned(void* ptr) {
+void free_aligned(void* ptr)
+{
 #if defined(HAVE_POSIX_MEMALIGN)
-    free(ptr);
-#elif defined(_WIN32) || defined(WIN32) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__BORLANDC__)
-    //on windows
-    _aligned_free(ptr);
+  free(ptr);
+#elif defined(_WIN32) || defined(WIN32) || defined(__CYGWIN__) \
+    || defined(__MINGW32__) || defined(__BORLANDC__)
+  // on windows
+  _aligned_free(ptr);
 #else
-    #error No known aligned allocator available
+#error No known aligned allocator available
 #endif
 }
 

--- a/src/MemUtils_CUDA.cpp
+++ b/src/MemUtils_CUDA.cpp
@@ -63,138 +63,138 @@
 
 #include "RAJA/policy/cuda/raja_cudaerrchk.hpp"
 
+#include <cassert>
 #include <iostream>
 #include <string>
-#include <cassert>
 
 namespace RAJA
 {
 
 namespace
 {
-  /*!
-   * \brief Number of currently active cuda reduction objects
-   */
-  int s_cuda_reducer_active_count = 0;
+/*!
+ * \brief Number of currently active cuda reduction objects
+ */
+int s_cuda_reducer_active_count = 0;
 
-  /*!
-   * \brief Number of cuda memblocks currently being used.
-   */
-  int s_cuda_memblock_used_count = 0;
+/*!
+ * \brief Number of cuda memblocks currently being used.
+ */
+int s_cuda_memblock_used_count = 0;
 
-  /*!
-   * \brief Static array used to keep track of which unique ids
-   * for CUDA reduction objects are used and which are not.
-   */
-  bool s_cuda_reduction_id_used[RAJA_MAX_REDUCE_VARS];
+/*!
+ * \brief Static array used to keep track of which unique ids
+ * for CUDA reduction objects are used and which are not.
+ */
+bool s_cuda_reduction_id_used[RAJA_MAX_REDUCE_VARS];
 
-  /*!
-   * \brief Static array used to keep track of which reduction
-   * memblocks are in use.
-   */
-  bool s_cuda_reduction_memblock_used[RAJA_MAX_REDUCE_VARS];
+/*!
+ * \brief Static array used to keep track of which reduction
+ * memblocks are in use.
+ */
+bool s_cuda_reduction_memblock_used[RAJA_MAX_REDUCE_VARS];
 
-  /*!
-   * \brief Pointer to device memory block for RAJA-Cuda reductions.
-   */
-  CudaReductionDummyBlockType* s_cuda_reduction_mem_block = 0;
+/*!
+ * \brief Pointer to device memory block for RAJA-Cuda reductions.
+ */
+CudaReductionDummyBlockType* s_cuda_reduction_mem_block = 0;
 
-  /*!
-   * \brief Pointer to the tally block on the device.
-   * 
-   * The tally block is a number of contiguous slots in memory where the 
-   * results of cuda reduction variables are stored. This is done so all 
-   * results may be copied back to the host with one memcpy.
-   */
-  CudaReductionDummyTallyType* s_cuda_reduction_tally_block_device = 0;
+/*!
+ * \brief Pointer to the tally block on the device.
+ *
+ * The tally block is a number of contiguous slots in memory where the
+ * results of cuda reduction variables are stored. This is done so all
+ * results may be copied back to the host with one memcpy.
+ */
+CudaReductionDummyTallyType* s_cuda_reduction_tally_block_device = 0;
 
-  /*!
-   * \brief Pointer to the tally block cache on the host.
-   * 
-   * This cache allows multiple reads from the tally cache on the host to 
-   * incur only one memcpy from device memory. This cache also allows 
-   * multiple cuda reduction variables to be initialized without writing to
-   * device memory. Changes to this cache are written back to the device 
-   * tally block in the next forall, before kernel launch so they are visible
-   * on the device when needed.
-   *
-   * Note: This buffer must be allocated in pageable memory (not pinned).
-   * CudaMemcpyAsync is always asynchronous with respect to managed memory.
-   * However, while cudaMemcpyAsync is asynchronous to the host when used with
-   * pinned or managed memory, it is synchronous to the host if the target 
-   * buffer is host pageable memory. Due to overheads associated with 
-   * synchronization of managed memory, using cudaMemcpyAsync with pageable 
-   * memory takes less time overall than using a synchronous routine. If 
-   * synchronizing managed memory incurs a smaller penalty inthe future, then
-   * using other memory types could take less time.
-   */
-  CudaReductionDummyTallyType* s_cuda_reduction_tally_block_host = 0;
+/*!
+ * \brief Pointer to the tally block cache on the host.
+ *
+ * This cache allows multiple reads from the tally cache on the host to
+ * incur only one memcpy from device memory. This cache also allows
+ * multiple cuda reduction variables to be initialized without writing to
+ * device memory. Changes to this cache are written back to the device
+ * tally block in the next forall, before kernel launch so they are visible
+ * on the device when needed.
+ *
+ * Note: This buffer must be allocated in pageable memory (not pinned).
+ * CudaMemcpyAsync is always asynchronous with respect to managed memory.
+ * However, while cudaMemcpyAsync is asynchronous to the host when used with
+ * pinned or managed memory, it is synchronous to the host if the target
+ * buffer is host pageable memory. Due to overheads associated with
+ * synchronization of managed memory, using cudaMemcpyAsync with pageable
+ * memory takes less time overall than using a synchronous routine. If
+ * synchronizing managed memory incurs a smaller penalty inthe future, then
+ * using other memory types could take less time.
+ */
+CudaReductionDummyTallyType* s_cuda_reduction_tally_block_host = 0;
 
-  //
-  /////////////////////////////////////////////////////////////////////////////
-  //
-  // Variables representing the state of the tally block cache on the host.
-  //
-  /////////////////////////////////////////////////////////////////////////////
-  //
+//
+/////////////////////////////////////////////////////////////////////////////
+//
+// Variables representing the state of the tally block cache on the host.
+//
+/////////////////////////////////////////////////////////////////////////////
+//
 
-  /*!
-   * \brief Validity of host tally block cache.
-   *
-   * Valid means that all slots are up to date and can be read from the cache.
-   * Invalid means that only dirty slots are up to date.
-   */
-  bool s_tally_valid = true;
-  /*
-   * \brief The number of slots that should be written back to the device 
-   *        tally block.
-   */
-  int s_tally_dirty = 0;
-  /*
-   * \brief Holds the dirty status of each slot.
-   *
-   * True indicates a slot written to by the host, but not copied back to
-   * the device tally block.
-   */
-  bool s_tally_block_dirty[RAJA_CUDA_REDUCE_TALLY_LENGTH] = {false};
+/*!
+ * \brief Validity of host tally block cache.
+ *
+ * Valid means that all slots are up to date and can be read from the cache.
+ * Invalid means that only dirty slots are up to date.
+ */
+bool s_tally_valid = true;
+/*
+ * \brief The number of slots that should be written back to the device
+ *        tally block.
+ */
+int s_tally_dirty = 0;
+/*
+ * \brief Holds the dirty status of each slot.
+ *
+ * True indicates a slot written to by the host, but not copied back to
+ * the device tally block.
+ */
+bool s_tally_block_dirty[RAJA_CUDA_REDUCE_TALLY_LENGTH] = {false};
 
-  //
-  /////////////////////////////////////////////////////////////////////////////
-  //
-  // Variables representing the state of dynamic shared memory usage.
-  //
-  /////////////////////////////////////////////////////////////////////////////
-  //
+//
+/////////////////////////////////////////////////////////////////////////////
+//
+// Variables representing the state of dynamic shared memory usage.
+//
+/////////////////////////////////////////////////////////////////////////////
+//
 
-  /*!
-   * \brief State of the host code, whether it is currently in a raja
-   *        cuda forall function or not.
-   */
-  int s_raja_cuda_forall_level = 0;
-  /*!
-   * \brief The amount of shared memory currently earmarked for use in
-   *        the current forall.
-   */
-  int s_shared_memory_amount_total = 0;
-  /*!
-   * \brief shared_memory_offsets holds the byte offsets into dynamic shared 
-   *        memory for each reduction variable.
-   * 
-   * Note: -1 indicates a reduction variable that is not participating in
-   * the current forall.
-   */
-  int s_shared_memory_offsets[RAJA_MAX_REDUCE_VARS] = {-1};
-  /*!
-   * \brief Holds the number of threads expected by each reduction variable.
-   * 
-   * This is used to check the execution policy against the reduction policies
-   * of participating reduction varaibles. 
-   *
-   * Note: -1 indicates a reduction variable that is not participating in the 
-   * current forall and 0 represents a reduction variable whose execution does
-   * not depend on the number of threads used by the execution policy.
-   */
-  int s_cuda_reduction_num_threads[RAJA_MAX_REDUCE_VARS] = {-1};
+/*!
+ * \brief State of the host code, whether it is currently in a raja
+ *        cuda forall function or not.
+ */
+int s_raja_cuda_forall_level = 0;
+/*!
+ * \brief The amount of shared memory currently earmarked for use in
+ *        the current forall.
+ */
+int s_shared_memory_amount_total = 0;
+/*!
+ * \brief shared_memory_offsets holds the byte offsets into dynamic shared
+ *        memory for each reduction variable.
+ *
+ * Note: -1 indicates a reduction variable that is not participating in
+ * the current forall.
+ */
+int s_shared_memory_offsets[RAJA_MAX_REDUCE_VARS] = {-1};
+/*!
+ * \brief Holds the number of threads expected by each reduction variable.
+ *
+ * This is used to check the execution policy against the reduction policies
+ * of participating reduction varaibles.
+ *
+ * Note: -1 indicates a reduction variable that is not participating in the
+ * current forall and 0 represents a reduction variable whose execution does
+ * not depend on the number of threads used by the execution policy.
+ */
+int s_cuda_reduction_num_threads[RAJA_MAX_REDUCE_VARS] = {-1};
 }
 
 /*
@@ -204,10 +204,7 @@ namespace
 *
 *******************************************************************************
 */
-int getCudaReducerActiveCount()
-{
-  return s_cuda_reducer_active_count;
-}
+int getCudaReducerActiveCount() { return s_cuda_reducer_active_count; }
 
 /*
 *******************************************************************************
@@ -216,10 +213,7 @@ int getCudaReducerActiveCount()
 *
 *******************************************************************************
 */
-int getCudaMemblockUsedCount()
-{
-  return s_cuda_memblock_used_count;
-}
+int getCudaMemblockUsedCount() { return s_cuda_memblock_used_count; }
 
 /*
 *******************************************************************************
@@ -291,9 +285,9 @@ void releaseCudaReductionId(int id)
 void getCudaReductionMemBlock(int id, void** device_memblock)
 {
   if (s_cuda_reduction_mem_block == 0) {
-    cudaErrchk(cudaMalloc((void**)&s_cuda_reduction_mem_block,
-                          sizeof(CudaReductionDummyBlockType) *
-                            RAJA_MAX_REDUCE_VARS));
+    cudaErrchk(
+        cudaMalloc((void**)&s_cuda_reduction_mem_block,
+                   sizeof(CudaReductionDummyBlockType) * RAJA_MAX_REDUCE_VARS));
 
     for (int i = 0; i < RAJA_MAX_REDUCE_VARS; ++i) {
       s_cuda_reduction_memblock_used[i] = false;
@@ -324,7 +318,6 @@ void freeCudaReductionMemBlock()
 }
 
 
-
 /*
 *******************************************************************************
 *
@@ -337,12 +330,12 @@ void freeCudaReductionMemBlock()
 void getCudaReductionTallyBlock(int id, void** host_tally, void** device_tally)
 {
   if (s_cuda_reduction_tally_block_host == 0) {
-    s_cuda_reduction_tally_block_host = 
+    s_cuda_reduction_tally_block_host =
         new CudaReductionDummyTallyType[RAJA_CUDA_REDUCE_TALLY_LENGTH];
 
     cudaErrchk(cudaMalloc((void**)&s_cuda_reduction_tally_block_device,
-                          sizeof(CudaReductionDummyTallyType) *
-                            RAJA_CUDA_REDUCE_TALLY_LENGTH));
+                          sizeof(CudaReductionDummyTallyType)
+                              * RAJA_CUDA_REDUCE_TALLY_LENGTH));
 
     s_tally_valid = true;
     s_tally_dirty = 0;
@@ -357,7 +350,7 @@ void getCudaReductionTallyBlock(int id, void** host_tally, void** device_tally)
   // set block dirty
   s_tally_block_dirty[id] = true;
 
-  *host_tally   = &(s_cuda_reduction_tally_block_host[id]);
+  *host_tally = &(s_cuda_reduction_tally_block_host[id]);
   *device_tally = &(s_cuda_reduction_tally_block_device[id]);
 }
 
@@ -385,7 +378,7 @@ static void writeBackCudaReductionTallyBlock()
                                    &s_cuda_reduction_tally_block_host[first],
                                    sizeof(CudaReductionDummyTallyType) * len,
                                    cudaMemcpyHostToDevice));
-        
+
         for (int i = first; i < end; ++i) {
           s_tally_block_dirty[i] = false;
         }
@@ -403,8 +396,8 @@ static void writeBackCudaReductionTallyBlock()
 *
 * Read tally block from device if invalid on host.
 * Must be called after tally blocks have been allocated.
-* The Async version is synchronous on the host if 
-* s_cuda_reduction_tally_block_host is allocated as pageable host memory 
+* The Async version is synchronous on the host if
+* s_cuda_reduction_tally_block_host is allocated as pageable host memory
 * and not if allocated as pinned host memory or managed memory.
 *
 *******************************************************************************
@@ -412,22 +405,22 @@ static void writeBackCudaReductionTallyBlock()
 static void readCudaReductionTallyBlockAsync()
 {
   if (!s_tally_valid) {
-    cudaErrchk(cudaMemcpyAsync( &s_cuda_reduction_tally_block_host[0],
-                                &s_cuda_reduction_tally_block_device[0],
-                                sizeof(CudaReductionDummyTallyType) *
-                                  RAJA_CUDA_REDUCE_TALLY_LENGTH,
-                                cudaMemcpyDeviceToHost));
+    cudaErrchk(cudaMemcpyAsync(&s_cuda_reduction_tally_block_host[0],
+                               &s_cuda_reduction_tally_block_device[0],
+                               sizeof(CudaReductionDummyTallyType)
+                                   * RAJA_CUDA_REDUCE_TALLY_LENGTH,
+                               cudaMemcpyDeviceToHost));
     s_tally_valid = true;
   }
 }
 static void readCudaReductionTallyBlock()
 {
   if (!s_tally_valid) {
-    cudaErrchk(cudaMemcpy(  &s_cuda_reduction_tally_block_host[0],
-                            &s_cuda_reduction_tally_block_device[0],
-                            sizeof(CudaReductionDummyTallyType) *
-                              RAJA_CUDA_REDUCE_TALLY_LENGTH,
-                            cudaMemcpyDeviceToHost));
+    cudaErrchk(cudaMemcpy(&s_cuda_reduction_tally_block_host[0],
+                          &s_cuda_reduction_tally_block_device[0],
+                          sizeof(CudaReductionDummyTallyType)
+                              * RAJA_CUDA_REDUCE_TALLY_LENGTH,
+                          cudaMemcpyDeviceToHost));
     s_tally_valid = true;
   }
 }
@@ -435,9 +428,9 @@ static void readCudaReductionTallyBlock()
 /*
 *******************************************************************************
 *
-* Must be called before each RAJA cuda kernel, and before the copy of the 
+* Must be called before each RAJA cuda kernel, and before the copy of the
 * loop body to setup state of the dynamic shared memory variables.
-* Ensures that all updates to the tally block are visible on the device by 
+* Ensures that all updates to the tally block are visible on the device by
 * writing back dirty cache lines; this invalidates the tally cache on the host.
 *
 *******************************************************************************
@@ -448,10 +441,10 @@ void beforeCudaKernelLaunch()
   if (s_raja_cuda_forall_level == 1) {
     if (s_cuda_reducer_active_count > 0) {
       s_shared_memory_amount_total = 0;
-      for(int i = 0; i < RAJA_MAX_REDUCE_VARS; ++i) {
+      for (int i = 0; i < RAJA_MAX_REDUCE_VARS; ++i) {
         s_shared_memory_offsets[i] = -1;
       }
-      for(int i = 0; i < RAJA_MAX_REDUCE_VARS; ++i) {
+      for (int i = 0; i < RAJA_MAX_REDUCE_VARS; ++i) {
         s_cuda_reduction_num_threads[i] = -1;
       }
 
@@ -469,20 +462,17 @@ void beforeCudaKernelLaunch()
 *
 *******************************************************************************
 */
-void afterCudaKernelLaunch()
-{
-  s_raja_cuda_forall_level--;
-}
+void afterCudaKernelLaunch() { s_raja_cuda_forall_level--; }
 
 /*
 *******************************************************************************
 *
 * Must be called before reading the tally block cache on the host.
-* Ensures that the host tally block cache for cuda reduction variable id can 
+* Ensures that the host tally block cache for cuda reduction variable id can
 * be read.
-* Writes any host changes to the tally block cache to the device before 
+* Writes any host changes to the tally block cache to the device before
 * updating the host tally blocks with the values on the GPU.
-* The Async version is only asynchronous with regards to managed memory and 
+* The Async version is only asynchronous with regards to managed memory and
 * is synchronous to host code.
 *
 *******************************************************************************
@@ -537,7 +527,7 @@ void freeCudaReductionTallyBlock()
 /*
 *******************************************************************************
 *
-* Earmark num_threads * size bytes of dynamic shared memory and get the byte 
+* Earmark num_threads * size bytes of dynamic shared memory and get the byte
 * offset.
 *
 *******************************************************************************
@@ -552,7 +542,7 @@ int getCudaSharedmemOffset(int id, dim3 reductionBlockDim, int size)
 
       s_shared_memory_offsets[id] = s_shared_memory_amount_total;
 
-      int num_threads = 
+      int num_threads =
           reductionBlockDim.x * reductionBlockDim.y * reductionBlockDim.z;
 
       // ignore reduction variables that don't use dynamic shared memory
@@ -570,7 +560,7 @@ int getCudaSharedmemOffset(int id, dim3 reductionBlockDim, int size)
 *******************************************************************************
 *
 * Get size in bytes of dynamic shared memory.
-* Check that the number of blocks launched is consistent with the max number of 
+* Check that the number of blocks launched is consistent with the max number of
 * blocks reduction variables can handle.
 * Check that execution policy num_threads is consistent with active reduction
 * policy num_threads.
@@ -580,35 +570,39 @@ int getCudaSharedmemOffset(int id, dim3 reductionBlockDim, int size)
 int getCudaSharedmemAmount(dim3 launchGridDim, dim3 launchBlockDim)
 {
   if (s_cuda_reducer_active_count > 0) {
-    int launch_num_blocks = 
-        launchGridDim.x * launchGridDim.y * launchGridDim.z;
+    int launch_num_blocks = launchGridDim.x * launchGridDim.y * launchGridDim.z;
 
-    int launch_num_threads = 
+    int launch_num_threads =
         launchBlockDim.x * launchBlockDim.y * launchBlockDim.z;
 
-    for(int i = 0; i < RAJA_MAX_REDUCE_VARS; ++i) {
+    for (int i = 0; i < RAJA_MAX_REDUCE_VARS; ++i) {
       int reducer_num_threads = s_cuda_reduction_num_threads[i];
 
       // check if reducer is active
       if (reducer_num_threads >= 0) {
-        
+
         // check if reducer cares about number of blocks
-        if (s_cuda_reduction_memblock_used[i] && launch_num_blocks > RAJA_CUDA_MAX_NUM_BLOCKS) {
+        if (s_cuda_reduction_memblock_used[i]
+            && launch_num_blocks > RAJA_CUDA_MAX_NUM_BLOCKS) {
           std::cerr << "\n Cuda execution error: "
-                    << "Can't launch " << launch_num_blocks << " blocks, " 
+                    << "Can't launch " << launch_num_blocks << " blocks, "
                     << "RAJA_CUDA_MAX_NUM_BLOCKS = " << RAJA_CUDA_MAX_NUM_BLOCKS
                     << ", "
-                    << "FILE: " << __FILE__ << " line: " << __LINE__ << std::endl;
+                    << "FILE: " << __FILE__ << " line: " << __LINE__
+                    << std::endl;
           exit(1);
         }
-        
+
         // check if reducer cares about number of threads
-        if (reducer_num_threads > 0 && launch_num_threads > reducer_num_threads) {
+        if (reducer_num_threads > 0
+            && launch_num_threads > reducer_num_threads) {
           std::cerr << "\n Cuda execution, reduction policy mismatch: "
-                    << "reduction policy with BLOCK_SIZE " << reducer_num_threads
+                    << "reduction policy with BLOCK_SIZE "
+                    << reducer_num_threads
                     << " can't be used with execution policy with BLOCK_SIZE "
                     << launch_num_threads << ", "
-                    << "FILE: " << __FILE__ << " line: " << __LINE__ << std::endl;
+                    << "FILE: " << __FILE__ << " line: " << __LINE__
+                    << std::endl;
           exit(1);
         }
       }

--- a/test/include/data_storage.hpp
+++ b/test/include/data_storage.hpp
@@ -138,8 +138,10 @@ struct storage<ExecPolicy, T, false> : public storage_base {
   using type = T;
 
 #ifdef RAJA_ENABLE_CUDA
-  using StorageType = typename internal::
-      storage<ExecPolicy, T, RAJA::is_cuda_policy<ExecPolicy>::value>;
+  using StorageType =
+      typename internal::storage<ExecPolicy,
+                                 T,
+                                 RAJA::is_cuda_policy<ExecPolicy>::value>;
 #else
   using StorageType = typename internal::storage<ExecPolicy, T, false>;
 #endif

--- a/test/unit/cpu/main-nested.cpp
+++ b/test/unit/cpu/main-nested.cpp
@@ -91,9 +91,9 @@ void run2dTest(std::string const &policy, Index_type size_i, Index_type size_j)
   //// DO WORK
   ////
 
-  typename POL::VIEW val_view(&values[0], make_permuted_layout({size_i,
-                                                                size_j},
-  POL::PERM::value));
+  typename POL::VIEW val_view(&values[0],
+                              make_permuted_layout({size_i, size_j},
+                                                   POL::PERM::value));
 
   forallN<typename POL::EXEC>(RangeSegment(1, size_i),
                               RangeSegment(0, size_j),
@@ -286,15 +286,14 @@ void runLTimesTest(std::string const &policy,
   typename POL::ELL_VIEW ell(&ell_data[0],
                              make_permuted_layout({num_moments, num_directions},
                                                   POL::ELL_PERM::value));
-  typename POL::PSI_VIEW psi(&psi_data[0],
-                             make_permuted_layout(
-                                 {num_directions, num_groups, num_zones},
-                                 POL::PSI_PERM::value));
-  typename POL::PHI_VIEW phi(&phi_data[0],
-                             make_permuted_layout({num_moments,
-                                                   num_groups,
-                                                   num_zones},
-                                                  POL::PHI_PERM::value));
+  typename POL::PSI_VIEW psi(
+      &psi_data[0],
+      make_permuted_layout({num_directions, num_groups, num_zones},
+                           POL::PSI_PERM::value));
+  typename POL::PHI_VIEW phi(
+      &phi_data[0],
+      make_permuted_layout({num_moments, num_groups, num_zones},
+                           POL::PHI_PERM::value));
 
   // get execution policy
   using EXEC = typename POL::EXEC;
@@ -306,7 +305,7 @@ void runLTimesTest(std::string const &policy,
       RangeSegment(0, num_groups),
       RangeSegment(0, num_zones),
       [=](IMoment m, IDirection d, IGroup g, IZone z) {
-    phi(m, g, z) += ell(m, d) * psi(d, g, z);
+        phi(m, g, z) += ell(m, d) * psi(d, g, z);
       });
 
   ////
@@ -392,18 +391,14 @@ struct PolLTimesC {
       EXEC;
 
   // psi[direction, group, zone]
-  typedef RAJA::
-      TypedView<double, Layout<3>, IDirection, IGroup, IZone>
-          PSI_VIEW;
+  typedef RAJA::TypedView<double, Layout<3>, IDirection, IGroup, IZone>
+      PSI_VIEW;
 
   // phi[moment, group, zone]
-  typedef RAJA::
-      TypedView<double, Layout<3>, IMoment, IGroup, IZone>
-          PHI_VIEW;
+  typedef RAJA::TypedView<double, Layout<3>, IMoment, IGroup, IZone> PHI_VIEW;
 
   // ell[moment, direction]
-  typedef RAJA::TypedView<double, Layout<2>, IMoment, IDirection>
-      ELL_VIEW;
+  typedef RAJA::TypedView<double, Layout<2>, IMoment, IDirection> ELL_VIEW;
 
   typedef RAJA::PERM_IJK PSI_PERM;
   typedef RAJA::PERM_KJI PHI_PERM;
@@ -423,18 +418,14 @@ struct PolLTimesD_OMP {
       EXEC;
 
   // psi[direction, group, zone]
-  typedef RAJA::
-      TypedView<double, Layout<3>, IDirection, IGroup, IZone>
-          PSI_VIEW;
+  typedef RAJA::TypedView<double, Layout<3>, IDirection, IGroup, IZone>
+      PSI_VIEW;
 
   // phi[moment, group, zone]
-  typedef RAJA::
-      TypedView<double, Layout<3>, IMoment, IGroup, IZone>
-          PHI_VIEW;
+  typedef RAJA::TypedView<double, Layout<3>, IMoment, IGroup, IZone> PHI_VIEW;
 
   // ell[moment, direction]
-  typedef RAJA::TypedView<double, Layout<2>, IMoment, IDirection>
-      ELL_VIEW;
+  typedef RAJA::TypedView<double, Layout<2>, IMoment, IDirection> ELL_VIEW;
 
   typedef RAJA::PERM_KJI PSI_PERM;
   typedef RAJA::PERM_KJI PHI_PERM;
@@ -458,18 +449,14 @@ struct PolLTimesE_OMP {
       EXEC;
 
   // psi[direction, group, zone]
-  typedef RAJA::
-      TypedView<double, Layout<3>, IDirection, IGroup, IZone>
-          PSI_VIEW;
+  typedef RAJA::TypedView<double, Layout<3>, IDirection, IGroup, IZone>
+      PSI_VIEW;
 
   // phi[moment, group, zone]
-  typedef RAJA::
-      TypedView<double, Layout<3>, IMoment, IGroup, IZone>
-          PHI_VIEW;
+  typedef RAJA::TypedView<double, Layout<3>, IMoment, IGroup, IZone> PHI_VIEW;
 
   // ell[moment, direction]
-  typedef RAJA::TypedView<double, Layout<2>, IMoment, IDirection>
-      ELL_VIEW;
+  typedef RAJA::TypedView<double, Layout<2>, IMoment, IDirection> ELL_VIEW;
 
   typedef RAJA::PERM_KJI PSI_PERM;
   typedef RAJA::PERM_KJI PHI_PERM;

--- a/test/unit/cpu/main-reduce.cpp
+++ b/test/unit/cpu/main-reduce.cpp
@@ -94,7 +94,7 @@ void runBasicMinReductionTest(const string& policy,
                               const RAJAVec<Index_type>& is_indices)
 {
   Real_ptr test_array;
-  test_array = (Real_ptr) allocate_aligned(DATA_ALIGN, alen * sizeof(Real_type));
+  test_array = (Real_ptr)allocate_aligned(DATA_ALIGN, alen * sizeof(Real_type));
 
   //
   // Make all test array values positve
@@ -241,7 +241,7 @@ void runBasicMinLocReductionTest(const string& policy,
                                  const RAJAVec<Index_type>& is_indices)
 {
   Real_ptr test_array;
-  test_array = (Real_ptr) allocate_aligned(DATA_ALIGN, alen * sizeof(Real_type));
+  test_array = (Real_ptr)allocate_aligned(DATA_ALIGN, alen * sizeof(Real_type));
 
   //
   // Make all test array values positve
@@ -393,7 +393,7 @@ void runBasicMaxReductionTest(const string& policy,
                               const RAJAVec<Index_type>& is_indices)
 {
   Real_ptr test_array;
-  test_array = (Real_ptr) allocate_aligned(DATA_ALIGN, alen * sizeof(Real_type));
+  test_array = (Real_ptr)allocate_aligned(DATA_ALIGN, alen * sizeof(Real_type));
 
   //
   // Make all test array values negative
@@ -541,7 +541,7 @@ void runBasicMaxLocReductionTest(const string& policy,
                                  const RAJAVec<Index_type>& is_indices)
 {
   Real_ptr test_array;
-  test_array = (Real_ptr) allocate_aligned(DATA_ALIGN, alen * sizeof(Real_type));
+  test_array = (Real_ptr)allocate_aligned(DATA_ALIGN, alen * sizeof(Real_type));
 
   //
   // Make all test array values negative
@@ -889,7 +889,8 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv))
   // Allocate "parent" array for traversal tests and initialize to...
   //
   Real_ptr parent;
-  parent = (Real_ptr) allocate_aligned(DATA_ALIGN, array_length * sizeof(Real_type));
+  parent =
+      (Real_ptr)allocate_aligned(DATA_ALIGN, array_length * sizeof(Real_type));
 
   for (Index_type i = 0; i < array_length; ++i) {
     parent[i] = Real_type(rand() % 65536);

--- a/test/unit/cpu/test-indexsets.cpp
+++ b/test/unit/cpu/test-indexsets.cpp
@@ -89,41 +89,41 @@ TEST_F(IndexSetTest, conditionalOperation_even_indices)
 
   RAJA::RAJAVec<RAJA::Index_type> even_indices;
   getIndicesConditional(even_indices, index_sets_[0], [](RAJA::Index_type idx) {
-      return !(idx % 2);
+    return !(idx % 2);
   });
 
   RAJA::RAJAVec<RAJA::Index_type> ref_even_indices;
   for (size_t i = 0; i < is_indices.size(); ++i) {
-      RAJA::Index_type idx = is_indices[i];
-      if (idx % 2 == 0) {
-          ref_even_indices.push_back(idx);
-      }
+    RAJA::Index_type idx = is_indices[i];
+    if (idx % 2 == 0) {
+      ref_even_indices.push_back(idx);
+    }
   }
 
   EXPECT_EQ(even_indices.size(), ref_even_indices.size());
   for (size_t i = 0; i < ref_even_indices.size(); ++i) {
-      EXPECT_EQ(even_indices[i], ref_even_indices[i]);
+    EXPECT_EQ(even_indices[i], ref_even_indices[i]);
   }
 }
 
 TEST_F(IndexSetTest, conditionalOperation_lt300_indices)
 {
   RAJA::RAJAVec<RAJA::Index_type> lt300_indices;
-  getIndicesConditional(lt300_indices, index_sets_[0], [](RAJA::Index_type idx) {
-      return (idx < 300);
-  });
+  getIndicesConditional(lt300_indices,
+                        index_sets_[0],
+                        [](RAJA::Index_type idx) { return (idx < 300); });
 
   RAJA::RAJAVec<RAJA::Index_type> ref_lt300_indices;
   for (size_t i = 0; i < is_indices.size(); ++i) {
-      RAJA::Index_type idx = is_indices[i];
-      if (idx < 300) {
-          ref_lt300_indices.push_back(idx);
-      }
+    RAJA::Index_type idx = is_indices[i];
+    if (idx < 300) {
+      ref_lt300_indices.push_back(idx);
+    }
   }
 
   EXPECT_EQ(lt300_indices.size(), ref_lt300_indices.size());
   for (size_t i = 0; i < ref_lt300_indices.size(); ++i) {
-      EXPECT_EQ(lt300_indices[i], ref_lt300_indices[i]);
+    EXPECT_EQ(lt300_indices[i], ref_lt300_indices[i]);
   }
 }
-#endif // !defined(RAJA_COMPILER_XLC12) && 1
+#endif  // !defined(RAJA_COMPILER_XLC12) && 1

--- a/test/unit/cpu/test-reductions.cpp
+++ b/test/unit/cpu/test-reductions.cpp
@@ -46,8 +46,8 @@
 
 #include "gtest/gtest.h"
 
-#include "RAJA/RAJA.hpp"
 #include <iostream>
+#include "RAJA/RAJA.hpp"
 
 #include <tuple>
 
@@ -69,108 +69,106 @@ TYPED_TEST_P(ReductionConstructorTest, ReductionConstructor)
   RAJA::ReduceMinLoc<ReducePolicy, NumericType> reduce_minloc(0.0, 1);
   RAJA::ReduceMaxLoc<ReducePolicy, NumericType> reduce_maxloc(0.0, 1);
 
-  ASSERT_EQ((NumericType) reduce_sum.get(), (NumericType)(0.0));
-  ASSERT_EQ((NumericType) reduce_min.get(), (NumericType)(0.0));
-  ASSERT_EQ((NumericType) reduce_max.get(), (NumericType)(0.0));
-  ASSERT_EQ((NumericType) reduce_minloc.get(), (NumericType)(0.0));
-  ASSERT_EQ((RAJA::Index_type) reduce_minloc.getLoc(), (RAJA::Index_type) 1);
-  ASSERT_EQ((NumericType) reduce_maxloc.get(), (NumericType)(0.0));
-  ASSERT_EQ((RAJA::Index_type) reduce_maxloc.getLoc(), (RAJA::Index_type) 1);
+  ASSERT_EQ((NumericType)reduce_sum.get(), (NumericType)(0.0));
+  ASSERT_EQ((NumericType)reduce_min.get(), (NumericType)(0.0));
+  ASSERT_EQ((NumericType)reduce_max.get(), (NumericType)(0.0));
+  ASSERT_EQ((NumericType)reduce_minloc.get(), (NumericType)(0.0));
+  ASSERT_EQ((RAJA::Index_type)reduce_minloc.getLoc(), (RAJA::Index_type)1);
+  ASSERT_EQ((NumericType)reduce_maxloc.get(), (NumericType)(0.0));
+  ASSERT_EQ((RAJA::Index_type)reduce_maxloc.getLoc(), (RAJA::Index_type)1);
 }
 
 REGISTER_TYPED_TEST_CASE_P(ReductionConstructorTest, ReductionConstructor);
 
 #if defined(RAJA_ENABLE_OPENMP)
-using constructor_types = ::testing::Types<
-    std::tuple<RAJA::seq_reduce, int>,
-    std::tuple<RAJA::seq_reduce, float>,
-    std::tuple<RAJA::seq_reduce, double>,
-    std::tuple<RAJA::omp_reduce, int>,
-    std::tuple<RAJA::omp_reduce, float>,
-    std::tuple<RAJA::omp_reduce, double>,
-    std::tuple<RAJA::omp_reduce_ordered, int>,
-    std::tuple<RAJA::omp_reduce_ordered, float>,
-    std::tuple<RAJA::omp_reduce_ordered, double> >;
+using constructor_types =
+    ::testing::Types<std::tuple<RAJA::seq_reduce, int>,
+                     std::tuple<RAJA::seq_reduce, float>,
+                     std::tuple<RAJA::seq_reduce, double>,
+                     std::tuple<RAJA::omp_reduce, int>,
+                     std::tuple<RAJA::omp_reduce, float>,
+                     std::tuple<RAJA::omp_reduce, double>,
+                     std::tuple<RAJA::omp_reduce_ordered, int>,
+                     std::tuple<RAJA::omp_reduce_ordered, float>,
+                     std::tuple<RAJA::omp_reduce_ordered, double> >;
 #else
-using constructor_types = ::testing::Types<
-    std::tuple<RAJA::seq_reduce, int>,
-    std::tuple<RAJA::seq_reduce, float>,
-    std::tuple<RAJA::seq_reduce, double> >;
+using constructor_types =
+    ::testing::Types<std::tuple<RAJA::seq_reduce, int>,
+                     std::tuple<RAJA::seq_reduce, float>,
+                     std::tuple<RAJA::seq_reduce, double> >;
 #endif
 
-INSTANTIATE_TYPED_TEST_CASE_P(ReduceBasicTests, ReductionConstructorTest, constructor_types);
+INSTANTIATE_TYPED_TEST_CASE_P(ReduceBasicTests,
+                              ReductionConstructorTest,
+                              constructor_types);
 
 
 template <typename TUPLE>
 class ReductionCorrectnessTest : public ::testing::Test
 {
- protected:
-   virtual void SetUp()
-   {
-     array_length = 102;
+protected:
+  virtual void SetUp()
+  {
+    array_length = 102;
 
-     array = RAJA::allocate_aligned_type<double>(RAJA::DATA_ALIGN,
-                                                 array_length * sizeof(double));
+    array = RAJA::allocate_aligned_type<double>(RAJA::DATA_ALIGN,
+                                                array_length * sizeof(double));
 
-     for (int i = 1; i < array_length-1; ++i) {
-       array[i] = (RAJA::Real_type) i;
-     }
-     array[0] = 0.0;
-     array[array_length-1] = -1.0;
+    for (int i = 1; i < array_length - 1; ++i) {
+      array[i] = (RAJA::Real_type)i;
+    }
+    array[0] = 0.0;
+    array[array_length - 1] = -1.0;
 
-     sum = 0.0;
-     min = array_length * 2;
-     max = 0.0;
-     minloc = -1;
-     maxloc = -1;
+    sum = 0.0;
+    min = array_length * 2;
+    max = 0.0;
+    minloc = -1;
+    maxloc = -1;
 
-     for (int i = 0; i < array_length; ++i) {
-       RAJA::Real_type val = array[i];
+    for (int i = 0; i < array_length; ++i) {
+      RAJA::Real_type val = array[i];
 
-       sum += val;
+      sum += val;
 
-       if (val > max) {
-         max = val;
-         maxloc = i;
-       }
+      if (val > max) {
+        max = val;
+        maxloc = i;
+      }
 
-       if (val < min) {
-         min = val;
-         minloc = i;
-       }
-     }
-   }
+      if (val < min) {
+        min = val;
+        minloc = i;
+      }
+    }
+  }
 
-   virtual void TearDown()
-   {
-     free(array);
-   }
+  virtual void TearDown() { free(array); }
 
-   RAJA::Real_ptr array;
+  RAJA::Real_ptr array;
 
-   RAJA::Real_type max;
-   RAJA::Real_type min;
-   RAJA::Real_type sum;
-   RAJA::Real_type maxloc;
-   RAJA::Real_type minloc;
+  RAJA::Real_type max;
+  RAJA::Real_type min;
+  RAJA::Real_type sum;
+  RAJA::Real_type maxloc;
+  RAJA::Real_type minloc;
 
-   RAJA::Index_type array_length;
- };
+  RAJA::Index_type array_length;
+};
 TYPED_TEST_CASE_P(ReductionCorrectnessTest);
 
 TYPED_TEST_P(ReductionCorrectnessTest, ReduceSum)
 {
   using ExecPolicy = typename std::tuple_element<0, TypeParam>::type;
   using ReducePolicy = typename std::tuple_element<1, TypeParam>::type;
-  //using NumericType = typename std::tuple_element<2, TypeParam>::type;
+  // using NumericType = typename std::tuple_element<2, TypeParam>::type;
 
   RAJA::ReduceSum<ReducePolicy, double> sum_reducer(0.0);
 
-  RAJA::forall<ExecPolicy>(RAJA::RangeSegment(0, this->array_length), [=] (int i) {
-    sum_reducer += this->array[i];
-  });
+  RAJA::forall<ExecPolicy>(RAJA::RangeSegment(0, this->array_length),
+                           [=](int i) { sum_reducer += this->array[i]; });
 
-  double raja_sum = (double) sum_reducer.get();
+  double raja_sum = (double)sum_reducer.get();
 
   ASSERT_FLOAT_EQ(this->sum, raja_sum);
 }
@@ -179,15 +177,14 @@ TYPED_TEST_P(ReductionCorrectnessTest, ReduceMin)
 {
   using ExecPolicy = typename std::tuple_element<0, TypeParam>::type;
   using ReducePolicy = typename std::tuple_element<1, TypeParam>::type;
-  //using NumericType = typename std::tuple_element<2, TypeParam>::type;
+  // using NumericType = typename std::tuple_element<2, TypeParam>::type;
 
   RAJA::ReduceMin<ReducePolicy, double> min_reducer(1024.0);
 
-  RAJA::forall<ExecPolicy>(RAJA::RangeSegment(0, this->array_length), [=] (int i) {
-    min_reducer.min(this->array[i]);
-  });
+  RAJA::forall<ExecPolicy>(RAJA::RangeSegment(0, this->array_length),
+                           [=](int i) { min_reducer.min(this->array[i]); });
 
-  double raja_min = (double) min_reducer.get();
+  double raja_min = (double)min_reducer.get();
 
   ASSERT_FLOAT_EQ(this->min, raja_min);
 }
@@ -196,15 +193,14 @@ TYPED_TEST_P(ReductionCorrectnessTest, ReduceMax)
 {
   using ExecPolicy = typename std::tuple_element<0, TypeParam>::type;
   using ReducePolicy = typename std::tuple_element<1, TypeParam>::type;
-  //using NumericType = typename std::tuple_element<2, TypeParam>::type;
+  // using NumericType = typename std::tuple_element<2, TypeParam>::type;
 
   RAJA::ReduceMax<ReducePolicy, double> max_reducer(0.0);
 
-  RAJA::forall<ExecPolicy>(RAJA::RangeSegment(0, this->array_length), [=] (int i) {
-    max_reducer.max(this->array[i]);
-  });
+  RAJA::forall<ExecPolicy>(RAJA::RangeSegment(0, this->array_length),
+                           [=](int i) { max_reducer.max(this->array[i]); });
 
-  double raja_max = (double) max_reducer.get();
+  double raja_max = (double)max_reducer.get();
 
   ASSERT_FLOAT_EQ(this->max, raja_max);
 }
@@ -213,15 +209,16 @@ TYPED_TEST_P(ReductionCorrectnessTest, ReduceMinLoc)
 {
   using ExecPolicy = typename std::tuple_element<0, TypeParam>::type;
   using ReducePolicy = typename std::tuple_element<1, TypeParam>::type;
-  //using NumericType = typename std::tuple_element<2, TypeParam>::type;
+  // using NumericType = typename std::tuple_element<2, TypeParam>::type;
 
   RAJA::ReduceMinLoc<ReducePolicy, double> minloc_reducer(1024.0, 0);
 
-  RAJA::forall<ExecPolicy>(RAJA::RangeSegment(0, this->array_length), [=] (int i) {
-    minloc_reducer.minloc(this->array[i], i);
-  });
+  RAJA::forall<ExecPolicy>(RAJA::RangeSegment(0, this->array_length),
+                           [=](int i) {
+                             minloc_reducer.minloc(this->array[i], i);
+                           });
 
-  double raja_min = (double) minloc_reducer.get();
+  double raja_min = (double)minloc_reducer.get();
   RAJA::Index_type raja_loc = minloc_reducer.getLoc();
 
   ASSERT_FLOAT_EQ(this->min, raja_min);
@@ -232,36 +229,39 @@ TYPED_TEST_P(ReductionCorrectnessTest, ReduceMaxLoc)
 {
   using ExecPolicy = typename std::tuple_element<0, TypeParam>::type;
   using ReducePolicy = typename std::tuple_element<1, TypeParam>::type;
-  //using NumericType = typename std::tuple_element<2, TypeParam>::type;
+  // using NumericType = typename std::tuple_element<2, TypeParam>::type;
 
   RAJA::ReduceMaxLoc<ReducePolicy, double> maxloc_reducer(0.0, -1);
 
-  RAJA::forall<ExecPolicy>(RAJA::RangeSegment(0, this->array_length), [=] (int i) {
-    maxloc_reducer.maxloc(this->array[i], i);
-  });
+  RAJA::forall<ExecPolicy>(RAJA::RangeSegment(0, this->array_length),
+                           [=](int i) {
+                             maxloc_reducer.maxloc(this->array[i], i);
+                           });
 
-  double raja_max = (double) maxloc_reducer.get();
+  double raja_max = (double)maxloc_reducer.get();
   RAJA::Index_type raja_loc = maxloc_reducer.getLoc();
 
   ASSERT_FLOAT_EQ(this->max, raja_max);
   ASSERT_EQ(this->maxloc, raja_loc);
 }
 
-REGISTER_TYPED_TEST_CASE_P(ReductionCorrectnessTest, ReduceSum, ReduceMin,
-                           ReduceMax, ReduceMinLoc, ReduceMaxLoc);
+REGISTER_TYPED_TEST_CASE_P(ReductionCorrectnessTest,
+                           ReduceSum,
+                           ReduceMin,
+                           ReduceMax,
+                           ReduceMinLoc,
+                           ReduceMaxLoc);
 
 #if defined(RAJA_ENABLE_OPENMP)
-using types = ::testing::Types<
-    std::tuple<RAJA::seq_exec, RAJA::seq_reduce>,
-    std::tuple<RAJA::simd_exec, RAJA::seq_reduce>,
-    std::tuple<RAJA::omp_parallel_for_exec, RAJA::omp_reduce>,
-    std::tuple<RAJA::omp_parallel_for_exec, RAJA::omp_reduce_ordered>
->;
+using types =
+    ::testing::Types<std::tuple<RAJA::seq_exec, RAJA::seq_reduce>,
+                     std::tuple<RAJA::simd_exec, RAJA::seq_reduce>,
+                     std::tuple<RAJA::omp_parallel_for_exec, RAJA::omp_reduce>,
+                     std::tuple<RAJA::omp_parallel_for_exec,
+                                RAJA::omp_reduce_ordered> >;
 #else
-using types = ::testing::Types<
-    std::tuple<RAJA::seq_exec, RAJA::seq_reduce>,
-    std::tuple<RAJA::simd_exec, RAJA::seq_reduce>
->;
+using types = ::testing::Types<std::tuple<RAJA::seq_exec, RAJA::seq_reduce>,
+                               std::tuple<RAJA::simd_exec, RAJA::seq_reduce> >;
 #endif
 
 INSTANTIATE_TYPED_TEST_CASE_P(Reduce, ReductionCorrectnessTest, types);
@@ -269,39 +269,36 @@ INSTANTIATE_TYPED_TEST_CASE_P(Reduce, ReductionCorrectnessTest, types);
 template <typename TUPLE>
 class NestedReductionCorrectnessTest : public ::testing::Test
 {
- protected:
-   virtual void SetUp()
-   {
-     x_size = 16;
-     y_size = 16;
-     z_size = 16;
+protected:
+  virtual void SetUp()
+  {
+    x_size = 16;
+    y_size = 16;
+    z_size = 16;
 
-     array = 
-       RAJA::allocate_aligned_type<double>(
-           RAJA::DATA_ALIGN, x_size * y_size * z_size * sizeof(double));
+    array = RAJA::allocate_aligned_type<double>(RAJA::DATA_ALIGN,
+                                                x_size * y_size * z_size
+                                                    * sizeof(double));
 
-     const double val = 4.0/(x_size * y_size * z_size);
+    const double val = 4.0 / (x_size * y_size * z_size);
 
-     for (int i = 0; i < (x_size * y_size * z_size); ++i) {
-           array[i] = (RAJA::Real_type) val;
-     }
+    for (int i = 0; i < (x_size * y_size * z_size); ++i) {
+      array[i] = (RAJA::Real_type)val;
+    }
 
-     sum = 4.0;
-   }
+    sum = 4.0;
+  }
 
-   virtual void TearDown()
-   {
-     free(array);
-   }
+  virtual void TearDown() { free(array); }
 
-   RAJA::Real_ptr array;
+  RAJA::Real_ptr array;
 
-   RAJA::Real_type sum;
+  RAJA::Real_type sum;
 
-   RAJA::Index_type x_size;
-   RAJA::Index_type y_size;
-   RAJA::Index_type z_size;
- };
+  RAJA::Index_type x_size;
+  RAJA::Index_type y_size;
+  RAJA::Index_type z_size;
+};
 TYPED_TEST_CASE_P(NestedReductionCorrectnessTest);
 
 TYPED_TEST_P(NestedReductionCorrectnessTest, NestedReduceSum)
@@ -311,18 +308,19 @@ TYPED_TEST_P(NestedReductionCorrectnessTest, NestedReduceSum)
 
   RAJA::ReduceSum<ReducePolicy, double> sum_reducer(0.0);
 
-  RAJA::View<double, RAJA::Layout<3> > view(
-      this->array, this->x_size, this->y_size, this->z_size);
+  RAJA::View<double, RAJA::Layout<3> > view(this->array,
+                                            this->x_size,
+                                            this->y_size,
+                                            this->z_size);
 
-  RAJA::forallN<ExecPolicy>(
-      RAJA::RangeSegment(0, this->x_size), 
-      RAJA::RangeSegment(0, this->y_size), 
-      RAJA::RangeSegment(0, this->z_size), 
-      [=] (int i, int j, int k) {
-        sum_reducer += view(i, j, k);
-  });
+  RAJA::forallN<ExecPolicy>(RAJA::RangeSegment(0, this->x_size),
+                            RAJA::RangeSegment(0, this->y_size),
+                            RAJA::RangeSegment(0, this->z_size),
+                            [=](int i, int j, int k) {
+                              sum_reducer += view(i, j, k);
+                            });
 
-  double raja_sum = (double) sum_reducer.get();
+  double raja_sum = (double)sum_reducer.get();
 
   ASSERT_FLOAT_EQ(this->sum, raja_sum);
 }
@@ -330,28 +328,47 @@ TYPED_TEST_P(NestedReductionCorrectnessTest, NestedReduceSum)
 REGISTER_TYPED_TEST_CASE_P(NestedReductionCorrectnessTest, NestedReduceSum);
 
 #if defined(RAJA_ENABLE_OPENMP)
-using nested_types = ::testing::Types<
-  std::tuple<RAJA::NestedPolicy<RAJA::ExecList<RAJA::seq_exec,
-        RAJA::seq_exec,
-        RAJA::seq_exec> >, RAJA::seq_reduce>, 
-  std::tuple<RAJA::NestedPolicy<RAJA::ExecList<RAJA::omp_collapse_nowait_exec,
-        RAJA::omp_collapse_nowait_exec,
-        RAJA::omp_collapse_nowait_exec>,
-        RAJA::OMP_Parallel<> >, RAJA::omp_reduce>, 
-  std::tuple<RAJA::NestedPolicy<RAJA::ExecList<RAJA::omp_parallel_for_exec,
-        RAJA::seq_exec,
-        RAJA::seq_exec> >, RAJA::omp_reduce>, 
-std::tuple<RAJA::NestedPolicy<RAJA::ExecList<RAJA::omp_collapse_nowait_exec,
-        RAJA::omp_collapse_nowait_exec,
-        RAJA::omp_collapse_nowait_exec>,
-        RAJA::OMP_Parallel<> >, RAJA::omp_reduce_ordered>
->;
+using nested_types = ::testing::
+    Types<std::tuple<RAJA::NestedPolicy<RAJA::ExecList<RAJA::seq_exec,
+                                                       RAJA::seq_exec,
+                                                       RAJA::seq_exec> >,
+                     RAJA::seq_reduce>,
+          std::
+              tuple<RAJA::
+                        NestedPolicy<RAJA::
+                                         ExecList<RAJA::
+                                                      omp_collapse_nowait_exec,
+                                                  RAJA::
+                                                      omp_collapse_nowait_exec,
+                                                  RAJA::
+                                                      omp_collapse_nowait_exec>,
+                                     RAJA::OMP_Parallel<> >,
+                    RAJA::omp_reduce>,
+          std::
+              tuple<RAJA::
+                        NestedPolicy<RAJA::ExecList<RAJA::omp_parallel_for_exec,
+                                                    RAJA::seq_exec,
+                                                    RAJA::seq_exec> >,
+                    RAJA::omp_reduce>,
+          std::
+              tuple<RAJA::
+                        NestedPolicy<RAJA::
+                                         ExecList<RAJA::
+                                                      omp_collapse_nowait_exec,
+                                                  RAJA::
+                                                      omp_collapse_nowait_exec,
+                                                  RAJA::
+                                                      omp_collapse_nowait_exec>,
+                                     RAJA::OMP_Parallel<> >,
+                    RAJA::omp_reduce_ordered> >;
 #else
-using nested_types = ::testing::Types<
-  std::tuple<RAJA::NestedPolicy<RAJA::ExecList<RAJA::seq_exec,
-        RAJA::seq_exec,
-        RAJA::seq_exec> >, RAJA::seq_reduce>
->;
+using nested_types = ::testing::
+    Types<std::tuple<RAJA::NestedPolicy<RAJA::ExecList<RAJA::seq_exec,
+                                                       RAJA::seq_exec,
+                                                       RAJA::seq_exec> >,
+                     RAJA::seq_reduce> >;
 #endif
 
-INSTANTIATE_TYPED_TEST_CASE_P(NestedReduce, NestedReductionCorrectnessTest, nested_types);
+INSTANTIATE_TYPED_TEST_CASE_P(NestedReduce,
+                              NestedReductionCorrectnessTest,
+                              nested_types);

--- a/test/unit/cpu/test-scan.cpp
+++ b/test/unit/cpu/test-scan.cpp
@@ -222,9 +222,7 @@ TYPED_TEST_CASE_P(ExclusiveScanTest);
 
 TYPED_TEST_P(InclusiveScanTest, InclusiveCorrectness)
 {
-  compareInclusive(this->original.get(),
-                   this->data.get(),
-                   this->function);
+  compareInclusive(this->original.get(), this->data.get(), this->function);
 }
 TYPED_TEST_P(ExclusiveScanTest, ExclusiveCorrectness)
 {

--- a/test/unit/gpu/ReduceSum.cpp
+++ b/test/unit/gpu/ReduceSum.cpp
@@ -210,7 +210,9 @@ int main(int argc, char *argv[])
       ReduceSum<cuda_reduce<block_size>, double> dsum2(dtinit * 3.0);
       ReduceSum<cuda_reduce<block_size>, int> isum3(itinit * 4);
 
-      forallN<NestedPolicy<ExecList<IndexSet::ExecPolicy<seq_segit, cuda_exec<block_size> > > > > (
+      forallN<NestedPolicy<ExecList<IndexSet::
+                                        ExecPolicy<seq_segit,
+                                                   cuda_exec<block_size> > > > >(
           iset, [=] __device__(int i) {
             dsum0 += dvalue[i];
             isum1 += 2 * ivalue[i];
@@ -309,7 +311,7 @@ int main(int argc, char *argv[])
 
     ////////////////////////////////////////////////////////////////////////////
 
-    {// Begin test4
+    {  // Begin test4
 
       ReduceSum<cuda_reduce_atomic<block_size>, double> dsumN(0.0);
       ReduceSum<cuda_reduce_atomic<block_size>, double> dsumP(0.0);
@@ -323,25 +325,21 @@ int main(int argc, char *argv[])
 
         for (int i = 0; i < TEST_VEC_LEN; ++i) {
           rand_dvalue[i] = drand48() - 0.5;
-          if(rand_dvalue[i] < 0.0) {
+          if (rand_dvalue[i] < 0.0) {
             neg_chk_val += rand_dvalue[i];
-          }
-          else {
+          } else {
             pos_chk_val += rand_dvalue[i];
-          } 
-        }
-        forall<cuda_exec<block_size> >(0,
-                                       TEST_VEC_LEN,
-                                       [=] __device__(int i) {
-          if(rand_dvalue[i] < 0.0) {
-            dsumN += rand_dvalue[i];
           }
-          else {
+        }
+        forall<cuda_exec<block_size> >(0, TEST_VEC_LEN, [=] __device__(int i) {
+          if (rand_dvalue[i] < 0.0) {
+            dsumN += rand_dvalue[i];
+          } else {
             dsumP += rand_dvalue[i];
           }
         });
 
-        if (   !equal(dsumN.get(), neg_chk_val)
+        if (!equal(dsumN.get(), neg_chk_val)
             || !equal(dsumP.get(), pos_chk_val)) {
           cout << "\n TEST 4 FAILURE: tcount, k = " << tcount << " , " << k
                << endl;
@@ -354,8 +352,8 @@ int main(int argc, char *argv[])
           s_ntests_passed++;
         }
       }
-    } //end test4
-  }  // end test repeat loop
+    }  // end test4
+  }    // end test repeat loop
 
   ///
   /// Print total number of tests passed/run.

--- a/test/unit/gpu/forall.cpp
+++ b/test/unit/gpu/forall.cpp
@@ -250,11 +250,9 @@ int main(int argc, char *argv[])
     ref_array[i] = parent[i] * parent[i];
   }
 
-  forall<cuda_exec<block_size> >(0,
-                                 0,
-                                 [=] __device__(Index_type idx) {
-                                   test_array[idx] = parent[idx] * parent[idx];
-                                 });
+  forall<cuda_exec<block_size> >(0, 0, [=] __device__(Index_type idx) {
+    test_array[idx] = parent[idx] * parent[idx];
+  });
 
   s_ntests_run++;
   if (!array_equal(ref_array, test_array, 0)) {

--- a/test/unit/gpu/forallN-strided.cpp
+++ b/test/unit/gpu/forallN-strided.cpp
@@ -41,7 +41,7 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 ///
-/// Source file containing tests for RAJA forallN strided tests. 
+/// Source file containing tests for RAJA forallN strided tests.
 ///
 
 #include <algorithm>
@@ -60,42 +60,47 @@
 const int x = 500, y = 500, z = 50;
 
 using namespace RAJA;
-void stride_test(int stride) {
-    double *arr = NULL;
-    cudaErrchk(cudaMallocManaged(&arr, sizeof(*arr) * x * y * z));
-    cudaMemset (arr, 0, sizeof(*arr) * x * y * z);
+void stride_test(int stride)
+{
+  double *arr = NULL;
+  cudaErrchk(cudaMallocManaged(&arr, sizeof(*arr) * x * y * z));
+  cudaMemset(arr, 0, sizeof(*arr) * x * y * z);
 
-    forallN<NestedPolicy<ExecList<seq_exec, cuda_block_x_exec, cuda_thread_y_exec>, Permute<PERM_IJK>>>(
-            RangeStrideSegment(0, z, stride),
-            RangeStrideSegment(0, y, stride),
-            RangeStrideSegment(0, x, stride),
-            [=] RAJA_DEVICE (int i, int j, int k) {
-            int val = z*y*i + y * j + k;
-            arr[val] = val;
-            });
-    cudaDeviceSynchronize();
+  forallN<NestedPolicy<ExecList<seq_exec,
+                                cuda_block_x_exec,
+                                cuda_thread_y_exec>,
+                       Permute<PERM_IJK>>>(RangeStrideSegment(0, z, stride),
+                                           RangeStrideSegment(0, y, stride),
+                                           RangeStrideSegment(0, x, stride),
+                                           [=] RAJA_DEVICE(int i,
+                                                           int j,
+                                                           int k) {
+                                             int val = z * y * i + y * j + k;
+                                             arr[val] = val;
+                                           });
+  cudaDeviceSynchronize();
 
-    int prev_val = 0;
-    for (int i=0; i < z; i+=stride) {
-        for (int j=0; j < y; j+=stride) {
-            for (int k=0; k < x; k+=stride) {
-                int val = z*y*i + y * j + k;
-                ASSERT_EQ(arr[val], val);
-                for (int inner=prev_val+1; inner < val; ++inner) {
-                    ASSERT_EQ(arr[inner], 0);
-                }
-                prev_val = val;
-            }
+  int prev_val = 0;
+  for (int i = 0; i < z; i += stride) {
+    for (int j = 0; j < y; j += stride) {
+      for (int k = 0; k < x; k += stride) {
+        int val = z * y * i + y * j + k;
+        ASSERT_EQ(arr[val], val);
+        for (int inner = prev_val + 1; inner < val; ++inner) {
+          ASSERT_EQ(arr[inner], 0);
         }
+        prev_val = val;
+      }
     }
-    cudaFree(arr);
+  }
+  cudaFree(arr);
 }
 
-TEST(forallN, rangeStrides) {
+TEST(forallN, rangeStrides)
+{
 
-    stride_test(1);
-    stride_test(2);
-    stride_test(3);
-    stride_test(4);
-
+  stride_test(1);
+  stride_test(2);
+  stride_test(3);
+  stride_test(4);
 }

--- a/test/unit/gpu/forallN.cpp
+++ b/test/unit/gpu/forallN.cpp
@@ -41,7 +41,7 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 ///
-/// Source file containing tests for RAJA GPU nested loop kernels. 
+/// Source file containing tests for RAJA GPU nested loop kernels.
 ///
 
 #include <time.h>
@@ -133,15 +133,15 @@ void runLTimesTest(std::string const &policy,
   // randomize data
   for (size_t i = 0; i < ell_data.size(); ++i) {
     ell_data[i] = drand48();
-    //ell_data[i] = 0.0;
+    // ell_data[i] = 0.0;
   }
-  //ell_data[0] = 2.0;
+  // ell_data[0] = 2.0;
 
   for (size_t i = 0; i < psi_data.size(); ++i) {
     psi_data[i] = drand48();
-    //psi_data[i] = 0.0;
+    // psi_data[i] = 0.0;
   }
-  //psi_data[0] = 5.0;
+  // psi_data[0] = 5.0;
   // create device memory
   double *d_ell, *d_phi, *d_psi;
   cudaErrchk(cudaMalloc(&d_ell, sizeof(double) * ell_data.size()));
@@ -163,9 +163,17 @@ void runLTimesTest(std::string const &policy,
              cudaMemcpyHostToDevice);
 
   // create views on data
-  typename POL::ELL_VIEW ell(d_ell, make_permuted_layout({num_moments, num_directions}, POL::ELL_PERM::value));
-  typename POL::PSI_VIEW psi(d_psi, make_permuted_layout({num_directions, num_groups, num_zones}, POL::PSI_PERM::value));
-  typename POL::PHI_VIEW phi(d_phi, make_permuted_layout({num_moments, num_groups, num_zones}, POL::PHI_PERM::value));
+  typename POL::ELL_VIEW ell(d_ell,
+                             make_permuted_layout({num_moments, num_directions},
+                                                  POL::ELL_PERM::value));
+  typename POL::PSI_VIEW psi(
+      d_psi,
+      make_permuted_layout({num_directions, num_groups, num_zones},
+                           POL::PSI_PERM::value));
+  typename POL::PHI_VIEW phi(
+      d_phi,
+      make_permuted_layout({num_moments, num_groups, num_zones},
+                           POL::PHI_PERM::value));
 
   // get execution policy
   using EXEC = typename POL::EXEC;
@@ -241,7 +249,7 @@ void runLTimesTest(std::string const &policy,
   if (std::abs(lsum - double(pdsum)) > 5e-9) {
     reductionsFailed++;
     whichFailed += "[ReduceSum]";
-    //printf("ReduceSum failed : EPS =  %g\n",std::abs(lsum - double(pdsum)));
+    // printf("ReduceSum failed : EPS =  %g\n",std::abs(lsum - double(pdsum)));
   }
 
   if (lmin != double(pdmin)) {

--- a/test/unit/gpu/test-scan.cpp
+++ b/test/unit/gpu/test-scan.cpp
@@ -217,9 +217,7 @@ TYPED_TEST_CASE_P(ExclusiveScanTest);
 
 TYPED_TEST_P(InclusiveScanTest, InclusiveCorrectness)
 {
-  compareInclusive(this->original.get(),
-                   this->data.get(),
-                   this->function);
+  compareInclusive(this->original.get(), this->data.get(), this->function);
 }
 TYPED_TEST_P(ExclusiveScanTest, ExclusiveCorrectness)
 {

--- a/test/unit/test-integral-limits.cpp
+++ b/test/unit/test-integral-limits.cpp
@@ -60,24 +60,27 @@ TYPED_TEST_CASE_P(IntegralLimitsTest);
 
 TYPED_TEST_P(IntegralLimitsTest, IntegralLimits)
 {
-  ASSERT_EQ(RAJA::operators::limits<TypeParam>::min(), std::numeric_limits<TypeParam>::min());
-  ASSERT_EQ(RAJA::operators::limits<TypeParam>::max(), std::numeric_limits<TypeParam>::max());
+  ASSERT_EQ(RAJA::operators::limits<TypeParam>::min(),
+            std::numeric_limits<TypeParam>::min());
+  ASSERT_EQ(RAJA::operators::limits<TypeParam>::max(),
+            std::numeric_limits<TypeParam>::max());
 }
 
 REGISTER_TYPED_TEST_CASE_P(IntegralLimitsTest, IntegralLimits);
 
-using integer_types = ::testing::Types<
-  char,
-  unsigned char,
-  short,
-  unsigned short,
-  int,
-  unsigned int,
-  long,
-  unsigned long,
-  long int,
-  unsigned long int,
-  long long,
-  unsigned long long>;
+using integer_types = ::testing::Types<char,
+                                       unsigned char,
+                                       short,
+                                       unsigned short,
+                                       int,
+                                       unsigned int,
+                                       long,
+                                       unsigned long,
+                                       long int,
+                                       unsigned long int,
+                                       long long,
+                                       unsigned long long>;
 
-INSTANTIATE_TYPED_TEST_CASE_P(IntegralLimitsTests, IntegralLimitsTest, integer_types);
+INSTANTIATE_TYPED_TEST_CASE_P(IntegralLimitsTests,
+                              IntegralLimitsTest,
+                              integer_types);

--- a/test/unit/test-layout.cpp
+++ b/test/unit/test-layout.cpp
@@ -84,7 +84,7 @@ TEST(TypedLayoutTest, 1D)
    */
   const RAJA::TypedLayout<TIL, TIX, TIY> l(10, 5);
 
-  ASSERT_EQ(TIL{0}, l(TIX{0},TIY{0}));
+  ASSERT_EQ(TIL{0}, l(TIX{0}, TIY{0}));
 
   ASSERT_EQ(TIL{2}, l(TIX{0}, TIY{2}));
 
@@ -95,14 +95,13 @@ TEST(TypedLayoutTest, 1D)
   l.toIndices(TIL{10}, y, x);
   ASSERT_EQ(x, TIX{0});
   ASSERT_EQ(y, TIY{2});
-
 }
 
 
 TEST(LayoutTest, OffsetVsRegular)
 {
-  const auto layout = RAJA::make_permuted_layout({6, 6},
-                                                   RAJA::Perm<1,0>::value);
+  const auto layout =
+      RAJA::make_permuted_layout({6, 6}, RAJA::Perm<1, 0>::value);
   const auto offset =
       RAJA::make_permuted_offset_layout({0, 0}, {5, 5}, RAJA::PERM_JI::value);
 
@@ -111,7 +110,8 @@ TEST(LayoutTest, OffsetVsRegular)
    */
   for (int j = 0; j < 6; ++j) {
     for (int i = 0; i < 6; ++i) {
-      ASSERT_EQ(offset(i, j), layout(i, j)) << layout.strides[0] << layout.strides[1];
+      ASSERT_EQ(offset(i, j), layout(i, j)) << layout.strides[0]
+                                            << layout.strides[1];
     }
   }
 }

--- a/test/unit/test-multipolicy.cpp
+++ b/test/unit/test-multipolicy.cpp
@@ -50,38 +50,39 @@
 
 TEST(multipolicy, basic)
 {
-  auto mp = RAJA::make_multi_policy<RAJA::seq_exec,RAJA::omp_parallel_for_exec>(
-      [] (const RAJA::RangeSegment& r) {
-        if (r.size() < 100) {
-          return 0;
-        } else {
-          return 1;
-        }
-      });
-  RAJA::forall(mp, RAJA::RangeSegment(0, 5), [](RAJA::Index_type){
+  auto mp =
+      RAJA::make_multi_policy<RAJA::seq_exec, RAJA::omp_parallel_for_exec>(
+          [](const RAJA::RangeSegment& r) {
+            if (r.size() < 100) {
+              return 0;
+            } else {
+              return 1;
+            }
+          });
+  RAJA::forall(mp, RAJA::RangeSegment(0, 5), [](RAJA::Index_type) {
     ASSERT_EQ(omp_get_num_threads(), 1);
   });
-  RAJA::forall(mp, RAJA::RangeSegment(0, 101), [](RAJA::Index_type){
+  RAJA::forall(mp, RAJA::RangeSegment(0, 101), [](RAJA::Index_type) {
     ASSERT_TRUE(omp_get_num_threads() > 1);
   });
   // Nest a multipolicy to ensure value-based policies are preserved
-  auto mp2 = RAJA::make_multi_policy(
-          std::make_tuple(RAJA::omp_parallel_for_exec{}, mp),
-          [] (const RAJA::RangeSegment& r) {
-        if (r.size() > 10 && r.size() < 90) {
-          return 0;
-        } else {
-          return 1;
-        }
-      });
-  RAJA::forall(mp2, RAJA::RangeSegment(0, 5), [](RAJA::Index_type){
+  auto mp2 =
+      RAJA::make_multi_policy(std::make_tuple(RAJA::omp_parallel_for_exec{},
+                                              mp),
+                              [](const RAJA::RangeSegment& r) {
+                                if (r.size() > 10 && r.size() < 90) {
+                                  return 0;
+                                } else {
+                                  return 1;
+                                }
+                              });
+  RAJA::forall(mp2, RAJA::RangeSegment(0, 5), [](RAJA::Index_type) {
     ASSERT_EQ(omp_get_num_threads(), 1);
   });
-  RAJA::forall(mp2, RAJA::RangeSegment(0, 91), [](RAJA::Index_type){
+  RAJA::forall(mp2, RAJA::RangeSegment(0, 91), [](RAJA::Index_type) {
     ASSERT_EQ(omp_get_num_threads(), 1);
   });
-  RAJA::forall(mp2, RAJA::RangeSegment(0, 50), [](RAJA::Index_type){
+  RAJA::forall(mp2, RAJA::RangeSegment(0, 50), [](RAJA::Index_type) {
     ASSERT_TRUE(omp_get_num_threads() > 1);
   });
 }
-

--- a/test/unit/test-timer.cpp
+++ b/test/unit/test-timer.cpp
@@ -48,40 +48,41 @@
 
 #include "RAJA/util/Timer.hpp"
 
-#include <string>
 #include <iostream>
+#include <string>
 
-#include <thread>
 #include <chrono>
+#include <thread>
 
 
 TEST(TimerTest, No1)
 {
   RAJA::Timer timer;
 
-  timer.start("test_timer"); 
+  timer.start("test_timer");
 
   std::cout << "Printing 1000 stars...\n";
-  for (int i=0; i<1000; ++i) std::cout << "*";
+  for (int i = 0; i < 1000; ++i)
+    std::cout << "*";
   std::cout << std::endl;
 
   timer.stop();
 
   RAJA::Timer::ElapsedType elapsed = timer.elapsed();
 
-  EXPECT_TRUE( elapsed > 0.0 );
+  EXPECT_TRUE(elapsed > 0.0);
 
   std::cout << "Printing 1000 stars took " << elapsed << " seconds.";
 }
 
- 
+
 TEST(TimerTest, No2)
-{ 
+{
   RAJA::Timer timer;
 
   timer.start("test_timer");
 
-  for (int i=2; i>0; --i) {
+  for (int i = 2; i > 0; --i) {
     std::cout << i << std::endl;
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
@@ -90,8 +91,8 @@ TEST(TimerTest, No2)
 
   RAJA::Timer::ElapsedType elapsed = timer.elapsed();
 
-  EXPECT_TRUE( elapsed > 2.0 );
+  EXPECT_TRUE(elapsed > 2.0);
 
   std::cout << "I slept for " << elapsed << " seconds. Refreshing!";
-  std::cout << std::endl; 
+  std::cout << std::endl;
 }

--- a/test/unit/test-type-traits.cpp
+++ b/test/unit/test-type-traits.cpp
@@ -52,7 +52,8 @@
 
 #ifdef RAJA_ENABLE_OPENMP
 
-static_assert(!RAJA::is_sequential_policy<RAJA::omp_parallel_for_exec>::value, "");
+static_assert(!RAJA::is_sequential_policy<RAJA::omp_parallel_for_exec>::value,
+              "");
 static_assert(RAJA::is_openmp_policy<RAJA::omp_parallel_for_exec>::value, "");
 static_assert(!RAJA::is_cuda_policy<RAJA::omp_parallel_for_exec>::value, "");
 #endif
@@ -68,13 +69,11 @@ static_assert(!RAJA::is_openmp_policy<RAJA::cuda_exec<128>>::value, "");
 static_assert(RAJA::is_cuda_policy<RAJA::cuda_exec<128>>::value, "");
 
 // check CUDA async policies...
-static_assert(!RAJA::is_sequential_policy<RAJA::cuda_exec<128, true>>::value, "");
+static_assert(!RAJA::is_sequential_policy<RAJA::cuda_exec<128, true>>::value,
+              "");
 static_assert(!RAJA::is_openmp_policy<RAJA::cuda_exec<128, true>>::value, "");
 static_assert(RAJA::is_cuda_policy<RAJA::cuda_exec<128, true>>::value, "");
 
 #endif
 
-TEST(TypeTraits, Default)
-{
-  ASSERT_EQ(true, true);
-}
+TEST(TypeTraits, Default) { ASSERT_EQ(true, true); }


### PR DESCRIPTION
Moving some forallN constructs to "public" or more appropriate header files based on conversation with @trws and @davidbeckingsale earlier today.

Also, ran source code through clang-format since this is a good PR to do it since not much other code has changed.