### PR TITLE
Fix function signatures for IndexSet builders

### DIFF
--- a/include/RAJA/index/IndexSetBuilders.hpp
+++ b/include/RAJA/index/IndexSetBuilders.hpp
@@ -81,7 +81,8 @@ void buildTypedIndexSetAligned(IndexSet& hiset,
  *
  ******************************************************************************
  */
-void buildLockFreeBlockIndexset(IndexSet& iset,
+void buildLockFreeBlockIndexset(RAJA::TypedIndexSet<RAJA::RangeSegment,
+                                RAJA::ListSegment, RAJA::RangeStrideSegment>& iset,
                                 int fastDim,
                                 int midDim,
                                 int slowDim);
@@ -97,7 +98,8 @@ void buildLockFreeBlockIndexset(IndexSet& iset,
  *
  ******************************************************************************
  */
-void buildLockFreeColorIndexset(IndexSet& iset,
+void buildLockFreeColorIndexset( RAJA::TypedIndexSet<RAJA::RangeSegment,
+                                RAJA::ListSegment, RAJA::RangeStrideSegment>& iset,
                                 Index_type const* domainToRange,
                                 int numEntity,
                                 int numRangePerDomain,

--- a/src/LockFreeIndexSetBuilders.cpp
+++ b/src/LockFreeIndexSetBuilders.cpp
@@ -214,7 +214,7 @@ void buildLockFreeBlockIndexset(RAJA::TypedIndexSet<RAJA::RangeSegment,
  ******************************************************************************
  */
 void buildLockFreeColorIndexset(RAJA::TypedIndexSet<RAJA::RangeSegment,
-                                RAJA::ListSegment>& iset,
+                                RAJA::ListSegment, RAJA::RangeStrideSegment>& iset,
                                 Index_type const* domainToRange,
                                 int numEntity,
                                 int numRangePerDomain,


### PR DESCRIPTION
These were missed when TypedIndexSet was created.