### PR TITLE
Switch back to multiple test executables

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,37 +43,6 @@
 
 include_directories(include)
 
-
-set(test_macro__internal_dir ${CMAKE_CURRENT_LIST_DIR} CACHE INTERNAL "")
-
-# use this macro to update the parent scope with the current list of sources used
-# for testing. NOTE: this is only required when the last command in a CMakeLists.txt
-# is add_directory(). add_gtest_sources() propagates the sources as expected
-macro(propagate_sources)
-  set (raja_test_SOURCES ${raja_test_SOURCES} PARENT_SCOPE)
-endmacro()
-
-# use this macro to add sources for testing. It will automatically add the
-# relative path (if required). NOTE: this internally updates @raja_test_SOURCES
-macro (add_gtest_sources)
-  file (RELATIVE_PATH _relPath "${test_macro__internal_dir}" "${CMAKE_CURRENT_SOURCE_DIR}")
-  foreach (_src ${ARGN})
-    if (_relPath)
-      list (APPEND raja_test_SOURCES "${_relPath}/${_src}")
-    else()
-      list (APPEND raja_test_SOURCES "${_src}")
-    endif()
-  endforeach()
-  if (_relPath)
-    propagate_sources()
-  endif()
-endmacro()
-
 add_subdirectory(unit)
 
 add_subdirectory(integration)
-
-# create the test once the sources have been visited
-raja_add_test(
-  NAME raja_test_suite
-  SOURCES ${raja_test_SOURCES})

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -43,5 +43,4 @@
 
 if (RAJA_ENABLE_CHAI)
   add_subdirectory(chai)
-  propagate_sources()
 endif(RAJA_ENABLE_CHAI)

--- a/test/integration/chai/CMakeLists.txt
+++ b/test/integration/chai/CMakeLists.txt
@@ -42,9 +42,15 @@
 ###############################################################################
 
 if (RAJA_ENABLE_CUDA)
-  add_gtest_sources(chai-nested.cpp)
+  raja_add_test(
+    NAME test-chai-nested
+    SOURCES chai-nested.cpp)
 endif(RAJA_ENABLE_CUDA)
 
-add_gtest_sources(
-  chai-policy-tests.cpp
-  chai-tests.cpp)
+raja_add_test(
+  NAME test-chai-policy
+  SOURCES chai-policy-tests.cpp)
+
+raja_add_test(
+  NAME test-chai
+  SOURCES chai-tests.cpp)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -41,11 +41,25 @@
 #
 ###############################################################################
 
-add_subdirectory(cpu)
+raja_add_test(
+  NAME test-layout
+  SOURCES test-layout.cpp)
+
+raja_add_test(
+  NAME test-timer
+  SOURCES test-timer.cpp)
+
+raja_add_test(
+  NAME test-integral-limits
+  SOURCES test-integral-limits.cpp)
 
 if(RAJA_ENABLE_OPENMP)
-  add_gtest_sources(test-multipolicy.cpp)
+  raja_add_test(
+    NAME test-multipolicy
+    SOURCES test-multipolicy.cpp)
 endif(RAJA_ENABLE_OPENMP)
+
+add_subdirectory(cpu)
 
 if(RAJA_ENABLE_CUDA)
   add_subdirectory(cuda)
@@ -54,8 +68,3 @@ endif(RAJA_ENABLE_CUDA)
 if(RAJA_ENABLE_TARGET_OPENMP)
   add_subdirectory(omp-target)
 endif(RAJA_ENABLE_TARGET_OPENMP)
-
-add_gtest_sources(
-  test-layout.cpp
-  test-timer.cpp
-  test-integral-limits.cpp)

--- a/test/unit/cpu/CMakeLists.txt
+++ b/test/unit/cpu/CMakeLists.txt
@@ -41,13 +41,41 @@
 #
 ###############################################################################
 
