### PR TITLE
Feature/ajk/viewptr

### DIFF
--- a/include/RAJA/util/View.hpp
+++ b/include/RAJA/util/View.hpp
@@ -125,8 +125,6 @@ using TypedView = TypedViewBase<DataType, DataType*, LayoutT, IndexTypes...>;
 
 #if defined(RAJA_ENABLE_CHAI)
 
-#if 1
-
 template <typename DataType, typename LayoutT>
 using ManagedArrayView = View<DataType, 
                               LayoutT, 
@@ -134,69 +132,10 @@ using ManagedArrayView = View<DataType,
 
 
 template <typename DataType, typename LayoutT, typename... IndexTypes>
-using TypedManagedArrayView = TypedViewBase<DataType
+using TypedManagedArrayView = TypedViewBase<DataType,
                                             chai::ManagedArray<DataType>,
                                             LayoutT,
                                             IndexTypes...>;
-
-#else
-template <typename DataType, typename LayoutT>
-struct ManagedArrayView {
-  LayoutT const layout;
-  chai::ManagedArray<DataType> array;
-
-  template <typename... Args>
-  RAJA_INLINE constexpr ManagedArrayView(chai::ManagedArray<DataType> data_ptr, Args... dim_sizes)
-      : layout(dim_sizes...), array(data_ptr)
-  {
-  }
-
-  RAJA_INLINE constexpr ManagedArrayView(chai::ManagedArray<DataType> data_ptr, LayoutT &&layout)
-      : layout(layout), array(data_ptr)
-  {
-  }
-
-  RAJA_INLINE void set_data(chai::ManagedArray<DataType> new_array) {
-      array = new_array;
-  }
-
-  // making this specifically typed would require unpacking the layout,
-  // this is easier to maintain
-  template <typename... Args>
-  RAJA_HOST_DEVICE RAJA_INLINE DataType &operator()(Args... args) const
-  {
-    return array[convertIndex<Index_type>(layout(args...))];
-  }
-};
-
-template <typename DataType, typename LayoutT, typename... IndexTypes>
-struct TypedManagedArrayView {
-  using Base = ManagedArrayView<DataType, LayoutT>;
-
-  Base base_;
-
-  template <typename... Args>
-  RAJA_INLINE constexpr TypedManagedArrayView(chai::ManagedArray<DataType> data_ptr, Args... dim_sizes)
-      : base_(data_ptr, dim_sizes...)
-  {
-  }
-
-  RAJA_INLINE constexpr TypedManagedArrayView(chai::ManagedArray<DataType> data_ptr, LayoutT &&layout)
-      : base_(data_ptr, layout)
-  {
-  }
-
-  RAJA_INLINE void set_data(chai::ManagedArray<DataType> new_array) {
-      base_.set_data(new_array);
-  }
-
-  RAJA_HOST_DEVICE RAJA_INLINE DataType &operator()(IndexTypes... args) const
-  {
-    return base_.operator()(convertIndex<Index_type>(args)...);
-  }
-};
-#endif
-
 
 #endif
 

--- a/include/RAJA/util/View.hpp
+++ b/include/RAJA/util/View.hpp
@@ -3,7 +3,7 @@
  *
  * \file
  *
- * \brief   RAJA header file defining view class used in forallN templates.
+ * \brief   RAJA header file defining a multi-dimensional view class.
  *
  ******************************************************************************
  */
