### PR TITLE
Bugfix/rhornung67/BLTbuild

### DIFF
--- a/cmake/SetupPackages.cmake
+++ b/cmake/SetupPackages.cmake
@@ -1,12 +1,12 @@
 ###############################################################################
 # Copyright (c) 2016, Lawrence Livermore National Security, LLC.
-#
+#    
 # Produced at the Lawrence Livermore National Laboratory
-#
+#    
 # LLNL-CODE-689114
-#
+# 
 # All rights reserved.
-#
+#  
 # This file is part of RAJA.
 #
 # For additional details, please also read RAJA/LICENSE.
@@ -82,6 +82,14 @@ endif()
 
 
 if (RAJA_ENABLE_TESTS)
+
+#
+# This conditional prevents build problems resulting from BLT and
+# RAJA each having their own copy of googletest.
+#
+if (RAJA_BUILD_WITH_BLT)
+else()
+
   include(ExternalProject)
   # Set default ExternalProject root directory
   SET_DIRECTORY_PROPERTIES(PROPERTIES EP_PREFIX ${CMAKE_BINARY_DIR}/tpl)
@@ -90,7 +98,7 @@ if (RAJA_ENABLE_TESTS)
       googletest
       GIT_REPOSITORY https://github.com/google/googletest.git
       GIT_TAG release-1.7.0
-      CMAKE_ARGS
+      CMAKE_ARGS                
           -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
           -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
       INSTALL_COMMAND ""
@@ -127,6 +135,8 @@ if (RAJA_ENABLE_TESTS)
   find_package(Threads)
 
   enable_testing()
+endif ()
+
 endif ()
 
 if (RAJA_ENABLE_DOCUMENTATION)


### PR DESCRIPTION
Reworking build system for perf suite. Now RAJA is a submodule
and BLT is used to build it. BLT and RAJA each pull in their own
copy of GoogleTest which breaks compilation when RAJA testing is enabled.
This minor change allows the new system to work properly and doesn't
adversely affect the current state of RAJA.

If we switch RAJA over to use BLT as well, a lot of our CMake stuff
will go away.