### PR TITLE
Fixed nested::forall to work with CUDA reducers

### DIFF
--- a/include/RAJA/policy/cuda/nested.hpp
+++ b/include/RAJA/policy/cuda/nested.hpp
@@ -337,7 +337,11 @@ struct Executor<Collapse<cuda_collapse_exec<Async>, FOR_TYPES ...>> {
 
       cudaStream_t stream = 0;
 
-      internal::cudaLauncher<<<dims.num_blocks, dims.num_threads, 0, stream>>>(cuda_wrap);
+      internal::cudaLauncher<<<dims.num_blocks, dims.num_threads, 0, stream>>>(
+          RAJA::cuda::make_launch_body(dims.num_blocks,
+                                       dims.num_threads,
+                                       0, stream,
+                                       cuda_wrap));
       RAJA::cuda::peekAtLastError();
 
       RAJA::cuda::launch(stream);

--- a/test/unit/nested.cpp
+++ b/test/unit/nested.cpp
@@ -201,4 +201,81 @@ CUDA_TEST(Nested, CudaCollapse2)
        });
 }
 
+
+CUDA_TEST(Nested, CudaReduceA)
+{
+
+  using Pol = RAJA::nested::Policy<
+      RAJA::nested::CudaCollapse<
+        RAJA::nested::For<0, RAJA::cuda_thread_x_exec>,
+        RAJA::nested::For<1, RAJA::cuda_threadblock_z_exec<4>>
+      >,
+      RAJA::nested::For<2, RAJA::cuda_loop_exec> >;
+
+  RAJA::ReduceSum<RAJA::cuda_reduce<12>, int> reducer(0);
+
+  RAJA::nested::forall(
+      Pol{},
+      camp::make_tuple(RAJA::RangeSegment(0, 3),
+                       RAJA::RangeSegment(0, 2),
+                       RAJA::RangeSegment(0, 5)),
+      [=] RAJA_DEVICE (Index_type i, Index_type j, Index_type k) {
+        reducer += 1;
+       });
+
+
+  ASSERT_EQ((int)reducer, 3*2*5);
+}
+
+
+CUDA_TEST(Nested, CudaReduceB)
+{
+
+  using Pol = RAJA::nested::Policy<
+      RAJA::nested::For<2, RAJA::loop_exec>,
+      RAJA::nested::CudaCollapse<
+        RAJA::nested::For<0, RAJA::cuda_thread_x_exec>,
+        RAJA::nested::For<1, RAJA::cuda_threadblock_z_exec<4>>
+      > >;
+
+  RAJA::ReduceSum<RAJA::cuda_reduce<12>, int> reducer(0);
+
+  RAJA::nested::forall(
+      Pol{},
+      camp::make_tuple(RAJA::RangeSegment(0, 3),
+                       RAJA::RangeSegment(0, 2),
+                       RAJA::RangeSegment(0, 5)),
+      [=] RAJA_DEVICE (Index_type i, Index_type j, Index_type k) {
+        reducer += 1;
+       });
+
+
+  ASSERT_EQ((int)reducer, 3*2*5);
+}
+
+
+CUDA_TEST(Nested, CudaReduceC)
+{
+
+  using Pol = RAJA::nested::Policy<
+      RAJA::nested::For<2, RAJA::loop_exec>,
+      RAJA::nested::For<0, RAJA::loop_exec>,
+      RAJA::nested::For<1, RAJA::cuda_exec<12>>
+      >;
+
+  RAJA::ReduceSum<RAJA::cuda_reduce<12>, int> reducer(0);
+
+  RAJA::nested::forall(
+      Pol{},
+      camp::make_tuple(RAJA::RangeSegment(0, 3),
+                       RAJA::RangeSegment(0, 2),
+                       RAJA::RangeSegment(0, 5)),
+      [=] RAJA_DEVICE (Index_type i, Index_type j, Index_type k) {
+        reducer += 1;
+       });
+
+
+  ASSERT_EQ((int)reducer, 3*2*5);
+}
+
 #endif


### PR DESCRIPTION
Added a call to  RAJA::cuda::make_launch_body  in the CUDA executor to make sure the reducers work properly.

Added a few unit tests to ensure correctness