### PR TITLE
Added occupancy calculator for CUDA backend

### DIFF
--- a/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
+++ b/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
@@ -51,6 +51,12 @@ namespace RAJA
 namespace cuda
 {
 
+namespace detail
+{
+  int get_num_sm();
+}
+
+
 //! Allocator for pinned memory for use in basic_mempool
 struct PinnedAllocator {
 

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -131,6 +131,21 @@ struct cuda_exec
 
 
 /*
+ * Policy like cuda_exec, but uses occupancy calculator to determine
+ * number of threads and blocks.
+ */
+template <bool Async = false>
+struct cuda_occ_exec
+    : public RAJA::
+          make_policy_pattern_launch_platform_t<RAJA::Policy::cuda,
+                                                RAJA::Pattern::forall,
+                                                detail::get_launch<Async>::
+                                                    value,
+                                                RAJA::Platform::cuda> {
+};
+
+
+/*
  * Policy for on-device loops, akin to RAJA::loop_exec
  */
 struct cuda_loop_exec
@@ -200,6 +215,7 @@ static_assert(MAX_BLOCK_SIZE % WARP_SIZE == 0,
 }  // end namespace policy
 
 using policy::cuda::cuda_exec;
+using policy::cuda::cuda_occ_exec;
 using policy::cuda::cuda_loop_exec;
 using policy::cuda::cuda_reduce;
 using policy::cuda::cuda_reduce_async;

--- a/src/MemUtils_CUDA.cpp
+++ b/src/MemUtils_CUDA.cpp
@@ -40,6 +40,32 @@ namespace cuda
 
 namespace detail
 {
+
+//
+/////////////////////////////////////////////////////////////////////////////
+//
+// Function to get the number of SM's on the current device
+//
+/////////////////////////////////////////////////////////////////////////////
+//
+
+int get_num_sm(){
+
+  static int num_sm = -1;
+
+  if(num_sm < 0){
+    int cur_device = -1;
+    cudaGetDevice(&cur_device);
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, cur_device);
+    num_sm = prop.multiProcessorCount;
+  }
+
+  return num_sm;
+}
+
+
+
 //
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -59,6 +85,8 @@ cudaInfo tl_status;
 
 //! State of raja cuda stream synchronization for cuda reducer objects
 std::unordered_map<cudaStream_t, bool> g_stream_info_map{ {cudaStream_t(0), true} };
+
+
 
 }  // closing brace for detail namespace
 


### PR DESCRIPTION
Two main things added here:

1) added occupancy calculator to cuda_exec to choose number of blocks to launch.  Uses grid-stride technique for large iteration spaces.

2) Added a cuda_occ_exec that uses occupancy calculator to choose number of threads and blocks to launch.  Also uses grid-stride.

With no other modification (no changing of exec policies, just grid-stride), unit tests on rzmanta.llnl.gov went from taking ~9.3 seconds to ~7.7 seconds.

@rhornung67 please let me know if there are performance implication on the perf suite.