-add_gtest_sources(
-  test-reduce.cpp
-  test-nested.cpp
-  test-nested-reduce.cpp
-  test-segments.cpp
-  test-indexsets.cpp
-  test-forall.cpp
-  test-scan.cpp
-  test-reductions.cpp
-  buildIndexSet.cpp)
+raja_add_library(
+  NAME bis
+  SOURCES buildIndexSet.cpp)
+
+raja_add_test(
+  NAME test-reduce
+  SOURCES test-reduce.cpp
+  DEPENDS_ON bis)
+
+raja_add_test(
+  NAME test-forall
+  SOURCES test-forall.cpp
+  DEPENDS_ON bis)
+
+raja_add_test(
+  NAME test-indexset
+  SOURCES test-indexsets.cpp
+  DEPENDS_ON bis)
+
+raja_add_test(
+  NAME test-nested
+  SOURCES test-nested.cpp)
+
+raja_add_test(
+  NAME test-nested-reduce
+  SOURCES test-nested-reduce.cpp)
+
+raja_add_test(
+  NAME test-segments
+  SOURCES test-segments.cpp)
+
+raja_add_test(
+  NAME test-scan
+  SOURCES test-scan.cpp)
+
+raja_add_test(
+  NAME test-reductions
+  SOURCES test-reductions.cpp)

--- a/test/unit/cuda/CMakeLists.txt
+++ b/test/unit/cuda/CMakeLists.txt
@@ -42,18 +42,41 @@
 ###############################################################################
 
 if(RAJA_ENABLE_OPENMP)
-  add_gtest_sources(test-nested.cpp)
+  raja_add_test(
+    NAME test-cuda-nested
+    SOURCES test-nested.cpp)
 endif(RAJA_ENABLE_OPENMP)
 
 if (NOT RAJA_ENABLE_CLANG_CUDA)
-  add_gtest_sources(test-scan.cpp)
+  raja_add_test(
+    NAME test-cuda-scan
+    SOURCES test-scan.cpp)
 endif()
 
-add_gtest_sources(
-  test-reduce-sum.cpp
-  test-reduce-max.cpp
-  test-reduce-min.cpp
-  test-reduce-maxloc.cpp
-  test-reduce-minloc.cpp
-  test-forall.cpp
-  test-nested-strided.cpp)
+raja_add_test(
+  NAME test-cuda-reduce-sum
+  SOURCES test-reduce-sum.cpp)
+
+raja_add_test(
+  NAME test-cuda-reduce-min
+  SOURCES test-reduce-min.cpp)
+
+raja_add_test(
+  NAME test-cuda-reduce-minloc
+  SOURCES test-reduce-minloc.cpp)
+
+raja_add_test(
+  NAME test-cuda-reduce-max
+  SOURCES test-reduce-max.cpp)
+
+raja_add_test(
+  NAME test-cuda-reduce-maxloc
+  SOURCES test-reduce-maxloc.cpp)
+
+raja_add_test(
+  NAME test-cuda-forall
+  SOURCES test-forall.cpp)
+
+raja_add_test(
+  NAME test-cuda-nested-strided
+  SOURCES test-nested-strided.cpp)

--- a/test/unit/omp-target/CMakeLists.txt
+++ b/test/unit/omp-target/CMakeLists.txt
@@ -42,7 +42,10 @@
 ###############################################################################
 
 if(RAJA_ENABLE_TARGET_OPENMP)
-  add_gtest_sources(
-    test-nested-reduce.cpp
-    test-reductions.cpp)
+  raja_add_test(
+    NAME test-omp-target-nested-reduce
+    SOURCES test-nested-reduce.cpp)
+  raja_add_test(
+    NAME test-omp-target-reductions
+    SOURCES test-reductions.cpp)
 endif(RAJA_ENABLE_TARGET_OPENMP)


### PR DESCRIPTION
Closes #298 

Instead of undoing all of the google-test refactor, this PR just updates the binary generation to it's previous state (one binary per test source file).

There are some performance implications with having the tests be separate binaries though -- on the order of 15% for compilation on `wiz` and 10% for execution.