### PR TITLE
Eliminated nested::TypeFor, changed variable names for readability

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.0.{build}
 skip_branch_with_pr: true
-image: Visual Studio 2017
+image: Previous Visual Studio 2017
 build_script:
 - cmd: >-
     git submodule init

--- a/include/RAJA/RAJA.hpp
+++ b/include/RAJA/RAJA.hpp
@@ -107,6 +107,7 @@
 //
 #include "RAJA/pattern/forallN.hpp"
 #include "RAJA/pattern/nested.hpp"
+#include "RAJA/pattern/nested/tile.hpp"
 
 
 //

--- a/include/RAJA/pattern/nested.hpp
+++ b/include/RAJA/pattern/nested.hpp
@@ -26,18 +26,18 @@ template <typename... Policies>
 using Policy = camp::tuple<Policies...>;
 
 
-template <camp::idx_t ArgumentId, typename Pol = camp::nil, typename... Rest>
+template <camp::idx_t ArgumentId, typename ExecPolicy = camp::nil, typename... Rest>
 struct For : public internal::ForList,
-             public internal::ForTraitBase<ArgumentId, Pol> {
+             public internal::ForTraitBase<ArgumentId, ExecPolicy> {
   using as_for_list = camp::list<For>;
 
   // used for execution space resolution
   using as_space_list = camp::list<For>;
 
   // TODO: add static_assert for valid policy in Pol
-  const Pol pol;
-  RAJA_HOST_DEVICE constexpr For() : pol{} {}
-  RAJA_HOST_DEVICE constexpr For(const Pol &p) : pol{p} {}
+  const ExecPolicy exec_policy;
+  RAJA_HOST_DEVICE constexpr For() : exec_policy{} {}
+  RAJA_HOST_DEVICE constexpr For(const ExecPolicy &p) : exec_policy{p} {}
 };
 
 
@@ -48,9 +48,9 @@ struct Collapse : public internal::ForList, public internal::CollapseBase {
   // used for execution space resolution
   using as_space_list = camp::list<For<-1, ExecPolicy>>;
 
-  const ExecPolicy pol;
-  RAJA_HOST_DEVICE constexpr Collapse() : pol{} {}
-  RAJA_HOST_DEVICE constexpr Collapse(ExecPolicy const &ep) : pol{ep} {}
+  const ExecPolicy exec_policy;
+  RAJA_HOST_DEVICE constexpr Collapse() : exec_policy{} {}
+  RAJA_HOST_DEVICE constexpr Collapse(ExecPolicy const &ep) : exec_policy{ep} {}
 };
 }
 
@@ -68,7 +68,7 @@ namespace detail
  * RAJA::nested::Policy
  */
 template <typename... POLICIES>
-struct get_space<camp::tuple<POLICIES...>>
+struct get_space<RAJA::nested::Policy<POLICIES...>>
     : public get_space_from_list<  // combines exec policies to find exec space
 
           // Extract just the execution policies from the tuple
