### PR TITLE
Fixed CHAI+CUDA unit tests to compile without OpenMP enabled

### DIFF
--- a/test/integration/chai/chai-nested.cpp
+++ b/test/integration/chai/chai-nested.cpp
@@ -147,7 +147,12 @@ CUDA_TEST(Chai, NestedView) {
 
 CUDA_TEST(Chai, NestedView2) {
   typedef RAJA::NestedPolicy< RAJA::ExecList< RAJA::seq_exec, RAJA::seq_exec> > POLICY;
+
+#ifdef RAJA_ENABLE_OPENMP
   typedef RAJA::NestedPolicy< RAJA::ExecList< RAJA::omp_for_nowait_exec, RAJA::cuda_thread_x_exec >, RAJA::OMP_Parallel<> > POLICY_GPU;
+#else
+  typedef RAJA::NestedPolicy< RAJA::ExecList< RAJA::seq_exec, RAJA::cuda_thread_x_exec > > POLICY_GPU;
+#endif
 
   const int X = 16;
   const int Y = 16;
@@ -363,12 +368,20 @@ struct PolLTimesB_GPU {
 // Combine OMP Parallel, omp nowait, and cuda thread-block launch
 struct PolLTimesC_GPU {
   // Loops: Moments, Directions, Groups, Zones
+#ifdef RAJA_ENABLE_OPENMP
   typedef NestedPolicy<ExecList<seq_exec,
                                 seq_exec,
                                 omp_for_nowait_exec,
                                 cuda_threadblock_y_exec<32>>,
                        OMP_Parallel<>>
       EXEC;
+#else
+  typedef NestedPolicy<ExecList<seq_exec,
+                                seq_exec,
+                                seq_exec,
+                                cuda_threadblock_y_exec<32>> >
+      EXEC;
+#endif
 
   // psi[direction, group, zone]
   typedef RAJA::TypedManagedArrayView<double, RAJA::Layout<3>, IDirection, IGroup, IZone>


### PR DESCRIPTION
When CHAI is enabled and OpenMP is not,  I just #ifdef the OpenMP policies in the unit tests to sequential.