### PR TITLE
Bugfix/kunen1/chai

### DIFF
--- a/include/RAJA/index/IndexSet.hpp
+++ b/include/RAJA/index/IndexSet.hpp
@@ -60,7 +60,7 @@ namespace indexset
 /// over segments.  The second describes the policy for executing
 /// each segment.
 ///
-template <typename SEG_ITER_POLICY_T, typename SEG_EXEC_POLICY_T>
+template <typename SEG_ITER_POLICY_T, typename SEG_EXEC_POLICY_T = void>
 struct ExecPolicy
     : public RAJA::make_policy_pattern_t<SEG_EXEC_POLICY_T::policy,
                                          RAJA::Pattern::forall> {

--- a/include/RAJA/pattern/forall.hpp
+++ b/include/RAJA/pattern/forall.hpp
@@ -207,15 +207,13 @@ RAJA_INLINE concepts::enable_if<
 forall(ExecutionPolicy&& p, Container&& c, LoopBody&& loop_body)
 {
 
-  detail::setChaiExecutionSpace<ExecutionPolicy>();
-
   using RAJA::internal::trigger_updates_before;
   auto body = trigger_updates_before(loop_body);
   forall_impl(std::forward<ExecutionPolicy>(p),
               std::forward<Container>(c),
               body);
 
-  detail::clearChaiExecutionSpace();
+
 }
 
 /*!
@@ -234,9 +232,6 @@ RAJA_INLINE void forall_Icount(ExecutionPolicy&& p,
                                IndexType&& icount,
                                LoopBody&& loop_body)
 {
-
-  detail::setChaiExecutionSpace<ExecutionPolicy>();
-
   using RAJA::internal::trigger_updates_before;
   auto body = trigger_updates_before(loop_body);
   using std::begin;
@@ -249,7 +244,6 @@ RAJA_INLINE void forall_Icount(ExecutionPolicy&& p,
   using policy::sequential::forall_impl;
   forall_impl(std::forward<ExecutionPolicy>(p), range, adapted);
 
-  detail::clearChaiExecutionSpace();
 }
 
 /*!
@@ -270,8 +264,6 @@ RAJA_INLINE void forall_Icount(ExecPolicy<SegmentIterPolicy, SegmentExecPolicy>,
                                LoopBody loop_body)
 {
 
-  detail::setChaiExecutionSpace<ExecPolicy<SegmentIterPolicy, SegmentExecPolicy>>();
-
   using RAJA::internal::trigger_updates_before;
   auto body = trigger_updates_before(loop_body);
 
@@ -283,7 +275,7 @@ RAJA_INLINE void forall_Icount(ExecPolicy<SegmentIterPolicy, SegmentExecPolicy>,
                      body);
   });
 
-  detail::clearChaiExecutionSpace();
+
 }
 
 template <typename SegmentIterPolicy,
@@ -295,7 +287,6 @@ RAJA_INLINE void forall(ExecPolicy<SegmentIterPolicy, SegmentExecPolicy>,
                              LoopBody loop_body)
 {
 
-  detail::setChaiExecutionSpace<ExecPolicy<SegmentIterPolicy, SegmentExecPolicy>>();
 
   using RAJA::internal::trigger_updates_before;
   auto body = trigger_updates_before(loop_body);
@@ -307,7 +298,6 @@ RAJA_INLINE void forall(ExecPolicy<SegmentIterPolicy, SegmentExecPolicy>,
                      body);
   });
 
-  detail::clearChaiExecutionSpace();
 }
 
 }  // end namespace wrap
@@ -327,9 +317,14 @@ RAJA_INLINE void forall_Icount(ExecutionPolicy&& p,
   static_assert(type_traits::is_index_set<IdxSet>::value,
                 "Expected an IndexSet but did not get one. Are you using an "
                 "IndexSet policy by mistake?");
+
+  detail::setChaiExecutionSpace<ExecutionPolicy>();
+
   wrap::forall_Icount(std::forward<ExecutionPolicy>(p),
                       std::forward<IdxSet>(c),
                       std::forward<LoopBody>(loop_body));
+
+  detail::clearChaiExecutionSpace();
 }
 
 /*!
@@ -347,9 +342,14 @@ forall(ExecutionPolicy&& p, IdxSet&& c, LoopBody&& loop_body)
   static_assert(type_traits::is_index_set<IdxSet>::value,
                 "Expected an IndexSet but did not get one. Are you using an "
                 "IndexSet policy by mistake?");
+
+  detail::setChaiExecutionSpace<ExecutionPolicy>();
+
   wrap::forall(std::forward<ExecutionPolicy>(p),
                std::forward<IdxSet>(c),
                std::forward<LoopBody>(loop_body));
+
+  detail::clearChaiExecutionSpace();
 }
 
 /*!
@@ -372,10 +372,15 @@ forall_Icount(ExecutionPolicy&& p,
 {
   static_assert(type_traits::is_random_access_range<Container>::value,
                 "Container does not model RandomAccessIterator");
+
+  detail::setChaiExecutionSpace<ExecutionPolicy>();
+
   wrap::forall_Icount(std::forward<ExecutionPolicy>(p),
                       std::forward<Container>(c),
                       icount,
                       std::forward<LoopBody>(loop_body));
+
+  detail::clearChaiExecutionSpace();
 }
 
 
@@ -394,9 +399,14 @@ forall(ExecutionPolicy&& p, Container&& c, LoopBody&& loop_body)
 {
   static_assert(type_traits::is_random_access_range<Container>::value,
                 "Container does not model RandomAccessIterator");
+
+  detail::setChaiExecutionSpace<ExecutionPolicy>();
+
   wrap::forall(std::forward<ExecutionPolicy>(p),
                std::forward<Container>(c),
                std::forward<LoopBody>(loop_body));
+
+  detail::clearChaiExecutionSpace();
 }
 
 //
@@ -432,12 +442,17 @@ forall_Icount(ExecutionPolicy&& p,
                 "Iterator pair does not meet requirement of "
                 "RandomAccessIterator");
 
+  detail::setChaiExecutionSpace<ExecutionPolicy>();
+
   auto len = std::distance(begin, end);
   using SpanType = impl::Span<Iterator, decltype(len)>;
+
   wrap::forall_Icount(std::forward<ExecutionPolicy>(p),
                       SpanType{begin, len},
                       icount,
                       std::forward<LoopBody>(loop_body));
+
+  detail::clearChaiExecutionSpace();
 }
 
 /*!
@@ -457,11 +472,16 @@ forall(ExecutionPolicy&& p, Iterator begin, Iterator end, LoopBody&& loop_body)
                 "Iterator pair does not meet requirement of "
                 "RandomAccessIterator");
 
+  detail::setChaiExecutionSpace<ExecutionPolicy>();
+
   auto len = std::distance(begin, end);
   using SpanType = impl::Span<Iterator, decltype(len)>;
+
   wrap::forall(std::forward<ExecutionPolicy>(p),
                SpanType{begin, len},
                std::forward<LoopBody>(loop_body));
+
+  detail::clearChaiExecutionSpace();
 }
 
 //
@@ -494,9 +514,14 @@ forall(ExecutionPolicy&& p,
   static_assert(
       type_traits::is_range_constructible<IndexType1, IndexType2>::value,
       "Cannot deduce a common type between begin and end for Range creation");
+
+  detail::setChaiExecutionSpace<ExecutionPolicy>();
+
   wrap::forall(std::forward<ExecutionPolicy>(p),
                make_range(begin, end),
                std::forward<LoopBody>(loop_body));
+
+  detail::clearChaiExecutionSpace();
 }
 
 /*!
@@ -525,10 +550,15 @@ forall_Icount(ExecutionPolicy&& p,
   static_assert(
       type_traits::is_range_constructible<IndexType1, IndexType2>::value,
       "Cannot deduce a common type between begin and end for Range creation");
+
+  detail::setChaiExecutionSpace<ExecutionPolicy>();
+
   wrap::forall_Icount(std::forward<ExecutionPolicy>(p),
                       make_range(begin, end),
                       icount,
                       std::forward<LoopBody>(loop_body));
+
+  detail::clearChaiExecutionSpace();
 }
 
 //
@@ -565,9 +595,14 @@ forall(ExecutionPolicy&& p,
                                                            IndexType3>::value,
                 "Cannot deduce a common type between begin and end for Range "
                 "creation");
+
+  detail::setChaiExecutionSpace<ExecutionPolicy>();
+
   wrap::forall(std::forward<ExecutionPolicy>(p),
                make_strided_range(begin, end, stride),
                std::forward<LoopBody>(loop_body));
+
+  detail::clearChaiExecutionSpace();
 }
 
 static_assert(
@@ -608,10 +643,15 @@ forall_Icount(ExecutionPolicy&& p,
                                                            IndexType3>::value,
                 "Cannot deduce a common type between begin and end for Range "
                 "creation");
+
+  detail::setChaiExecutionSpace<ExecutionPolicy>();
+
   wrap::forall_Icount(std::forward<ExecutionPolicy>(p),
                       make_strided_range(begin, end, stride),
                       icount,
                       std::forward<LoopBody>(loop_body));
+
+  detail::clearChaiExecutionSpace();
 }
 
 //
@@ -641,9 +681,13 @@ forall(ExecutionPolicy&& p,
        const IndexType len,
        LoopBody&& loop_body)
 {
+  detail::setChaiExecutionSpace<ExecutionPolicy>();
+
   wrap::forall(std::forward<ExecutionPolicy>(p),
                TypedListSegment<ArrayIdxType>(idx, len, Unowned),
                std::forward<LoopBody>(loop_body));
+
+  detail::clearChaiExecutionSpace();
 }
 
 /*!
@@ -673,11 +717,16 @@ forall_Icount(ExecutionPolicy&& p,
               const OffsetType icount,
               LoopBody&& loop_body)
 {
+
+  detail::setChaiExecutionSpace<ExecutionPolicy>();
+
   // turn into an iterator
   forall_Icount(std::forward<ExecutionPolicy>(p),
                 TypedListSegment<ArrayIdxType>(idx, len, Unowned),
                 icount,
                 std::forward<LoopBody>(loop_body));
+
+  detail::clearChaiExecutionSpace();
 }
 
 /*!
@@ -688,7 +737,12 @@ forall_Icount(ExecutionPolicy&& p,
 template <typename ExecutionPolicy, typename... Args>
 RAJA_INLINE void forall(Args&&... args)
 {
+
+  detail::setChaiExecutionSpace<ExecutionPolicy>();
+
   forall(ExecutionPolicy(), std::forward<Args>(args)...);
+
+  detail::clearChaiExecutionSpace();
 }
 
 /*!
@@ -700,7 +754,12 @@ RAJA_INLINE void forall(Args&&... args)
 template <typename ExecutionPolicy, typename... Args>
 RAJA_INLINE void forall_Icount(Args&&... args)
 {
+
+  detail::setChaiExecutionSpace<ExecutionPolicy>();
+
   forall_Icount(ExecutionPolicy(), std::forward<Args>(args)...);
+
+  detail::clearChaiExecutionSpace();
 }
 
 namespace detail

--- a/include/RAJA/pattern/forall.hpp
+++ b/include/RAJA/pattern/forall.hpp
@@ -82,13 +82,8 @@
 
 #include "RAJA/pattern/detail/forall.hpp"
 
-#if defined(RAJA_ENABLE_CHAI)
 #include "RAJA/util/chai_support.hpp"
 
-#include "chai/ArrayManager.hpp"
-#include "chai/ExecutionSpaces.hpp"
-
-#endif
 
 
 namespace RAJA
@@ -211,11 +206,8 @@ RAJA_INLINE concepts::enable_if<
     type_traits::is_range<Container>>
 forall(ExecutionPolicy&& p, Container&& c, LoopBody&& loop_body)
 {
-#if defined(RAJA_ENABLE_CHAI)
-  chai::ArrayManager* rm = chai::ArrayManager::getInstance();
-  using EP = typename std::decay<ExecutionPolicy>::type;
-  rm->setExecutionSpace(detail::get_space<EP>::value);
-#endif
+
+  detail::setChaiExecutionSpace<ExecutionPolicy>();
 
   using RAJA::internal::trigger_updates_before;
   auto body = trigger_updates_before(loop_body);
@@ -223,9 +215,7 @@ forall(ExecutionPolicy&& p, Container&& c, LoopBody&& loop_body)
               std::forward<Container>(c),
               body);
 
-#if defined(RAJA_ENABLE_CHAI)
-  rm->setExecutionSpace(chai::NONE);
-#endif
+  detail::clearChaiExecutionSpace();
 }
 
 /*!
@@ -245,11 +235,7 @@ RAJA_INLINE void forall_Icount(ExecutionPolicy&& p,
                                LoopBody&& loop_body)
 {
 
-#if defined(RAJA_ENABLE_CHAI)
-  chai::ArrayManager* rm = chai::ArrayManager::getInstance();
-  using EP = typename std::decay<ExecutionPolicy>::type;
-  rm->setExecutionSpace(detail::get_space<EP>::value);
-#endif
+  detail::setChaiExecutionSpace<ExecutionPolicy>();
 
   using RAJA::internal::trigger_updates_before;
   auto body = trigger_updates_before(loop_body);
@@ -263,9 +249,7 @@ RAJA_INLINE void forall_Icount(ExecutionPolicy&& p,
   using policy::sequential::forall_impl;
   forall_impl(std::forward<ExecutionPolicy>(p), range, adapted);
 
-#if defined(RAJA_ENABLE_CHAI)
-  rm->setExecutionSpace(chai::NONE);
-#endif
+  detail::clearChaiExecutionSpace();
 }
 
 /*!
@@ -286,11 +270,7 @@ RAJA_INLINE void forall_Icount(ExecPolicy<SegmentIterPolicy, SegmentExecPolicy>,
                                LoopBody loop_body)
 {
 
-#if defined(RAJA_ENABLE_CHAI)
-  chai::ArrayManager* rm = chai::ArrayManager::getInstance();
-  using EP = typename std::decay<ExecutionPolicy>::type;
-  rm->setExecutionSpace(detail::get_space<EP>::value);
-#endif
+  detail::setChaiExecutionSpace<ExecPolicy<SegmentIterPolicy, SegmentExecPolicy>>();
 
   using RAJA::internal::trigger_updates_before;
   auto body = trigger_updates_before(loop_body);
@@ -303,9 +283,7 @@ RAJA_INLINE void forall_Icount(ExecPolicy<SegmentIterPolicy, SegmentExecPolicy>,
                      body);
   });
 
-#if defined(RAJA_ENABLE_CHAI)
-  rm->setExecutionSpace(chai::NONE);
-#endif
+  detail::clearChaiExecutionSpace();
 }
 
 template <typename SegmentIterPolicy,
@@ -316,11 +294,8 @@ RAJA_INLINE void forall(ExecPolicy<SegmentIterPolicy, SegmentExecPolicy>,
                              const StaticIndexSet<SegmentTypes...>& iset,
                              LoopBody loop_body)
 {
-#if defined(RAJA_ENABLE_CHAI)
-  chai::ArrayManager* rm = chai::ArrayManager::getInstance();
-  using EP = typename std::decay<ExecutionPolicy>::type;
-  rm->setExecutionSpace(detail::get_space<EP>::value);
-#endif
+
+  detail::setChaiExecutionSpace<ExecPolicy<SegmentIterPolicy, SegmentExecPolicy>>();
 
   using RAJA::internal::trigger_updates_before;
   auto body = trigger_updates_before(loop_body);
@@ -331,9 +306,8 @@ RAJA_INLINE void forall(ExecPolicy<SegmentIterPolicy, SegmentExecPolicy>,
                      SegmentExecPolicy(),
                      body);
   });
-#if defined(RAJA_ENABLE_CHAI)
-  rm->setExecutionSpace(chai::NONE);
-#endif
+
+  detail::clearChaiExecutionSpace();
 }
 
 }  // end namespace wrap

--- a/include/RAJA/pattern/forallN.hpp
+++ b/include/RAJA/pattern/forallN.hpp
@@ -76,8 +76,7 @@ struct ForallN_Executor<maybe_cuda, POLICY_INIT, POLICY_REST...> {
   RAJA_INLINE void operator()(BODY const &body) const
   {
     ForallN_PeelOuter<build_device, NextExec, BODY> outer(next_exec, body);
-    //wrap::forall(POLICY_I(), static_cast<TYPE_I>(is_i), outer);
-    forall_impl(POLICY_I(), static_cast<TYPE_I>(is_i), outer);
+    wrap::forall(POLICY_I(), static_cast<TYPE_I>(is_i), outer);
   }
 };
 

--- a/include/RAJA/pattern/nested.hpp
+++ b/include/RAJA/pattern/nested.hpp
@@ -9,6 +9,8 @@
 
 #include "RAJA/pattern/nested/internal.hpp"
 
+#include "RAJA/util/chai_support.hpp"
+
 #include "camp/camp.hpp"
 #include "camp/concepts.hpp"
 #include "camp/tuple.hpp"
@@ -18,6 +20,43 @@
 
 namespace RAJA
 {
+namespace nested
+{
+template <typename... Policies>
+using Policy = camp::tuple<Policies...>;
+}
+
+
+
+#ifdef RAJA_ENABLE_CHAI
+
+namespace detail {
+
+
+/*
+ * Define CHAI support for nested policies.
+ *
+ * We need to walk the entire set of execution policies inside of the
+ * RAJA::nested::Policy
+ */
+template <typename... POLICIES>
+struct get_space<camp::tuple<POLICIES ...>>
+    : public get_space_from_list< // combines exec policies to find exec space
+
+         // Extract just the execution policies from the tuple
+         RAJA::nested::internal::get_for_policies<
+            typename camp::tuple<POLICIES ...>::TList
+         >
+
+      >
+{};
+
+
+} // end detail namespace
+
+#endif // RAJA_ENABLE_CHAI
+
+
 namespace nested
 {
 
@@ -46,8 +85,7 @@ struct TypedFor : public internal::TypedForBase,
   using Base::Base;
 };
 
