### PR TITLE
Usability/Performance tweaks for atomics

### DIFF
--- a/include/RAJA/pattern/atomic.hpp
+++ b/include/RAJA/pattern/atomic.hpp
@@ -320,6 +320,11 @@ public:
   RAJA_HOST_DEVICE
   T *getPointer() const { return m_value_ptr; }
 
+
+  RAJA_INLINE
+  RAJA_HOST_DEVICE
+  T operator=(T rhs) const { *m_value_ptr = rhs; return rhs; }
+
   RAJA_INLINE
   RAJA_HOST_DEVICE
   T operator++() const { return RAJA::atomic::atomicInc<Policy>(m_value_ptr); }


### PR DESCRIPTION
Added assignment operator (non-atomic) to AtomicRef. (usability tweak)

Added pass-thru AtomicViewWrapper for seq_atomic. This gives slightly better cpu performance with some compilers when using the seq_atomic policy (non-atomic).

