### PR TITLE
Fixed deprecation warning for Intel compiler

### DIFF
--- a/include/RAJA/index/IndexSet.hpp
+++ b/include/RAJA/index/IndexSet.hpp
@@ -757,8 +757,9 @@ private:
   Index_type m_len;
 };
 
-using IndexSet RAJA_DEPRECATE_ALIAS("IndexSet will be deprecated soon. Please transition to TypedIndexSet")  =
-    TypedIndexSet<RAJA::RangeSegment, RAJA::ListSegment, RAJA::RangeStrideSegment>;
+
+RAJA_DEPRECATE_ALIAS("IndexSet will be deprecated soon. Please transition to TypedIndexSet")  
+typedef TypedIndexSet<RAJA::RangeSegment, RAJA::ListSegment, RAJA::RangeStrideSegment> IndexSet;
 
 namespace type_traits
 {


### PR DESCRIPTION
If a compilation unit doesn't reference IndexSet, the deprecation warning on the IndexSet type alias makes the Intel compiler bark at you.

I switched IndexSet to typedef instead of type alias.

This seems to make the Intel compiler happy.