-template <typename... Policies>
-using Policy = camp::tuple<Policies...>;
+
 
 template <typename PolicyTuple, typename SegmentTuple, typename Fn>
 struct LoopData {
@@ -197,6 +235,8 @@ struct Wrapper<n_policies, n_policies, Data, Own> {
   void operator()() const { camp::invoke(data.index_tuple, data.f); }
 };
 
+
+
 template <typename Data>
 auto make_base_wrapper(Data &d) -> Wrapper<0, Data::n_policies, Data>
 {
@@ -206,11 +246,8 @@ auto make_base_wrapper(Data &d) -> Wrapper<0, Data::n_policies, Data>
 template <typename Pol, typename SegmentTuple, typename Body>
 RAJA_INLINE void forall(const Pol &p, const SegmentTuple &st, const Body &b)
 {
-#if defined(RAJA_ENABLE_CHAI)
-  chai::ArrayManager *rm = chai::ArrayManager::getInstance();
-  using EP = typename std::decay<POLICY>::type;
-  rm->setExecutionSpace(detail::get_space<EP>::value);
-#endif
+  detail::setChaiExecutionSpace<Pol>();
+
   using fors = internal::get_for_policies<typename Pol::TList>;
   // TODO: ensure no duplicate indices in For<>s
   // TODO: ensure no gaps in For<>s
@@ -226,13 +263,20 @@ RAJA_INLINE void forall(const Pol &p, const SegmentTuple &st, const Body &b)
   //           << typeid(data.index_tuple).name() << std::endl;
   ld();
 
-#if defined(RAJA_ENABLE_CHAI)
-  rm->setExecutionSpace(chai::NONE);
-#endif
+  detail::clearChaiExecutionSpace();
 }
 
 }  // end namespace nested
+
+
+
+
+
 }  // end namespace RAJA
