### PR TITLE
Fix: OpenMP scans broken when num threads didn't match requested num threads

### DIFF
--- a/include/RAJA/policy/openmp/scan.hpp
+++ b/include/RAJA/policy/openmp/scan.hpp
@@ -65,10 +65,11 @@ concepts::enable_if<type_traits::is_openmp_policy<Policy>> inclusive_inplace(
 {
   using Value = typename ::std::iterator_traits<Iter>::value_type;
   const int n = end - begin;
-  const int p = std::min(n, omp_get_max_threads());
-  ::std::vector<Value> sums(p, Value());
-#pragma omp parallel num_threads(p)
+  const int p0 = std::min(n, omp_get_max_threads());
+  ::std::vector<Value> sums(p0, Value());
+#pragma omp parallel num_threads(p0)
   {
+    const int p = omp_get_num_threads();
     const int pid = omp_get_thread_num();
     const int i0 = firstIndex(n, p, pid);
     const int i1 = firstIndex(n, p, pid + 1);
@@ -98,10 +99,11 @@ concepts::enable_if<type_traits::is_openmp_policy<Policy>> exclusive_inplace(
 {
   using Value = typename ::std::iterator_traits<Iter>::value_type;
   const int n = end - begin;
-  const int p = std::min(n, omp_get_max_threads());
-  ::std::vector<Value> sums(p, v);
-#pragma omp parallel num_threads(p)
+  const int p0 = std::min(n, omp_get_max_threads());
+  ::std::vector<Value> sums(p0, v);
+#pragma omp parallel num_threads(p0)
   {
+    const int p = omp_get_num_threads();
     const int pid = omp_get_thread_num();
     const int i0 = firstIndex(n, p, pid);
     const int i1 = firstIndex(n, p, pid + 1);

--- a/scripts/travis_build_and_test.sh
+++ b/scripts/travis_build_and_test.sh
@@ -21,7 +21,7 @@ if [[ "$DO_BUILD" == "yes" ]] ; then
       or_die make -j 3 VERBOSE=1
     fi
     if [[ "${DO_TEST}" == "yes" ]] ; then
-        OMP_NUM_THREADS=3 or_die ctest -V
+      or_die ctest -V
     fi
 fi
 

--- a/scripts/travis_build_and_test.sh
+++ b/scripts/travis_build_and_test.sh
@@ -21,7 +21,7 @@ if [[ "$DO_BUILD" == "yes" ]] ; then
       or_die make -j 3 VERBOSE=1
     fi
     if [[ "${DO_TEST}" == "yes" ]] ; then
-        or_die ctest -V
+        OMP_NUM_THREADS=3 or_die ctest -V
     fi
 fi
 

--- a/test/unit/cpu/test-scan.cpp
+++ b/test/unit/cpu/test-scan.cpp
@@ -224,15 +224,3 @@ REGISTER_TYPED_TEST_CASE_P(Scan,
 
 INSTANTIATE_TYPED_TEST_CASE_P(ScanTests, Scan, CrossTypes);
 
-
-#ifdef RAJA_ENABLE_OPENMP
-TEST(Scan, OmpNumThreads)
-{
-  int num_threads = 0;
-#pragma omp parallel
-  {
-    num_threads = omp_get_num_threads();
-  }
-  printf("OMP_NUM_THREADS=%d\n", num_threads);
-}
-#endif

--- a/test/unit/cpu/test-scan.cpp
+++ b/test/unit/cpu/test-scan.cpp
@@ -223,3 +223,16 @@ REGISTER_TYPED_TEST_CASE_P(Scan,
                            exclusive_inplace_offset);
 
 INSTANTIATE_TYPED_TEST_CASE_P(ScanTests, Scan, CrossTypes);
+
+
+#ifdef RAJA_ENABLE_OPENMP
+TEST(Scan, OmpNumThreads)
+{
+  int num_threads = 0;
+#pragma omp parallel
+  {
+    num_threads = omp_get_num_threads();
+  }
+  printf("OMP_NUM_THREADS=%d\n", num_threads);
+}
+#endif


### PR DESCRIPTION
Building manually on rzhasgpu with nvcc+gcc-4.9.3 failes test-scan.exe when running more than 1 thread.

I don't see this building just gcc-4.9.3 w/ openmp.

Just checking that our CI is running w/ threads.