### PR TITLE
make typed ranges work with IndexValue, remove base_iterator, add inn…

### DIFF
--- a/include/RAJA/index/IndexValue.hpp
+++ b/include/RAJA/index/IndexValue.hpp
@@ -28,6 +28,8 @@
 
 #include "RAJA/config.hpp"
 
+#include "RAJA/index/RangeSegment.hpp"
+#include "RAJA/index/ListSegment.hpp"
 #include "RAJA/util/defines.hpp"
 #include "RAJA/util/types.hpp"
 
@@ -63,9 +65,7 @@ struct IndexValue {
   }
 
   //! Dereference provides cast-to-integer.
-  RAJA_HOST_DEVICE RAJA_INLINE Index_type &operator*() {
-    return value;
-  }
+  RAJA_HOST_DEVICE RAJA_INLINE Index_type &operator*() { return value; }
 
   //! Dereference provides cast-to-integer.
   RAJA_HOST_DEVICE RAJA_INLINE const Index_type &operator*() const
@@ -85,7 +85,7 @@ struct IndexValue {
   RAJA_HOST_DEVICE RAJA_INLINE TYPE &operator++()
   {
     value++;
-    return static_cast<TYPE&>(*this);
+    return static_cast<TYPE &>(*this);
   }
 
   //! postdecrement -- returns a copy
@@ -100,7 +100,7 @@ struct IndexValue {
   RAJA_HOST_DEVICE RAJA_INLINE TYPE &operator--()
   {
     value--;
-    return static_cast<TYPE&>(*this);
+    return static_cast<TYPE &>(*this);
   }
 
   //! addition to underlying index from an Index_type
@@ -154,49 +154,49 @@ struct IndexValue {
   RAJA_HOST_DEVICE RAJA_INLINE TYPE &operator+=(Index_type x)
   {
     value += x;
-    return static_cast<TYPE&>(*this);
+    return static_cast<TYPE &>(*this);
   }
 
   RAJA_HOST_DEVICE RAJA_INLINE TYPE &operator+=(TYPE x)
   {
     value += x.value;
-    return static_cast<TYPE&>(*this);
+    return static_cast<TYPE &>(*this);
   }
 
   RAJA_HOST_DEVICE RAJA_INLINE TYPE &operator-=(Index_type x)
   {
     value -= x;
-    return static_cast<TYPE&>(*this);
+    return static_cast<TYPE &>(*this);
   }
 
   RAJA_HOST_DEVICE RAJA_INLINE TYPE &operator-=(TYPE x)
   {
     value -= x.value;
-    return static_cast<TYPE&>(*this);
+    return static_cast<TYPE &>(*this);
   }
 
   RAJA_HOST_DEVICE RAJA_INLINE TYPE &operator*=(Index_type x)
   {
     value *= x;
-    return static_cast<TYPE&>(*this);
+    return static_cast<TYPE &>(*this);
   }
 
   RAJA_HOST_DEVICE RAJA_INLINE TYPE &operator*=(TYPE x)
   {
     value *= x.value;
-    return static_cast<TYPE&>(*this);
+    return static_cast<TYPE &>(*this);
   }
 
   RAJA_HOST_DEVICE RAJA_INLINE TYPE &operator/=(Index_type x)
   {
     value /= x;
-    return static_cast<TYPE&>(*this);
+    return static_cast<TYPE &>(*this);
   }
 
   RAJA_HOST_DEVICE RAJA_INLINE TYPE &operator/=(TYPE x)
   {
     value /= x.value;
-    return static_cast<TYPE&>(*this);
+    return static_cast<TYPE &>(*this);
   }
 
   RAJA_HOST_DEVICE RAJA_INLINE bool operator<(Index_type x) const
@@ -282,7 +282,7 @@ convertIndex_helper(typename FROM::IndexValueType val)
   return static_cast<TO>(*val);
 }
 
-} // closing brace for namespace impl
+}  // closing brace for namespace impl
 
 /*!
  * \brief Function provides a way to take either an int or any Index<> type, and
@@ -315,6 +315,9 @@ RAJA_HOST_DEVICE RAJA_INLINE TO convertIndex(FROM val)
     {                                                                \
     }                                                                \
     static inline std::string getName() { return NAME; }             \
+    using range = RAJA::TypedRangeSegment<TYPE>;                     \
+    using strided_range = RAJA::TypedRangeStrideSegment<TYPE>;       \
+    using list = RAJA::TypedListSegment<TYPE>;                       \
   };
 
 #endif

--- a/include/RAJA/index/RangeSegment.hpp
+++ b/include/RAJA/index/RangeSegment.hpp
@@ -75,11 +75,11 @@ namespace RAJA
  *
  ******************************************************************************
  */
