### PR TITLE
remove compile-time error from memutils, add portable alligned allocator

### DIFF
--- a/cmake/SetupCompilers.cmake
+++ b/cmake/SetupCompilers.cmake
@@ -135,8 +135,3 @@ set(RAJA_RANGE_MIN_LENGTH 32 CACHE INT "")
 set(RAJA_DATA_ALIGN 64 CACHE INT "")
 set(RAJA_COHERENCE_BLOCK_SIZE 64 CACHE INT "")
 
-include(CheckFunctionExists)
-check_function_exists(posix_memalign HAVE_POSIX_MEMALIGN)
-if(${HAVE_POSIX_MEMALIGN})
-  add_definitions(-DHAVE_POSIX_MEMALIGN)
-endif(${HAVE_POSIX_MEMALIGN})

--- a/cmake/SetupRajaConfig.cmake
+++ b/cmake/SetupRajaConfig.cmake
@@ -83,6 +83,10 @@ else ()
     set(RAJA_USE_CLOCK   OFF CACHE BOOL "Use clock from time.h for timer"    )
 endif ()
 
+include(CheckFunctionExists)
+check_function_exists(posix_memalign RAJA_HAVE_POSIX_MEMALIGN)
+check_function_exists(aligned_alloc RAJA_HAVE_ALIGNED_ALLOC)
+
 # Configure a header file with all the variables we found.
 configure_file(${PROJECT_SOURCE_DIR}/include/RAJA/config.hpp.in
   ${PROJECT_BINARY_DIR}/include/RAJA/config.hpp)

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -266,6 +266,9 @@ const int COHERENCE_BLOCK_SIZE = @RAJA_COHERENCE_BLOCK_SIZE@;
 
 #endif
 
+#cmakedefine RAJA_HAVE_POSIX_MEMALIGN
+#cmakedefine RAJA_HAVE_ALIGNED_ALLOC
+
 }  // closing brace for RAJA namespace
 
 #endif // closing endif for header file include guard

--- a/include/RAJA/internal/MemUtils_CPU.hpp
+++ b/include/RAJA/internal/MemUtils_CPU.hpp
@@ -90,6 +90,7 @@ inline void* allocate_aligned(size_t alignment, size_t size)
   if (nullptr == mem) return nullptr;
   void **ptr = (void **)((std::uintptr_t)(mem + alignment + sizeof(void *))
                          & ~(alignment - 1));
+  // Store the originall address one position behind what we give the user.
   ptr[-1] = mem;
   return ptr;
 #endif
@@ -116,6 +117,8 @@ inline void free_aligned(void* ptr)
 #elif defined(RAJA_PLATFORM_WINDOWS)
   _aligned_free(ptr);
 #else
+  // Free the address stored one position behind the user data in ptr.
+  // This is valid for pointers allocated with allocate_aligned
   free(((void**)ptr)[-1]);
 #endif
 }

--- a/include/RAJA/internal/MemUtils_CPU.hpp
+++ b/include/RAJA/internal/MemUtils_CPU.hpp
@@ -90,7 +90,7 @@ inline void* allocate_aligned(size_t alignment, size_t size)
   if (nullptr == mem) return nullptr;
   void **ptr = (void **)((std::uintptr_t)(mem + alignment + sizeof(void *))
                          & ~(alignment - 1));
-  // Store the originall address one position behind what we give the user.
+  // Store the original address one position behind what we give the user.
   ptr[-1] = mem;
   return ptr;
 #endif

--- a/include/RAJA/policy/openmp/reduce.hpp
+++ b/include/RAJA/policy/openmp/reduce.hpp
@@ -102,7 +102,7 @@ public:
 
 } /* detail */
 
-RAJA_DECLARE_ALL_REDUCERS(omp_reduce, detail::ReduceOMP);
+RAJA_DECLARE_ALL_REDUCERS(omp_reduce, detail::ReduceOMP)
 
 ///////////////////////////////////////////////////////////////////////////////
 //
@@ -154,7 +154,7 @@ public:
 
 } /* detail */
 
-RAJA_DECLARE_ALL_REDUCERS(omp_reduce_ordered, detail::ReduceOMPOrdered);
+RAJA_DECLARE_ALL_REDUCERS(omp_reduce_ordered, detail::ReduceOMPOrdered)
 
 }  // closing brace for RAJA namespace
 

--- a/include/RAJA/policy/sequential/reduce.hpp
+++ b/include/RAJA/policy/sequential/reduce.hpp
@@ -84,7 +84,7 @@ public:
 
 } /* detail */
 
-RAJA_DECLARE_ALL_REDUCERS(seq_reduce, detail::ReduceSeq);
+RAJA_DECLARE_ALL_REDUCERS(seq_reduce, detail::ReduceSeq)
 
 }  // closing brace for RAJA namespace
 

--- a/include/RAJA/policy/tbb/reduce.hpp
+++ b/include/RAJA/policy/tbb/reduce.hpp
@@ -110,7 +110,7 @@ public:
 };
 }
 
-RAJA_DECLARE_ALL_REDUCERS(tbb_reduce, detail::ReduceTBB);
+RAJA_DECLARE_ALL_REDUCERS(tbb_reduce, detail::ReduceTBB)
 
 }  // closing brace for RAJA namespace
 


### PR DESCRIPTION
Thanks to @tepperly for reporting this one.  After moving the aligned allocation and free stuff out of implementation and into a header it's possible for the `#error` condition to come up in user code.  This PR makes them dependent on configuration time, rather than compile-time, parameters and adds a portable aligned allocation capability such that the error pragma is never needed.