+
+
+
+
 
 
 #include "RAJA/pattern/nested/tile.hpp"

--- a/include/RAJA/pattern/nested/internal.hpp
+++ b/include/RAJA/pattern/nested/internal.hpp
@@ -52,10 +52,37 @@ using has_for_list = typename camp::bind_front<std::is_base_of, ForList>::type;
 template <typename T>
 using get_for_list = typename T::as_for_list;
 
+template <typename T>
+using get_space_list = typename T::as_space_list;
+
+/*
+ * Get a camp::list of execution policies from a RAJA::nested::Policy.
+ *
+ * This extracts the execution policy from each For<>, and extracts the
+ * policies from inside of Collapse<P, ...>, but drops P
+ *
+ * The size of the returned camp::list is exactly the number of For<>'s
+ * in the policy
+ */
 template <typename Seq>
 using get_for_policies = typename camp::flatten<typename camp::transform<
     get_for_list,
     typename camp::filter_l<has_for_list, Seq>::type>::type>::type;
+
+/*
+ * Get a camp::list of execution policies from a RAJA::nested::Policy to be
+ * used to determine the execution space.
+ *
+ * This extracts the execution policy from each For<>, and extracts the
+ * COLLAPSE policy P from inside of Collapse<P, ...>.  It drops all of the
+ * For<>'s inside of a collapse.
+ *
+ */
+template <typename Seq>
+using get_space_policies = typename camp::flatten<typename camp::transform<
+    get_space_list,
+    typename camp::filter_l<has_for_list, Seq>::type>::type>::type;
+
 
 template <typename T>
 using is_nil_type =

