### PR TITLE
Task/rhornung67/detect release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,34 +1,5 @@
-*******************************************************************************
-
-RAJA: ................................, version 0.3.1
-
-Copyright (c) 2016-17, Lawrence Livermore National Security, LLC. 
-Produced at the Lawrence Livermore National Laboratory.
-All rights reserved. See details below.
-
-Unlimited Open Source - BSD Distribution
-LLNL-CODE-689114
-OCEC-16-063
-
-The original developers of RAJA are:
-
-Rich Hornung (hornung1@llnl.gov)
-Jeff Keasler (keasler1@llnl.gov)
-
-Contributors include:
-
-David Beckingsale (beckingsale1@llnl.gov)
-Jason Burmark (burmark1@llnl.gov)
-Jeff Hammond (jeff.science@gmail.com)
-Holger Jones (jones19@llnl.gov)
-Will Killian (killian4@llnl.gov)
-Adam Kunen (kunen1@llnl.gov)
-Olga Pearce (pearce8@llnl.gov)
-David Poliakoff (poliakoff1@llnl.gov)
-Tom Scogland (scogland1@llnl.gov)
-Arturo Vargas (vargas45@llnl.gov)
-
-*******************************************************************************
+Copyright (c) 2016-17, Lawrence Livermore National Security, LLC.
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without 
 modification, are permitted provided that the following conditions are met:
@@ -55,25 +26,3 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
 OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Additional BSD Notice
-
-1. This notice is required to be provided under our contract with the U.S. 
-Department of Energy (DOE). This work was produced at Lawrence Livermore 
-National Laboratory under Contract No. DE-AC52-07NA27344 with the DOE.
-
-2. Neither the United States Government nor Lawrence Livermore National 
-Security, LLC nor any of their employees, makes any warranty, express or 
-implied, or assumes any liability or responsibility for the accuracy, 
-completeness, or usefulness of any information, apparatus, product, or 
-process disclosed, or represents that its use would not infringe 
-privately-owned rights.
-
-3. Also, reference herein to any specific commercial products, process, 
-or services by trade name, trademark, manufacturer or otherwise does not 
-necessarily constitute or imply its endorsement, recommendation, or favoring 
-by the United States Government or Lawrence Livermore National Security, LLC. 
-The views and opinions of authors expressed herein do not necessarily state 
-or reflect those of the United States Government or Lawrence Livermore 
-National Security, LLC, and shall not be used for advertising or product 
-endorsement purposes.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,21 @@
+Additional BSD Notice
+
+1. This notice is required to be provided under our contract with the U.S. 
+Department of Energy (DOE). This work was produced at Lawrence Livermore 
+National Laboratory under Contract No. DE-AC52-07NA27344 with the DOE.
+
+2. Neither the United States Government nor Lawrence Livermore National 
+Security, LLC nor any of their employees, makes any warranty, express or 
+implied, or assumes any liability or responsibility for the accuracy, 
+completeness, or usefulness of any information, apparatus, product, or 
+process disclosed, or represents that its use would not infringe 
+privately-owned rights.
+
+3. Also, reference herein to any specific commercial products, process, 
+or services by trade name, trademark, manufacturer or otherwise does not 
+necessarily constitute or imply its endorsement, recommendation, or favoring 
+by the United States Government or Lawrence Livermore National Security, LLC. 
+The views and opinions of authors expressed herein do not necessarily state 
+or reflect those of the United States Government or Lawrence Livermore 
+National Security, LLC, and shall not be used for advertising or product 
+endorsement purposes.

--- a/README.md
+++ b/README.md
@@ -122,10 +122,12 @@ Produced at the Lawrence Livermore National Laboratory.
 
 All rights reserved.
 
+`LLNL-CODE-689114`  `OCEC-16-063`
+
 Unlimited Open Source - BSD Distribution
 
-For release details and restrictions, please read the LICENSE file.
-It is also linked here:
+For release details and restrictions, please read the RELEASE, LICENSE,
+and NOTICE files, also linked here:
+- [RELEASE](./RELEASE)
 - [LICENSE](./LICENSE)
-
-`LLNL-CODE-689114`  `OCEC-16-063`
+- [NOTICE](./NOTICE)

--- a/RELEASE
+++ b/RELEASE
@@ -1,0 +1,27 @@
+*******************************************************************************
+
+RAJA: ................................, version 0.3.1
+
+Copyright (c) 2016-17, Lawrence Livermore National Security, LLC. 
+Produced at the Lawrence Livermore National Laboratory.
+All rights reserved. See details in RAJA/LICENSE and RAJA/NOTICE files.
+
+Unlimited Open Source - BSD Distribution
+LLNL-CODE-689114
+OCEC-16-063
+
+The original developers of RAJA are:
+
+Rich Hornung (hornung1@llnl.gov)
+Jeff Keasler (keasler1@llnl.gov)
+
+Contributors include:
+
+David Beckingsale (beckingsale1@llnl.gov)
+Jason Burmark (burmark1@llnl.gov)
+Holger Jones (jones19@llnl.gov)
+Will Killian (killian4@llnl.gov)
+Adam Kunen (kunen1@llnl.gov)
+Olga Pearce (pearce8@llnl.gov)
+David Poliakoff (poliakoff1@llnl.gov)
+Tom Scogland (scogland1@llnl.gov)

--- a/RELEASE
+++ b/RELEASE
@@ -19,9 +19,12 @@ Contributors include:
 
 David Beckingsale (beckingsale1@llnl.gov)
 Jason Burmark (burmark1@llnl.gov)
+Matt Cordery (cordery1@llnl.gov)
+Jeff Hammond (jeff.science@gmail.com)
 Holger Jones (jones19@llnl.gov)
 Will Killian (killian4@llnl.gov)
 Adam Kunen (kunen1@llnl.gov)
 Olga Pearce (pearce8@llnl.gov)
 David Poliakoff (poliakoff1@llnl.gov)
 Tom Scogland (scogland1@llnl.gov)
+Arturo Vargas (vargas45@llnl.gov)


### PR DESCRIPTION
Breaking LICENSE file into three (RELEASE, LICENSE, NOTICE). Having a clean license file (w/no extraneous content) allows GitHub to automatically detect release and add a link to release info at the top of the page.