### PR TITLE
[RFC] Introduce better CMake macros for gtest binary creation

### DIFF
--- a/cmake/RAJAMacros.cmake
+++ b/cmake/RAJAMacros.cmake
@@ -176,4 +176,6 @@ macro(raja_gtest_add_binary)
   target_include_directories(
     ${arg_NAME}
     PUBLIC ${arg_INCLUDES})
+
+  set(raja_gtest_SOURCES "")
 endmacro(raja_gtest_add_binary)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,39 +41,11 @@
 #
 ###############################################################################
 
-include_directories(include)
+raja_gtest_add_subdirectory(unit)
 
-
-set(test_macro__internal_dir ${CMAKE_CURRENT_LIST_DIR} CACHE INTERNAL "")
-
-# use this macro to update the parent scope with the current list of sources used
-# for testing. NOTE: this is only required when the last command in a CMakeLists.txt
-# is add_directory(). add_gtest_sources() propagates the sources as expected
-macro(propagate_sources)
-  set (raja_test_SOURCES ${raja_test_SOURCES} PARENT_SCOPE)
-endmacro()
-
-# use this macro to add sources for testing. It will automatically add the
-# relative path (if required). NOTE: this internally updates @raja_test_SOURCES
-macro (add_gtest_sources)
-  file (RELATIVE_PATH _relPath "${test_macro__internal_dir}" "${CMAKE_CURRENT_SOURCE_DIR}")
-  foreach (_src ${ARGN})
-    if (_relPath)
-      list (APPEND raja_test_SOURCES "${_relPath}/${_src}")
-    else()
-      list (APPEND raja_test_SOURCES "${_src}")
-    endif()
-  endforeach()
-  if (_relPath)
-    propagate_sources()
-  endif()
-endmacro()
-
-add_subdirectory(unit)
-
-add_subdirectory(integration)
+raja_gtest_add_subdirectory(integration)
 
 # create the test once the sources have been visited
-raja_add_test(
+raja_gtest_add_binary(
   NAME raja_test_suite
-  SOURCES ${raja_test_SOURCES})
+  INCLUDES include)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -42,6 +42,5 @@
 ###############################################################################
 
 if (RAJA_ENABLE_CHAI)
-  add_subdirectory(chai)
-  propagate_sources()
+  raja_gtest_add_subdirectory(chai)
 endif(RAJA_ENABLE_CHAI)

--- a/test/integration/chai/CMakeLists.txt
+++ b/test/integration/chai/CMakeLists.txt
@@ -42,9 +42,9 @@
 ###############################################################################
 
 if (RAJA_ENABLE_CUDA)
-  add_gtest_sources(chai-nested.cpp)
+  raja_gtest_add_sources(chai-nested.cpp)
 endif(RAJA_ENABLE_CUDA)
 
