### PR TITLE
add type indexed get<T>() for camp::tuple

### DIFF
--- a/include/camp/camp.hpp
+++ b/include/camp/camp.hpp
@@ -9,6 +9,7 @@
 #include "camp/lambda.hpp"
 #include "camp/list/at.hpp"
 #include "camp/list/find_if.hpp"
+#include "camp/map.hpp"
 #include "camp/number.hpp"
 #include "camp/tuple.hpp"
 #include "camp/value.hpp"
@@ -151,6 +152,37 @@ namespace test
 {
   CHECK_TSAME((accumulate<append, list<>, list<int, float, double>>),
               (list<int, float, double>));
+}
+#endif
+
+template<typename T, typename L>
+struct index_of;
+template<typename T, typename ...Elements>
+struct index_of<T, list<Elements...>> {
+  template<typename Seq, typename Item>
+  using inc_until = if_<typename std::is_same<T, Item>::type,
+                        if_c<Seq::size == 1,
+                             typename prepend<Seq, num<first<Seq>::value>>::type,
+                             Seq>,
+                        list<num<first<Seq>::value + 1>>
+                               >;
+  using indices = typename accumulate<inc_until, list<num<0>>, list<Elements...>>::type;
+  using type = typename if_c<indices::size == 2, first<indices>, camp::nil>::type;
+};
+
+#if defined(CAMP_TEST)
+namespace test
+{
+  CHECK_TSAME((index_of<int, list<>>), (nil));
+  CHECK_TSAME((index_of<int, list<float, double, int>>), (num<2>));
+  CHECK_TSAME((index_of<int, list<float, double, int, int, int, int>>), (num<2>));
+  // CHECK_TSAME((find_if<std::is_pointer, list<float, double>>), (nil));
+  // CHECK_TSAME((find_if_l<bind_front<std::is_same, For<num<1>, int>>,
+  //                        list<For<num<0>, int>, For<num<1>, int>>>),
+  //             (For<num<1>, int>));
+  // CHECK_TSAME((find_if_l<bind_front<index_matches, num<1>>,
+  //                        list<For<num<0>, int>, For<num<1>, int>>>),
+  //             (For<num<1>, int>));
 }
 #endif
 

--- a/include/camp/map.hpp
+++ b/include/camp/map.hpp
@@ -1,0 +1,51 @@
+#ifndef CAMP_LIST_MAP_HPP
+#define CAMP_LIST_MAP_HPP
+
+#include "camp/helpers.hpp"  // declptr
+#include "camp/list/list.hpp"
+#include "camp/value.hpp"
+
+namespace camp
+{
+// TODO: document
+
+namespace detail
+{
+  template <typename Key, typename Val>
+  Val lookup(list<Key, Val>*);
+
+  template <typename>
+  nil lookup(...);
+
+  template <typename Seq, typename = nil>
+  struct lookup_table;
+
+  template <typename... Keys, typename... Values>
+  struct lookup_table<list<list<Keys, Values>...>>
+      : list<Keys, Values>... {
+  };
+}  // namespace detail
+
+template <typename Seq, typename Key>
+struct at_key_s {
+  using type =
+      decltype(detail::lookup<Key>(declptr<detail::lookup_table<Seq>>()));
+};
+
+template <typename Seq, typename Key>
+using at_key = typename at_key_s<Seq, Key>::type;
+
+
+#if defined(CAMP_TEST)
+namespace test
+{
+  using tl1 = list<list<int, num<0>>, list<char, num<1>>>;
+  CHECK_TSAME((at_key<tl1, int>), (num<0>));
+  CHECK_TSAME((at_key<tl1, char>), (num<1>));
+  CHECK_TSAME((at_key<tl1, bool>), (nil));
+}  // namespace test
+#endif
+
+}  // namespace camp
+
+#endif /* CAMP_LIST_MAP_HPP */

--- a/include/camp/value.hpp
+++ b/include/camp/value.hpp
@@ -16,7 +16,7 @@ namespace detail
 // TODO: document
 template <typename val = detail::nothing>
 struct value {
-  using type = val;
+  using type = value;
 };
 
 /// A non-value, in truth tests evaluates to false


### PR DESCRIPTION
This adds a new "map" concept to camp, with just an "at_key"
functionality for use in the tuple to implement type-based indexing.
This can probably be made faster and cleaner, but it has the desired
behavior at this point.

@ajkunen: This does what we discussed, though it could probably use better error messages for when a user repeats a type and then uses get on that type.  As of now, it doesn't cry foul for a tuple with multiple of the same type unless a user attempts to index by *that type* specifically.

```c++
#include <camp/camp.hpp>
#include <camp/tuple.hpp>
#include <iostream>


int main(int argc, char *argv[])
{
  camp::tuple<int,char> t(5, 'a');
  std::cout << camp::get<int>(t) << std::endl;
  std::cout << camp::get<char>(t) << std::endl;
  camp::tuple<int,char, char> t2(5, 'a', 'b');
  std::cout << camp::get<int>(t2) << std::endl;
  // std::cout << camp::get<char>(t) << std::endl; // error!

  return 0;
}

```