### PR TITLE
Fixed strided_numeric_iterator to apply the stride sign to comparison operators

### DIFF
--- a/include/RAJA/internal/Iterators.hpp
+++ b/include/RAJA/internal/Iterators.hpp
@@ -315,7 +315,34 @@ public:
       const strided_numeric_iterator& rhs) const
   {
     return (base::val - rhs.val) / stride;
+  }  
+  RAJA_HOST_DEVICE inline bool operator==(
+      const strided_numeric_iterator& rhs) const
+  {
+    return !((base::val - rhs.val) / stride);
   }
+  
+  RAJA_HOST_DEVICE inline bool operator>(
+      const strided_numeric_iterator& rhs) const
+  {
+    return base::val*stride > rhs.val*stride;
+  }
+  RAJA_HOST_DEVICE inline bool operator<(
+      const strided_numeric_iterator& rhs) const
+  {
+    return base::val*stride < rhs.val*stride;
+  }
+  RAJA_HOST_DEVICE inline bool operator>=(
+      const strided_numeric_iterator& rhs) const
+  {
+    return base::val*stride >= rhs.val*stride;
+  }
+  RAJA_HOST_DEVICE inline bool operator<=(
+      const strided_numeric_iterator& rhs) const
+  {
+    return base::val*stride <= rhs.val*stride;
+  }
+  
 
   RAJA_HOST_DEVICE inline Type operator*() const { return base::val; }
   RAJA_HOST_DEVICE inline Type operator->() const { return base::val; }

--- a/test/unit/cpu/test-segments.cpp
+++ b/test/unit/cpu/test-segments.cpp
@@ -242,17 +242,31 @@ TEST(RangeStrideSegmentTest, forall_values_forward_stride3)
   
   ASSERT_EQ(segment.size(), 5);
  
-  for(RAJA::Index_type i = 0;i < segment.size();++ i){
+  for(RAJA::Index_type i = 0;i < segment.size();++ i)
+  {
     ASSERT_EQ(segment.begin()[i], expected[i]);
   } 
   
   size_t j = 0;
-  size_t *jptr = &j;
   
-  RAJA::forall<RAJA::seq_exec>(segment, [=](RAJA::Index_type i)
+  
+  for(auto i = segment.begin();i < segment.end();++i)
   {
-    ASSERT_EQ(i, expected[(*jptr)++]);
+    ASSERT_EQ(*i, expected[j++]);
+  } 
+  
+  ASSERT_EQ((RAJA::Index_type)j, segment.size());
+  
+  
+  j = 0;
+  
+  RAJA::forall<RAJA::seq_exec>(segment, [&](RAJA::Index_type i)
+  {
+    ASSERT_EQ(i, expected[j++]);
   }); 
+  
+  
+  ASSERT_EQ((RAJA::Index_type)j, segment.size());
 }
 
 
@@ -267,11 +281,21 @@ TEST(RangeStrideSegmentTest, forall_values_reverse_stride5)
     ASSERT_EQ(segment.begin()[i], expected[i]);
   } 
   
-  size_t j = 0;
-  size_t *jptr = &j;
+  size_t j = 0; 
   
-  RAJA::forall<RAJA::seq_exec>(segment, [=](RAJA::Index_type i)
+  for(auto i = segment.begin();i < segment.end();++i)
   {
-    ASSERT_EQ(i, expected[(*jptr)++]);
+    ASSERT_EQ(*i, expected[j++]);
+  } 
+  
+  ASSERT_EQ((RAJA::Index_type)j, segment.size());
+  
+  j = 0;
+  
+  RAJA::forall<RAJA::seq_exec>(segment, [&](RAJA::Index_type i)
+  {
+    ASSERT_EQ(i, expected[j++]);
   }); 
+  
+  ASSERT_EQ((RAJA::Index_type)j, segment.size());
 }


### PR DESCRIPTION
The following loop wasn't working with negative strides: (and therefore forall wasn't working either)

for(auto i = segment.begin();i < segment.end();++i)
  { ... }
    
Since the operator< wasn't "direction" aware.

So I fixed the iterator to take stride direction into account, and also fixed the unit tests to properly detect this error.