@@ -87,20 +87,23 @@ namespace nested
 {
 
 
-template <typename PolicyTuple, typename SegmentTuple, typename Fn>
+template <typename PolicyTuple, typename SegmentTuple, typename Body>
 struct LoopData {
-  constexpr static size_t n_policies = camp::tuple_size<PolicyTuple>::value;
-  const PolicyTuple pt;
-  SegmentTuple st;
-  const typename std::remove_reference<Fn>::type f;
 
+  constexpr static size_t n_policies = camp::tuple_size<PolicyTuple>::value;
 
   using index_tuple_t = internal::index_tuple_from_segments<
-      typename SegmentTuple::TList>;
+  typename SegmentTuple::TList>;
 
+
+  const PolicyTuple policy_tuple;
+  SegmentTuple segment_tuple;
+  const typename std::remove_reference<Body>::type body;
   index_tuple_t index_tuple;
-  LoopData(PolicyTuple const &p, SegmentTuple const &s, Fn const &fn)
-      : pt(p), st(s), f(fn)
+
+
+  LoopData(PolicyTuple const &p, SegmentTuple const &s, Body const &b)
+      : policy_tuple(p), segment_tuple(s), body(b)
   {
   }
   template <camp::idx_t Idx, typename IndexT>
@@ -118,20 +121,24 @@ struct Executor;
 template <camp::idx_t Index, typename BaseWrapper>
 struct GenericWrapper {
   using data_type = camp::decay<typename BaseWrapper::data_type>;
-  GenericWrapper(BaseWrapper const &w) : bw{w} {}
-  GenericWrapper(data_type &d) : bw{d} {}
-  BaseWrapper bw;
+
+  BaseWrapper wrapper;
+
+  GenericWrapper(BaseWrapper const &w) : wrapper{w} {}
+  GenericWrapper(data_type &d) : wrapper{d} {}
+
 };
 
 template <camp::idx_t Index, typename BaseWrapper>
 struct ForWrapper : GenericWrapper<Index, BaseWrapper> {
   using Base = GenericWrapper<Index, BaseWrapper>;
   using Base::Base;
+
   template <typename InIndexType>
   void operator()(InIndexType i)
   {
-    Base::bw.data.template assign_index<Index>(i);
-    Base::bw();
+    Base::wrapper.data.template assign_index<Index>(i);
+    Base::wrapper();
   }
 };
 
@@ -140,10 +147,13 @@ struct NestedPrivatizer {
   using data_type = typename T::data_type;
   using value_type = camp::decay<T>;
   using reference_type = value_type &;
-  data_type data;
-  value_type priv;
-  NestedPrivatizer(const T &o) : data{o.bw.data}, priv{value_type{data}} {}
-  reference_type get_priv() { return priv; }
+
+  data_type privatized_data;
+  value_type privatized_wrapper;
+
+  NestedPrivatizer(const T &o) : privatized_data{o.bw.data}, privatized_wrapper{value_type{privatized_data}} {}
+
+  reference_type get_private() { return privatized_wrapper; }
 };
 
 
@@ -165,8 +175,8 @@ struct Executor {
   void operator()(ForType const &fp, WrappedBody const &wrap)
   {
     using ::RAJA::policy::sequential::forall_impl;
-    forall_impl(fp.pol,
-                camp::get<ForType::index_val>(wrap.data.st),
+    forall_impl(fp.exec_policy,
+                camp::get<ForType::index_val>(wrap.data.segment_tuple),
                 ForWrapper<ForType::index_val, WrappedBody>{wrap});
   }
 };
@@ -184,11 +194,11 @@ struct Executor<Collapse<seq_exec, FT0, FT1>> {
   template <typename WrappedBody>
   void operator()(Collapse<seq_exec, FT0, FT1> const &, WrappedBody const &wrap)
   {
-    auto b0 = std::begin(camp::get<FT0::index_val>(wrap.data.st));
-    auto b1 = std::begin(camp::get<FT1::index_val>(wrap.data.st));
+    auto b0 = std::begin(camp::get<FT0::index_val>(wrap.data.segment_tuple));
+    auto b1 = std::begin(camp::get<FT1::index_val>(wrap.data.segment_tuple));
 
-    auto e0 = std::end(camp::get<FT0::index_val>(wrap.data.st));
-    auto e1 = std::end(camp::get<FT1::index_val>(wrap.data.st));
+    auto e0 = std::end(camp::get<FT0::index_val>(wrap.data.segment_tuple));
+    auto e1 = std::end(camp::get<FT1::index_val>(wrap.data.segment_tuple));
 
     // Skip a level
     for (auto i0 = b0; i0 < e0; ++i0) {
@@ -202,6 +212,7 @@ struct Executor<Collapse<seq_exec, FT0, FT1>> {
 };
 
 
+
 template <int idx, int n_policies, typename Data>
 struct Wrapper {
   constexpr static int cur_policy = idx;
@@ -212,7 +223,7 @@ struct Wrapper {
   explicit Wrapper(Data &d) : data{d} {}
   void operator()() const
   {
-    auto const &pol = camp::get<idx>(data.pt);
+    auto const &pol = camp::get<idx>(data.policy_tuple);
     Executor<internal::remove_all_t<decltype(pol)>> e{};
     Next next_wrapper{data};
     e(pol, next_wrapper);
@@ -228,7 +239,7 @@ struct Wrapper<n_policies, n_policies, Data> {
   using data_type = typename std::remove_reference<Data>::type;
   Data &data;
   explicit Wrapper(Data &d) : data{d} {}
-  void operator()() const { camp::invoke(data.index_tuple, data.f); }
+  void operator()() const { camp::invoke(data.index_tuple, data.body); }
 };
 
 
@@ -267,6 +278,5 @@ RAJA_INLINE void forall(const Pol &p, const SegmentTuple &st, const Body &b)
 }  // end namespace RAJA
 
 
-#include "RAJA/pattern/nested/tile.hpp"
 
 #endif /* RAJA_pattern_nested_HPP */

--- a/include/RAJA/pattern/nested.hpp
+++ b/include/RAJA/pattern/nested.hpp
@@ -151,9 +151,9 @@ struct NestedPrivatizer {
   data_type privatized_data;
   value_type privatized_wrapper;
 
-  NestedPrivatizer(const T &o) : privatized_data{o.bw.data}, privatized_wrapper{value_type{privatized_data}} {}
+  NestedPrivatizer(const T &o) : privatized_data{o.wrapper.data}, privatized_wrapper{value_type{privatized_data}} {}
 
-  reference_type get_private() { return privatized_wrapper; }
+  reference_type get_priv() { return privatized_wrapper; }
 };
 
 

--- a/include/RAJA/pattern/nested.hpp
+++ b/include/RAJA/pattern/nested.hpp
@@ -87,30 +87,17 @@ namespace nested
 {
 
 
-template <camp::idx_t ArgumentId,
-          typename Pol,
-          typename IndexType,
-          typename... Rest>
-struct TypedFor : public internal::TypedForBase,
-                  public For<ArgumentId, Pol, Rest...> {
-  using Base = For<ArgumentId, Pol, Rest...>;
-  using Self = TypedFor<ArgumentId, Pol, IndexType, Rest...>;
-  using index_type = IndexType;
-  using as_for_list = camp::list<Self>;
-  // TODO: add static_assert for valid policy in Pol
-  using Base::Base;
-};
-
-
 template <typename PolicyTuple, typename SegmentTuple, typename Fn>
 struct LoopData {
   constexpr static size_t n_policies = camp::tuple_size<PolicyTuple>::value;
   const PolicyTuple pt;
   SegmentTuple st;
   const typename std::remove_reference<Fn>::type f;
-  using index_tuple_t = internal::index_tuple_from_policies_and_segments<
-      typename PolicyTuple::TList,
+
+
+  using index_tuple_t = internal::index_tuple_from_segments<
       typename SegmentTuple::TList>;
+
   index_tuple_t index_tuple;
   LoopData(PolicyTuple const &p, SegmentTuple const &s, Fn const &fn)
       : pt(p), st(s), f(fn)
@@ -256,15 +243,15 @@ RAJA_INLINE void forall(const Pol &p, const SegmentTuple &st, const Body &b)
 {
   detail::setChaiExecutionSpace<Pol>();
 
-  using fors = internal::get_for_policies<typename Pol::TList>;
+//  using fors = internal::get_for_policies<typename Pol::TList>;
   // TODO: ensure no duplicate indices in For<>s
   // TODO: ensure no gaps in For<>s
   // TODO: test that all policy members model the Executor policy concept
   // TODO: add a static_assert for functors which cannot be invoked with
   //       index_tuple
-  static_assert(camp::tuple_size<SegmentTuple>::value
-                    == camp::size<fors>::value,
-                "policy and segment index counts do not match");
+//  static_assert(camp::tuple_size<SegmentTuple>::value
+//                    == camp::size<fors>::value,
+//                "policy and segment index counts do not match");
   auto data = LoopData<Pol, SegmentTuple, Body>{p, st, b};
   auto ld = make_base_wrapper(data);
   // std::cout << typeid(ld).name() << std::endl

--- a/include/RAJA/pattern/nested/internal.hpp
+++ b/include/RAJA/pattern/nested/internal.hpp
@@ -1,7 +1,6 @@
 #ifndef RAJA_pattern_nested_internal_HPP
 #define RAJA_pattern_nested_internal_HPP
 
-#include "RAJA/RAJA.hpp"
 #include "RAJA/config.hpp"
 #include "RAJA/policy/cuda.hpp"
 #include "RAJA/util/defines.hpp"
@@ -32,12 +31,12 @@ struct ForBase {
 };
 struct CollapseBase {
 };
-template <camp::idx_t ArgumentId, typename Pol>
+template <camp::idx_t ArgumentId, typename Policy>
 struct ForTraitBase : public ForBase {
   constexpr static camp::idx_t index_val = ArgumentId;
   using index = camp::num<ArgumentId>;
   using index_type = camp::nil;  // default to invalid type
-  using policy_type = Pol;
+  using policy_type = Policy;
   using type = ForTraitBase;  // make camp::value compatible
 };
 

--- a/include/RAJA/pattern/nested/internal.hpp
+++ b/include/RAJA/pattern/nested/internal.hpp
@@ -30,8 +30,6 @@ struct ForList {
 };
 struct ForBase {
 };
-struct TypedForBase : public ForBase {
-};
 struct CollapseBase {
 };
 template <camp::idx_t ArgumentId, typename Pol>
@@ -43,32 +41,11 @@ struct ForTraitBase : public ForBase {
   using type = ForTraitBase;  // make camp::value compatible
 };
 
-using is_for_policy = typename camp::bind_front<std::is_base_of, ForBase>::type;
-using is_typed_for_policy =
-    typename camp::bind_front<std::is_base_of, TypedForBase>::type;
-
 using has_for_list = typename camp::bind_front<std::is_base_of, ForList>::type;
-
-template <typename T>
-using get_for_list = typename T::as_for_list;
 
 template <typename T>
 using get_space_list = typename T::as_space_list;
 
-/*
- * Get a camp::list of execution policies from a RAJA::nested::Policy.
- *
- * This extracts the execution policy from each For<>, and extracts the
- * policies from inside of Collapse<P, ...>, but drops P
- *
- * The size of the returned camp::list is exactly the number of For<>'s
- * in the policy
- */
-template <typename Seq>
-using get_for_policies = typename camp::flatten<
-    typename camp::transform<get_for_list,
-                             typename camp::filter_l<has_for_list,
-                                                     Seq>::type>::type>::type;
 
 /*
  * Get a camp::list of execution policies from a RAJA::nested::Policy to be
@@ -86,39 +63,6 @@ using get_space_policies = typename camp::flatten<
                                                      Seq>::type>::type>::type;
 
 
-template <typename T>
-using is_nil_type =
-    camp::bind_front<camp::concepts::metalib::is_same, camp::nil>;
-
-template <typename Index, typename ForPol>
-struct index_matches {
-  using type = camp::num<Index::value == ForPol::index::value>;
-};
-
-template <typename IndexTypes,
-          typename ForPolicies,
-          typename Current,
-          typename Index>
-struct evaluate_policy {
-  using ForPolicy = typename camp::find_if_l<
-      typename camp::bind_front<index_matches, Index>::type,
-      ForPolicies>::type;
-  using type = typename camp::
-      append<Current,
-             camp::if_<typename std::is_base_of<TypedForBase, ForPolicy>::type,
-                       typename ForPolicy::index_type,
-                       typename camp::at<IndexTypes,
-                                         typename ForPolicy::index>::type>>::
-          type;
-};
-
-template <typename Policies, typename IndexTypes>
-using get_for_index_types = typename camp::accumulate_l<
-    typename camp::bind_front<evaluate_policy,
-                              IndexTypes,
-                              get_for_policies<Policies>>::type,
-    camp::list<>,
-    camp::as_list<camp::idx_seq_from_t<IndexTypes>>>::type;
 
 template <typename Iterator>
 struct iterable_value_type_getter {
@@ -134,11 +78,11 @@ template <typename Segments>
 using value_type_list_from_segments =
     typename camp::transform<iterable_value_type_getter, Segments>::type;
 
-template <typename Policies, typename Segments>
-using index_tuple_from_policies_and_segments = typename camp::
-    apply_l<camp::lambda<camp::tuple>,
-            get_for_index_types<Policies,
-                                value_type_list_from_segments<Segments>>>::type;
+
+template <typename Segments>
+using index_tuple_from_segments =
+    typename camp::apply_l<camp::lambda<camp::tuple>,
+                           value_type_list_from_segments<Segments> >::type;
 
 }  // end namespace internal
 }  // end namespace nested

--- a/include/RAJA/pattern/nested/tile.hpp
+++ b/include/RAJA/pattern/nested/tile.hpp
@@ -1,7 +1,6 @@
 #ifndef RAJA_pattern_nested_tile_HPP
 #define RAJA_pattern_nested_tile_HPP
 
-#include "RAJA/RAJA.hpp"
 #include "RAJA/config.hpp"
 #include "RAJA/util/defines.hpp"
 #include "RAJA/util/types.hpp"
@@ -21,21 +20,21 @@ namespace nested
 
 template <camp::idx_t Index, typename TilePolicy, typename ExecPolicy>
 struct Tile {
-  const TilePolicy tpol;
-  const ExecPolicy epol;
+  const TilePolicy tile_policy;
+  const ExecPolicy exec_policy;
   RAJA_HOST_DEVICE constexpr Tile(TilePolicy const &tp = TilePolicy{},
                                   ExecPolicy const &ep = ExecPolicy{})
-      : tpol{tp}, epol{ep}
+      : tile_policy{tp}, exec_policy{ep}
   {
   }
 };
 
-///! tag for a tiling loop, tile_static renamed to avoid MSVC keyword
+///! tag for a tiling loop
 template <camp::idx_t chunk_size_>
-struct tile_s {
+struct tile_fixed {
   static constexpr camp::idx_t chunk_size = chunk_size_;
 
-  RAJA_HOST_DEVICE constexpr tile_s() {}
+  RAJA_HOST_DEVICE constexpr tile_fixed() {}
   constexpr camp::idx_t get_chunk_size() const { return chunk_size; }
 };
 
@@ -58,8 +57,8 @@ struct TileWrapper : GenericWrapper<Index, BaseWrapper> {
   template <typename InSegmentType>
   void operator()(InSegmentType s)
   {
-    camp::get<Index>(Base::bw.data.st) = s;
-    Base::bw();
+    camp::get<Index>(Base::wrapper.data.segment_tuple) = s;
+    Base::wrapper();
   }
 };
 
@@ -162,12 +161,15 @@ struct Executor<Tile<Index, TPol, EPol>> {
   template <typename WrappedBody>
   void operator()(TileType const &fp, WrappedBody const &wrap)
   {
-    auto const &st = camp::get<Index>(wrap.data.st);
-    IterableTiler<decltype(st)> tiled_iterable(st, fp.tpol.get_chunk_size());
+    auto const &st = camp::get<Index>(wrap.data.segment_tuple);
+
+    IterableTiler<decltype(st)> tiled_iterable(st, fp.tile_policy.get_chunk_size());
+
     using ::RAJA::policy::sequential::forall_impl;
-    forall_impl(fp.epol, tiled_iterable, TileWrapper<Index, WrappedBody>{wrap});
+    forall_impl(fp.exec_policy, tiled_iterable, TileWrapper<Index, WrappedBody>{wrap});
+
     // Set range back to original values
-    camp::get<Index>(wrap.data.st) = tiled_iterable.it;
+    camp::get<Index>(wrap.data.segment_tuple) = tiled_iterable.it;
   }
 };
 

--- a/test/unit/cpu/test-nested.cpp
+++ b/test/unit/cpu/test-nested.cpp
@@ -309,15 +309,15 @@ TYPED_TEST_P(LTimesTest, LTimesNestedTest)
     // create views on data
     typename POL::ELL_VIEW ell(
         &ell_data[0],
-        make_permuted_layout({num_moments, num_directions},
+        make_permuted_layout({{num_moments, num_directions}},
                              RAJA::as_array<typename POL::ELL_PERM>::get()));
     typename POL::PSI_VIEW psi(
         &psi_data[0],
-        make_permuted_layout({num_directions, num_groups, num_zones},
+        make_permuted_layout({{num_directions, num_groups, num_zones}},
                              RAJA::as_array<typename POL::PSI_PERM>::get()));
     typename POL::PHI_VIEW phi(
         &phi_data[0],
-        make_permuted_layout({num_moments, num_groups, num_zones},
+        make_permuted_layout({{num_moments, num_groups, num_zones}},
                              RAJA::as_array<typename POL::PHI_PERM>::get()));
 
     // get execution policy

--- a/test/unit/nested.cpp
+++ b/test/unit/nested.cpp
@@ -113,7 +113,7 @@ using OMPTypes = ::testing::Types<
         Policy<For<1, RAJA::omp_parallel_for_exec>, For<0, s>>,
         list<TypedIndex, Index_type>,
         RAJA::omp_reduce>,
-    list<Policy<Tile<1, tile_fixed_s<2>, RAJA::omp_parallel_for_exec>,
+    list<Policy<Tile<1, tile_fixed<2>, RAJA::omp_parallel_for_exec>,
                 For<1, RAJA::loop_exec>,
                 For<0, s>>,
          list<TypedIndex, Index_type>,

--- a/test/unit/nested.cpp
+++ b/test/unit/nested.cpp
@@ -68,8 +68,8 @@ CUDA_TYPED_TEST_P(Nested, Basic)
   using Idx1 = at_v<IndexTypes, 1>;
   RAJA::ReduceSum<at_v<TypeParam, 2>, RAJA::Real_type> tsum(0.0);
   RAJA::Real_type total{0.0};
-  auto ranges = camp::make_tuple(RAJA::RangeSegment(0, x_len),
-                                 RAJA::RangeSegment(0, y_len));
+  auto ranges = camp::make_tuple(RAJA::TypedRangeSegment<Idx0>(0, x_len),
+                                 RAJA::TypedRangeSegment<Idx1>(0, y_len));
   auto v = this->view;
   using namespace RAJA::nested;
   RAJA::nested::forall(Pol{}, ranges, [=] RAJA_HOST_DEVICE(Idx0 i, Idx1 j) {
@@ -92,7 +92,7 @@ using namespace RAJA::nested;
 using camp::list;
 using s = RAJA::seq_exec;
 using TestTypes =
-    ::testing::Types<list<Policy<For<1, s>, TypedFor<0, s, TypedIndex>>,
+    ::testing::Types<list<Policy<For<1, s>, For<0, s>>,
                           list<TypedIndex, Index_type>,
                           RAJA::seq_reduce>,
                      list<Policy<Tile<1, tile_s<2>, RAJA::loop_exec>,
@@ -110,26 +110,26 @@ INSTANTIATE_TYPED_TEST_CASE_P(Sequential, Nested, TestTypes);
 #if defined(RAJA_ENABLE_OPENMP)
 using OMPTypes = ::testing::Types<
     list<
-        Policy<For<1, RAJA::omp_parallel_for_exec>, TypedFor<0, s, TypedIndex>>,
+        Policy<For<1, RAJA::omp_parallel_for_exec>, For<0, s>>,
         list<TypedIndex, Index_type>,
         RAJA::omp_reduce>,
     list<Policy<Tile<1, tile_s<2>, RAJA::omp_parallel_for_exec>,
                 For<1, RAJA::loop_exec>,
-                TypedFor<0, s, TypedIndex>>,
+                For<0, s>>,
          list<TypedIndex, Index_type>,
          RAJA::omp_reduce>>;
 INSTANTIATE_TYPED_TEST_CASE_P(OpenMP, Nested, OMPTypes);
 #endif
 #if defined(RAJA_ENABLE_TBB)
 using TBBTypes = ::testing::Types<
-    list<Policy<For<1, RAJA::tbb_for_exec>, TypedFor<0, s, TypedIndex>>,
+    list<Policy<For<1, RAJA::tbb_for_exec>, For<0, s>>,
          list<TypedIndex, Index_type>,
          RAJA::tbb_reduce>>;
 INSTANTIATE_TYPED_TEST_CASE_P(TBB, Nested, TBBTypes);
 #endif
 #if defined(RAJA_ENABLE_CUDA)
 using CUDATypes = ::testing::Types<
-    list<Policy<For<1, s>, TypedFor<0, RAJA::cuda_exec<128>, TypedIndex>>,
+    list<Policy<For<1, s>, For<0, RAJA::cuda_exec<128>>>,
          list<TypedIndex, Index_type>,
          RAJA::cuda_reduce<128>>>;
 INSTANTIATE_TYPED_TEST_CASE_P(CUDA, Nested, CUDATypes);

--- a/test/unit/nested.cpp
+++ b/test/unit/nested.cpp
@@ -95,7 +95,7 @@ using TestTypes =
     ::testing::Types<list<Policy<For<1, s>, For<0, s>>,
                           list<TypedIndex, Index_type>,
                           RAJA::seq_reduce>,
-                     list<Policy<Tile<1, tile_s<2>, RAJA::loop_exec>,
+                     list<Policy<Tile<1, tile_fixed<2>, RAJA::loop_exec>,
                                  Tile<0, tile<2>, RAJA::loop_exec>,
                                  For<0, s>,
                                  For<1, s>>,
@@ -113,7 +113,7 @@ using OMPTypes = ::testing::Types<
         Policy<For<1, RAJA::omp_parallel_for_exec>, For<0, s>>,
         list<TypedIndex, Index_type>,
         RAJA::omp_reduce>,
-    list<Policy<Tile<1, tile_s<2>, RAJA::omp_parallel_for_exec>,
+    list<Policy<Tile<1, tile_fixed_s<2>, RAJA::omp_parallel_for_exec>,
                 For<1, RAJA::loop_exec>,
                 For<0, s>>,
          list<TypedIndex, Index_type>,
@@ -488,3 +488,5 @@ CUDA_TEST(Nested, SubRange_Complex)
 }
 
 #endif
+
+


### PR DESCRIPTION
I eliminated the TypedFor, in favor of using the TypedRangeSegment to set the loop index types.  This makes calculating the loop types MUCH easier, gets index types out of the policies, and should help pave the way for more complex nested::forall development.

Also, I've changed variable names in the nested::forall internal data structures... mostly just expanding things like pt and st to policy_tuple and segment_tuple. 