### PR TITLE
Fixed wonkey logic in TypedRangeStrideSegment, added barrage of unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ include(cmake/SetupRajaConfig.cmake)
 # Macros for building executables and libraries
 include (cmake/RAJAMacros.cmake)
 # Sanity check for compiler compatibility
-include (cmake/CompilerCompatibility.cmake)
+#include (cmake/CompilerCompatibility.cmake)
 
 include_directories(${PROJECT_BINARY_DIR}/include/RAJA)
 include_directories(${PROJECT_BINARY_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ include(cmake/SetupRajaConfig.cmake)
 # Macros for building executables and libraries
 include (cmake/RAJAMacros.cmake)
 # Sanity check for compiler compatibility
-#include (cmake/CompilerCompatibility.cmake)
+include (cmake/CompilerCompatibility.cmake)
 
 include_directories(${PROJECT_BINARY_DIR}/include/RAJA)
 include_directories(${PROJECT_BINARY_DIR}/include)

--- a/include/RAJA/index/RangeSegment.hpp
+++ b/include/RAJA/index/RangeSegment.hpp
@@ -200,7 +200,7 @@ private:
 /*!
  ******************************************************************************
  *
- * \brief  Segment class representing a contiguous typed range of indices
+ * \brief  Segment class representing a strided and typed range of indices
  *
  * \tparam StorageT the underlying data type for the Segment
  *
@@ -208,9 +208,22 @@ private:
  *
  *  begin() -- returns an iterator (TypedRangeStrideSegment::iterator)
  *  end() -- returns an iterator (TypedRangeStrideSegment::iterator)
- *  size() -- returns the total size of the Segment
+ *  size() -- returns the total iteration size of the Segment, not
+ *            necessarily the distance between begin() and end()
  *
  * NOTE: TypedRangeStrideSegment::iterator is a RandomAccessIterator
+ *
+ * NOTE: TypedRangeStrideSegment allows for positive or negative strides, but
+ *       a stride of zero is undefined and will cause DBZ
+ *
+ * 
+ * As with other segment, the iteration space is inclusive of begin() and 
+ * exclusive of end()
+ *
+ * For positive strides, begin() > end() implies size()==0
+ * For negative strides, begin() < end() implies size()==0
+ *
+ * NOTE: Proper handling of negative strides requires StorageT is a signed type
  *
  * Usage:
  *
@@ -219,6 +232,13 @@ private:
  * for (T i = begin; i < end; i += incr) {
  *   // loop body -- use i as index value
  * }
+ *
+ * Or, equivalently for a negative stride (incr < 0):
+ *
+ * for (T i = begin; i > end; i += incr) {
+ *   // loop body -- use i as index value
+ * }
+ *
  *
  * Using a TypedRangeStrideSegment, this becomes:
  *
@@ -232,6 +252,7 @@ private:
  * for (auto i : TypedRangeStrideSegment<T>(begin, end, incr)) {
  *   // loop body -- use i as index value
  * }
+ *
  *
  ******************************************************************************
  */
@@ -258,10 +279,13 @@ struct TypedRangeStrideSegment {
                                            StorageT stride)
       : m_begin(iterator(begin, stride)),
         m_end(iterator(end, stride)),
-        m_size((end - begin) >= stride
-                   ? (end - begin) / stride + ((end - begin) % stride)
-                   : 0)
+        // essentially a ceil((end-begin)/stride) but using integer math,
+        // and allowing for negative strides
+        m_size((end - begin + stride - ( stride > 0 ? 1 : -1  ) ) / stride)
   {
+    // if m_size was initialized as negative, that indicates a zero iteration
+    // space
+    m_size = m_size < 0 ? 0 : m_size;
   }
 
   //! disable compiler generated constructor

--- a/include/RAJA/internal/Iterators.hpp
+++ b/include/RAJA/internal/Iterators.hpp
@@ -295,12 +295,8 @@ public:
   RAJA_HOST_DEVICE inline difference_type operator-(
       const strided_numeric_iterator& rhs) const
   {
-    auto diff = static_cast<difference_type>(base::val)
-                - (static_cast<difference_type>(rhs.val));
-    if (diff < stride) return 0;
-    if (diff % stride)  // check for off-stride endpoint
-      return diff / stride + 1;
-    return diff / stride;
+    return static_cast<difference_type>(base::val)
+           - (static_cast<difference_type>(rhs.val * stride));
   }
   RAJA_HOST_DEVICE inline strided_numeric_iterator operator+(
       const difference_type& rhs) const
@@ -318,9 +314,7 @@ public:
   RAJA_HOST_DEVICE inline bool operator!=(
       const strided_numeric_iterator& rhs) const
   {
-    if (base::val == rhs.val) return false;
-    auto rem = rhs.val % stride;
-    return base::val != rhs.val + rem;
+    return (base::val - rhs.val) / stride;
   }
 
   RAJA_HOST_DEVICE inline Type operator*() const { return base::val; }

--- a/test/unit/cpu/CMakeLists.txt
+++ b/test/unit/cpu/CMakeLists.txt
@@ -51,6 +51,11 @@ raja_add_test(
 raja_add_test(
   NAME test-nested
   SOURCES main-nested.cpp)
+  
+raja_add_test(
+  NAME test-segments
+  SOURCES test-segments.cpp
+  DEPENDS_ON gtest gtest_main)
 
 if(RAJA_ENABLE_OPENMP)
   raja_add_test(

--- a/test/unit/cpu/CMakeLists.txt
+++ b/test/unit/cpu/CMakeLists.txt
@@ -55,7 +55,7 @@ raja_add_test(
 raja_add_test(
   NAME test-segments
   SOURCES test-segments.cpp
-  DEPENDS_ON gtest gtest_main)
+  DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
 
 if(RAJA_ENABLE_OPENMP)
   raja_add_test(

--- a/test/unit/cpu/test-segments.cpp
+++ b/test/unit/cpu/test-segments.cpp
@@ -1,0 +1,277 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-689114
+//
+// All rights reserved.
+//
+// This file is part of RAJA.
+//
+// For additional details, please also read RAJA/README.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the disclaimer below.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the disclaimer (as noted below) in the
+//   documentation and/or other materials provided with the distribution.
+//
+// * Neither the name of the LLNS/LLNL nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+// LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Source file containing tests for RAJA index set mechanics.
+///
+
+#include "gtest/gtest.h"
+#include "RAJA/RAJA.hpp"
+
+
+TEST(RangeStrideSegmentTest, sizes_no_roundoff)
+{
+  RAJA::RangeStrideSegment segment1(0, 20, 1);  
+  ASSERT_EQ(segment1.size(), 20);
+  
+  RAJA::RangeStrideSegment segment2(0, 20, 2);  
+  ASSERT_EQ(segment2.size(), 10);
+  
+  RAJA::RangeStrideSegment segment3(0, 20, 4);  
+  ASSERT_EQ(segment3.size(), 5);
+  
+  RAJA::RangeStrideSegment segment4(0, 20, 5);  
+  ASSERT_EQ(segment4.size(), 4);
+  
+  RAJA::RangeStrideSegment segment5(0, 20, 10);  
+  ASSERT_EQ(segment5.size(), 2);
+  
+  RAJA::RangeStrideSegment segment6(0, 20, 20);  
+  ASSERT_EQ(segment6.size(), 1);
+}
+
+
+TEST(RangeStrideSegmentTest, sizes_roundoff1)
+{
+  RAJA::RangeStrideSegment segment2(0, 21, 2);  
+  ASSERT_EQ(segment2.size(), 11);
+  
+  RAJA::RangeStrideSegment segment3(0, 21, 4);  
+  ASSERT_EQ(segment3.size(), 6);
+  
+  RAJA::RangeStrideSegment segment4(0, 21, 5);
+  ASSERT_EQ(segment4.size(), 5);
+  
+  RAJA::RangeStrideSegment segment5(0, 21, 10);  
+  ASSERT_EQ(segment5.size(), 3);
+  
+  RAJA::RangeStrideSegment segment6(0, 21, 20);  
+  ASSERT_EQ(segment6.size(), 2);
+}
+
+
+TEST(RangeStrideSegmentTest, sizes_primes)
+{
+  RAJA::RangeStrideSegment segment1(0, 7, 3);  // should produce 0,3,6
+  ASSERT_EQ(segment1.size(), 3);
+  
+  RAJA::RangeStrideSegment segment2(0, 13, 3); // shoudl produce 0,3,6,9,12
+  ASSERT_EQ(segment2.size(), 5);
+ 
+  RAJA::RangeStrideSegment segment3(0, 17, 5); // shoudl produce 0,5,10,15
+  ASSERT_EQ(segment3.size(), 4);
+}
+
+
+TEST(RangeStrideSegmentTest, sizes_reverse_no_roundoff)
+{
+  RAJA::RangeStrideSegment segment1(19, -1, -1);  
+  ASSERT_EQ(segment1.size(), 20);
+  
+  RAJA::RangeStrideSegment segment2(19, -1, -2);  
+  ASSERT_EQ(segment2.size(), 10);
+  
+  RAJA::RangeStrideSegment segment3(19, -1, -4);  
+  ASSERT_EQ(segment3.size(), 5);
+  
+  RAJA::RangeStrideSegment segment4(19, -1, -5);  
+  ASSERT_EQ(segment4.size(), 4);
+  
+  RAJA::RangeStrideSegment segment5(19, -1, -10);  
+  ASSERT_EQ(segment5.size(), 2);
+  
+  RAJA::RangeStrideSegment segment6(19, -1, -20);  
+  ASSERT_EQ(segment6.size(), 1);
+}
+
+
+TEST(RangeStrideSegmentTest, sizes_reverse_roundoff1)
+{  
+  RAJA::RangeStrideSegment segment2(20, -1, -2);  
+  ASSERT_EQ(segment2.size(), 11);
+  
+  RAJA::RangeStrideSegment segment3(20, -1, -4);  
+  ASSERT_EQ(segment3.size(), 6);
+  
+  RAJA::RangeStrideSegment segment4(20, -1, -5);  
+  ASSERT_EQ(segment4.size(), 5);
+  
+  RAJA::RangeStrideSegment segment5(20, -1, -10);  
+  ASSERT_EQ(segment5.size(), 3);
+  
+  RAJA::RangeStrideSegment segment6(20, -1, -20);  
+  ASSERT_EQ(segment6.size(), 2);
+}
+
+
+TEST(RangeStrideSegmentTest, values_forward_stride1)
+{    
+  RAJA::Index_type expected[] = {0,1,2,3,4,5};
+  RAJA::RangeStrideSegment segment(0,6,1);
+  
+  ASSERT_EQ(segment.size(), 6);
+ 
+  for(size_t i = 0;i < segment.size();++ i){
+    ASSERT_EQ(segment.begin()[i], expected[i]);
+  } 
+  
+  size_t j = 0;
+  for(auto i : segment){
+    ASSERT_EQ(i, expected[j]);
+    ++ j;
+  } 
+}
+
+TEST(RangeStrideSegmentTest, values_forward_stride3)
+{    
+  RAJA::Index_type expected[] = {0,3,6,9,12};
+  RAJA::RangeStrideSegment segment(0,14,3);
+  
+  ASSERT_EQ(segment.size(), 5);
+ 
+  for(size_t i = 0;i < segment.size();++ i){
+    ASSERT_EQ(segment.begin()[i], expected[i]);
+  } 
+  
+  size_t j = 0;
+  for(auto i : segment){
+    ASSERT_EQ(i, expected[j]);
+    ++ j;
+  } 
+}
+
+TEST(RangeStrideSegmentTest, values_reverse_stride1)
+{    
+  RAJA::Index_type expected[] = {5,4,3,2,1,0};
+  RAJA::RangeStrideSegment segment(5,-1,-1);
+  
+  ASSERT_EQ(segment.size(), 6);
+ 
+  for(size_t i = 0;i < segment.size();++ i){
+    ASSERT_EQ(segment.begin()[i], expected[i]);
+  } 
+  
+  size_t j = 0;
+  for(auto i : segment){
+    ASSERT_EQ(i, expected[j]);
+    ++ j;
+  } 
+}
+
+
+TEST(RangeStrideSegmentTest, values_reverse_stride1_negative)
+{    
+  RAJA::Index_type expected[] = {-10,-11,-12,-13};
+  RAJA::RangeStrideSegment segment(-10,-14,-1);
+  
+  ASSERT_EQ(segment.size(), 4);
+ 
+  for(size_t i = 0;i < segment.size();++ i){
+    ASSERT_EQ(segment.begin()[i], expected[i]);
+  } 
+  
+  size_t j = 0;
+  for(auto i : segment){
+    ASSERT_EQ(i, expected[j]);
+    ++ j;
+  } 
+}
+
+
+TEST(RangeStrideSegmentTest, zero_size)
+{    
+  RAJA::RangeStrideSegment segment(3,2,1);
+  
+  ASSERT_EQ(segment.size(), 0);
+ 
+}
+
+TEST(RangeStrideSegmentTest, zero_size_reverse)
+{    
+  RAJA::RangeStrideSegment segment(-3, 3,-1);
+  
+  ASSERT_EQ(segment.size(), 0);
+ 
+}
+
+
+
+TEST(RangeStrideSegmentTest, forall_values_forward_stride3)
+{    
+  RAJA::Index_type expected[] = {0,3,6,9,12};
+  RAJA::RangeStrideSegment segment(0,14,3);
+  
+  ASSERT_EQ(segment.size(), 5);
+ 
+  for(size_t i = 0;i < segment.size();++ i){
+    ASSERT_EQ(segment.begin()[i], expected[i]);
+  } 
+  
+  size_t j = 0;
+  size_t *jptr = &j;
+  
+  RAJA::forall<RAJA::seq_exec>(segment, [=](RAJA::Index_type i)
+  {
+    ASSERT_EQ(i, expected[(*jptr)++]);
+  }); 
+}
+
+
+TEST(RangeStrideSegmentTest, forall_values_reverse_stride5)
+{    
+  RAJA::Index_type expected[] = {7,2,-3,-8};
+  RAJA::RangeStrideSegment segment(7,-11,-5);
+  
+  ASSERT_EQ(segment.size(), 4);
+ 
+  for(size_t i = 0;i < segment.size();++ i){
+    ASSERT_EQ(segment.begin()[i], expected[i]);
+  } 
+  
+  size_t j = 0;
+  size_t *jptr = &j;
+  
+  RAJA::forall<RAJA::seq_exec>(segment, [=](RAJA::Index_type i)
+  {
+    ASSERT_EQ(i, expected[(*jptr)++]);
+  }); 
+}

--- a/test/unit/cpu/test-segments.cpp
+++ b/test/unit/cpu/test-segments.cpp
@@ -150,7 +150,7 @@ TEST(RangeStrideSegmentTest, values_forward_stride1)
   
   ASSERT_EQ(segment.size(), 6);
  
-  for(size_t i = 0;i < segment.size();++ i){
+  for(RAJA::Index_type i = 0;i < segment.size();++ i){
     ASSERT_EQ(segment.begin()[i], expected[i]);
   } 
   
@@ -168,7 +168,7 @@ TEST(RangeStrideSegmentTest, values_forward_stride3)
   
   ASSERT_EQ(segment.size(), 5);
  
-  for(size_t i = 0;i < segment.size();++ i){
+  for(RAJA::Index_type i = 0;i < segment.size();++ i){
     ASSERT_EQ(segment.begin()[i], expected[i]);
   } 
   
@@ -186,7 +186,7 @@ TEST(RangeStrideSegmentTest, values_reverse_stride1)
   
   ASSERT_EQ(segment.size(), 6);
  
-  for(size_t i = 0;i < segment.size();++ i){
+  for(RAJA::Index_type i = 0;i < segment.size();++ i){
     ASSERT_EQ(segment.begin()[i], expected[i]);
   } 
   
@@ -205,7 +205,7 @@ TEST(RangeStrideSegmentTest, values_reverse_stride1_negative)
   
   ASSERT_EQ(segment.size(), 4);
  
-  for(size_t i = 0;i < segment.size();++ i){
+  for(RAJA::Index_type i = 0;i < segment.size();++ i){
     ASSERT_EQ(segment.begin()[i], expected[i]);
   } 
   
@@ -263,7 +263,7 @@ TEST(RangeStrideSegmentTest, forall_values_reverse_stride5)
   
   ASSERT_EQ(segment.size(), 4);
  
-  for(size_t i = 0;i < segment.size();++ i){
+  for(RAJA::Index_type i = 0;i < segment.size();++ i){
     ASSERT_EQ(segment.begin()[i], expected[i]);
   } 
   

--- a/test/unit/cpu/test-segments.cpp
+++ b/test/unit/cpu/test-segments.cpp
@@ -242,7 +242,7 @@ TEST(RangeStrideSegmentTest, forall_values_forward_stride3)
   
   ASSERT_EQ(segment.size(), 5);
  
-  for(size_t i = 0;i < segment.size();++ i){
+  for(RAJA::Index_type i = 0;i < segment.size();++ i){
     ASSERT_EQ(segment.begin()[i], expected[i]);
   } 
   


### PR DESCRIPTION
The TypedRangeStrideSegment had some implementation issues that this PR aims to resolve:
1) didn't handle non-exact ending values correctly, such as  TypedRangeStrideSegment(1, 13, 3)
2) didn't handle negative strides at all, such as TypedRangeStrideSegment(10, 3, -1)

I've gotten this all working, at least sequentially. Still need to make sure it works with OMP/CUDA/etc.