### PR TITLE
Bugfix/kunen1/tuple warn

### DIFF
--- a/include/RAJA/pattern/nested.hpp
+++ b/include/RAJA/pattern/nested.hpp
@@ -36,8 +36,8 @@ struct For : public internal::ForList,
 
   // TODO: add static_assert for valid policy in Pol
   const Pol pol;
-  For() : pol{} {}
-  For(const Pol &p) : pol{p} {}
+  RAJA_HOST_DEVICE constexpr For() : pol{} {}
+  RAJA_HOST_DEVICE constexpr For(const Pol &p) : pol{p} {}
 };
 
 
@@ -49,8 +49,8 @@ struct Collapse : public internal::ForList, public internal::CollapseBase {
   using as_space_list = camp::list<For<-1, ExecPolicy>>;
 
   const ExecPolicy pol;
-  Collapse() : pol{} {}
-  Collapse(ExecPolicy const &ep) : pol{ep} {}
+  RAJA_HOST_DEVICE constexpr Collapse() : pol{} {}
+  RAJA_HOST_DEVICE constexpr Collapse(ExecPolicy const &ep) : pol{ep} {}
 };
 
 }

--- a/include/RAJA/pattern/nested/tile.hpp
+++ b/include/RAJA/pattern/nested/tile.hpp
@@ -23,7 +23,9 @@ template <camp::idx_t Index, typename TilePolicy, typename ExecPolicy>
 struct Tile {
   const TilePolicy tpol;
   const ExecPolicy epol;
-  Tile(TilePolicy const &tp = TilePolicy{}, ExecPolicy const &ep = ExecPolicy{})
+  RAJA_HOST_DEVICE constexpr
+  Tile(TilePolicy const &tp = TilePolicy{},
+      ExecPolicy const &ep = ExecPolicy{})
       : tpol{tp}, epol{ep}
   {
   }
@@ -34,7 +36,7 @@ template <camp::idx_t chunk_size_>
 struct tile_s {
   static constexpr camp::idx_t chunk_size = chunk_size_;
 
-  tile_s() {}
+  RAJA_HOST_DEVICE constexpr tile_s() {}
   constexpr camp::idx_t get_chunk_size() const { return chunk_size; }
 };
 
@@ -43,7 +45,7 @@ template <camp::idx_t default_chunk_size>
 struct tile {
   camp::idx_t chunk_size;
 
-  tile(camp::idx_t chunk_size_ = default_chunk_size) : chunk_size{chunk_size_}
+  RAJA_HOST_DEVICE constexpr tile(camp::idx_t chunk_size_ = default_chunk_size) : chunk_size{chunk_size_}
   {
   }
   camp::idx_t get_chunk_size() const { return chunk_size; }

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -43,7 +43,7 @@ namespace internal
 {
   template <camp::idx_t index, typename Type>
   struct tuple_storage {
-    tuple_storage() = default;
+    CAMP_HOST_DEVICE constexpr tuple_storage() : val() {};
     CAMP_HOST_DEVICE constexpr tuple_storage(Type val) : val{val} {}
 
     CAMP_HOST_DEVICE constexpr const Type& get_inner() const noexcept
@@ -70,7 +70,7 @@ namespace internal
   struct tuple_helper<camp::idx_seq<Indices...>, camp::list<Types...>>
       : public internal::tuple_storage<Indices, Types>... {
 
-    tuple_helper() = default;
+    CAMP_HOST_DEVICE constexpr tuple_helper(){}
 
     CAMP_HOST_DEVICE constexpr tuple_helper(Types... args)
         : internal::tuple_storage<Indices, Types>(std::forward<Types>(args))...


### PR DESCRIPTION
Fixed a number ctor "issues" that nvcc complained about "host device function calling a host function"

nvcc doesn't like defaulted constructors being marked host device :( so we are forced to implement them in cases where the default ctors are disabled