### PR TITLE
Initial implementation of the nested::Collapse for CUDA policies.

### DIFF
--- a/include/RAJA/internal/LegacyCompatibility.hpp
+++ b/include/RAJA/internal/LegacyCompatibility.hpp
@@ -180,6 +180,22 @@ RAJA_HOST_DEVICE RAJA_INLINE constexpr Result max(Args... args)
 }
 
 
+struct miner {
+  template <typename Result>
+  RAJA_HOST_DEVICE RAJA_INLINE constexpr Result operator()(
+      const Result& l,
+      const Result& r) const
+  {
+    return l < r ? l : r;
+  }
+};
+
+template <typename Result, typename... Args>
+RAJA_HOST_DEVICE RAJA_INLINE constexpr Result min(Args... args)
+{
+  return foldl(miner(), args...);
+}
+
 // template<typename Result, size_t N>
 // struct product_first_n;
 //

--- a/include/RAJA/internal/LegacyCompatibility.hpp
+++ b/include/RAJA/internal/LegacyCompatibility.hpp
@@ -145,55 +145,24 @@ RAJA_HOST_DEVICE RAJA_INLINE constexpr auto foldl(Op&& operation,
                camp::forward<Rest>(rest)...);
 }
 
-struct adder {
-  template <typename Result>
-  RAJA_HOST_DEVICE RAJA_INLINE constexpr Result operator()(
-      const Result& l,
-      const Result& r) const
-  {
-    return l + r;
-  }
-};
 
 // Convenience folds
 template <typename Result, typename... Args>
 RAJA_HOST_DEVICE RAJA_INLINE constexpr Result sum(Args... args)
 {
-  return foldl(adder(), args...);
+  return foldl(RAJA::operators::plus<Result>(), args...);
 }
-
-
-struct maxer {
-  template <typename Result>
-  RAJA_HOST_DEVICE RAJA_INLINE constexpr Result operator()(
-      const Result& l,
-      const Result& r) const
-  {
-    return l > r ? l : r;
-  }
-};
 
 template <typename Result, typename... Args>
 RAJA_HOST_DEVICE RAJA_INLINE constexpr Result max(Args... args)
 {
-  return foldl(maxer(), args...);
+  return foldl(RAJA::operators::maximum<Result>(), args...);
 }
-
-
-struct miner {
-  template <typename Result>
-  RAJA_HOST_DEVICE RAJA_INLINE constexpr Result operator()(
-      const Result& l,
-      const Result& r) const
-  {
-    return l < r ? l : r;
-  }
-};
 
 template <typename Result, typename... Args>
 RAJA_HOST_DEVICE RAJA_INLINE constexpr Result min(Args... args)
 {
-  return foldl(miner(), args...);
+  return foldl(RAJA::operators::minimum<Result>(), args...);
 }
 
 // template<typename Result, size_t N>

