### PR TITLE
Enable all but two tests (Scan and Reductions) to MSVC CI

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -42,30 +42,30 @@
 #
 ###############################################################################
 
-if (NOT MSVC)
+raja_add_test(
+  NAME test-layout
+  SOURCES test-layout.cpp
+  DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT}
+)
+raja_add_test(
+  NAME test-timer
+  SOURCES test-timer.cpp
+  DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT}
+)
+
+if(RAJA_ENABLE_OPENMP)
   raja_add_test(
-    NAME test-layout
-    SOURCES test-layout.cpp
-    DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT}
+          NAME test-multipolicy
+          SOURCES test-multipolicy.cpp
+          DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT}
   )
-  raja_add_test(
-    NAME test-timer
-    SOURCES test-timer.cpp
-    DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT}
-  )
-  if(RAJA_ENABLE_OPENMP)
-    raja_add_test(
-            NAME test-multipolicy
-            SOURCES test-multipolicy.cpp
-            DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT}
-    )
-  endif(RAJA_ENABLE_OPENMP)
-  raja_add_test(
-    NAME test-integral-limits
-    SOURCES test-integral-limits.cpp
-    DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT}
-  )
-endif()
+endif(RAJA_ENABLE_OPENMP)
+
+raja_add_test(
+  NAME test-integral-limits
+  SOURCES test-integral-limits.cpp
+  DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT}
+)
 
 add_subdirectory(cpu)
 

--- a/test/unit/cpu/CMakeLists.txt
+++ b/test/unit/cpu/CMakeLists.txt
@@ -69,16 +69,18 @@ raja_add_test(
   DEPENDS_ON bis gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
 
 raja_add_test(
-  NAME test-reduction
-  SOURCES test-reductions.cpp
-  DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
-
-raja_add_test(
-  NAME test-scan
-  SOURCES test-scan.cpp
-  DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
-
-raja_add_test(
   NAME test-forall
   SOURCES test-forall.cpp
   DEPENDS_ON bis gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
+
+if(NOT MSVC)
+  raja_add_test(
+    NAME test-scan
+    SOURCES test-scan.cpp
+    DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
+
+  raja_add_test(
+    NAME test-reduction
+    SOURCES test-reductions.cpp
+    DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
+endif()

--- a/test/unit/cpu/CMakeLists.txt
+++ b/test/unit/cpu/CMakeLists.txt
@@ -51,7 +51,7 @@ raja_add_test(
 raja_add_test(
   NAME test-nested
   SOURCES main-nested.cpp)
-  
+
 raja_add_test(
   NAME test-segments
   SOURCES test-segments.cpp
@@ -68,19 +68,17 @@ raja_add_test(
   SOURCES test-indexsets.cpp
   DEPENDS_ON bis gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
 
-if (NOT MSVC)
-  raja_add_test(
-    NAME test-reduction
-    SOURCES test-reductions.cpp
-    DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
+raja_add_test(
+  NAME test-reduction
+  SOURCES test-reductions.cpp
+  DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
 
-  raja_add_test(
-    NAME test-scan
-    SOURCES test-scan.cpp
-    DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
+raja_add_test(
+  NAME test-scan
+  SOURCES test-scan.cpp
+  DEPENDS_ON gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
 
-  raja_add_test(
-    NAME test-forall
-    SOURCES test-forall.cpp
-    DEPENDS_ON bis gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
-endif ()
+raja_add_test(
+  NAME test-forall
+  SOURCES test-forall.cpp
+  DEPENDS_ON bis gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
Amazingly, the new IndexSet, Concepts, and Multipolicy *work*. I'll wait for a newer compiler instead of attempting to resolve the remaining tests, but there are only two tests we aren't running.