### PR TITLE
Fixed TypedRangeStrideSegment::slice, used for Tile policies.

### DIFF
--- a/include/RAJA/index/RangeSegment.hpp
+++ b/include/RAJA/index/RangeSegment.hpp
@@ -298,6 +298,15 @@ struct TypedRangeStrideSegment {
   {
   }
 
+  //! copy assignment
+  RAJA_HOST_DEVICE TypedRangeStrideSegment& operator=(TypedRangeStrideSegment const& o)
+  {
+    m_begin = o.m_begin;
+    m_end = o.m_end;
+    m_size = o.m_size;
+    return *this;
+  }
+
   //! destructor
   RAJA_HOST_DEVICE ~TypedRangeStrideSegment() {}
 
@@ -341,9 +350,12 @@ struct TypedRangeStrideSegment {
   RAJA_HOST_DEVICE TypedRangeStrideSegment slice(Index_type begin,
                                                  Index_type length) const
   {
-    return TypedRangeStrideSegment{*(this->begin() + begin),
-                                   *(this->begin() + begin + length),
-                                   m_begin.stride};
+    auto start = m_begin[0] + begin;
+    auto end = start + length > m_end[0] ? m_end[0] : start + length;
+
+    return TypedRangeStrideSegment{start,
+                                   end,
+                                   m_begin.get_stride()};
   }
 
   //! equality comparison

--- a/include/RAJA/internal/Iterators.hpp
+++ b/include/RAJA/internal/Iterators.hpp
@@ -212,6 +212,11 @@ public:
   {
   }
 
+  RAJA_HOST_DEVICE inline DifferenceType get_stride() const
+  {
+    return stride;
+  }
+
   RAJA_HOST_DEVICE inline strided_numeric_iterator& operator++()
   {
     val += stride;

--- a/test/unit/nested.cpp
+++ b/test/unit/nested.cpp
@@ -84,7 +84,7 @@ CUDA_TYPED_TEST_P(Nested, Basic)
   RAJA::ReduceSum<at_v<TypeParam, 2>, RAJA::Real_type> tsum(0.0);
   RAJA::Real_type total{0.0};
   auto ranges = RAJA::make_tuple(RAJA::TypedRangeSegment<Idx0>(0, x_len),
-                                 RAJA::TypedRangeSegment<Idx1>(0, y_len));
+                                 RAJA::TypedRangeStrideSegment<Idx1>(0, y_len, 1));
   auto v = this->view;
   using namespace RAJA::nested;
   RAJA::nested::forall(Pol{}, ranges, [=] RAJA_HOST_DEVICE(Idx0 i, Idx1 j) {
@@ -160,10 +160,10 @@ TEST(Nested, TileDynamic)
                        For<0, RAJA::seq_exec>{},
                        For<1, RAJA::seq_exec>{}),
       RAJA::make_tuple(RAJA::RangeSegment(0, length),
-                       RAJA::RangeSegment(0, length)),
+                       RAJA::RangeStrideSegment(0, length, 1)),
       [=, &count](Index_type i, Index_type j) {
-        std::cerr << "i: " << get_val(i) << " j: " << j << " count: " << count
-                  << std::endl;
+//        std::cerr << "i: " << get_val(i) << " j: " << j << " count: " << count
+//                  << std::endl;
 
         ASSERT_EQ(count,
                   count < (length * tile_size)


### PR DESCRIPTION
TypedRangeStrideSegment::slice() didn't actually compile, but we didn't notice since it wasn't being unit tested.

Also, logic needed some fix up in order to clamp to m_end, like TypeRangeSegment.

Also TypedRangeStrideSegment had no copy assignment operator, also used in Tile policies.