### PR TITLE
hotfix for CMakelists.txt for omp-target tests

### DIFF
--- a/test/unit/omp-target/CMakeLists.txt
+++ b/test/unit/omp-target/CMakeLists.txt
@@ -15,10 +15,6 @@
 ###############################################################################
 
 if(ENABLE_TARGET_OPENMP)
-  add_gtest_sources(
-    test-nested-reduce.cpp
-    test-reductions.cpp)
-
   raja_add_test(
     NAME test-omp-target-nested-reduce
     SOURCES test-nested-reduce.cpp)


### PR DESCRIPTION
A quick fix to remove older add_gtest method of adding unit tests