### PR TITLE
add an extra check before activating 14 on nvcc

### DIFF
--- a/cmake/SetupCompilers.cmake
+++ b/cmake/SetupCompilers.cmake
@@ -103,11 +103,16 @@ if ( MSVC )
 endif()
 
 if (RAJA_ENABLE_CUDA)
+  set(RAJA_NVCC_STD "c++11")
   # When we require cmake 3.8+, replace this with setting CUDA_STANDARD
   if(CUDA_VERSION_MAJOR GREATER "8")
-    set(RAJA_NVCC_STD "c++14")
+    execute_process(COMMAND ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc -std c++14 . 
+                    ERROR_VARIABLE TEST_NVCC_ERR
+                    OUTPUT_QUIET)
+    if (NOT TEST_NVCC_ERR MATCHES "flag is not supported with the configured host compiler")
+      set(RAJA_NVCC_STD "c++14")
+    endif()
   else()
-    set(RAJA_NVCC_STD "c++11")
   endif()
   if(CMAKE_BUILD_TYPE MATCHES Release)
     set(RAJA_NVCC_FLAGS -O2; -restrict; -arch ${RAJA_CUDA_ARCH}; -std ${RAJA_NVCC_STD}; --expt-extended-lambda; -ccbin; ${CMAKE_CXX_COMPILER} CACHE LIST "")

--- a/cmake/SetupCompilers.cmake
+++ b/cmake/SetupCompilers.cmake
@@ -106,7 +106,7 @@ if (RAJA_ENABLE_CUDA)
   set(RAJA_NVCC_STD "c++11")
   # When we require cmake 3.8+, replace this with setting CUDA_STANDARD
   if(CUDA_VERSION_MAJOR GREATER "8")
-    execute_process(COMMAND ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc -std c++14 . 
+      execute_process(COMMAND ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc -std c++14 -ccbin ${CMAKE_CXX_COMPILER} . 
                     ERROR_VARIABLE TEST_NVCC_ERR
                     OUTPUT_QUIET)
     if (NOT TEST_NVCC_ERR MATCHES "flag is not supported with the configured host compiler")


### PR DESCRIPTION
Turns out nvcc is picky about host compilers for 14.  Rather than try and write out their actual check, especially since they haven't told us what it is, this just tries to use the dang flag with the configured host compiler and checks the result.