--- a/include/RAJA/pattern/nested.hpp
+++ b/include/RAJA/pattern/nested.hpp
@@ -110,7 +110,7 @@ struct TypedFor : public internal::TypedForBase,
 template <typename PolicyTuple, typename SegmentTuple, typename Fn>
 struct LoopData {
   constexpr static size_t n_policies = camp::tuple_size<PolicyTuple>::value;
-  const PolicyTuple &pt;
+  const PolicyTuple pt;
   SegmentTuple st;
   const typename std::remove_reference<Fn>::type f;
   using index_tuple_t = internal::index_tuple_from_policies_and_segments<
@@ -225,8 +225,10 @@ struct Executor<Collapse<seq_exec, FT0, FT1>> {
 
 
 
-template <int idx, int n_policies, typename Data, bool Own = false>
+template <int idx, int n_policies, typename Data>
 struct Wrapper {
+  constexpr static int cur_policy = idx;
+  constexpr static int num_policies = n_policies;
   using Next = Wrapper<idx + 1, n_policies, Data>;
   using data_type = typename std::remove_reference<Data>::type;
   Data &data;
@@ -241,8 +243,11 @@ struct Wrapper {
 };
 
 // Innermost, execute body
-template <int n_policies, typename Data, bool Own>
-struct Wrapper<n_policies, n_policies, Data, Own> {
+template <int n_policies, typename Data>
+struct Wrapper<n_policies, n_policies, Data> {
+  constexpr static int cur_policy = n_policies;
+  constexpr static int num_policies = n_policies;
+  using Next = Wrapper<n_policies, n_policies, Data>;
   using data_type = typename std::remove_reference<Data>::type;
   Data &data;
   explicit Wrapper(Data &d) : data{d} {}

--- a/include/RAJA/policy/cuda/forall.hpp
+++ b/include/RAJA/policy/cuda/forall.hpp
@@ -193,6 +193,32 @@ RAJA_INLINE void forall_impl(cuda_exec<BlockSize, Async>,
 
 
 //
+////////////////////////////////////////////////////////////////////////
+//
+// Function templates for CUDA execution over iterables for within
+// and device kernel.  Called from RAJA::nested::*
+//
+////////////////////////////////////////////////////////////////////////
+//
+
+template <typename Iterable, typename LoopBody>
+RAJA_INLINE RAJA_DEVICE void forall_impl(cuda_loop_exec,
+                        Iterable&& iter,
+                        LoopBody&& loop_body)
+{
+  // TODO: we need a portable std::begin, std::end, and std::distance
+  auto begin = iter.begin(); //std::begin(iter);
+  auto end   = iter.end(); //std::end(iter);
+
+  auto len = end-begin; //std::distance(begin, end);
+
+  for (decltype(len) i = 0; i < len; ++i) {
+    loop_body(*(begin + i));
+  }
+}
+
+
+//
 //////////////////////////////////////////////////////////////////////
 //
 // The following function templates iterate over index set segments

--- a/include/RAJA/policy/cuda/forallN.hpp
+++ b/include/RAJA/policy/cuda/forallN.hpp
@@ -68,18 +68,6 @@ struct ForallN_BindFirstArg_Device {
 };
 
 
-RAJA_INLINE
-constexpr int numBlocks(CudaDim const &dim)
-{
-  return dim.num_blocks.x * dim.num_blocks.y * dim.num_blocks.z;
-}
-
-RAJA_INLINE
-constexpr int numThreads(CudaDim const &dim)
-{
-  return dim.num_threads.x * dim.num_threads.y * dim.num_threads.z;
-}
-
 template <typename CUDA_EXEC, typename Iterator>
 struct CudaIterableWrapper {
   CUDA_EXEC pol_;

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -41,6 +41,8 @@ using cuda_dim_t = uint3;
 using cuda_dim_t = dim3;
 #endif
 
+
+
 ///
 /////////////////////////////////////////////////////////////////////
 ///
@@ -164,6 +166,8 @@ struct CudaPolicy
                                                 RAJA::Pattern::forall,
                                                 RAJA::Launch::undefined,
                                                 RAJA::Platform::cuda> {
+
+  using cuda_exec_policy = POL;
 };
 
 //
@@ -210,6 +214,20 @@ struct CudaDim {
            num_threads.z);
   }
 };
+
+
+RAJA_INLINE
+constexpr int numBlocks(CudaDim const &dim)
+{
+  return dim.num_blocks.x * dim.num_blocks.y * dim.num_blocks.z;
+}
+
+RAJA_INLINE
+constexpr int numThreads(CudaDim const &dim)
+{
+  return dim.num_threads.x * dim.num_threads.y * dim.num_threads.z;
+}
+
 
 template <typename POL, typename IDX>
 struct CudaIndexPair : public POL {

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -127,6 +127,18 @@ struct cuda_exec
                                                 RAJA::Platform::cuda> {
 };
 
+
+/*
+ * Policy for on-device loops, akin to RAJA::loop_exec
+ */
+struct cuda_loop_exec
+    : public RAJA::
+              make_policy_pattern_launch_platform_t<RAJA::Policy::cuda,
+                                                    RAJA::Pattern::forall,
+                                                    RAJA::Launch::sync,
+                                                    RAJA::Platform::cuda> {
+    };
+
 //
 // NOTE: There is no Index set segment iteration policy for CUDA
 //
@@ -187,6 +199,7 @@ static_assert(MAX_BLOCK_SIZE % WARP_SIZE == 0,
 } // end namespace policy
 
 using policy::cuda::cuda_exec;
+using policy::cuda::cuda_loop_exec;
 using policy::cuda::cuda_reduce;
 using policy::cuda::cuda_reduce_async;
 using policy::cuda::cuda_reduce_atomic;

--- a/test/unit/nested.cpp
+++ b/test/unit/nested.cpp
@@ -158,20 +158,20 @@ TEST(Nested, TileDynamic)
 }
 
 
-#if 0 // NOT WORKING YET
+#if 1 // NOT WORKING YET
 #if defined(RAJA_ENABLE_CUDA)
 CUDA_TEST(Nested, CudaCollapse)
 {
-  camp::idx_t length = 5;
   RAJA::nested::forall(
-      camp::make_tuple(RAJA::nested::Collapse<
-                         RAJA::nested::cuda_collapse_exec,
-                         RAJA::nested::For<0, RAJA::cuda_exec<32>>,
-                         RAJA::nested::For<1, RAJA::cuda_exec<32>>>{}),
-      camp::make_tuple(RAJA::RangeSegment(0, length),
-                       RAJA::RangeSegment(0, length)),
-      [=] RAJA_HOST_DEVICE (Index_type i, Index_type j) {
-          printf("(%d, %d)\n", int(i), int(j));
+      camp::make_tuple(RAJA::nested::CudaCollapse<
+                         RAJA::nested::For<0, RAJA::cuda_thread_x_exec>,
+                         RAJA::nested::For<1, RAJA::cuda_threadblock_z_exec<4>>,
+                         RAJA::nested::For<2, RAJA::cuda_thread_y_exec>>{}),
+      camp::make_tuple(RAJA::RangeSegment(0, 3),
+                       RAJA::RangeSegment(0, 2),
+                       RAJA::RangeSegment(0, 5)),
+      [=] RAJA_HOST_DEVICE (Index_type i, Index_type j, Index_type k) {
+          printf("(%d, %d, %d)\n", (int)i, (int)j, (int)k);
        });
 }
 #endif


### PR DESCRIPTION
This enables nested::forall to use the cuda_thread_*_exec and related policies from forallN inside of a CudaCollapse clause.

I've got this running with one unit test off the bat... I've got to try and get more testing established, but I wanted to get some feedback before I went gonzo.