-template <typename StorageT>
+template <typename StorageT, typename DiffT = Index_type>
 struct TypedRangeSegment {
 
   //! the underlying iterator type
-  using iterator = Iterators::numeric_iterator<StorageT>;
+  using iterator = Iterators::numeric_iterator<StorageT,DiffT>;
   //! the underlying value_type type
   /*!
    * this corresponds to the template parameter
@@ -91,8 +91,8 @@ struct TypedRangeSegment {
    * \param[in] begin the starting value (inclusive) for the range
    * \param[in] end the ending value (exclusive) for the range
    */
-  RAJA_HOST_DEVICE TypedRangeSegment(StorageT begin, StorageT end)
-      : m_begin(iterator(begin)), m_end(iterator(end)), m_size(end - begin)
+  RAJA_HOST_DEVICE TypedRangeSegment(Index_type begin, Index_type end)
+      : m_begin(iterator{begin}), m_end(iterator{end}), m_size(end - begin)
   {
   }
 
@@ -186,7 +186,7 @@ private:
   iterator m_end;
 
   //! member variable for size of segment
-  StorageT m_size;
+  DiffT m_size;
 };
 
 
@@ -249,11 +249,11 @@ private:
  *
  ******************************************************************************
  */
-template <typename StorageT>
+template <typename StorageT, typename DiffT = Index_type>
 struct TypedRangeStrideSegment {
 
   //! the underlying iterator type
-  using iterator = Iterators::strided_numeric_iterator<StorageT>;
+  using iterator = Iterators::strided_numeric_iterator<StorageT, DiffT>;
 
   //! the underlying value_type type
   /*!

--- a/include/RAJA/internal/Iterators.hpp
+++ b/include/RAJA/internal/Iterators.hpp
@@ -42,143 +42,119 @@ namespace Iterators
 
 // Containers
 
-template <typename Type,
-          typename DifferenceType = std::ptrdiff_t,
+template <typename Type = Index_type,
+          typename DifferenceType = Index_type,
           typename PointerType = Type*>
-struct base_iterator {
-
+class numeric_iterator
+{
+public:
   using value_type = Type;
   using difference_type = DifferenceType;
-  using pointer = value_type*;
+  using pointer = PointerType;
   using reference = value_type&;
   using iterator_category = std::random_access_iterator_tag;
 
-  RAJA_HOST_DEVICE constexpr base_iterator() : val(0) {}
-  RAJA_HOST_DEVICE constexpr base_iterator(Type rhs) : val(rhs) {}
-  RAJA_HOST_DEVICE constexpr base_iterator(const base_iterator& rhs)
+  RAJA_HOST_DEVICE constexpr numeric_iterator() : val(0) {}
+  RAJA_HOST_DEVICE constexpr numeric_iterator(const difference_type& rhs)
+      : val(rhs)
+  {
+  }
+  RAJA_HOST_DEVICE constexpr numeric_iterator(const numeric_iterator& rhs)
       : val(rhs.val)
   {
   }
-
-  RAJA_HOST_DEVICE inline bool operator==(const base_iterator& rhs) const
+  RAJA_HOST_DEVICE inline bool operator==(const numeric_iterator& rhs) const
   {
     return val == rhs.val;
   }
-  RAJA_HOST_DEVICE inline bool operator!=(const base_iterator& rhs) const
+  RAJA_HOST_DEVICE inline bool operator!=(const numeric_iterator& rhs) const
   {
     return val != rhs.val;
   }
-  RAJA_HOST_DEVICE inline bool operator>(const base_iterator& rhs) const
+  RAJA_HOST_DEVICE inline bool operator>(const numeric_iterator& rhs) const
   {
     return val > rhs.val;
   }
-  RAJA_HOST_DEVICE inline bool operator<(const base_iterator& rhs) const
+  RAJA_HOST_DEVICE inline bool operator<(const numeric_iterator& rhs) const
   {
     return val < rhs.val;
   }
-  RAJA_HOST_DEVICE inline bool operator>=(const base_iterator& rhs) const
+  RAJA_HOST_DEVICE inline bool operator>=(const numeric_iterator& rhs) const
   {
     return val >= rhs.val;
   }
-  RAJA_HOST_DEVICE inline bool operator<=(const base_iterator& rhs) const
+  RAJA_HOST_DEVICE inline bool operator<=(const numeric_iterator& rhs) const
   {
     return val <= rhs.val;
   }
 
-protected:
-  Type val;
-};
-
-template <typename Type = Index_type,
-          typename DifferenceType = Index_type,
-          typename PointerType = Type*>
-class numeric_iterator : public base_iterator<Type, DifferenceType>
-{
-  using base = base_iterator<Type, DifferenceType>;
-
-public:
-  using value_type = typename base::value_type;
-  using difference_type = typename base::difference_type;
-  using pointer = typename base::pointer;
-  using reference = typename base::reference;
-  using iterator_category = typename base::iterator_category;
-
-  RAJA_HOST_DEVICE constexpr numeric_iterator() : base(0) {}
-  RAJA_HOST_DEVICE constexpr numeric_iterator(const Type& rhs) : base(rhs) {}
-  RAJA_HOST_DEVICE constexpr numeric_iterator(const numeric_iterator& rhs)
-      : base(rhs.val)
-  {
-  }
-
   RAJA_HOST_DEVICE inline numeric_iterator& operator++()
   {
-    ++base::val;
+    ++val;
     return *this;
   }
   RAJA_HOST_DEVICE inline numeric_iterator& operator--()
   {
-    --base::val;
+    --val;
     return *this;
   }
   RAJA_HOST_DEVICE inline numeric_iterator operator++(int)
   {
     numeric_iterator tmp(*this);
-    ++base::val;
+    ++val;
     return tmp;
   }
   RAJA_HOST_DEVICE inline numeric_iterator operator--(int)
   {
     numeric_iterator tmp(*this);
-    --base::val;
+    --val;
     return tmp;
   }
 
   RAJA_HOST_DEVICE inline numeric_iterator& operator+=(
       const difference_type& rhs)
   {
-    base::val += rhs;
+    val += rhs;
     return *this;
   }
   RAJA_HOST_DEVICE inline numeric_iterator& operator-=(
       const difference_type& rhs)
   {
-    base::val -= rhs;
+    val -= rhs;
     return *this;
   }
   RAJA_HOST_DEVICE inline numeric_iterator& operator+=(
       const numeric_iterator& rhs)
   {
-    base::val += rhs.val;
+    val += rhs.val;
     return *this;
   }
   RAJA_HOST_DEVICE inline numeric_iterator& operator-=(
       const numeric_iterator& rhs)
   {
-    base::val -= rhs.val;
+    val -= rhs.val;
     return *this;
   }
 
   RAJA_HOST_DEVICE inline difference_type operator+(
       const numeric_iterator& rhs) const
   {
-    return static_cast<difference_type>(base::val)
-           + static_cast<difference_type>(rhs.val);
+    return val + rhs.val;
   }
   RAJA_HOST_DEVICE inline difference_type operator-(
       const numeric_iterator& rhs) const
   {
-    return static_cast<difference_type>(base::val)
-           - static_cast<difference_type>(rhs.val);
+    return val - rhs.val;
   }
   RAJA_HOST_DEVICE inline numeric_iterator operator+(
       const difference_type& rhs) const
   {
-    return numeric_iterator(base::val + rhs);
+    return numeric_iterator(val + rhs);
   }
   RAJA_HOST_DEVICE inline numeric_iterator operator-(
       const difference_type& rhs) const
   {
-    return numeric_iterator(base::val - rhs);
+    return numeric_iterator(val - rhs);
   }
   RAJA_HOST_DEVICE friend constexpr numeric_iterator operator+(
       difference_type lhs,
@@ -193,76 +169,83 @@ public:
     return numeric_iterator(lhs - rhs.val);
   }
 
-  RAJA_HOST_DEVICE inline Type operator*() const { return base::val; }
-  RAJA_HOST_DEVICE inline Type operator->() const { return base::val; }
-  RAJA_HOST_DEVICE constexpr Type operator[](difference_type rhs) const
+  RAJA_HOST_DEVICE inline value_type operator*() const
   {
-    return base::val + rhs;
+    return value_type(val);
   }
+  RAJA_HOST_DEVICE inline value_type operator->() const
+  {
+    return value_type(val);
+  }
+  RAJA_HOST_DEVICE constexpr value_type operator[](difference_type rhs) const
+  {
+    return value_type(val + rhs);
+  }
+
+private:
+  difference_type val;
 };
 
 template <typename Type = Index_type,
           typename DifferenceType = Index_type,
           typename PointerType = Type*>
-class strided_numeric_iterator : public base_iterator<Type, DifferenceType>
+class strided_numeric_iterator
 {
-  using base = base_iterator<Type, DifferenceType>;
-
 public:
-  using value_type = typename base::value_type;
-  using difference_type = typename base::difference_type;
-  using pointer = typename base::pointer;
-  using reference = typename base::reference;
-  using iterator_category = typename base::iterator_category;
+  using value_type = Type;
+  using difference_type = DifferenceType;
+  using pointer = DifferenceType*;
+  using reference = DifferenceType&;
+  using iterator_category = std::random_access_iterator_tag;
 
-  RAJA_HOST_DEVICE constexpr strided_numeric_iterator() : base(0), stride(1) {}
+  RAJA_HOST_DEVICE constexpr strided_numeric_iterator() : val(0), stride(1) {}
   RAJA_HOST_DEVICE constexpr strided_numeric_iterator(const Type& rhs,
                                                       DifferenceType stride = 1)
-      : base(rhs), stride(stride)
+      : val(rhs), stride(stride)
   {
   }
 
   RAJA_HOST_DEVICE constexpr strided_numeric_iterator(
       const strided_numeric_iterator& rhs)
-      : base(rhs.val), stride(rhs.stride)
+      : val(rhs.val), stride(rhs.stride)
   {
   }
 
   RAJA_HOST_DEVICE inline strided_numeric_iterator& operator++()
   {
-    base::val += stride;
+    val += stride;
     return *this;
   }
   RAJA_HOST_DEVICE inline strided_numeric_iterator& operator--()
   {
-    base::val -= stride;
+    val -= stride;
     return *this;
   }
 
   RAJA_HOST_DEVICE inline strided_numeric_iterator& operator+=(
       const difference_type& rhs)
   {
-    base::val += rhs * stride;
+    val += rhs * stride;
     return *this;
   }
   RAJA_HOST_DEVICE inline strided_numeric_iterator& operator-=(
       const difference_type& rhs)
   {
-    base::val -= rhs * stride;
+    val -= rhs * stride;
     return *this;
   }
 
   RAJA_HOST_DEVICE inline difference_type operator+(
       const strided_numeric_iterator& rhs) const
   {
-    return (static_cast<difference_type>(base::val)
+    return (static_cast<difference_type>(val)
             + (static_cast<difference_type>(rhs.val)))
            / stride;
   }
   RAJA_HOST_DEVICE inline difference_type operator-(
       const strided_numeric_iterator& rhs) const
   {
-    difference_type diff = (static_cast<difference_type>(base::val)
+    difference_type diff = (static_cast<difference_type>(val)
                             - (static_cast<difference_type>(rhs.val)));
 
     return (diff % stride) ? (1 + diff / stride) : diff / stride;
@@ -270,12 +253,12 @@ public:
   RAJA_HOST_DEVICE inline strided_numeric_iterator operator+(
       const difference_type& rhs) const
   {
-    return strided_numeric_iterator(base::val + rhs * stride);
+    return strided_numeric_iterator(val + rhs * stride);
   }
   RAJA_HOST_DEVICE inline strided_numeric_iterator operator-(
       const difference_type& rhs) const
   {
-    return strided_numeric_iterator(base::val - rhs * stride);
+    return strided_numeric_iterator(val - rhs * stride);
   }
 
   // Specialized comparison to allow normal iteration to work on off-stride
@@ -283,49 +266,56 @@ public:
   RAJA_HOST_DEVICE inline bool operator!=(
       const strided_numeric_iterator& rhs) const
   {
-    return (base::val - rhs.val) / stride;
+    return (val - rhs.val) / stride;
   }
   RAJA_HOST_DEVICE inline bool operator==(
       const strided_numeric_iterator& rhs) const
   {
-    return !((base::val - rhs.val) / stride);
+    return !((val - rhs.val) / stride);
   }
 
   RAJA_HOST_DEVICE inline bool operator>(
       const strided_numeric_iterator& rhs) const
   {
-    return base::val * stride > rhs.val * stride;
+    return val * stride > rhs.val * stride;
   }
   RAJA_HOST_DEVICE inline bool operator<(
       const strided_numeric_iterator& rhs) const
   {
-    return base::val * stride < rhs.val * stride;
+    return val * stride < rhs.val * stride;
   }
   RAJA_HOST_DEVICE inline bool operator>=(
       const strided_numeric_iterator& rhs) const
   {
-    return base::val * stride >= rhs.val * stride;
+    return val * stride >= rhs.val * stride;
   }
   RAJA_HOST_DEVICE inline bool operator<=(
       const strided_numeric_iterator& rhs) const
   {
-    return base::val * stride <= rhs.val * stride;
+    return val * stride <= rhs.val * stride;
   }
 
 
-  RAJA_HOST_DEVICE inline Type operator*() const { return base::val; }
-  RAJA_HOST_DEVICE inline Type operator->() const { return base::val; }
-  RAJA_HOST_DEVICE inline Type operator[](difference_type rhs) const
+  RAJA_HOST_DEVICE inline value_type operator*() const
   {
-    return base::val + rhs * stride;
+    return value_type(val);
+  }
+  RAJA_HOST_DEVICE inline value_type operator->() const
+  {
+    return value_type(val);
+  }
+  RAJA_HOST_DEVICE constexpr value_type operator[](difference_type rhs) const
+  {
+    return value_type(val + rhs * stride);
   }
 
 private:
+  DifferenceType val;
   DifferenceType stride;
 };
 
-} // closing brace for namespace Iterators
+}  // closing brace for namespace Iterators
 
-} // closing brace for namespace RAJA
+}  // closing brace for namespace RAJA
 
 #endif /* RAJA_ITERATORS_HPP */

--- a/test/unit/test-iterators.cpp
+++ b/test/unit/test-iterators.cpp
@@ -20,21 +20,6 @@
 #include "RAJA/RAJA.hpp"
 #include "RAJA_gtest.hpp"
 
-TEST(BaseIterator, simple)
-{
-  RAJA::Iterators::base_iterator<int> a;
-  RAJA::Iterators::base_iterator<int> two(2);
-  ASSERT_LT(a, two);
-  ASSERT_LE(a, two);
-  ASSERT_LE(a, a);
-  ASSERT_EQ(a, a);
-  ASSERT_GE(two, a);
-  ASSERT_GT(two, a);
-  ASSERT_NE(two, a);
-  RAJA::Iterators::base_iterator<int> b(a);
-  ASSERT_EQ(a, b);
-}
-
 TEST(NumericIterator, simple)
 {
   RAJA::Iterators::numeric_iterator<> i;


### PR DESCRIPTION
…er-aliases for ranges and lists in the IndexValue type for convenient use

This makes the following example a valid program:

```c++
#include <RAJA/RAJA.hpp>
#include <iostream>

RAJA_INDEX_VALUE(ID, "ID");
RAJA_INDEX_VALUE(IZ, "IZ");
RAJA_INDEX_VALUE(IG, "IG");
RAJA_INDEX_VALUE(IM, "IM");

int main(int argc, char *argv[])
{
  using RAJA::nested::For;
  RAJA::nested::forall(
      RAJA::nested::Policy<For<3, RAJA::seq_exec>,
                           For<2, RAJA::seq_exec>,
                           For<1, RAJA::seq_exec>,
                           For<0, RAJA::seq_exec> >{},
      camp::make_tuple(
          ID::range(0, 3), IZ::range(0, 3), IG::range(0, 3), IM::range(0, 3)),
      [=](ID d, IZ z, IG g, IM m) {
        std::cout << *d << *z << *g << *m << std::endl;
      });

  return 0;
}
```