### PR TITLE
Add header and namespace for getenv and abort [updated]

### DIFF
--- a/include/RAJA/util/defines.hpp
+++ b/include/RAJA/util/defines.hpp
@@ -55,7 +55,7 @@
 
 #include "RAJA/config.hpp"
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <stdexcept>
 
 //
@@ -148,8 +148,8 @@
 
 inline void RAJA_ABORT_OR_THROW(const char *str)
 {
-  if (getenv("RAJA_NO_EXCEPT") != NULL) {
-    abort();
+  if (std::getenv("RAJA_NO_EXCEPT") != nullptr) {
+    std::abort();
   } else {
     throw std::runtime_error(str);
   }


### PR DESCRIPTION
This is the second attempt at this PR (trying to get Intel build to not error in CI). Trying a clean branch with the commits merged from @jeffhammond 's initial PR

Closes #263 

this was previously addressed by https://github.com/LLNL/RAJA/pull/231
but that used the C header.  subsequently, that change was undone.

this fix uses the correct C++ solution, which means `cstdlib` instead of
`stdlib.h` and prepending `getenv` and `abort` with `std::`