-add_gtest_sources(
+raja_gtest_add_sources(
   chai-policy-tests.cpp
   chai-tests.cpp)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -41,21 +41,21 @@
 #
 ###############################################################################
 
-add_subdirectory(cpu)
-
-if(RAJA_ENABLE_OPENMP)
-  add_gtest_sources(test-multipolicy.cpp)
-endif(RAJA_ENABLE_OPENMP)
-
-if(RAJA_ENABLE_CUDA)
-  add_subdirectory(cuda)
-endif(RAJA_ENABLE_CUDA)
-
-if(RAJA_ENABLE_TARGET_OPENMP)
-  add_subdirectory(omp-target)
-endif(RAJA_ENABLE_TARGET_OPENMP)
-
-add_gtest_sources(
+raja_gtest_add_sources(
   test-layout.cpp
   test-timer.cpp
   test-integral-limits.cpp)
+
+if(RAJA_ENABLE_OPENMP)
+  raja_gtest_add_sources(test-multipolicy.cpp)
+endif(RAJA_ENABLE_OPENMP)
+
+raja_gtest_add_subdirectory(cpu)
+
+if(RAJA_ENABLE_CUDA)
+  raja_gtest_add_subdirectory(cuda)
+endif(RAJA_ENABLE_CUDA)
+
+if(RAJA_ENABLE_TARGET_OPENMP)
+  raja_gtest_add_subdirectory(omp-target)
+endif(RAJA_ENABLE_TARGET_OPENMP)

--- a/test/unit/cpu/CMakeLists.txt
+++ b/test/unit/cpu/CMakeLists.txt
@@ -41,7 +41,7 @@
 #
 ###############################################################################
 
-add_gtest_sources(
+raja_gtest_add_sources(
   test-reduce.cpp
   test-nested.cpp
   test-nested-reduce.cpp

--- a/test/unit/cuda/CMakeLists.txt
+++ b/test/unit/cuda/CMakeLists.txt
@@ -42,14 +42,10 @@
 ###############################################################################
 
 if(RAJA_ENABLE_OPENMP)
-  add_gtest_sources(test-nested.cpp)
+  raja_gtest_add_sources(test-nested.cpp)
 endif(RAJA_ENABLE_OPENMP)
 
-if (NOT RAJA_ENABLE_CLANG_CUDA)
-  add_gtest_sources(test-scan.cpp)
-endif()
-
-add_gtest_sources(
+raja_gtest_add_sources(
   test-reduce-sum.cpp
   test-reduce-max.cpp
   test-reduce-min.cpp
@@ -57,3 +53,7 @@ add_gtest_sources(
   test-reduce-minloc.cpp
   test-forall.cpp
   test-nested-strided.cpp)
+
+if (NOT RAJA_ENABLE_CLANG_CUDA)
+  raja_gtest_add_sources(test-scan.cpp)
+endif()

--- a/test/unit/omp-target/CMakeLists.txt
+++ b/test/unit/omp-target/CMakeLists.txt
@@ -42,7 +42,7 @@
 ###############################################################################
 
 if(RAJA_ENABLE_TARGET_OPENMP)
-  add_gtest_sources(
+  raja_gtest_add_sources(
     test-nested-reduce.cpp
     test-reductions.cpp)
 endif(RAJA_ENABLE_TARGET_OPENMP)


### PR DESCRIPTION
yin : yang as this : #299  (up for debate on which is yin and yang)

The first PR unifying the test binary had some wonky logic required (e.g. `propagate_sources`). This PR introduces a few CMake macros to make defining our tests much easier.

**Additions**

* `raja_gtest_add_subdirectory` -- adds a subdirectory and updates the parent directory with all added sources. NOTE: if you want to create a test binary in the current directory, you only need to state `add_subdirectory`
* `raja_gtest_add_sources` -- adds any number of source files to the current working list of test source files.
*  `raja_gtest_add_binary` -- create a google-test binary. arguments: `NAME <name>` name of executable to generate; `INCLUDES <includes...>` zero or more include paths (ultimately calls `target_include_directories(<name> PUBLIC <includes...>)`)

These macros are added to cmake/RAJAMacros.cmake

This PR just refines the existing implementation we have, but also allows us to cleanly build up any number of google-test binaries without extra cruft. Maybe it makes more sense for an option to be specified to indicate parent propagation or not. Ideally, something flexible would be nice.

**If you want to create a test that only depends on source files found in one directory, `raja_add_test()` is a better option**

Here's an example of constructing binaries from multiple subdirectories.
```
test/CMakeLists.txt
      raja_gtest_add_sources(...) # add files in current dir
      # visit child directory. some source files may be propagated to here
      add_subdirectory(unit) 
      raja_gtest_add_binary(host-tests)

  unit/CMakeLists.txt
        # create a gtest binary only for GPU tests
        add_subdirectory(cuda) # normal add_subdirectory works here, since we don't need to propagate
        add_subdirectory(omp-target)
        raja_gtest_add_binary(gpu-tests)
        # propagates all source files from cpu directory to parent
        raja_gtest_add_subdirectory(cpu)

    cpu/CMakeLists.txt
          raja_gtest_add_sources(...)

    cuda/CMakeLists.txt
          raja_gtest_add_sources(...)

    omp-target/CMakeLists.txt
          raja_gtest_add_sources(...)
```