### PR TITLE
Remove narrowing errors

### DIFF
--- a/include/RAJA/index/RangeSegment.hpp
+++ b/include/RAJA/index/RangeSegment.hpp
@@ -272,9 +272,9 @@ struct TypedRangeStrideSegment {
         m_end(iterator(DiffT{end}, DiffT{stride})),
         // essentially a ceil((end-begin)/stride) but using integer math,
         // and allowing for negative strides
-        m_size((value_type{end} - value_type{begin} + value_type{stride}
+        m_size((static_cast<value_type>(end) - static_cast<value_type>(begin) + static_cast<value_type>(stride)
                 - (stride > 0 ? value_type{1} : value_type{-1}))
-               / value_type{stride})
+               / static_cast<value_type>(stride))
   {
     // if m_size was initialized as negative, that indicates a zero iteration
     // space

--- a/test/unit/cpu/test-segments.cpp
+++ b/test/unit/cpu/test-segments.cpp
@@ -96,19 +96,19 @@ TEST(RangeStrideSegmentTest, sizes_primes)
 
 TEST(RangeStrideSegmentTest, basic_types)
 {
-  RAJA::TypedRangeStrideSegment<signed char> segment1(0, 21, 3);
+  RAJA::TypedRangeStrideSegment<signed char> segment1(0, 31, 3);
   ASSERT_EQ(segment1.size(), 11);
 
-  RAJA::TypedRangeStrideSegment<short> segment2(0, 21, 3);
+  RAJA::TypedRangeStrideSegment<short> segment2(0, 31, 3);
   ASSERT_EQ(segment2.size(), 11);
 
-  RAJA::TypedRangeStrideSegment<int> segment3(0, 21, 5);
+  RAJA::TypedRangeStrideSegment<int> segment3(0, 31, 3);
   ASSERT_EQ(segment3.size(), 11);
 
-  RAJA::TypedRangeStrideSegment<long> segment4(0, 21, 5);
+  RAJA::TypedRangeStrideSegment<long> segment4(0, 31, 3);
   ASSERT_EQ(segment3.size(), 11);
 
-  RAJA::TypedRangeStrideSegment<long long> segment5(0, 21, 5);
+  RAJA::TypedRangeStrideSegment<long long> segment5(0, 31, 3);
   ASSERT_EQ(segment3.size(), 11);
 }
 

--- a/test/unit/cpu/test-segments.cpp
+++ b/test/unit/cpu/test-segments.cpp
@@ -94,6 +94,24 @@ TEST(RangeStrideSegmentTest, sizes_primes)
   ASSERT_EQ(segment3.size(), 4);
 }
 
+TEST(RangeStrideSegmentTest, basic_types)
+{
+  RAJA::TypedRangeStrideSegment<signed char> segment1(0, 21, 3);
+  ASSERT_EQ(segment1.size(), 11);
+
+  RAJA::TypedRangeStrideSegment<short> segment2(0, 21, 3);
+  ASSERT_EQ(segment2.size(), 11);
+
+  RAJA::TypedRangeStrideSegment<int> segment3(0, 21, 5);
+  ASSERT_EQ(segment3.size(), 11);
+
+  RAJA::TypedRangeStrideSegment<long> segment4(0, 21, 5);
+  ASSERT_EQ(segment3.size(), 11);
+
+  RAJA::TypedRangeStrideSegment<long long> segment5(0, 21, 5);
+  ASSERT_EQ(segment3.size(), 11);
+}
+
 RAJA_INDEX_VALUE(StrongType, "StrongType");
 
 TEST(RangeStrideSegmentTest, strongly_typed)


### PR DESCRIPTION
Remove narrowing errors in TypedRangeStrideSegment constructor when used with types smaller than Index_type.