--- a/include/RAJA/policy/MultiPolicy.hpp
+++ b/include/RAJA/policy/MultiPolicy.hpp
@@ -33,6 +33,7 @@
 
 #include "RAJA/policy/PolicyBase.hpp"
 
+#include "RAJA/util/chai_support.hpp"
 #include "RAJA/util/concepts.hpp"
 
 namespace RAJA
@@ -148,6 +149,18 @@ auto make_multi_policy(std::tuple<Policies...> policies, Selector s)
 namespace detail
 {
 
+#ifdef RAJA_ENABLE_CHAI
+// Top level MultiPolicy shouldn't select a CHAI execution space
+// Once a specific policy is selected, that policy will select the correct
+// policy... see policy_invoker in MultiPolicy.hpp
+template <typename SELECTOR, typename... POLICIES>
+struct get_space<RAJA::MultiPolicy<SELECTOR, POLICIES ...>>
+    : public get_space_impl<Platform::undefined> {
+};
+#endif
+
+
+
 template <size_t index, size_t size, typename Policy, typename... rest>
 struct policy_invoker : public policy_invoker<index - 1, size, rest...> {
   static_assert(index < size, "index must be in the range of possibilities");
@@ -176,8 +189,18 @@ struct policy_invoker<0, size, Policy, rest...> {
   void invoke(int offset, Iterable &&iter, Body &&body)
   {
     if (offset == size - 1) {
+
+      // Now we know what policy is going to be invoked, so we can tell
+      // CHAI what execution space to use
+      detail::setChaiExecutionSpace<Policy>();
+
+
       using policy::multi::forall_impl;
       forall_impl(_p, iter, body);
+
+
+      detail::clearChaiExecutionSpace();
+
     } else {
       throw std::runtime_error("unknown offset invoked");
     }

--- a/include/RAJA/util/View.hpp
+++ b/include/RAJA/util/View.hpp
@@ -93,7 +93,7 @@ struct View {
   template <typename... Args>
   RAJA_HOST_DEVICE RAJA_INLINE value_type &operator()(Args... args) const
   {
-    return data[convertIndex<Index_type>(layout(args...))];
+    return data[(int)convertIndex<Index_type>(layout(args...))];
   }
 };
 

--- a/test/integration/chai/chai-policy-tests.cpp
+++ b/test/integration/chai/chai-policy-tests.cpp
@@ -42,6 +42,7 @@ static_assert(RAJA::detail::get_space<RAJA::NestedPolicy< RAJA::ExecList< RAJA::
 
 #if defined(RAJA_ENABLE_CUDA)
 static_assert(RAJA::detail::get_space<RAJA::NestedPolicy< RAJA::ExecList< RAJA::seq_exec, RAJA::cuda_exec<16> > > >::value == chai::GPU, "");
+static_assert(RAJA::detail::get_space<RAJA::NestedPolicy< RAJA::ExecList< RAJA::seq_exec, RAJA::cuda_thread_x_exec > > >::value == chai::GPU, "");
 #endif
 
 TEST(ChaiPolicyTest, Default) {

--- a/test/unit/nested.cpp
+++ b/test/unit/nested.cpp
@@ -47,7 +47,6 @@ protected:
 };
 TYPED_TEST_CASE_P(Nested);
 
-#if 0
 
 RAJA_HOST_DEVICE constexpr Index_type get_val(Index_type v) noexcept
 {
@@ -158,8 +157,8 @@ TEST(Nested, TileDynamic)
       });
 }
 
-#endif
 
+#if 0 // NOT WORKING YET
 #if defined(RAJA_ENABLE_CUDA)
 CUDA_TEST(Nested, CudaCollapse)
 {
@@ -175,4 +174,5 @@ CUDA_TEST(Nested, CudaCollapse)
           printf("(%d, %d)\n", int(i), int(j));
        });
 }
+#endif
 #endif

--- a/test/unit/nested.cpp
+++ b/test/unit/nested.cpp
@@ -47,6 +47,8 @@ protected:
 };
 TYPED_TEST_CASE_P(Nested);
 
+#if 0
+
 RAJA_HOST_DEVICE constexpr Index_type get_val(Index_type v) noexcept
 {
   return v;
@@ -156,7 +158,7 @@ TEST(Nested, TileDynamic)
       });
 }
 
-
+#endif
 
 #if defined(RAJA_ENABLE_CUDA)
 CUDA_TEST(Nested, CudaCollapse)


### PR DESCRIPTION
Mostly fixed the RAJA+CHAI interop.
    
Abstracted calls to chai into two functions setChaiExecutionSpace and clearChaiExecutionSpace, eliminating a lot of duplicated code.
    
Fixed some of the unit tests.
    
Setup correct policies for MultiPolicy to interact correctly with CHAI, by deferring the initial CHAI space selection until a specific policy is selected.
    
Added CHAI space resolution for RAJA::nested::Policy
    
Fixed max_platorm operator.
    
Added CHAI RAJA::nested::forall test.
    
Updated RAJA::forall* to set the CHAI execution space instead of RAJA::wrap::forall* because forallN needs to call wrap::forall, but has already set the execution space in the outer RAJA::forallN function.

