### PR TITLE
repair includes for headers, based on creation of a module-map for clang

### DIFF
--- a/include/RAJA/index/IndexSetUtils.hpp
+++ b/include/RAJA/index/IndexSetUtils.hpp
@@ -54,9 +54,8 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "RAJA/config.hpp"
-
-#include "RAJA/util/types.hpp"
+#include "RAJA/pattern/forall.hpp"
+#include "RAJA/policy/sequential.hpp"
 
 namespace RAJA
 {

--- a/include/RAJA/internal/IndexArray.hpp
+++ b/include/RAJA/internal/IndexArray.hpp
@@ -55,7 +55,7 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 
-#include <RAJA/LegacyCompatibility.hxx>
+#include <RAJA/internal/LegacyCompatibility.hpp>
 
 namespace RAJA
 {

--- a/include/RAJA/internal/rangelist_forall.hpp
+++ b/include/RAJA/internal/rangelist_forall.hpp
@@ -54,6 +54,9 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+#include "RAJA/pattern/forall.hpp"
+#include "RAJA/policy/sequential.hpp"
+
 namespace RAJA
 {
 namespace impl


### PR DESCRIPTION
As part of a test for something else I tried modularizing RAJA, turns out that's less hard than I thought, but these include issues popped out as part of the process.  By way of a side note, a compilation of a minimal test file using modules turned out to be about six times faster than the classic header model.