### PR TITLE
Fixed a number of excessive copies, mostly in camp::tuple.

### DIFF
--- a/include/RAJA/policy/cuda/forall.hpp
+++ b/include/RAJA/policy/cuda/forall.hpp
@@ -145,7 +145,7 @@ __launch_bounds__(BlockSize, 1) __global__
 {
   using RAJA::internal::thread_privatize;
   auto privatizer = thread_privatize(loop_body);
-  auto body = privatizer.get_priv();
+  auto &body = privatizer.get_priv();
   auto ii = static_cast<IndexType>(getGlobalIdx_1D_1D());
   if (ii < length) {
     body(idx[ii]);


### PR DESCRIPTION
This was wreaking havoc with reductions.

Also, the cuda forall was doing an extra privatization copy by accident (was unnecessary).

The way camp::tuple was implemented, it accidentally forced a number of copy constructions of temporary objects.  This is a serious performance issue, and it completely broke reductions in the refactored nested::forall.