### PR TITLE
Extra Copy in ForallN_BindFirstArg_HostDevice Constructor

### DIFF
--- a/include/RAJA/internal/ForallNPolicy.hpp
+++ b/include/RAJA/internal/ForallNPolicy.hpp
@@ -97,7 +97,7 @@ struct ForallN_BindFirstArg_HostDevice {
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
-  constexpr ForallN_BindFirstArg_HostDevice(BODY b, INDEX_TYPE i0)
+  constexpr ForallN_BindFirstArg_HostDevice(BODY const &b, INDEX_TYPE i0)
       : body(b), i(i0)
   {
   }


### PR DESCRIPTION
The constructor of ForallN_BindFirstArg_HostDevice took body by value which caused an extra copy to be made.
This fixes the ReduceSumCUDA.indexset_aligned test. The current cuda reducers assume that the first copy in device code will be destroyed after running the lambda. The cuda reducers in #283 assume that their constructors and destructors are called in a nested fashion in device code.