@@ -63,23 +63,25 @@
 namespace RAJA
 {
 
-template <typename DataType, typename LayoutT>
+template <typename DataType, 
+          typename LayoutT, 
+          typename DataPointer = DataType*>
 struct View {
   LayoutT const layout;
-  DataType *data;
+  DataPointer data;
 
   template <typename... Args>
-  RAJA_INLINE constexpr View(DataType *data_ptr, Args... dim_sizes)
+  RAJA_INLINE constexpr View(DataPointer data_ptr, Args... dim_sizes)
       : layout(dim_sizes...), data(data_ptr)
   {
   }
 
-  RAJA_INLINE constexpr View(DataType *data_ptr, LayoutT &&layout)
+  RAJA_INLINE constexpr View(DataPointer data_ptr, LayoutT &&layout)
       : layout(layout), data(data_ptr)
   {
   }
 
-  RAJA_INLINE void set_data(DataType *data_ptr) { data = data_ptr; }
+  RAJA_INLINE void set_data(DataPointer data_ptr) { data = data_ptr; }
 
   // making this specifically typed would require unpacking the layout,
   // this is easier to maintain
@@ -90,24 +92,27 @@ struct View {
   }
 };
 
-template <typename DataType, typename LayoutT, typename... IndexTypes>
-struct TypedView {
-  using Base = View<DataType, LayoutT>;
+template <typename DataType, 
+          typename DataPointer, 
+          typename LayoutT, 
+          typename... IndexTypes>
+struct TypedViewBase {
+  using Base = View<DataType, LayoutT, DataPointer>;
 
   Base base_;
 
   template <typename... Args>
-  RAJA_INLINE constexpr TypedView(DataType *data_ptr, Args... dim_sizes)
+  RAJA_INLINE constexpr TypedViewBase(DataPointer data_ptr, Args... dim_sizes)
       : base_(data_ptr, dim_sizes...)
   {
   }
 
-  RAJA_INLINE constexpr TypedView(DataType *data_ptr, LayoutT &&layout)
+  RAJA_INLINE constexpr TypedViewBase(DataPointer data_ptr, LayoutT &&layout)
       : base_(data_ptr, layout)
   {
   }
 
-  RAJA_INLINE void set_data(DataType *data_ptr) { base_.set_data(data_ptr); }
+  RAJA_INLINE void set_data(DataPointer data_ptr) { base_.set_data(data_ptr); }
 
   RAJA_HOST_DEVICE RAJA_INLINE DataType &operator()(IndexTypes... args) const
   {
@@ -115,8 +120,26 @@ struct TypedView {
   }
 };
 
+template <typename DataType, typename LayoutT, typename... IndexTypes>
+using TypedView = TypedViewBase<DataType, DataType*, LayoutT, IndexTypes...>;
+
 #if defined(RAJA_ENABLE_CHAI)
 
+#if 1
+
+template <typename DataType, typename LayoutT>
+using ManagedArrayView = View<DataType, 
+                              LayoutT, 
+                              chai::ManagedArray<DataType>>;
+
+
+template <typename DataType, typename LayoutT, typename... IndexTypes>
+using TypedManagedArrayView = TypedViewBase<DataType
+                                            chai::ManagedArray<DataType>,
+                                            LayoutT,
+                                            IndexTypes...>;
+
+#else
 template <typename DataType, typename LayoutT>
 struct ManagedArrayView {
   LayoutT const layout;
@@ -172,6 +195,8 @@ struct TypedManagedArrayView {
     return base_.operator()(convertIndex<Index_type>(args)...);
   }
 };
+#endif
+
 
 #endif
 

--- a/test/integration/chai/chai-policy-tests.cxx
+++ b/test/integration/chai/chai-policy-tests.cxx
@@ -13,14 +13,25 @@ static_assert(RAJA::detail::get_space<RAJA::omp_parallel_for_exec>::value == cha
 
 #if defined(RAJA_ENABLE_CUDA)
 static_assert(RAJA::detail::get_space<RAJA::cuda_exec<128> >::value == chai::GPU, "");
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
 static_assert(RAJA::detail::get_space<RAJA::IndexSet::ExecPolicy<RAJA::seq_segit, RAJA::cuda_exec<128> > >::value == chai::GPU, "");
 #endif
 
 static_assert(RAJA::detail::get_space<RAJA::NestedPolicy< RAJA::ExecList< RAJA::seq_exec, RAJA::seq_exec > > >::value == chai::CPU, "");
+
+#if defined(RAJA_ENABLE_CUDA)
 static_assert(RAJA::detail::get_space<RAJA::NestedPolicy< RAJA::ExecList< RAJA::seq_exec, RAJA::cuda_exec<16> > > >::value == chai::GPU, "");
+#endif
 
 TEST(ChaiPolicyTest, Default) {
+
+#if defined(RAJA_ENABLE_CUDA)
   std::cout << RAJA::detail::get_space<RAJA::IndexSet::ExecPolicy<RAJA::seq_segit, RAJA::cuda_exec<128> > >::value << std::endl;
+#else
+  std::cout << RAJA::detail::get_space<RAJA::IndexSet::ExecPolicy<RAJA::seq_segit, RAJA::simd_exec > >::value << std::endl;
+#endif
 
   ASSERT_EQ(true, true);
 }

--- a/test/integration/chai/chai-tests.cxx
+++ b/test/integration/chai/chai-tests.cxx
@@ -6,10 +6,19 @@
 
 #include <iostream>
 
+
+#if defined(RAJA_ENABLE_CUDA)
+
 #define CUDA_TEST(X, Y) \
   static void cuda_test_ ## X ## Y();\
   TEST(X,Y) { cuda_test_ ## X ## Y();} \
   static void cuda_test_ ## X ## Y()
+
+#else
+
+#define CUDA_TEST(X, Y) TEST(X,Y)
+
+#endif
 
 CUDA_TEST(ChaiTest, Simple) {
   chai::ManagedArray<float> v1(10);
@@ -21,9 +30,16 @@ CUDA_TEST(ChaiTest, Simple) {
 
   std::cout << "end of loop 1" << std::endl;
 
+
+#if defined(RAJA_ENABLE_CUDA)
   RAJA::forall<RAJA::cuda_exec<16> >(0, 10, [=] __device__ (int i) {
       v2[i] = v1[i]*2.0f;
   });
+#else
+  RAJA::forall<RAJA::omp_for_exec >(0, 10, [=] (int i) {
+      v2[i] = v1[i]*2.0f;
+  });
+#endif
 
   std::cout << "end of loop 2" << std::endl;
 
@@ -31,9 +47,16 @@ CUDA_TEST(ChaiTest, Simple) {
       ASSERT_FLOAT_EQ(v2[i], i*2.0f);
   });
 
+
+#if defined(RAJA_ENABLE_CUDA)
   RAJA::forall<RAJA::cuda_exec<16> >(0, 10, [=] __device__ (int i) {
       v2[i] *= 2.0f;
   });
+#else
+  RAJA::forall<RAJA::omp_for_exec >(0, 10, [=] (int i) {
+      v2[i] *= 2.0f;
+  });
+#endif
 
   float * raw_v2 = v2;
   for (int i = 0; i < 10; i++ ) {
@@ -54,19 +77,32 @@ CUDA_TEST(ChaiTest, Views) {
       v1(i) = static_cast<float>(i * 1.0f);
   });
 
+#if defined(RAJA_ENABLE_CUDA)
   RAJA::forall<RAJA::cuda_exec<16> >(0, 10, [=] __device__ (int i) {
       v2(i) = v1(i)*2.0f;
   });
+#else
+  RAJA::forall<RAJA::omp_for_exec >(0, 10, [=](int i) {
+      v2(i) = v1(i)*2.0f;
+  });
+#endif
 
   RAJA::forall<RAJA::seq_exec>(0, 10, [=] (int i) {
       ASSERT_FLOAT_EQ(v2(i), i*2.0f);
   });
 
+
+#if defined(RAJA_ENABLE_CUDA)
   RAJA::forall<RAJA::cuda_exec<16> >(0, 10, [=] __device__ (int i) {
       v2(i) *= 2.0f;
   });
+#else
+  RAJA::forall<RAJA::omp_for_exec >(0, 10, [=](int i) {
+      v2(i) *= 2.0f;
+  });
+#endif
 
-  float * raw_v2 = v2.array;
+  float * raw_v2 = v2.data;
   for (int i = 0; i < 10; i++ ) {
       ASSERT_FLOAT_EQ(raw_v2[i], i*1.0f*2.0f*2.0f);;
   }


### PR DESCRIPTION
Changed View and TypedView to allow templating on the data type and the container of the data type.  This directly allows the use of chai::ManagedArray, without having to reimplement them.

By default, it assumes that DataPointer = DataType*, but can be overridden.

Also, all of the CHAI testing assumed that CUDA was available.  I put in some gaurds/alternate code to support non-CUDA builds