### PR TITLE
hotfix to properly handle initial value

### DIFF
--- a/test/unit/omp-target/test-reductions.cpp
+++ b/test/unit/omp-target/test-reductions.cpp
@@ -36,18 +36,20 @@ TYPED_TEST_P(ReductionConstructorTestTargetOMP, ReductionConstructor)
   using ReducePolicy = typename std::tuple_element<0, TypeParam>::type;
   using NumericType = typename std::tuple_element<1, TypeParam>::type;
 
-  RAJA::ReduceSum<ReducePolicy, NumericType> reduce_sum(0.0);
-  RAJA::ReduceMin<ReducePolicy, NumericType> reduce_min(0.0);
-  RAJA::ReduceMax<ReducePolicy, NumericType> reduce_max(0.0);
-  RAJA::ReduceMinLoc<ReducePolicy, NumericType> reduce_minloc(0.0, 1);
-  RAJA::ReduceMaxLoc<ReducePolicy, NumericType> reduce_maxloc(0.0, 1);
+  NumericType initVal = 5;
 
-  ASSERT_EQ((NumericType)reduce_sum.get(), (NumericType)(0.0));
-  ASSERT_EQ((NumericType)reduce_min.get(), (NumericType)(0.0));
-  ASSERT_EQ((NumericType)reduce_max.get(), (NumericType)(0.0));
-  ASSERT_EQ((NumericType)reduce_minloc.get(), (NumericType)(0.0));
+  RAJA::ReduceSum<ReducePolicy, NumericType> reduce_sum(initVal);
+  RAJA::ReduceMin<ReducePolicy, NumericType> reduce_min(initVal);
+  RAJA::ReduceMax<ReducePolicy, NumericType> reduce_max(initVal);
+  RAJA::ReduceMinLoc<ReducePolicy, NumericType> reduce_minloc(initVal, 1);
+  RAJA::ReduceMaxLoc<ReducePolicy, NumericType> reduce_maxloc(initVal, 1);
+
+  ASSERT_EQ((NumericType)reduce_sum.get(), (NumericType)(initVal));
+  ASSERT_EQ((NumericType)reduce_min.get(), (NumericType)(initVal));
+  ASSERT_EQ((NumericType)reduce_max.get(), (NumericType)(initVal));
+  ASSERT_EQ((NumericType)reduce_minloc.get(), (NumericType)(initVal));
   ASSERT_EQ((RAJA::Index_type)reduce_minloc.getLoc(), (RAJA::Index_type)1);
-  ASSERT_EQ((NumericType)reduce_maxloc.get(), (NumericType)(0.0));
+  ASSERT_EQ((NumericType)reduce_maxloc.get(), (NumericType)(initVal));
   ASSERT_EQ((RAJA::Index_type)reduce_maxloc.getLoc(), (RAJA::Index_type)1);
 }
 
@@ -117,7 +119,7 @@ protected:
   }
 
   RAJA::Real_ptr array;
-
+  
   RAJA::Real_type max;
   RAJA::Real_type min;
   RAJA::Real_type sum;


### PR DESCRIPTION
Previously each thread started with this value leading to the wrong calculation, so kernels not using identity as the initial value would generate numeric errors. Oddly, the unit tests did not catch this, and was noticed later in the Perfsuite TRAP_INT kernel. 

 Initial value is now deferred to the TargetReduce classes which now provide storage for initVal,finalVal (analogously for loc), and calculation is finalized in the get() call.

Note, that I believe omp-target reductions need some serious work, especially on the performance front. But, this is a necessary hotfix for correctness. 

