### PR TITLE
Fixed bug in nested::forall CUDA Collapse when using strongly typed indices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,10 +73,12 @@ matrix:
     - CMAKE_EXTRA_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DENABLE_CUDA=On -DENABLE_TBB=On"
     - TRAVIS_INSTALL_COMPILER="nvcc"
     - DO_TEST=no
+cache:
+  directories:
+  - $HOME/llvm
 before_install:
 - sudo apt-get update -qq
 - mkdir -p ${HOME}/download
-- mkdir -p ${HOME}/llvm
 - if [[ -n "${LLVM_VERSION}" ]]; then . ./scripts/install_llvm.sh ; fi
 - CMAKE_URL="https://cmake.org/files/v3.7/cmake-3.7.0-rc2-Linux-x86_64.tar.gz"
 - curl -o ${HOME}/cmake-tarball.tar.gz ${CMAKE_URL} &&

--- a/include/RAJA/policy/cuda/nested.hpp
+++ b/include/RAJA/policy/cuda/nested.hpp
@@ -252,7 +252,7 @@ struct Executor<Collapse<cuda_collapse_exec<Async>, FOR_TYPES...>> {
 
       // Increment the begin iterator by the offset
       auto &begin = camp::get<idx>(begin_tuple);
-      RAJA::Index_type loop_value = *(begin + policy());
+      auto loop_value = *(begin + policy());
 
       // Assign the For index value to the correct argument
       data.template assign_index<ft::index_val>(loop_value);

--- a/test/unit/nested.cpp
+++ b/test/unit/nested.cpp
@@ -481,12 +481,12 @@ CUDA_TEST(Nested, SubRange_Complex)
 
   RAJA::nested::forall(
       ExecPolicy{},
-      RAJA::make_tuple(RAJA::RangeSegment(first, last),
-                       RAJA::RangeSegment(0, 16),
-                       RAJA::RangeSegment(0, 32)),
-      [=] RAJA_HOST_DEVICE (Index_type i, Index_type j, Index_type k) {
+      RAJA::make_tuple(RAJA::TypedRangeSegment<TypedIndex>(first, last),
+                       RAJA::TypedRangeSegment<TypedIndex>(0, 16),
+                       RAJA::TypedRangeSegment<TypedIndex>(0, 32)),
+      [=] RAJA_HOST_DEVICE (TypedIndex i, TypedIndex j, TypedIndex k) {
         //if(j == 0 && k == 0){
-          RAJA::atomic::atomicAdd<RAJA::atomic::cuda_atomic>(ptr+i, 1.0);
+          RAJA::atomic::atomicAdd<RAJA::atomic::cuda_atomic>(ptr+(*i), 1.0);
         //}
        });
   cudaDeviceSynchronize();


### PR DESCRIPTION
Also, changed a unit test to tickle this issue