### PR TITLE
Intel - SIMD Bugs  (DO NOT MERGE)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ if (NOT RAJA_LOADED)
   option(ENABLE_WARNINGS "Enable warnings as errors for CI" Off)
   option(ENABLE_DOCUMENTATION "Build RAJA documentation" Off)
   option(ENABLE_COVERAGE "Enable coverage (only supported with GCC)" Off)
+  option(ENABLE_SIMD_ISSUES "Build SIMD issues" On) 
 
   set(TEST_DRIVER "" CACHE STRING "driver used to wrap test commands")
 
@@ -146,6 +147,10 @@ if (NOT RAJA_LOADED)
 
   if(ENABLE_EXAMPLES)
     add_subdirectory(examples)
+  endif()
+
+  if(ENABLE_SIMD_ISSUES)
+   add_subdirectory(simd-issues)
   endif()
 
   if (ENABLE_DOCUMENTATION)

--- a/scripts/intel-build.sh
+++ b/scripts/intel-build.sh
@@ -1,0 +1,4 @@
+git submodule init && git submodule update
+mkdir build-intel && cd build-intel && cmake -DCMAKE_CXX_COMPILER=icpc -DCMAKE_C_COMPILER=icc   -DCMAKE_CXX_FLAGS=' -std=c++11 -qopenmp -O3 -xCORE-AVX2' ../
+make -j
+

--- a/simd-issues/CMakeLists.txt
+++ b/simd-issues/CMakeLists.txt
@@ -1,0 +1,24 @@
+###############################################################################
+#
+# Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
+#
+# Produced at the Lawrence Livermore National Laboratory
+#
+# LLNL-CODE-689114
+#
+# All rights reserved.
+#
+# This file is part of RAJA.
+#
+# For details about use and distribution, please read RAJA/LICENSE.
+#
+###############################################################################
+
+raja_add_executable(
+  NAME view
+  SOURCES view.cpp)
+
+raja_add_executable(
+  NAME sw4Kernel
+  SOURCES sw4Kernel.cpp)
+

--- a/simd-issues/CMakeLists.txt
+++ b/simd-issues/CMakeLists.txt
@@ -19,6 +19,14 @@ raja_add_executable(
   SOURCES view.cpp)
 
 raja_add_executable(
+  NAME view1
+  SOURCES view1.cpp)
+
+raja_add_executable(
+  NAME view2
+  SOURCES view2.cpp)
+
+raja_add_executable(
   NAME sw4Kernel
   SOURCES sw4Kernel.cpp)
 

--- a/simd-issues/sw4Kernel.cpp
+++ b/simd-issues/sw4Kernel.cpp
@@ -32,7 +32,12 @@
 
 
 #include "RAJA/RAJA.hpp"
+#include <cstdio>
+#include <time.h>       /* time */
 #include <cstdlib>
+#include <iostream>
+#include <chrono>
+#include <cmath>
 
 #define float_sw4 double
 
@@ -121,8 +126,6 @@ int main(int argc, char *argv[])
    double * a_strx       = new double[arr_len];
    double * a_stry       = new double[arr_len];
    double * a_strz       = new double[arr_len];
-
-   
    for(auto i=0; i<dim*arr_len; ++i)
       {
          a_lu_native[i]  = 0.0; //output for the native version
@@ -162,7 +165,7 @@ int main(int argc, char *argv[])
 
    for(auto i=0; i<arr_len; ++i)
       {
-         double err = abs(a_lu_native[i]-a_lu_raja[i]);
+        double err = std::abs(a_lu_native[i]-a_lu_raja[i]);
          if(err > 1e-8){
             pass = false; 
          }
@@ -175,7 +178,20 @@ int main(int argc, char *argv[])
       {
          std::cout<<"RAJA and native versions did NOT produce the same output"<<std::endl;
       }
+
+   delete[] a_lu_native;
+   delete[] a_lu_raja;
    
+   delete[] a_acof;
+   delete[] a_bope;
+   delete[] a_ghcof;
+   delete[] a_u;
+   delete[] a_mu;
+   delete[] a_lambda;
+   delete[] a_strx;
+   delete[] a_stry;
+   delete[] a_strz;
+
    return 0;
 }
 

--- a/simd-issues/sw4Kernel.cpp
+++ b/simd-issues/sw4Kernel.cpp
@@ -131,6 +131,7 @@ int main(int argc, char *argv[])
       {
          a_lu_native[i]  = 0.0; //output for the native version
          a_lu_raja[i]    = 0.0; //output for the raja version
+         a_u[i]       = rand() % 10 + 1;
       }
 
    for(auto i=0; i<arr_len; ++i)
@@ -138,7 +139,6 @@ int main(int argc, char *argv[])
          a_acof[i]  = rand() % 10 + 1;
          a_bope[i]    = rand() % 10 + 1;
          a_ghcof[i]   = rand() % 10 + 1;
-         a_u[i]       = rand() % 10 + 1;
          a_mu[i]      = rand() % 10 + 1;
          a_lambda[i]  = rand() % 10 + 1;
          a_strx[i]    = rand() % 10 + 1;

--- a/simd-issues/sw4Kernel.cpp
+++ b/simd-issues/sw4Kernel.cpp
@@ -551,12 +551,12 @@ void rhs4sg_rev_raja( int ifirst, int ilast, int jfirst, int jlast, int kfirst, 
 #ifdef KERNEL
    std::cout<<"using RAJA Kernel"<<std::endl;
    RAJA::kernel<POL>(RAJA::make_tuple(i_range,j_range,k_range),
-                     [=] (int i, int j, int k) {
+                     [=] (RAJA::Index_type i, RAJA::Index_type j,RAJA::Index_type k) {
 #else
   std::cout<<"using RAJA Forall nesting"<<std::endl;
-  RAJA::forall<POL2>(k_range, [=] (int k){
-        RAJA::forall<POL1>(j_range, [=] (int j){
-              RAJA::forall<POL0>(i_range, [=] (int i){
+  RAJA::forall<POL2>(k_range, [=] (RAJA::Index_type k){
+      RAJA::forall<POL1>(j_range, [=] (RAJA::Index_type j){
+          RAJA::forall<POL0>(i_range, [=] (RAJA::Index_type i){
 #endif
 
       float_sw4 mux1,mux2,mux3,mux4,muy1,muy2,muy3,muy4;

--- a/simd-issues/sw4Kernel.cpp
+++ b/simd-issues/sw4Kernel.cpp
@@ -1,0 +1,790 @@
+//  SW4 LICENSE
+// # ----------------------------------------------------------------------
+// # SW4 - Seismic Waves, 4th order
+// # ----------------------------------------------------------------------
+// # Copyright (c) 2013, Lawrence Livermore National Security, LLC. 
+// # Produced at the Lawrence Livermore National Laboratory. 
+// # 
+// # Written by:
+// # N. Anders Petersson (petersson1@llnl.gov)
+// # Bjorn Sjogreen      (sjogreen2@llnl.gov)
+// # 
+// # LLNL-CODE-643337 
+// # 
+// # All rights reserved. 
+// # 
+// # This file is part of SW4, Version: 1.0
+// # 
+// # Please also read LICENCE.txt, which contains "Our Notice and GNU General Public License"
+// # 
+// # This program is free software; you can redistribute it and/or modify
+// # it under the terms of the GNU General Public License (as published by
+// # the Free Software Foundation) version 2, dated June 1991. 
+// # 
+// # This program is distributed in the hope that it will be useful, but
+// # WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+// # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+// # conditions of the GNU General Public License for more details. 
+// # 
+// # You should have received a copy of the GNU General Public License
+// # along with this program; if not, write to the Free Software
+// # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA
+
+
+#include "RAJA/RAJA.hpp"
+#include <cstdlib>
+
+#define float_sw4 double
+
+/// - Generates incorrect ouput
+using POL = 
+   RAJA::KernelPolicy<
+    RAJA::statement::For<2, RAJA::omp_parallel_for_exec,
+    RAJA::statement::For<1, RAJA::loop_exec,
+    RAJA::statement::For<0, RAJA::simd_exec,
+    RAJA::statement::Lambda<0> > > > >;
+
+
+//using POL =  //Produces incorrect output
+//RAJA::KernelPolicy<
+//RAJA::statement::For<2, RAJA::omp_parallel_for_exec,
+//    RAJA::statement::For<1, RAJA::loop_exec,
+//    RAJA::statement::For<0, RAJA::loop_exec,
+//    RAJA::statement::Lambda<0> > > > >;
+
+
+#define KERNEL //produces incorrect ouput
+#undef KERNEL //traditional nesting - produces correct ouput 
+
+using POL2 = RAJA::omp_parallel_for_exec;
+using POL1 = RAJA::loop_exec;
+using POL0 = RAJA::loop_exec;
+
+#define mu(i,j,k)     a_mu[base+i+ni*(j)+nij*(k)]
+#define la(i,j,k) a_lambda[base+i+ni*(j)+nij*(k)]
+
+// Reversed indexation                                                                                            
+#define u(c,i,j,k)   a_u[base3+i+ni*(j)+nij*(k)+nijk*(c)]
+#define lu(c,i,j,k) a_lu[base3+i+ni*(j)+nij*(k)+nijk*(c)]
+#define strx(i) a_strx[i-ifirst0]
+#define stry(j) a_stry[j-jfirst0]
+#define strz(k) a_strz[k-kfirst0]
+#define acof(i,j,k) a_acof[(i-1)+6*(j-1)+48*(k-1)]
+#define bope(i,j) a_bope[i-1+6*(j-1)]
+#define ghcof(i) a_ghcof[i-1]
+
+
+void rhs4sg_rev_native( int ifirst, int ilast, int jfirst, int jlast, int kfirst, int klast,
+                        int nk, float_sw4* __restrict__ a_acof, float_sw4 *__restrict__ a_bope,
+                        float_sw4* __restrict__ a_ghcof, float_sw4* __restrict__ a_lu, float_sw4* __restrict__ a_u,
+                        float_sw4* __restrict__ a_mu, float_sw4* __restrict__ a_lambda, 
+                        float_sw4 h, float_sw4* __restrict__ a_strx, float_sw4* __restrict__ a_stry, 
+                        float_sw4* __restrict__ a_strz );
+
+
+void rhs4sg_rev_raja( int ifirst, int ilast, int jfirst, int jlast, int kfirst, int klast,
+                      int nk, float_sw4* __restrict__ a_acof, float_sw4 *__restrict__ a_bope,
+                      float_sw4* __restrict__ a_ghcof, float_sw4* __restrict__ a_lu, float_sw4* __restrict__ a_u,
+                      float_sw4* __restrict__ a_mu, float_sw4* __restrict__ a_lambda, 
+                      float_sw4 h, float_sw4* __restrict__ a_strx, float_sw4* __restrict__ a_stry, 
+                      float_sw4* __restrict__ a_strz );
+
+
+
+
+
+int main(int argc, char *argv[])
+{
+
+   long int kfirst=-1, klast=103;
+   long int jfirst=-1, jlast=203;
+   long int ifirst=-1, ilast=203;
+   double   h  = 0.04;
+   long int nk = 101;
+
+   long int k_len = klast-kfirst + 10;
+   long int j_len = jlast-jfirst + 10;
+   long int i_len = ilast-ifirst + 10;
+   long int arr_len = k_len*j_len*i_len;
+
+   //Allocate arrays
+   long int dim = 3;
+   double * a_lu_native  = new double[dim*arr_len]; //ref solution
+   double * a_lu_raja    = new double[dim*arr_len]; //SIMD solution
+   
+   double * a_acof       = new double[arr_len];
+   double * a_bope       = new double[arr_len];
+   double * a_ghcof      = new double[arr_len];
+   double * a_u          = new double[arr_len];
+   double * a_mu         = new double[arr_len];
+   double * a_lambda     = new double[arr_len];
+   double * a_strx       = new double[arr_len];
+   double * a_stry       = new double[arr_len];
+   double * a_strz       = new double[arr_len];
+
+   
+   for(auto i=0; i<dim*arr_len; ++i)
+      {
+         a_lu_native[i]  = 0.0; //output for the native version
+         a_lu_raja[i]    = 0.0; //output for the raja version
+      }
+
+   for(auto i=0; i<arr_len; ++i)
+      {
+         a_acof[i]  = rand() % 10 + 1;
+         a_bope[i]    = rand() % 10 + 1;
+         a_ghcof[i]   = rand() % 10 + 1;
+         a_u[i]       = rand() % 10 + 1;
+         a_mu[i]      = rand() % 10 + 1;
+         a_lambda[i]  = rand() % 10 + 1;
+         a_strx[i]    = rand() % 10 + 1;
+         a_stry[i]    = rand() % 10 + 1;
+         a_strz[i]    = rand() % 10 + 1;
+      }
+   
+   
+   std::cout<<"Calling native version..."<<std::endl;
+   //Call native version
+   rhs4sg_rev_native(ifirst, ilast, jfirst, jlast, kfirst, klast,
+                     nk, a_acof, a_bope, a_ghcof, a_lu_native, a_u,
+                     a_mu, a_lambda, h, a_strx, a_stry, a_strz );
+
+   
+
+   std::cout<<"Calling RAJA version..."<<std::endl;
+   //Call RAJA version
+   rhs4sg_rev_raja(ifirst, ilast, jfirst, jlast, kfirst, klast,
+                   nk, a_acof, a_bope, a_ghcof, a_lu_raja, a_u,
+                   a_mu, a_lambda, h, a_strx, a_stry, a_strz );
+
+
+   bool pass = true;
+
+   for(auto i=0; i<arr_len; ++i)
+      {
+         double err = abs(a_lu_native[i]-a_lu_raja[i]);
+         if(err > 1e-8){
+            pass = false; 
+         }
+      }
+
+   if(pass)
+      {
+         std::cout<<"RAJA and native versions produced the same output"<<std::endl;
+      }else
+      {
+         std::cout<<"RAJA and native versions did NOT produce the same output"<<std::endl;
+      }
+   
+   return 0;
+}
+
+void rhs4sg_rev_native( int ifirst, int ilast, int jfirst, int jlast, int kfirst, int klast,
+		 int nk, float_sw4* __restrict__ a_acof, float_sw4 *__restrict__ a_bope,
+		 float_sw4* __restrict__ a_ghcof, float_sw4* __restrict__ a_lu, float_sw4* __restrict__ a_u,
+		 float_sw4* __restrict__ a_mu, float_sw4* __restrict__ a_lambda, 
+		 float_sw4 h, float_sw4* __restrict__ a_strx, float_sw4* __restrict__ a_stry, 
+		 float_sw4* __restrict__ a_strz )
+{//raja fun start
+
+
+ // Direct reuse of fortran code by these macro definitions:
+#define mu(i,j,k)     a_mu[base+i+ni*(j)+nij*(k)]
+#define la(i,j,k) a_lambda[base+i+ni*(j)+nij*(k)]
+   // Reversed indexation
+#define u(c,i,j,k)   a_u[base3+i+ni*(j)+nij*(k)+nijk*(c)]   
+#define lu(c,i,j,k) a_lu[base3+i+ni*(j)+nij*(k)+nijk*(c)]   
+#define strx(i) a_strx[i-ifirst0]
+#define stry(j) a_stry[j-jfirst0]
+#define strz(k) a_strz[k-kfirst0]
+#define acof(i,j,k) a_acof[(i-1)+6*(j-1)+48*(k-1)]
+#define bope(i,j) a_bope[i-1+6*(j-1)]
+#define ghcof(i) a_ghcof[i-1]
+   
+   const float_sw4 a1   = 0;
+   const float_sw4 i6   = 1.0/6;
+   const float_sw4 i12  = 1.0/12;
+   const float_sw4 i144 = 1.0/144;
+   const float_sw4 tf   = 0.75;
+
+   const int ni    = ilast-ifirst+1;
+   const int nij   = ni*(jlast-jfirst+1);
+   const int nijk  = nij*(klast-kfirst+1);
+   const int base  = -(ifirst+ni*jfirst+nij*kfirst);
+   const int base3 = base-nijk;
+
+   const int nic  = 3*ni;
+   const int nijc = 3*nij;
+   const int ifirst0 = ifirst;
+   const int jfirst0 = jfirst;
+   const int kfirst0 = kfirst;
+
+
+   const float_sw4 cof = 1.0/(h*h);
+   
+   int k1 = 7; 
+   int k2 = 101;   
+   RAJA::RangeSegment k_range(k1,k2+1);
+   RAJA::RangeSegment j_range(jfirst+2,jlast-1);
+   RAJA::RangeSegment i_range(ifirst+2,ilast-1);
+
+#pragma omp parallel for                                                                                             
+   for(int  k= k1; k <= k2 ; k++ ){
+      for(int j=jfirst+2; j <= jlast-2 ; j++ ) {
+#pragma omp simd                                                                      
+#pragma ivdep                                                                                                     
+         //#pragma forceinline recursive 
+         for(int i=ifirst+2; i <= ilast-2 ; i++ )
+            {
+
+      float_sw4 mux1,mux2,mux3,mux4,muy1,muy2,muy3,muy4;
+      float_sw4 r1,r2,r3,mucof,mu1zz,mu2zz,mu3zz,lap2mu,q,u3zip2,u3zip1;
+      float_sw4 u3zim1,u3zim2,lau3zx,mu3xz,u3zjp2,u3zjp1,u3zjm1,u3zjm2,lau3zy;
+      float_sw4 mu3yz,mu1zx,u1zip2,u1zip1,u1zim1,u1zim2;
+      float_sw4 u2zjp2,u2zjp1,u2zjm1,u2zjm2,mu2zy,lau1xz,lau2yz,muz1,muz2,muz3,muz4;
+      
+/* from inner_loop_4a, 28x3 = 84 ops */
+            mux1 = mu(i-1,j,k)*strx(i-1)-
+	       tf*(mu(i,j,k)*strx(i)+mu(i-2,j,k)*strx(i-2));
+            mux2 = mu(i-2,j,k)*strx(i-2)+mu(i+1,j,k)*strx(i+1)+
+	       3*(mu(i,j,k)*strx(i)+mu(i-1,j,k)*strx(i-1));
+            mux3 = mu(i-1,j,k)*strx(i-1)+mu(i+2,j,k)*strx(i+2)+
+	       3*(mu(i+1,j,k)*strx(i+1)+mu(i,j,k)*strx(i));
+            mux4 = mu(i+1,j,k)*strx(i+1)-
+	       tf*(mu(i,j,k)*strx(i)+mu(i+2,j,k)*strx(i+2));
+
+            muy1 = mu(i,j-1,k)*stry(j-1)-
+	       tf*(mu(i,j,k)*stry(j)+mu(i,j-2,k)*stry(j-2));
+            muy2 = mu(i,j-2,k)*stry(j-2)+mu(i,j+1,k)*stry(j+1)+
+	       3*(mu(i,j,k)*stry(j)+mu(i,j-1,k)*stry(j-1));
+            muy3 = mu(i,j-1,k)*stry(j-1)+mu(i,j+2,k)*stry(j+2)+
+	       3*(mu(i,j+1,k)*stry(j+1)+mu(i,j,k)*stry(j));
+            muy4 = mu(i,j+1,k)*stry(j+1)-
+	       tf*(mu(i,j,k)*stry(j)+mu(i,j+2,k)*stry(j+2));
+
+            muz1 = mu(i,j,k-1)*strz(k-1)-
+	       tf*(mu(i,j,k)*strz(k)+mu(i,j,k-2)*strz(k-2));
+            muz2 = mu(i,j,k-2)*strz(k-2)+mu(i,j,k+1)*strz(k+1)+
+	       3*(mu(i,j,k)*strz(k)+mu(i,j,k-1)*strz(k-1));
+            muz3 = mu(i,j,k-1)*strz(k-1)+mu(i,j,k+2)*strz(k+2)+
+	       3*(mu(i,j,k+1)*strz(k+1)+mu(i,j,k)*strz(k));
+            muz4 = mu(i,j,k+1)*strz(k+1)-
+	       tf*(mu(i,j,k)*strz(k)+mu(i,j,k+2)*strz(k+2));
+/* xx, yy, and zz derivatives:*/
+/* 75 ops */
+            r1 = i6*( strx(i)*( (2*mux1+la(i-1,j,k)*strx(i-1)-
+               tf*(la(i,j,k)*strx(i)+la(i-2,j,k)*strx(i-2)))*
+                              (u(1,i-2,j,k)-u(1,i,j,k))+
+           (2*mux2+la(i-2,j,k)*strx(i-2)+la(i+1,j,k)*strx(i+1)+
+                3*(la(i,j,k)*strx(i)+la(i-1,j,k)*strx(i-1)))*
+                              (u(1,i-1,j,k)-u(1,i,j,k))+ 
+           (2*mux3+la(i-1,j,k)*strx(i-1)+la(i+2,j,k)*strx(i+2)+
+                3*(la(i+1,j,k)*strx(i+1)+la(i,j,k)*strx(i)))*
+                              (u(1,i+1,j,k)-u(1,i,j,k))+
+                (2*mux4+ la(i+1,j,k)*strx(i+1)-
+               tf*(la(i,j,k)*strx(i)+la(i+2,j,k)*strx(i+2)))*
+                (u(1,i+2,j,k)-u(1,i,j,k)) ) + stry(j)*(
+                     muy1*(u(1,i,j-2,k)-u(1,i,j,k)) + 
+                     muy2*(u(1,i,j-1,k)-u(1,i,j,k)) + 
+                     muy3*(u(1,i,j+1,k)-u(1,i,j,k)) +
+                     muy4*(u(1,i,j+2,k)-u(1,i,j,k)) ) + strz(k)*(
+                     muz1*(u(1,i,j,k-2)-u(1,i,j,k)) + 
+                     muz2*(u(1,i,j,k-1)-u(1,i,j,k)) + 
+                     muz3*(u(1,i,j,k+1)-u(1,i,j,k)) +
+                     muz4*(u(1,i,j,k+2)-u(1,i,j,k)) ) );
+
+/* 75 ops */
+            r2 = i6*( strx(i)*(mux1*(u(2,i-2,j,k)-u(2,i,j,k)) + 
+                      mux2*(u(2,i-1,j,k)-u(2,i,j,k)) + 
+                      mux3*(u(2,i+1,j,k)-u(2,i,j,k)) +
+                      mux4*(u(2,i+2,j,k)-u(2,i,j,k)) ) + stry(j)*(
+                  (2*muy1+la(i,j-1,k)*stry(j-1)-
+                      tf*(la(i,j,k)*stry(j)+la(i,j-2,k)*stry(j-2)))*
+                          (u(2,i,j-2,k)-u(2,i,j,k))+
+           (2*muy2+la(i,j-2,k)*stry(j-2)+la(i,j+1,k)*stry(j+1)+
+                     3*(la(i,j,k)*stry(j)+la(i,j-1,k)*stry(j-1)))*
+                          (u(2,i,j-1,k)-u(2,i,j,k))+ 
+           (2*muy3+la(i,j-1,k)*stry(j-1)+la(i,j+2,k)*stry(j+2)+
+                     3*(la(i,j+1,k)*stry(j+1)+la(i,j,k)*stry(j)))*
+                          (u(2,i,j+1,k)-u(2,i,j,k))+
+                  (2*muy4+la(i,j+1,k)*stry(j+1)-
+                    tf*(la(i,j,k)*stry(j)+la(i,j+2,k)*stry(j+2)))*
+                          (u(2,i,j+2,k)-u(2,i,j,k)) ) + strz(k)*(
+                     muz1*(u(2,i,j,k-2)-u(2,i,j,k)) + 
+                     muz2*(u(2,i,j,k-1)-u(2,i,j,k)) + 
+                     muz3*(u(2,i,j,k+1)-u(2,i,j,k)) +
+                     muz4*(u(2,i,j,k+2)-u(2,i,j,k)) ) );
+
+/* 75 ops */
+            r3 = i6*( strx(i)*(mux1*(u(3,i-2,j,k)-u(3,i,j,k)) + 
+                      mux2*(u(3,i-1,j,k)-u(3,i,j,k)) + 
+                      mux3*(u(3,i+1,j,k)-u(3,i,j,k)) +
+                      mux4*(u(3,i+2,j,k)-u(3,i,j,k))  ) + stry(j)*(
+                     muy1*(u(3,i,j-2,k)-u(3,i,j,k)) + 
+                     muy2*(u(3,i,j-1,k)-u(3,i,j,k)) + 
+                     muy3*(u(3,i,j+1,k)-u(3,i,j,k)) +
+                     muy4*(u(3,i,j+2,k)-u(3,i,j,k)) ) + strz(k)*(
+                  (2*muz1+la(i,j,k-1)*strz(k-1)-
+                      tf*(la(i,j,k)*strz(k)+la(i,j,k-2)*strz(k-2)))*
+                          (u(3,i,j,k-2)-u(3,i,j,k))+
+           (2*muz2+la(i,j,k-2)*strz(k-2)+la(i,j,k+1)*strz(k+1)+
+                      3*(la(i,j,k)*strz(k)+la(i,j,k-1)*strz(k-1)))*
+                          (u(3,i,j,k-1)-u(3,i,j,k))+ 
+           (2*muz3+la(i,j,k-1)*strz(k-1)+la(i,j,k+2)*strz(k+2)+
+                      3*(la(i,j,k+1)*strz(k+1)+la(i,j,k)*strz(k)))*
+                          (u(3,i,j,k+1)-u(3,i,j,k))+
+                  (2*muz4+la(i,j,k+1)*strz(k+1)-
+                    tf*(la(i,j,k)*strz(k)+la(i,j,k+2)*strz(k+2)))*
+		  (u(3,i,j,k+2)-u(3,i,j,k)) ) );
+
+
+/* Mixed derivatives: */
+/* 29ops /mixed derivative */
+/* 116 ops for r1 */
+/*   (la*v_y)_x */
+            r1 = r1 + strx(i)*stry(j)*
+                 i144*( la(i-2,j,k)*(u(2,i-2,j-2,k)-u(2,i-2,j+2,k)+
+                             8*(-u(2,i-2,j-1,k)+u(2,i-2,j+1,k))) - 8*(
+                        la(i-1,j,k)*(u(2,i-1,j-2,k)-u(2,i-1,j+2,k)+
+                             8*(-u(2,i-1,j-1,k)+u(2,i-1,j+1,k))) )+8*(
+                        la(i+1,j,k)*(u(2,i+1,j-2,k)-u(2,i+1,j+2,k)+
+                             8*(-u(2,i+1,j-1,k)+u(2,i+1,j+1,k))) ) - (
+                        la(i+2,j,k)*(u(2,i+2,j-2,k)-u(2,i+2,j+2,k)+
+                             8*(-u(2,i+2,j-1,k)+u(2,i+2,j+1,k))) )) 
+/*   (la*w_z)_x */
+               + strx(i)*strz(k)*       
+                 i144*( la(i-2,j,k)*(u(3,i-2,j,k-2)-u(3,i-2,j,k+2)+
+                             8*(-u(3,i-2,j,k-1)+u(3,i-2,j,k+1))) - 8*(
+                        la(i-1,j,k)*(u(3,i-1,j,k-2)-u(3,i-1,j,k+2)+
+                             8*(-u(3,i-1,j,k-1)+u(3,i-1,j,k+1))) )+8*(
+                        la(i+1,j,k)*(u(3,i+1,j,k-2)-u(3,i+1,j,k+2)+
+                             8*(-u(3,i+1,j,k-1)+u(3,i+1,j,k+1))) ) - (
+                        la(i+2,j,k)*(u(3,i+2,j,k-2)-u(3,i+2,j,k+2)+
+                             8*(-u(3,i+2,j,k-1)+u(3,i+2,j,k+1))) )) 
+/*   (mu*v_x)_y */
+               + strx(i)*stry(j)*       
+                 i144*( mu(i,j-2,k)*(u(2,i-2,j-2,k)-u(2,i+2,j-2,k)+
+                             8*(-u(2,i-1,j-2,k)+u(2,i+1,j-2,k))) - 8*(
+                        mu(i,j-1,k)*(u(2,i-2,j-1,k)-u(2,i+2,j-1,k)+
+                             8*(-u(2,i-1,j-1,k)+u(2,i+1,j-1,k))) )+8*(
+                        mu(i,j+1,k)*(u(2,i-2,j+1,k)-u(2,i+2,j+1,k)+
+                             8*(-u(2,i-1,j+1,k)+u(2,i+1,j+1,k))) ) - (
+                        mu(i,j+2,k)*(u(2,i-2,j+2,k)-u(2,i+2,j+2,k)+
+                             8*(-u(2,i-1,j+2,k)+u(2,i+1,j+2,k))) )) 
+/*   (mu*w_x)_z */
+               + strx(i)*strz(k)*       
+                 i144*( mu(i,j,k-2)*(u(3,i-2,j,k-2)-u(3,i+2,j,k-2)+
+                             8*(-u(3,i-1,j,k-2)+u(3,i+1,j,k-2))) - 8*(
+                        mu(i,j,k-1)*(u(3,i-2,j,k-1)-u(3,i+2,j,k-1)+
+                             8*(-u(3,i-1,j,k-1)+u(3,i+1,j,k-1))) )+8*(
+                        mu(i,j,k+1)*(u(3,i-2,j,k+1)-u(3,i+2,j,k+1)+
+                             8*(-u(3,i-1,j,k+1)+u(3,i+1,j,k+1))) ) - (
+                        mu(i,j,k+2)*(u(3,i-2,j,k+2)-u(3,i+2,j,k+2)+
+				     8*(-u(3,i-1,j,k+2)+u(3,i+1,j,k+2))) )) ;
+
+/* 116 ops for r2 */
+/*   (mu*u_y)_x */
+            r2 = r2 + strx(i)*stry(j)*
+                 i144*( mu(i-2,j,k)*(u(1,i-2,j-2,k)-u(1,i-2,j+2,k)+
+                             8*(-u(1,i-2,j-1,k)+u(1,i-2,j+1,k))) - 8*(
+                        mu(i-1,j,k)*(u(1,i-1,j-2,k)-u(1,i-1,j+2,k)+
+                             8*(-u(1,i-1,j-1,k)+u(1,i-1,j+1,k))) )+8*(
+                        mu(i+1,j,k)*(u(1,i+1,j-2,k)-u(1,i+1,j+2,k)+
+                             8*(-u(1,i+1,j-1,k)+u(1,i+1,j+1,k))) ) - (
+                        mu(i+2,j,k)*(u(1,i+2,j-2,k)-u(1,i+2,j+2,k)+
+                             8*(-u(1,i+2,j-1,k)+u(1,i+2,j+1,k))) )) 
+/* (la*u_x)_y */
+              + strx(i)*stry(j)*
+                 i144*( la(i,j-2,k)*(u(1,i-2,j-2,k)-u(1,i+2,j-2,k)+
+                             8*(-u(1,i-1,j-2,k)+u(1,i+1,j-2,k))) - 8*(
+                        la(i,j-1,k)*(u(1,i-2,j-1,k)-u(1,i+2,j-1,k)+
+                             8*(-u(1,i-1,j-1,k)+u(1,i+1,j-1,k))) )+8*(
+                        la(i,j+1,k)*(u(1,i-2,j+1,k)-u(1,i+2,j+1,k)+
+                             8*(-u(1,i-1,j+1,k)+u(1,i+1,j+1,k))) ) - (
+                        la(i,j+2,k)*(u(1,i-2,j+2,k)-u(1,i+2,j+2,k)+
+                             8*(-u(1,i-1,j+2,k)+u(1,i+1,j+2,k))) )) 
+/* (la*w_z)_y */
+               + stry(j)*strz(k)*
+                 i144*( la(i,j-2,k)*(u(3,i,j-2,k-2)-u(3,i,j-2,k+2)+
+                             8*(-u(3,i,j-2,k-1)+u(3,i,j-2,k+1))) - 8*(
+                        la(i,j-1,k)*(u(3,i,j-1,k-2)-u(3,i,j-1,k+2)+
+                             8*(-u(3,i,j-1,k-1)+u(3,i,j-1,k+1))) )+8*(
+                        la(i,j+1,k)*(u(3,i,j+1,k-2)-u(3,i,j+1,k+2)+
+                             8*(-u(3,i,j+1,k-1)+u(3,i,j+1,k+1))) ) - (
+                        la(i,j+2,k)*(u(3,i,j+2,k-2)-u(3,i,j+2,k+2)+
+                             8*(-u(3,i,j+2,k-1)+u(3,i,j+2,k+1))) ))
+/* (mu*w_y)_z */
+               + stry(j)*strz(k)*
+                 i144*( mu(i,j,k-2)*(u(3,i,j-2,k-2)-u(3,i,j+2,k-2)+
+                             8*(-u(3,i,j-1,k-2)+u(3,i,j+1,k-2))) - 8*(
+                        mu(i,j,k-1)*(u(3,i,j-2,k-1)-u(3,i,j+2,k-1)+
+                             8*(-u(3,i,j-1,k-1)+u(3,i,j+1,k-1))) )+8*(
+                        mu(i,j,k+1)*(u(3,i,j-2,k+1)-u(3,i,j+2,k+1)+
+                             8*(-u(3,i,j-1,k+1)+u(3,i,j+1,k+1))) ) - (
+                        mu(i,j,k+2)*(u(3,i,j-2,k+2)-u(3,i,j+2,k+2)+
+				     8*(-u(3,i,j-1,k+2)+u(3,i,j+1,k+2))) )) ;
+/* 116 ops for r3 */
+/*  (mu*u_z)_x */
+            r3 = r3 + strx(i)*strz(k)*
+                 i144*( mu(i-2,j,k)*(u(1,i-2,j,k-2)-u(1,i-2,j,k+2)+
+                             8*(-u(1,i-2,j,k-1)+u(1,i-2,j,k+1))) - 8*(
+                        mu(i-1,j,k)*(u(1,i-1,j,k-2)-u(1,i-1,j,k+2)+
+                             8*(-u(1,i-1,j,k-1)+u(1,i-1,j,k+1))) )+8*(
+                        mu(i+1,j,k)*(u(1,i+1,j,k-2)-u(1,i+1,j,k+2)+
+                             8*(-u(1,i+1,j,k-1)+u(1,i+1,j,k+1))) ) - (
+                        mu(i+2,j,k)*(u(1,i+2,j,k-2)-u(1,i+2,j,k+2)+
+                             8*(-u(1,i+2,j,k-1)+u(1,i+2,j,k+1))) )) 
+/* (mu*v_z)_y */
+              + stry(j)*strz(k)*
+                 i144*( mu(i,j-2,k)*(u(2,i,j-2,k-2)-u(2,i,j-2,k+2)+
+                             8*(-u(2,i,j-2,k-1)+u(2,i,j-2,k+1))) - 8*(
+                        mu(i,j-1,k)*(u(2,i,j-1,k-2)-u(2,i,j-1,k+2)+
+                             8*(-u(2,i,j-1,k-1)+u(2,i,j-1,k+1))) )+8*(
+                        mu(i,j+1,k)*(u(2,i,j+1,k-2)-u(2,i,j+1,k+2)+
+                             8*(-u(2,i,j+1,k-1)+u(2,i,j+1,k+1))) ) - (
+                        mu(i,j+2,k)*(u(2,i,j+2,k-2)-u(2,i,j+2,k+2)+
+                             8*(-u(2,i,j+2,k-1)+u(2,i,j+2,k+1))) ))
+/*   (la*u_x)_z */
+              + strx(i)*strz(k)*
+                 i144*( la(i,j,k-2)*(u(1,i-2,j,k-2)-u(1,i+2,j,k-2)+
+                             8*(-u(1,i-1,j,k-2)+u(1,i+1,j,k-2))) - 8*(
+                        la(i,j,k-1)*(u(1,i-2,j,k-1)-u(1,i+2,j,k-1)+
+                             8*(-u(1,i-1,j,k-1)+u(1,i+1,j,k-1))) )+8*(
+                        la(i,j,k+1)*(u(1,i-2,j,k+1)-u(1,i+2,j,k+1)+
+                             8*(-u(1,i-1,j,k+1)+u(1,i+1,j,k+1))) ) - (
+                        la(i,j,k+2)*(u(1,i-2,j,k+2)-u(1,i+2,j,k+2)+
+                             8*(-u(1,i-1,j,k+2)+u(1,i+1,j,k+2))) )) 
+/* (la*v_y)_z */
+              + stry(j)*strz(k)*
+                 i144*( la(i,j,k-2)*(u(2,i,j-2,k-2)-u(2,i,j+2,k-2)+
+                             8*(-u(2,i,j-1,k-2)+u(2,i,j+1,k-2))) - 8*(
+                        la(i,j,k-1)*(u(2,i,j-2,k-1)-u(2,i,j+2,k-1)+
+                             8*(-u(2,i,j-1,k-1)+u(2,i,j+1,k-1))) )+8*(
+                        la(i,j,k+1)*(u(2,i,j-2,k+1)-u(2,i,j+2,k+1)+
+                             8*(-u(2,i,j-1,k+1)+u(2,i,j+1,k+1))) ) - (
+                        la(i,j,k+2)*(u(2,i,j-2,k+2)-u(2,i,j+2,k+2)+
+				     8*(-u(2,i,j-1,k+2)+u(2,i,j+1,k+2))) )) ;
+
+/* 9 ops */
+//	    lu(1,i,j,k) = a1*lu(1,i,j,k) + cof*r1;
+//            lu(2,i,j,k) = a1*lu(2,i,j,k) + cof*r2;
+//            lu(3,i,j,k) = a1*lu(3,i,j,k) + cof*r3;
+            lu(1,i,j,k) =  cof*r1;
+            lu(2,i,j,k) =  cof*r2;
+            lu(3,i,j,k) =  cof*r3;
+            }
+      }
+   }
+
+
+            
+
+}//end brace
+
+
+void rhs4sg_rev_raja( int ifirst, int ilast, int jfirst, int jlast, int kfirst, int klast,
+		 int nk, float_sw4* __restrict__ a_acof, float_sw4 *__restrict__ a_bope,
+		 float_sw4* __restrict__ a_ghcof, float_sw4* __restrict__ a_lu, float_sw4* __restrict__ a_u,
+		 float_sw4* __restrict__ a_mu, float_sw4* __restrict__ a_lambda, 
+		 float_sw4 h, float_sw4* __restrict__ a_strx, float_sw4* __restrict__ a_stry, 
+		 float_sw4* __restrict__ a_strz )
+{//raja fun start
+
+
+ // Direct reuse of fortran code by these macro definitions:
+#define mu(i,j,k)     a_mu[base+i+ni*(j)+nij*(k)]
+#define la(i,j,k) a_lambda[base+i+ni*(j)+nij*(k)]
+   // Reversed indexation
+#define u(c,i,j,k)   a_u[base3+i+ni*(j)+nij*(k)+nijk*(c)]   
+#define lu(c,i,j,k) a_lu[base3+i+ni*(j)+nij*(k)+nijk*(c)]   
+#define strx(i) a_strx[i-ifirst0]
+#define stry(j) a_stry[j-jfirst0]
+#define strz(k) a_strz[k-kfirst0]
+#define acof(i,j,k) a_acof[(i-1)+6*(j-1)+48*(k-1)]
+#define bope(i,j) a_bope[i-1+6*(j-1)]
+#define ghcof(i) a_ghcof[i-1]
+   
+   const float_sw4 a1   = 0;
+   const float_sw4 i6   = 1.0/6;
+   const float_sw4 i12  = 1.0/12;
+   const float_sw4 i144 = 1.0/144;
+   const float_sw4 tf   = 0.75;
+
+   const int ni    = ilast-ifirst+1;
+   const int nij   = ni*(jlast-jfirst+1);
+   const int nijk  = nij*(klast-kfirst+1);
+   const int base  = -(ifirst+ni*jfirst+nij*kfirst);
+   const int base3 = base-nijk;
+
+   const int nic  = 3*ni;
+   const int nijc = 3*nij;
+   const int ifirst0 = ifirst;
+   const int jfirst0 = jfirst;
+   const int kfirst0 = kfirst;
+
+
+   const float_sw4 cof = 1.0/(h*h);
+   
+   int k1 = 7; 
+   int k2 = 101;   
+   RAJA::RangeSegment k_range(k1,k2+1);
+   RAJA::RangeSegment j_range(jfirst+2,jlast-1);
+   RAJA::RangeSegment i_range(ifirst+2,ilast-1);
+
+#ifdef KERNEL
+   std::cout<<"using RAJA Kernel"<<std::endl;
+   RAJA::kernel<POL>(RAJA::make_tuple(i_range,j_range,k_range),
+                     [=] (int i, int j, int k) {
+#else
+  std::cout<<"using RAJA Forall nesting"<<std::endl;
+  RAJA::forall<POL2>(k_range, [=] (int k){
+        RAJA::forall<POL1>(j_range, [=] (int j){
+              RAJA::forall<POL0>(i_range, [=] (int i){
+#endif
+
+      float_sw4 mux1,mux2,mux3,mux4,muy1,muy2,muy3,muy4;
+      float_sw4 r1,r2,r3,mucof,mu1zz,mu2zz,mu3zz,lap2mu,q,u3zip2,u3zip1;
+      float_sw4 u3zim1,u3zim2,lau3zx,mu3xz,u3zjp2,u3zjp1,u3zjm1,u3zjm2,lau3zy;
+      float_sw4 mu3yz,mu1zx,u1zip2,u1zip1,u1zim1,u1zim2;
+      float_sw4 u2zjp2,u2zjp1,u2zjm1,u2zjm2,mu2zy,lau1xz,lau2yz,muz1,muz2,muz3,muz4;
+      
+/* from inner_loop_4a, 28x3 = 84 ops */
+            mux1 = mu(i-1,j,k)*strx(i-1)-
+	       tf*(mu(i,j,k)*strx(i)+mu(i-2,j,k)*strx(i-2));
+            mux2 = mu(i-2,j,k)*strx(i-2)+mu(i+1,j,k)*strx(i+1)+
+	       3*(mu(i,j,k)*strx(i)+mu(i-1,j,k)*strx(i-1));
+            mux3 = mu(i-1,j,k)*strx(i-1)+mu(i+2,j,k)*strx(i+2)+
+	       3*(mu(i+1,j,k)*strx(i+1)+mu(i,j,k)*strx(i));
+            mux4 = mu(i+1,j,k)*strx(i+1)-
+	       tf*(mu(i,j,k)*strx(i)+mu(i+2,j,k)*strx(i+2));
+
+            muy1 = mu(i,j-1,k)*stry(j-1)-
+	       tf*(mu(i,j,k)*stry(j)+mu(i,j-2,k)*stry(j-2));
+            muy2 = mu(i,j-2,k)*stry(j-2)+mu(i,j+1,k)*stry(j+1)+
+	       3*(mu(i,j,k)*stry(j)+mu(i,j-1,k)*stry(j-1));
+            muy3 = mu(i,j-1,k)*stry(j-1)+mu(i,j+2,k)*stry(j+2)+
+	       3*(mu(i,j+1,k)*stry(j+1)+mu(i,j,k)*stry(j));
+            muy4 = mu(i,j+1,k)*stry(j+1)-
+	       tf*(mu(i,j,k)*stry(j)+mu(i,j+2,k)*stry(j+2));
+
+            muz1 = mu(i,j,k-1)*strz(k-1)-
+	       tf*(mu(i,j,k)*strz(k)+mu(i,j,k-2)*strz(k-2));
+            muz2 = mu(i,j,k-2)*strz(k-2)+mu(i,j,k+1)*strz(k+1)+
+	       3*(mu(i,j,k)*strz(k)+mu(i,j,k-1)*strz(k-1));
+            muz3 = mu(i,j,k-1)*strz(k-1)+mu(i,j,k+2)*strz(k+2)+
+	       3*(mu(i,j,k+1)*strz(k+1)+mu(i,j,k)*strz(k));
+            muz4 = mu(i,j,k+1)*strz(k+1)-
+	       tf*(mu(i,j,k)*strz(k)+mu(i,j,k+2)*strz(k+2));
+/* xx, yy, and zz derivatives:*/
+/* 75 ops */
+            r1 = i6*( strx(i)*( (2*mux1+la(i-1,j,k)*strx(i-1)-
+               tf*(la(i,j,k)*strx(i)+la(i-2,j,k)*strx(i-2)))*
+                              (u(1,i-2,j,k)-u(1,i,j,k))+
+           (2*mux2+la(i-2,j,k)*strx(i-2)+la(i+1,j,k)*strx(i+1)+
+                3*(la(i,j,k)*strx(i)+la(i-1,j,k)*strx(i-1)))*
+                              (u(1,i-1,j,k)-u(1,i,j,k))+ 
+           (2*mux3+la(i-1,j,k)*strx(i-1)+la(i+2,j,k)*strx(i+2)+
+                3*(la(i+1,j,k)*strx(i+1)+la(i,j,k)*strx(i)))*
+                              (u(1,i+1,j,k)-u(1,i,j,k))+
+                (2*mux4+ la(i+1,j,k)*strx(i+1)-
+               tf*(la(i,j,k)*strx(i)+la(i+2,j,k)*strx(i+2)))*
+                (u(1,i+2,j,k)-u(1,i,j,k)) ) + stry(j)*(
+                     muy1*(u(1,i,j-2,k)-u(1,i,j,k)) + 
+                     muy2*(u(1,i,j-1,k)-u(1,i,j,k)) + 
+                     muy3*(u(1,i,j+1,k)-u(1,i,j,k)) +
+                     muy4*(u(1,i,j+2,k)-u(1,i,j,k)) ) + strz(k)*(
+                     muz1*(u(1,i,j,k-2)-u(1,i,j,k)) + 
+                     muz2*(u(1,i,j,k-1)-u(1,i,j,k)) + 
+                     muz3*(u(1,i,j,k+1)-u(1,i,j,k)) +
+                     muz4*(u(1,i,j,k+2)-u(1,i,j,k)) ) );
+
+/* 75 ops */
+            r2 = i6*( strx(i)*(mux1*(u(2,i-2,j,k)-u(2,i,j,k)) + 
+                      mux2*(u(2,i-1,j,k)-u(2,i,j,k)) + 
+                      mux3*(u(2,i+1,j,k)-u(2,i,j,k)) +
+                      mux4*(u(2,i+2,j,k)-u(2,i,j,k)) ) + stry(j)*(
+                  (2*muy1+la(i,j-1,k)*stry(j-1)-
+                      tf*(la(i,j,k)*stry(j)+la(i,j-2,k)*stry(j-2)))*
+                          (u(2,i,j-2,k)-u(2,i,j,k))+
+           (2*muy2+la(i,j-2,k)*stry(j-2)+la(i,j+1,k)*stry(j+1)+
+                     3*(la(i,j,k)*stry(j)+la(i,j-1,k)*stry(j-1)))*
+                          (u(2,i,j-1,k)-u(2,i,j,k))+ 
+           (2*muy3+la(i,j-1,k)*stry(j-1)+la(i,j+2,k)*stry(j+2)+
+                     3*(la(i,j+1,k)*stry(j+1)+la(i,j,k)*stry(j)))*
+                          (u(2,i,j+1,k)-u(2,i,j,k))+
+                  (2*muy4+la(i,j+1,k)*stry(j+1)-
+                    tf*(la(i,j,k)*stry(j)+la(i,j+2,k)*stry(j+2)))*
+                          (u(2,i,j+2,k)-u(2,i,j,k)) ) + strz(k)*(
+                     muz1*(u(2,i,j,k-2)-u(2,i,j,k)) + 
+                     muz2*(u(2,i,j,k-1)-u(2,i,j,k)) + 
+                     muz3*(u(2,i,j,k+1)-u(2,i,j,k)) +
+                     muz4*(u(2,i,j,k+2)-u(2,i,j,k)) ) );
+
+/* 75 ops */
+            r3 = i6*( strx(i)*(mux1*(u(3,i-2,j,k)-u(3,i,j,k)) + 
+                      mux2*(u(3,i-1,j,k)-u(3,i,j,k)) + 
+                      mux3*(u(3,i+1,j,k)-u(3,i,j,k)) +
+                      mux4*(u(3,i+2,j,k)-u(3,i,j,k))  ) + stry(j)*(
+                     muy1*(u(3,i,j-2,k)-u(3,i,j,k)) + 
+                     muy2*(u(3,i,j-1,k)-u(3,i,j,k)) + 
+                     muy3*(u(3,i,j+1,k)-u(3,i,j,k)) +
+                     muy4*(u(3,i,j+2,k)-u(3,i,j,k)) ) + strz(k)*(
+                  (2*muz1+la(i,j,k-1)*strz(k-1)-
+                      tf*(la(i,j,k)*strz(k)+la(i,j,k-2)*strz(k-2)))*
+                          (u(3,i,j,k-2)-u(3,i,j,k))+
+           (2*muz2+la(i,j,k-2)*strz(k-2)+la(i,j,k+1)*strz(k+1)+
+                      3*(la(i,j,k)*strz(k)+la(i,j,k-1)*strz(k-1)))*
+                          (u(3,i,j,k-1)-u(3,i,j,k))+ 
+           (2*muz3+la(i,j,k-1)*strz(k-1)+la(i,j,k+2)*strz(k+2)+
+                      3*(la(i,j,k+1)*strz(k+1)+la(i,j,k)*strz(k)))*
+                          (u(3,i,j,k+1)-u(3,i,j,k))+
+                  (2*muz4+la(i,j,k+1)*strz(k+1)-
+                    tf*(la(i,j,k)*strz(k)+la(i,j,k+2)*strz(k+2)))*
+		  (u(3,i,j,k+2)-u(3,i,j,k)) ) );
+
+
+/* Mixed derivatives: */
+/* 29ops /mixed derivative */
+/* 116 ops for r1 */
+/*   (la*v_y)_x */
+            r1 = r1 + strx(i)*stry(j)*
+                 i144*( la(i-2,j,k)*(u(2,i-2,j-2,k)-u(2,i-2,j+2,k)+
+                             8*(-u(2,i-2,j-1,k)+u(2,i-2,j+1,k))) - 8*(
+                        la(i-1,j,k)*(u(2,i-1,j-2,k)-u(2,i-1,j+2,k)+
+                             8*(-u(2,i-1,j-1,k)+u(2,i-1,j+1,k))) )+8*(
+                        la(i+1,j,k)*(u(2,i+1,j-2,k)-u(2,i+1,j+2,k)+
+                             8*(-u(2,i+1,j-1,k)+u(2,i+1,j+1,k))) ) - (
+                        la(i+2,j,k)*(u(2,i+2,j-2,k)-u(2,i+2,j+2,k)+
+                             8*(-u(2,i+2,j-1,k)+u(2,i+2,j+1,k))) )) 
+/*   (la*w_z)_x */
+               + strx(i)*strz(k)*       
+                 i144*( la(i-2,j,k)*(u(3,i-2,j,k-2)-u(3,i-2,j,k+2)+
+                             8*(-u(3,i-2,j,k-1)+u(3,i-2,j,k+1))) - 8*(
+                        la(i-1,j,k)*(u(3,i-1,j,k-2)-u(3,i-1,j,k+2)+
+                             8*(-u(3,i-1,j,k-1)+u(3,i-1,j,k+1))) )+8*(
+                        la(i+1,j,k)*(u(3,i+1,j,k-2)-u(3,i+1,j,k+2)+
+                             8*(-u(3,i+1,j,k-1)+u(3,i+1,j,k+1))) ) - (
+                        la(i+2,j,k)*(u(3,i+2,j,k-2)-u(3,i+2,j,k+2)+
+                             8*(-u(3,i+2,j,k-1)+u(3,i+2,j,k+1))) )) 
+/*   (mu*v_x)_y */
+               + strx(i)*stry(j)*       
+                 i144*( mu(i,j-2,k)*(u(2,i-2,j-2,k)-u(2,i+2,j-2,k)+
+                             8*(-u(2,i-1,j-2,k)+u(2,i+1,j-2,k))) - 8*(
+                        mu(i,j-1,k)*(u(2,i-2,j-1,k)-u(2,i+2,j-1,k)+
+                             8*(-u(2,i-1,j-1,k)+u(2,i+1,j-1,k))) )+8*(
+                        mu(i,j+1,k)*(u(2,i-2,j+1,k)-u(2,i+2,j+1,k)+
+                             8*(-u(2,i-1,j+1,k)+u(2,i+1,j+1,k))) ) - (
+                        mu(i,j+2,k)*(u(2,i-2,j+2,k)-u(2,i+2,j+2,k)+
+                             8*(-u(2,i-1,j+2,k)+u(2,i+1,j+2,k))) )) 
+/*   (mu*w_x)_z */
+               + strx(i)*strz(k)*       
+                 i144*( mu(i,j,k-2)*(u(3,i-2,j,k-2)-u(3,i+2,j,k-2)+
+                             8*(-u(3,i-1,j,k-2)+u(3,i+1,j,k-2))) - 8*(
+                        mu(i,j,k-1)*(u(3,i-2,j,k-1)-u(3,i+2,j,k-1)+
+                             8*(-u(3,i-1,j,k-1)+u(3,i+1,j,k-1))) )+8*(
+                        mu(i,j,k+1)*(u(3,i-2,j,k+1)-u(3,i+2,j,k+1)+
+                             8*(-u(3,i-1,j,k+1)+u(3,i+1,j,k+1))) ) - (
+                        mu(i,j,k+2)*(u(3,i-2,j,k+2)-u(3,i+2,j,k+2)+
+				     8*(-u(3,i-1,j,k+2)+u(3,i+1,j,k+2))) )) ;
+
+/* 116 ops for r2 */
+/*   (mu*u_y)_x */
+            r2 = r2 + strx(i)*stry(j)*
+                 i144*( mu(i-2,j,k)*(u(1,i-2,j-2,k)-u(1,i-2,j+2,k)+
+                             8*(-u(1,i-2,j-1,k)+u(1,i-2,j+1,k))) - 8*(
+                        mu(i-1,j,k)*(u(1,i-1,j-2,k)-u(1,i-1,j+2,k)+
+                             8*(-u(1,i-1,j-1,k)+u(1,i-1,j+1,k))) )+8*(
+                        mu(i+1,j,k)*(u(1,i+1,j-2,k)-u(1,i+1,j+2,k)+
+                             8*(-u(1,i+1,j-1,k)+u(1,i+1,j+1,k))) ) - (
+                        mu(i+2,j,k)*(u(1,i+2,j-2,k)-u(1,i+2,j+2,k)+
+                             8*(-u(1,i+2,j-1,k)+u(1,i+2,j+1,k))) )) 
+/* (la*u_x)_y */
+              + strx(i)*stry(j)*
+                 i144*( la(i,j-2,k)*(u(1,i-2,j-2,k)-u(1,i+2,j-2,k)+
+                             8*(-u(1,i-1,j-2,k)+u(1,i+1,j-2,k))) - 8*(
+                        la(i,j-1,k)*(u(1,i-2,j-1,k)-u(1,i+2,j-1,k)+
+                             8*(-u(1,i-1,j-1,k)+u(1,i+1,j-1,k))) )+8*(
+                        la(i,j+1,k)*(u(1,i-2,j+1,k)-u(1,i+2,j+1,k)+
+                             8*(-u(1,i-1,j+1,k)+u(1,i+1,j+1,k))) ) - (
+                        la(i,j+2,k)*(u(1,i-2,j+2,k)-u(1,i+2,j+2,k)+
+                             8*(-u(1,i-1,j+2,k)+u(1,i+1,j+2,k))) )) 
+/* (la*w_z)_y */
+               + stry(j)*strz(k)*
+                 i144*( la(i,j-2,k)*(u(3,i,j-2,k-2)-u(3,i,j-2,k+2)+
+                             8*(-u(3,i,j-2,k-1)+u(3,i,j-2,k+1))) - 8*(
+                        la(i,j-1,k)*(u(3,i,j-1,k-2)-u(3,i,j-1,k+2)+
+                             8*(-u(3,i,j-1,k-1)+u(3,i,j-1,k+1))) )+8*(
+                        la(i,j+1,k)*(u(3,i,j+1,k-2)-u(3,i,j+1,k+2)+
+                             8*(-u(3,i,j+1,k-1)+u(3,i,j+1,k+1))) ) - (
+                        la(i,j+2,k)*(u(3,i,j+2,k-2)-u(3,i,j+2,k+2)+
+                             8*(-u(3,i,j+2,k-1)+u(3,i,j+2,k+1))) ))
+/* (mu*w_y)_z */
+               + stry(j)*strz(k)*
+                 i144*( mu(i,j,k-2)*(u(3,i,j-2,k-2)-u(3,i,j+2,k-2)+
+                             8*(-u(3,i,j-1,k-2)+u(3,i,j+1,k-2))) - 8*(
+                        mu(i,j,k-1)*(u(3,i,j-2,k-1)-u(3,i,j+2,k-1)+
+                             8*(-u(3,i,j-1,k-1)+u(3,i,j+1,k-1))) )+8*(
+                        mu(i,j,k+1)*(u(3,i,j-2,k+1)-u(3,i,j+2,k+1)+
+                             8*(-u(3,i,j-1,k+1)+u(3,i,j+1,k+1))) ) - (
+                        mu(i,j,k+2)*(u(3,i,j-2,k+2)-u(3,i,j+2,k+2)+
+				     8*(-u(3,i,j-1,k+2)+u(3,i,j+1,k+2))) )) ;
+/* 116 ops for r3 */
+/*  (mu*u_z)_x */
+            r3 = r3 + strx(i)*strz(k)*
+                 i144*( mu(i-2,j,k)*(u(1,i-2,j,k-2)-u(1,i-2,j,k+2)+
+                             8*(-u(1,i-2,j,k-1)+u(1,i-2,j,k+1))) - 8*(
+                        mu(i-1,j,k)*(u(1,i-1,j,k-2)-u(1,i-1,j,k+2)+
+                             8*(-u(1,i-1,j,k-1)+u(1,i-1,j,k+1))) )+8*(
+                        mu(i+1,j,k)*(u(1,i+1,j,k-2)-u(1,i+1,j,k+2)+
+                             8*(-u(1,i+1,j,k-1)+u(1,i+1,j,k+1))) ) - (
+                        mu(i+2,j,k)*(u(1,i+2,j,k-2)-u(1,i+2,j,k+2)+
+                             8*(-u(1,i+2,j,k-1)+u(1,i+2,j,k+1))) )) 
+/* (mu*v_z)_y */
+              + stry(j)*strz(k)*
+                 i144*( mu(i,j-2,k)*(u(2,i,j-2,k-2)-u(2,i,j-2,k+2)+
+                             8*(-u(2,i,j-2,k-1)+u(2,i,j-2,k+1))) - 8*(
+                        mu(i,j-1,k)*(u(2,i,j-1,k-2)-u(2,i,j-1,k+2)+
+                             8*(-u(2,i,j-1,k-1)+u(2,i,j-1,k+1))) )+8*(
+                        mu(i,j+1,k)*(u(2,i,j+1,k-2)-u(2,i,j+1,k+2)+
+                             8*(-u(2,i,j+1,k-1)+u(2,i,j+1,k+1))) ) - (
+                        mu(i,j+2,k)*(u(2,i,j+2,k-2)-u(2,i,j+2,k+2)+
+                             8*(-u(2,i,j+2,k-1)+u(2,i,j+2,k+1))) ))
+/*   (la*u_x)_z */
+              + strx(i)*strz(k)*
+                 i144*( la(i,j,k-2)*(u(1,i-2,j,k-2)-u(1,i+2,j,k-2)+
+                             8*(-u(1,i-1,j,k-2)+u(1,i+1,j,k-2))) - 8*(
+                        la(i,j,k-1)*(u(1,i-2,j,k-1)-u(1,i+2,j,k-1)+
+                             8*(-u(1,i-1,j,k-1)+u(1,i+1,j,k-1))) )+8*(
+                        la(i,j,k+1)*(u(1,i-2,j,k+1)-u(1,i+2,j,k+1)+
+                             8*(-u(1,i-1,j,k+1)+u(1,i+1,j,k+1))) ) - (
+                        la(i,j,k+2)*(u(1,i-2,j,k+2)-u(1,i+2,j,k+2)+
+                             8*(-u(1,i-1,j,k+2)+u(1,i+1,j,k+2))) )) 
+/* (la*v_y)_z */
+              + stry(j)*strz(k)*
+                 i144*( la(i,j,k-2)*(u(2,i,j-2,k-2)-u(2,i,j+2,k-2)+
+                             8*(-u(2,i,j-1,k-2)+u(2,i,j+1,k-2))) - 8*(
+                        la(i,j,k-1)*(u(2,i,j-2,k-1)-u(2,i,j+2,k-1)+
+                             8*(-u(2,i,j-1,k-1)+u(2,i,j+1,k-1))) )+8*(
+                        la(i,j,k+1)*(u(2,i,j-2,k+1)-u(2,i,j+2,k+1)+
+                             8*(-u(2,i,j-1,k+1)+u(2,i,j+1,k+1))) ) - (
+                        la(i,j,k+2)*(u(2,i,j-2,k+2)-u(2,i,j+2,k+2)+
+				     8*(-u(2,i,j-1,k+2)+u(2,i,j+1,k+2))) )) ;
+
+/* 9 ops */
+//	    lu(1,i,j,k) = a1*lu(1,i,j,k) + cof*r1;
+//            lu(2,i,j,k) = a1*lu(2,i,j,k) + cof*r2;
+//            lu(3,i,j,k) = a1*lu(3,i,j,k) + cof*r3;
+            lu(1,i,j,k) =  cof*r1;
+            lu(2,i,j,k) =  cof*r2;
+            lu(3,i,j,k) =  cof*r3;
+
+#ifdef KERNEL            
+                 });
+#else
+                 });
+              });
+        });
+#endif  
+
+}//end brace
+

--- a/simd-issues/sw4Kernel.cpp
+++ b/simd-issues/sw4Kernel.cpp
@@ -113,9 +113,13 @@ int main(int argc, char *argv[])
    long int arr_len = k_len*j_len*i_len;
 
    //Allocate arrays
-   long int dim = 3;
-   double * a_lu_native  = new double[dim*arr_len]; //ref solution
-   double * a_lu_raja    = new double[dim*arr_len]; //SIMD solution
+   //long int dim = 3;
+   //double * a_lu_native  = new double[dim*arr_len]; //ref solution
+   //double * a_lu_raja    = new double[dim*arr_len]; //SIMD solution
+
+   size_t lu_arraySz = 13153412 + 10;  //padding
+   double * a_lu_native  = new double[lu_arraySz]; //ref solution
+   double * a_lu_raja    = new double[lu_arraySz]; //SIMD solution
    
    double * a_acof       = new double[arr_len];
    double * a_bope       = new double[arr_len];
@@ -126,7 +130,7 @@ int main(int argc, char *argv[])
    double * a_strx       = new double[arr_len];
    double * a_stry       = new double[arr_len];
    double * a_strz       = new double[arr_len];
-   for(auto i=0; i<dim*arr_len; ++i)
+   for(auto i=0; i<lu_arraySz; ++i)
       {
          a_lu_native[i]  = 0.0; //output for the native version
          a_lu_raja[i]    = 0.0; //output for the raja version
@@ -163,7 +167,7 @@ int main(int argc, char *argv[])
 
    bool pass = true;
 
-   for(auto i=0; i<arr_len; ++i)
+   for(auto i=0; i<lu_arraySz; ++i)
       {
         double err = std::abs(a_lu_native[i]-a_lu_raja[i]);
          if(err > 1e-8){

--- a/simd-issues/sw4Kernel.cpp
+++ b/simd-issues/sw4Kernel.cpp
@@ -113,18 +113,15 @@ int main(int argc, char *argv[])
    long int arr_len = k_len*j_len*i_len;
 
    //Allocate arrays
-   //long int dim = 3;
-   //double * a_lu_native  = new double[dim*arr_len]; //ref solution
-   //double * a_lu_raja    = new double[dim*arr_len]; //SIMD solution
 
    size_t lu_arraySz = 13153412 + 10;  //padding
    double * a_lu_native  = new double[lu_arraySz]; //ref solution
    double * a_lu_raja    = new double[lu_arraySz]; //SIMD solution
-   
+   double * a_u          = new double[lu_arraySz];
+      
    double * a_acof       = new double[arr_len];
    double * a_bope       = new double[arr_len];
    double * a_ghcof      = new double[arr_len];
-   double * a_u          = new double[arr_len];
    double * a_mu         = new double[arr_len];
    double * a_lambda     = new double[arr_len];
    double * a_strx       = new double[arr_len];

--- a/simd-issues/sw4Kernel.cpp
+++ b/simd-issues/sw4Kernel.cpp
@@ -54,11 +54,11 @@ using POL =
 
 
 #define KERNEL //produces incorrect ouput
-#undef KERNEL //traditional nesting - produces correct ouput 
+//#undef KERNEL //traditional nesting - produces correct ouput 
 
 using POL2 = RAJA::omp_parallel_for_exec;
 using POL1 = RAJA::loop_exec;
-using POL0 = RAJA::loop_exec;
+using POL0 = RAJA::simd_exec;
 
 #define mu(i,j,k)     a_mu[base+i+ni*(j)+nij*(k)]
 #define la(i,j,k) a_lambda[base+i+ni*(j)+nij*(k)]

--- a/simd-issues/view.cpp
+++ b/simd-issues/view.cpp
@@ -1,0 +1,75 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-17, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-689114
+//
+// All rights reserved.
+//
+// This file is part of RAJA.
+//
+// For details about use and distribution, please read RAJA/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include <cstdlib>
+#include <iostream>
+#include <chrono>
+
+#include <time.h>       /* time */
+
+#include "RAJA/RAJA.hpp"
+#include "RAJA/util/defines.hpp"
+
+using arr_type = double; 
+
+#define nestedTest 1
+
+int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
+{
+
+
+  srand (time(NULL));
+  RAJA::Index_type stride = rand() % 50 + 1; 
+  RAJA::Index_type arrLen = stride*stride*stride;  
+  arr_type *A = new arr_type[arrLen];   
+  arr_type *B = new arr_type[arrLen];   
+  arr_type *C = new arr_type[arrLen];   
+  RAJA::View<arr_type, RAJA::Layout<3> > Aview(A,stride,stride,stride);
+  RAJA::View<arr_type, RAJA::Layout<3> > Bview(B,stride,stride,stride);
+  RAJA::View<arr_type, RAJA::Layout<3> > Cview(C,stride,stride,stride);
+  
+  for(int i=0; i<arrLen; ++i){
+    A[i] = 0.5;
+    B[i] = 2; 
+  }
+
+  RAJA::RangeSegment myStride(0,stride);
+
+  using POL = 
+    RAJA::KernelPolicy<
+    RAJA::statement::For<2, RAJA::omp_parallel_for_exec,
+    RAJA::statement::For<1, RAJA::loop_exec,
+    RAJA::statement::For<0, RAJA::simd_exec,
+    RAJA::statement::Lambda<0> > > > >;
+
+
+
+  RAJA::kernel<POL>(RAJA::make_tuple(myStride,myStride,myStride), [=] (RAJA::Index_type k, RAJA::Index_type j, 
+                                                                       RAJA::Index_type i){
+                      Cview(k,j,i) = Aview(k,j,i)*Bview(k,j,i) ;                                     
+                    });
+
+                   
+  double sum = 0.0;
+  for(int i=0; i<arrLen; ++i){
+    sum += C[i];
+  }
+
+  std::cout<<"arrLen should equal sum"<<std::endl;
+  std::cout<<"arrLen = "<<arrLen<<" "<<"sum = "<<sum<<std::endl;
+  assert(std::abs(arrLen-sum) < 1e-8);
+
+  return 0;
+}

--- a/simd-issues/view1.cpp
+++ b/simd-issues/view1.cpp
@@ -1,0 +1,85 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-17, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-689114
+//
+// All rights reserved.
+//
+// This file is part of RAJA.
+//
+// For details about use and distribution, please read RAJA/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include <cstdlib>
+#include <iostream>
+#include <chrono>
+
+#include <time.h>       /* time */
+
+#include "RAJA/RAJA.hpp"
+#include "RAJA/util/defines.hpp"
+
+using arr_type = double; 
+
+#define KERNEL //produces incorrect ouput
+//#undef KERNEL //traditional nesting - produces correct ouput 
+
+using POL = 
+  RAJA::KernelPolicy<
+  RAJA::statement::For<0, RAJA::simd_exec,
+  RAJA::statement::Lambda<0> > >;
+
+using POL0 = RAJA::simd_exec;
+
+int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
+{
+
+
+  srand (time(NULL));
+  RAJA::Index_type stride = rand() % 50 + 8; 
+  RAJA::Index_type arrLen = stride;  
+  arr_type *A = new arr_type[arrLen];   
+  arr_type *B = new arr_type[arrLen];   
+  arr_type *C = new arr_type[arrLen];   
+
+  for(int i=0; i<arrLen; ++i){
+    A[i] = 0.5;
+    B[i] = 2; 
+  }
+
+  RAJA::RangeSegment myStride(0,stride);
+
+  std::cout<<"stride = "<<stride<<std::endl;
+  
+
+#ifdef KERNEL
+  RAJA::kernel<POL>(RAJA::make_tuple(myStride), [=] (RAJA::Index_type i) {
+#else
+
+      //#pragma forceinline recursive
+      RAJA::forall<POL0>(myStride, [=] (RAJA::Index_type i){
+#endif
+	  
+	  C[i] = A[i]*B[i];
+	  
+#ifdef KERNEL
+	});
+#else                                          
+    });
+#endif  
+  
+  
+  double sum = 0.0;
+  for(int i=0; i<arrLen; ++i){
+    sum += C[i];
+  }
+  
+  std::cout<<"arrLen should equal sum"<<std::endl;
+  std::cout<<"arrLen = "<<arrLen<<" "<<"sum = "<<sum<<std::endl;
+  assert(std::abs(arrLen-sum) < 1e-8);
+
+  return 0;
+}

--- a/simd-issues/view2.cpp
+++ b/simd-issues/view2.cpp
@@ -1,0 +1,89 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-17, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-689114
+//
+// All rights reserved.
+//
+// This file is part of RAJA.
+//
+// For details about use and distribution, please read RAJA/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include <cstdlib>
+#include <iostream>
+#include <chrono>
+
+#include <time.h>       /* time */
+
+#include "RAJA/RAJA.hpp"
+#include "RAJA/util/defines.hpp"
+
+using arr_type = double; 
+
+#define KERNEL //produces incorrect ouput
+//#undef KERNEL //traditional nesting - produces correct ouput 
+
+using POL = 
+  RAJA::KernelPolicy<
+  RAJA::statement::For<1, RAJA::omp_parallel_for_exec,
+  RAJA::statement::For<0, RAJA::simd_exec,
+  RAJA::statement::Lambda<0> > > >;
+
+
+using POL1 = RAJA::omp_parallel_for_exec;
+using POL0 = RAJA::simd_exec;
+
+int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
+{
+
+
+  srand (time(NULL));
+  RAJA::Index_type stride = rand() % 50 + 8; 
+  RAJA::Index_type arrLen = stride*stride;  
+  arr_type *A = new arr_type[arrLen];   
+  arr_type *B = new arr_type[arrLen];   
+  arr_type *C = new arr_type[arrLen];   
+  
+  for(int i=0; i<arrLen; ++i){
+    A[i] = 0.5;
+    B[i] = 2; 
+  }
+
+  RAJA::RangeSegment myStride(0,stride);
+
+  std::cout<<"stride = "<<stride<<std::endl;
+  
+
+#ifdef KERNEL
+  RAJA::kernel<POL>(RAJA::make_tuple(myStride,myStride), [=] (RAJA::Index_type i, RAJA::Index_type j) {
+#else
+
+      RAJA::forall<POL1>(myStride, [=] (RAJA::Index_type j){
+	  RAJA::forall<POL0>(myStride, [=] (RAJA::Index_type i){
+#endif
+	      RAJA::Index_type id =  i + j*stride; 
+	      C[id] = A[id]*B[id];
+	      
+#ifdef KERNEL
+	    });
+#else                                          
+	});
+    });
+#endif  
+
+                   
+  double sum = 0.0;
+  for(int i=0; i<arrLen; ++i){
+    sum += C[i];
+  }
+
+  std::cout<<"arrLen should equal sum"<<std::endl;
+  std::cout<<"arrLen = "<<arrLen<<" "<<"sum = "<<sum<<std::endl;
+  assert(std::abs(arrLen-sum) < 1e-8);
+
+  return 0;
+}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -55,6 +55,10 @@ raja_add_test(
   SOURCES kernel.cpp)
 
 raja_add_test(
+  NAME simd
+  SOURCES simd.cpp)
+
+raja_add_test(
   NAME test-multipolicy
   SOURCES test-multipolicy.cpp)
 

--- a/test/unit/simd.cpp
+++ b/test/unit/simd.cpp
@@ -21,6 +21,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <chrono>
+#include <cmath>
 
 
 using namespace RAJA;
@@ -1115,7 +1116,7 @@ TEST(Kernel, SW4For){
 
   for(auto i=0; i<arr_len; ++i)
     {
-      double err = abs(a_lu_native[i]-a_lu_raja[i]);
+      double err = std::abs(a_lu_native[i]-a_lu_raja[i]);
       if(err > 1e-8){
 	pass = -1.0; 
       }
@@ -1196,7 +1197,7 @@ TEST(Kernel, SW4Nested){
 
   for(auto i=0; i<arr_len; ++i)
     {
-      double err = abs(a_lu_native[i]-a_lu_raja[i]);
+      double err = std::abs(a_lu_native[i]-a_lu_raja[i]);
       if(err > 1e-8){
 	pass = -1.0; 
       }

--- a/test/unit/simd.cpp
+++ b/test/unit/simd.cpp
@@ -1094,6 +1094,7 @@ TEST(Kernel, SW4For){
     {
       a_lu_native[i]  = 0.0; //output for the native version
       a_lu_raja[i]    = 0.0; //output for the raja version
+      a_u[i]       = rand() % 10 + 1;
     }
 
   for(auto i=0; i<arr_len; ++i)
@@ -1101,7 +1102,6 @@ TEST(Kernel, SW4For){
       a_acof[i]  = rand() % 10 + 1;
       a_bope[i]    = rand() % 10 + 1;
       a_ghcof[i]   = rand() % 10 + 1;
-      a_u[i]       = rand() % 10 + 1;
       a_mu[i]      = rand() % 10 + 1;
       a_lambda[i]  = rand() % 10 + 1;
       a_strx[i]    = rand() % 10 + 1;
@@ -1186,6 +1186,7 @@ TEST(Kernel, SW4Nested){
     {
       a_lu_native[i]  = 0.0; //output for the native version
       a_lu_raja[i]    = 0.0; //output for the raja version
+      a_u[i]       = rand() % 10 + 1;
     }
 
   for(auto i=0; i<arr_len; ++i)
@@ -1193,7 +1194,6 @@ TEST(Kernel, SW4Nested){
       a_acof[i]  = rand() % 10 + 1;
       a_bope[i]    = rand() % 10 + 1;
       a_ghcof[i]   = rand() % 10 + 1;
-      a_u[i]       = rand() % 10 + 1;
       a_mu[i]      = rand() % 10 + 1;
       a_lambda[i]  = rand() % 10 + 1;
       a_strx[i]    = rand() % 10 + 1;

--- a/test/unit/simd.cpp
+++ b/test/unit/simd.cpp
@@ -1,0 +1,1208 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
+// 
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-689114
+//
+// All rights reserved.
+//
+// This file is part of RAJA.
+//
+// For details about use and distribution, please read RAJA/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "RAJA/RAJA.hpp"
+#include "RAJA_gtest.hpp"
+
+#include <cstdio>
+#include <time.h>       /* time */
+#include <cstdlib>
+#include <iostream>
+#include <chrono>
+
+
+using namespace RAJA;
+using namespace RAJA::statement;
+
+TEST(Kernel, ViewNestedFor){
+
+  using arr_type = double;
+
+
+   srand (time(NULL));
+   RAJA::Index_type stride = rand() % 50 + 1; 
+   RAJA::Index_type arrLen = stride*stride*stride;  
+   arr_type *A = new arr_type[arrLen];   
+   arr_type *B = new arr_type[arrLen];   
+   arr_type *C = new arr_type[arrLen];   
+   RAJA::View<arr_type, RAJA::Layout<3> > Aview(A,stride,stride,stride);
+   RAJA::View<arr_type, RAJA::Layout<3> > Bview(B,stride,stride,stride);
+   RAJA::View<arr_type, RAJA::Layout<3> > Cview(C,stride,stride,stride);
+
+   for(int i=0; i<arrLen; ++i){
+     A[i] = 0.5;
+     B[i] = 2; 
+   }
+   
+   RAJA::RangeSegment myStride(0,stride);
+   using POL2 = RAJA::omp_parallel_for_exec;
+   using POL1 = RAJA::loop_exec;
+   using POL0 = RAJA::simd_exec;
+
+   RAJA::forall<POL2>(myStride, [=] (int k){
+    RAJA::forall<POL1>(myStride, [=] (int j){
+     RAJA::forall<POL0>(myStride, [=] (int i){
+
+       Cview(k,j,i) = Aview(k,j,i)*Bview(k,j,i);
+       });
+     });
+   });
+
+
+   //check output
+   for(int i=0; i<arrLen; ++i)
+     {
+       ASSERT_FLOAT_EQ(C[i], 1.0);
+     }
+  
+   
+}
+
+
+
+
+
+TEST(Kernel, ViewNested){
+
+  using arr_type = double;
+using POL = 
+  RAJA::KernelPolicy<
+    RAJA::statement::For<2, RAJA::omp_parallel_for_exec,
+    RAJA::statement::For<1, RAJA::loop_exec,
+    RAJA::statement::For<0, RAJA::simd_exec,
+			 RAJA::statement::Lambda<0> > > > >;
+
+   srand (time(NULL));
+   RAJA::Index_type stride = rand() % 50 + 1; 
+   RAJA::Index_type arrLen = stride*stride*stride;  
+   arr_type *A = new arr_type[arrLen];   
+   arr_type *B = new arr_type[arrLen];   
+   arr_type *C = new arr_type[arrLen];   
+   RAJA::View<arr_type, RAJA::Layout<3> > Aview(A,stride,stride,stride);
+   RAJA::View<arr_type, RAJA::Layout<3> > Bview(B,stride,stride,stride);
+   RAJA::View<arr_type, RAJA::Layout<3> > Cview(C,stride,stride,stride);
+
+   for(int i=0; i<arrLen; ++i){
+     A[i] = 0.5;
+     B[i] = 2; 
+   }
+   
+   RAJA::RangeSegment myStride(0,stride);
+
+   RAJA::kernel<POL>(RAJA::make_tuple(myStride,myStride,myStride), [=] (RAJA::Index_type k, 
+									RAJA::Index_type j, 
+									RAJA::Index_type i){
+		       Cview(k,j,i) = Aview(k,j,i)*Bview(k,j,i);
+		     });
+
+
+   //check output
+   for(int i=0; i<arrLen; ++i)
+     {
+       ASSERT_FLOAT_EQ(C[i], 1.0);
+     }
+  
+   
+}
+
+
+
+//----
+//---- [SW4 Kernel]
+///----
+#define float_sw4 double
+
+
+#define mu(i,j,k)     a_mu[base+i+ni*(j)+nij*(k)]
+#define la(i,j,k) a_lambda[base+i+ni*(j)+nij*(k)]
+
+  // Reversed indexation                                                                                            
+#define u(c,i,j,k)   a_u[base3+i+ni*(j)+nij*(k)+nijk*(c)]
+#define lu(c,i,j,k) a_lu[base3+i+ni*(j)+nij*(k)+nijk*(c)]
+#define strx(i) a_strx[i-ifirst0]
+#define stry(j) a_stry[j-jfirst0]
+#define strz(k) a_strz[k-kfirst0]
+#define acof(i,j,k) a_acof[(i-1)+6*(j-1)+48*(k-1)]
+#define bope(i,j) a_bope[i-1+6*(j-1)]
+#define ghcof(i) a_ghcof[i-1]
+
+
+void rhs4sg_rev_native( int ifirst, int ilast, int jfirst, int jlast, int kfirst, int klast,
+		 int nk, float_sw4* RAJA_RESTRICT a_acof, float_sw4 *RAJA_RESTRICT a_bope,
+		 float_sw4* RAJA_RESTRICT a_ghcof, float_sw4* RAJA_RESTRICT a_lu, float_sw4* RAJA_RESTRICT a_u,
+		 float_sw4* RAJA_RESTRICT a_mu, float_sw4* RAJA_RESTRICT a_lambda, 
+		 float_sw4 h, float_sw4* RAJA_RESTRICT a_strx, float_sw4* RAJA_RESTRICT a_stry, 
+		 float_sw4* RAJA_RESTRICT a_strz )
+{//raja fun start
+
+
+ // Direct reuse of fortran code by these macro definitions:
+#define mu(i,j,k)     a_mu[base+i+ni*(j)+nij*(k)]
+#define la(i,j,k) a_lambda[base+i+ni*(j)+nij*(k)]
+   // Reversed indexation
+#define u(c,i,j,k)   a_u[base3+i+ni*(j)+nij*(k)+nijk*(c)]   
+#define lu(c,i,j,k) a_lu[base3+i+ni*(j)+nij*(k)+nijk*(c)]   
+#define strx(i) a_strx[i-ifirst0]
+#define stry(j) a_stry[j-jfirst0]
+#define strz(k) a_strz[k-kfirst0]
+#define acof(i,j,k) a_acof[(i-1)+6*(j-1)+48*(k-1)]
+#define bope(i,j) a_bope[i-1+6*(j-1)]
+#define ghcof(i) a_ghcof[i-1]
+   
+   const float_sw4 a1   = 0;
+   const float_sw4 i6   = 1.0/6;
+   const float_sw4 i12  = 1.0/12;
+   const float_sw4 i144 = 1.0/144;
+   const float_sw4 tf   = 0.75;
+
+   const int ni    = ilast-ifirst+1;
+   const int nij   = ni*(jlast-jfirst+1);
+   const int nijk  = nij*(klast-kfirst+1);
+   const int base  = -(ifirst+ni*jfirst+nij*kfirst);
+   const int base3 = base-nijk;
+
+   const int nic  = 3*ni;
+   const int nijc = 3*nij;
+   const int ifirst0 = ifirst;
+   const int jfirst0 = jfirst;
+   const int kfirst0 = kfirst;
+
+
+   const float_sw4 cof = 1.0/(h*h);
+   
+   int k1 = 7; 
+   int k2 = 101;   
+   RAJA::RangeSegment k_range(k1,k2+1);
+   RAJA::RangeSegment j_range(jfirst+2,jlast-1);
+   RAJA::RangeSegment i_range(ifirst+2,ilast-1);
+
+#pragma omp parallel for                                                                                             
+   for(int  k= k1; k <= k2 ; k++ ){
+      for(int j=jfirst+2; j <= jlast-2 ; j++ ) {
+#pragma omp simd                                                                      
+#pragma ivdep                                                                                                     
+         //#pragma forceinline recursive 
+         for(int i=ifirst+2; i <= ilast-2 ; i++ )
+            {
+
+      float_sw4 mux1,mux2,mux3,mux4,muy1,muy2,muy3,muy4;
+      float_sw4 r1,r2,r3,mucof,mu1zz,mu2zz,mu3zz,lap2mu,q,u3zip2,u3zip1;
+      float_sw4 u3zim1,u3zim2,lau3zx,mu3xz,u3zjp2,u3zjp1,u3zjm1,u3zjm2,lau3zy;
+      float_sw4 mu3yz,mu1zx,u1zip2,u1zip1,u1zim1,u1zim2;
+      float_sw4 u2zjp2,u2zjp1,u2zjm1,u2zjm2,mu2zy,lau1xz,lau2yz,muz1,muz2,muz3,muz4;
+      
+/* from inner_loop_4a, 28x3 = 84 ops */
+            mux1 = mu(i-1,j,k)*strx(i-1)-
+	       tf*(mu(i,j,k)*strx(i)+mu(i-2,j,k)*strx(i-2));
+            mux2 = mu(i-2,j,k)*strx(i-2)+mu(i+1,j,k)*strx(i+1)+
+	       3*(mu(i,j,k)*strx(i)+mu(i-1,j,k)*strx(i-1));
+            mux3 = mu(i-1,j,k)*strx(i-1)+mu(i+2,j,k)*strx(i+2)+
+	       3*(mu(i+1,j,k)*strx(i+1)+mu(i,j,k)*strx(i));
+            mux4 = mu(i+1,j,k)*strx(i+1)-
+	       tf*(mu(i,j,k)*strx(i)+mu(i+2,j,k)*strx(i+2));
+
+            muy1 = mu(i,j-1,k)*stry(j-1)-
+	       tf*(mu(i,j,k)*stry(j)+mu(i,j-2,k)*stry(j-2));
+            muy2 = mu(i,j-2,k)*stry(j-2)+mu(i,j+1,k)*stry(j+1)+
+	       3*(mu(i,j,k)*stry(j)+mu(i,j-1,k)*stry(j-1));
+            muy3 = mu(i,j-1,k)*stry(j-1)+mu(i,j+2,k)*stry(j+2)+
+	       3*(mu(i,j+1,k)*stry(j+1)+mu(i,j,k)*stry(j));
+            muy4 = mu(i,j+1,k)*stry(j+1)-
+	       tf*(mu(i,j,k)*stry(j)+mu(i,j+2,k)*stry(j+2));
+
+            muz1 = mu(i,j,k-1)*strz(k-1)-
+	       tf*(mu(i,j,k)*strz(k)+mu(i,j,k-2)*strz(k-2));
+            muz2 = mu(i,j,k-2)*strz(k-2)+mu(i,j,k+1)*strz(k+1)+
+	       3*(mu(i,j,k)*strz(k)+mu(i,j,k-1)*strz(k-1));
+            muz3 = mu(i,j,k-1)*strz(k-1)+mu(i,j,k+2)*strz(k+2)+
+	       3*(mu(i,j,k+1)*strz(k+1)+mu(i,j,k)*strz(k));
+            muz4 = mu(i,j,k+1)*strz(k+1)-
+	       tf*(mu(i,j,k)*strz(k)+mu(i,j,k+2)*strz(k+2));
+/* xx, yy, and zz derivatives:*/
+/* 75 ops */
+            r1 = i6*( strx(i)*( (2*mux1+la(i-1,j,k)*strx(i-1)-
+               tf*(la(i,j,k)*strx(i)+la(i-2,j,k)*strx(i-2)))*
+                              (u(1,i-2,j,k)-u(1,i,j,k))+
+           (2*mux2+la(i-2,j,k)*strx(i-2)+la(i+1,j,k)*strx(i+1)+
+                3*(la(i,j,k)*strx(i)+la(i-1,j,k)*strx(i-1)))*
+                              (u(1,i-1,j,k)-u(1,i,j,k))+ 
+           (2*mux3+la(i-1,j,k)*strx(i-1)+la(i+2,j,k)*strx(i+2)+
+                3*(la(i+1,j,k)*strx(i+1)+la(i,j,k)*strx(i)))*
+                              (u(1,i+1,j,k)-u(1,i,j,k))+
+                (2*mux4+ la(i+1,j,k)*strx(i+1)-
+               tf*(la(i,j,k)*strx(i)+la(i+2,j,k)*strx(i+2)))*
+                (u(1,i+2,j,k)-u(1,i,j,k)) ) + stry(j)*(
+                     muy1*(u(1,i,j-2,k)-u(1,i,j,k)) + 
+                     muy2*(u(1,i,j-1,k)-u(1,i,j,k)) + 
+                     muy3*(u(1,i,j+1,k)-u(1,i,j,k)) +
+                     muy4*(u(1,i,j+2,k)-u(1,i,j,k)) ) + strz(k)*(
+                     muz1*(u(1,i,j,k-2)-u(1,i,j,k)) + 
+                     muz2*(u(1,i,j,k-1)-u(1,i,j,k)) + 
+                     muz3*(u(1,i,j,k+1)-u(1,i,j,k)) +
+                     muz4*(u(1,i,j,k+2)-u(1,i,j,k)) ) );
+
+/* 75 ops */
+            r2 = i6*( strx(i)*(mux1*(u(2,i-2,j,k)-u(2,i,j,k)) + 
+                      mux2*(u(2,i-1,j,k)-u(2,i,j,k)) + 
+                      mux3*(u(2,i+1,j,k)-u(2,i,j,k)) +
+                      mux4*(u(2,i+2,j,k)-u(2,i,j,k)) ) + stry(j)*(
+                  (2*muy1+la(i,j-1,k)*stry(j-1)-
+                      tf*(la(i,j,k)*stry(j)+la(i,j-2,k)*stry(j-2)))*
+                          (u(2,i,j-2,k)-u(2,i,j,k))+
+           (2*muy2+la(i,j-2,k)*stry(j-2)+la(i,j+1,k)*stry(j+1)+
+                     3*(la(i,j,k)*stry(j)+la(i,j-1,k)*stry(j-1)))*
+                          (u(2,i,j-1,k)-u(2,i,j,k))+ 
+           (2*muy3+la(i,j-1,k)*stry(j-1)+la(i,j+2,k)*stry(j+2)+
+                     3*(la(i,j+1,k)*stry(j+1)+la(i,j,k)*stry(j)))*
+                          (u(2,i,j+1,k)-u(2,i,j,k))+
+                  (2*muy4+la(i,j+1,k)*stry(j+1)-
+                    tf*(la(i,j,k)*stry(j)+la(i,j+2,k)*stry(j+2)))*
+                          (u(2,i,j+2,k)-u(2,i,j,k)) ) + strz(k)*(
+                     muz1*(u(2,i,j,k-2)-u(2,i,j,k)) + 
+                     muz2*(u(2,i,j,k-1)-u(2,i,j,k)) + 
+                     muz3*(u(2,i,j,k+1)-u(2,i,j,k)) +
+                     muz4*(u(2,i,j,k+2)-u(2,i,j,k)) ) );
+
+/* 75 ops */
+            r3 = i6*( strx(i)*(mux1*(u(3,i-2,j,k)-u(3,i,j,k)) + 
+                      mux2*(u(3,i-1,j,k)-u(3,i,j,k)) + 
+                      mux3*(u(3,i+1,j,k)-u(3,i,j,k)) +
+                      mux4*(u(3,i+2,j,k)-u(3,i,j,k))  ) + stry(j)*(
+                     muy1*(u(3,i,j-2,k)-u(3,i,j,k)) + 
+                     muy2*(u(3,i,j-1,k)-u(3,i,j,k)) + 
+                     muy3*(u(3,i,j+1,k)-u(3,i,j,k)) +
+                     muy4*(u(3,i,j+2,k)-u(3,i,j,k)) ) + strz(k)*(
+                  (2*muz1+la(i,j,k-1)*strz(k-1)-
+                      tf*(la(i,j,k)*strz(k)+la(i,j,k-2)*strz(k-2)))*
+                          (u(3,i,j,k-2)-u(3,i,j,k))+
+           (2*muz2+la(i,j,k-2)*strz(k-2)+la(i,j,k+1)*strz(k+1)+
+                      3*(la(i,j,k)*strz(k)+la(i,j,k-1)*strz(k-1)))*
+                          (u(3,i,j,k-1)-u(3,i,j,k))+ 
+           (2*muz3+la(i,j,k-1)*strz(k-1)+la(i,j,k+2)*strz(k+2)+
+                      3*(la(i,j,k+1)*strz(k+1)+la(i,j,k)*strz(k)))*
+                          (u(3,i,j,k+1)-u(3,i,j,k))+
+                  (2*muz4+la(i,j,k+1)*strz(k+1)-
+                    tf*(la(i,j,k)*strz(k)+la(i,j,k+2)*strz(k+2)))*
+		  (u(3,i,j,k+2)-u(3,i,j,k)) ) );
+
+
+/* Mixed derivatives: */
+/* 29ops /mixed derivative */
+/* 116 ops for r1 */
+/*   (la*v_y)_x */
+            r1 = r1 + strx(i)*stry(j)*
+                 i144*( la(i-2,j,k)*(u(2,i-2,j-2,k)-u(2,i-2,j+2,k)+
+                             8*(-u(2,i-2,j-1,k)+u(2,i-2,j+1,k))) - 8*(
+                        la(i-1,j,k)*(u(2,i-1,j-2,k)-u(2,i-1,j+2,k)+
+                             8*(-u(2,i-1,j-1,k)+u(2,i-1,j+1,k))) )+8*(
+                        la(i+1,j,k)*(u(2,i+1,j-2,k)-u(2,i+1,j+2,k)+
+                             8*(-u(2,i+1,j-1,k)+u(2,i+1,j+1,k))) ) - (
+                        la(i+2,j,k)*(u(2,i+2,j-2,k)-u(2,i+2,j+2,k)+
+                             8*(-u(2,i+2,j-1,k)+u(2,i+2,j+1,k))) )) 
+/*   (la*w_z)_x */
+               + strx(i)*strz(k)*       
+                 i144*( la(i-2,j,k)*(u(3,i-2,j,k-2)-u(3,i-2,j,k+2)+
+                             8*(-u(3,i-2,j,k-1)+u(3,i-2,j,k+1))) - 8*(
+                        la(i-1,j,k)*(u(3,i-1,j,k-2)-u(3,i-1,j,k+2)+
+                             8*(-u(3,i-1,j,k-1)+u(3,i-1,j,k+1))) )+8*(
+                        la(i+1,j,k)*(u(3,i+1,j,k-2)-u(3,i+1,j,k+2)+
+                             8*(-u(3,i+1,j,k-1)+u(3,i+1,j,k+1))) ) - (
+                        la(i+2,j,k)*(u(3,i+2,j,k-2)-u(3,i+2,j,k+2)+
+                             8*(-u(3,i+2,j,k-1)+u(3,i+2,j,k+1))) )) 
+/*   (mu*v_x)_y */
+               + strx(i)*stry(j)*       
+                 i144*( mu(i,j-2,k)*(u(2,i-2,j-2,k)-u(2,i+2,j-2,k)+
+                             8*(-u(2,i-1,j-2,k)+u(2,i+1,j-2,k))) - 8*(
+                        mu(i,j-1,k)*(u(2,i-2,j-1,k)-u(2,i+2,j-1,k)+
+                             8*(-u(2,i-1,j-1,k)+u(2,i+1,j-1,k))) )+8*(
+                        mu(i,j+1,k)*(u(2,i-2,j+1,k)-u(2,i+2,j+1,k)+
+                             8*(-u(2,i-1,j+1,k)+u(2,i+1,j+1,k))) ) - (
+                        mu(i,j+2,k)*(u(2,i-2,j+2,k)-u(2,i+2,j+2,k)+
+                             8*(-u(2,i-1,j+2,k)+u(2,i+1,j+2,k))) )) 
+/*   (mu*w_x)_z */
+               + strx(i)*strz(k)*       
+                 i144*( mu(i,j,k-2)*(u(3,i-2,j,k-2)-u(3,i+2,j,k-2)+
+                             8*(-u(3,i-1,j,k-2)+u(3,i+1,j,k-2))) - 8*(
+                        mu(i,j,k-1)*(u(3,i-2,j,k-1)-u(3,i+2,j,k-1)+
+                             8*(-u(3,i-1,j,k-1)+u(3,i+1,j,k-1))) )+8*(
+                        mu(i,j,k+1)*(u(3,i-2,j,k+1)-u(3,i+2,j,k+1)+
+                             8*(-u(3,i-1,j,k+1)+u(3,i+1,j,k+1))) ) - (
+                        mu(i,j,k+2)*(u(3,i-2,j,k+2)-u(3,i+2,j,k+2)+
+				     8*(-u(3,i-1,j,k+2)+u(3,i+1,j,k+2))) )) ;
+
+/* 116 ops for r2 */
+/*   (mu*u_y)_x */
+            r2 = r2 + strx(i)*stry(j)*
+                 i144*( mu(i-2,j,k)*(u(1,i-2,j-2,k)-u(1,i-2,j+2,k)+
+                             8*(-u(1,i-2,j-1,k)+u(1,i-2,j+1,k))) - 8*(
+                        mu(i-1,j,k)*(u(1,i-1,j-2,k)-u(1,i-1,j+2,k)+
+                             8*(-u(1,i-1,j-1,k)+u(1,i-1,j+1,k))) )+8*(
+                        mu(i+1,j,k)*(u(1,i+1,j-2,k)-u(1,i+1,j+2,k)+
+                             8*(-u(1,i+1,j-1,k)+u(1,i+1,j+1,k))) ) - (
+                        mu(i+2,j,k)*(u(1,i+2,j-2,k)-u(1,i+2,j+2,k)+
+                             8*(-u(1,i+2,j-1,k)+u(1,i+2,j+1,k))) )) 
+/* (la*u_x)_y */
+              + strx(i)*stry(j)*
+                 i144*( la(i,j-2,k)*(u(1,i-2,j-2,k)-u(1,i+2,j-2,k)+
+                             8*(-u(1,i-1,j-2,k)+u(1,i+1,j-2,k))) - 8*(
+                        la(i,j-1,k)*(u(1,i-2,j-1,k)-u(1,i+2,j-1,k)+
+                             8*(-u(1,i-1,j-1,k)+u(1,i+1,j-1,k))) )+8*(
+                        la(i,j+1,k)*(u(1,i-2,j+1,k)-u(1,i+2,j+1,k)+
+                             8*(-u(1,i-1,j+1,k)+u(1,i+1,j+1,k))) ) - (
+                        la(i,j+2,k)*(u(1,i-2,j+2,k)-u(1,i+2,j+2,k)+
+                             8*(-u(1,i-1,j+2,k)+u(1,i+1,j+2,k))) )) 
+/* (la*w_z)_y */
+               + stry(j)*strz(k)*
+                 i144*( la(i,j-2,k)*(u(3,i,j-2,k-2)-u(3,i,j-2,k+2)+
+                             8*(-u(3,i,j-2,k-1)+u(3,i,j-2,k+1))) - 8*(
+                        la(i,j-1,k)*(u(3,i,j-1,k-2)-u(3,i,j-1,k+2)+
+                             8*(-u(3,i,j-1,k-1)+u(3,i,j-1,k+1))) )+8*(
+                        la(i,j+1,k)*(u(3,i,j+1,k-2)-u(3,i,j+1,k+2)+
+                             8*(-u(3,i,j+1,k-1)+u(3,i,j+1,k+1))) ) - (
+                        la(i,j+2,k)*(u(3,i,j+2,k-2)-u(3,i,j+2,k+2)+
+                             8*(-u(3,i,j+2,k-1)+u(3,i,j+2,k+1))) ))
+/* (mu*w_y)_z */
+               + stry(j)*strz(k)*
+                 i144*( mu(i,j,k-2)*(u(3,i,j-2,k-2)-u(3,i,j+2,k-2)+
+                             8*(-u(3,i,j-1,k-2)+u(3,i,j+1,k-2))) - 8*(
+                        mu(i,j,k-1)*(u(3,i,j-2,k-1)-u(3,i,j+2,k-1)+
+                             8*(-u(3,i,j-1,k-1)+u(3,i,j+1,k-1))) )+8*(
+                        mu(i,j,k+1)*(u(3,i,j-2,k+1)-u(3,i,j+2,k+1)+
+                             8*(-u(3,i,j-1,k+1)+u(3,i,j+1,k+1))) ) - (
+                        mu(i,j,k+2)*(u(3,i,j-2,k+2)-u(3,i,j+2,k+2)+
+				     8*(-u(3,i,j-1,k+2)+u(3,i,j+1,k+2))) )) ;
+/* 116 ops for r3 */
+/*  (mu*u_z)_x */
+            r3 = r3 + strx(i)*strz(k)*
+                 i144*( mu(i-2,j,k)*(u(1,i-2,j,k-2)-u(1,i-2,j,k+2)+
+                             8*(-u(1,i-2,j,k-1)+u(1,i-2,j,k+1))) - 8*(
+                        mu(i-1,j,k)*(u(1,i-1,j,k-2)-u(1,i-1,j,k+2)+
+                             8*(-u(1,i-1,j,k-1)+u(1,i-1,j,k+1))) )+8*(
+                        mu(i+1,j,k)*(u(1,i+1,j,k-2)-u(1,i+1,j,k+2)+
+                             8*(-u(1,i+1,j,k-1)+u(1,i+1,j,k+1))) ) - (
+                        mu(i+2,j,k)*(u(1,i+2,j,k-2)-u(1,i+2,j,k+2)+
+                             8*(-u(1,i+2,j,k-1)+u(1,i+2,j,k+1))) )) 
+/* (mu*v_z)_y */
+              + stry(j)*strz(k)*
+                 i144*( mu(i,j-2,k)*(u(2,i,j-2,k-2)-u(2,i,j-2,k+2)+
+                             8*(-u(2,i,j-2,k-1)+u(2,i,j-2,k+1))) - 8*(
+                        mu(i,j-1,k)*(u(2,i,j-1,k-2)-u(2,i,j-1,k+2)+
+                             8*(-u(2,i,j-1,k-1)+u(2,i,j-1,k+1))) )+8*(
+                        mu(i,j+1,k)*(u(2,i,j+1,k-2)-u(2,i,j+1,k+2)+
+                             8*(-u(2,i,j+1,k-1)+u(2,i,j+1,k+1))) ) - (
+                        mu(i,j+2,k)*(u(2,i,j+2,k-2)-u(2,i,j+2,k+2)+
+                             8*(-u(2,i,j+2,k-1)+u(2,i,j+2,k+1))) ))
+/*   (la*u_x)_z */
+              + strx(i)*strz(k)*
+                 i144*( la(i,j,k-2)*(u(1,i-2,j,k-2)-u(1,i+2,j,k-2)+
+                             8*(-u(1,i-1,j,k-2)+u(1,i+1,j,k-2))) - 8*(
+                        la(i,j,k-1)*(u(1,i-2,j,k-1)-u(1,i+2,j,k-1)+
+                             8*(-u(1,i-1,j,k-1)+u(1,i+1,j,k-1))) )+8*(
+                        la(i,j,k+1)*(u(1,i-2,j,k+1)-u(1,i+2,j,k+1)+
+                             8*(-u(1,i-1,j,k+1)+u(1,i+1,j,k+1))) ) - (
+                        la(i,j,k+2)*(u(1,i-2,j,k+2)-u(1,i+2,j,k+2)+
+                             8*(-u(1,i-1,j,k+2)+u(1,i+1,j,k+2))) )) 
+/* (la*v_y)_z */
+              + stry(j)*strz(k)*
+                 i144*( la(i,j,k-2)*(u(2,i,j-2,k-2)-u(2,i,j+2,k-2)+
+                             8*(-u(2,i,j-1,k-2)+u(2,i,j+1,k-2))) - 8*(
+                        la(i,j,k-1)*(u(2,i,j-2,k-1)-u(2,i,j+2,k-1)+
+                             8*(-u(2,i,j-1,k-1)+u(2,i,j+1,k-1))) )+8*(
+                        la(i,j,k+1)*(u(2,i,j-2,k+1)-u(2,i,j+2,k+1)+
+                             8*(-u(2,i,j-1,k+1)+u(2,i,j+1,k+1))) ) - (
+                        la(i,j,k+2)*(u(2,i,j-2,k+2)-u(2,i,j+2,k+2)+
+				     8*(-u(2,i,j-1,k+2)+u(2,i,j+1,k+2))) )) ;
+
+/* 9 ops */
+//	    lu(1,i,j,k) = a1*lu(1,i,j,k) + cof*r1;
+//            lu(2,i,j,k) = a1*lu(2,i,j,k) + cof*r2;
+//            lu(3,i,j,k) = a1*lu(3,i,j,k) + cof*r3;
+            lu(1,i,j,k) =  cof*r1;
+            lu(2,i,j,k) =  cof*r2;
+            lu(3,i,j,k) =  cof*r3;
+            }
+      }
+   }
+
+
+}//end brace
+
+//RAJA version
+void rhs4sg_rev_raja_Nested( int ifirst, int ilast, int jfirst, int jlast, int kfirst, int klast,
+		 int nk, float_sw4* RAJA_RESTRICT a_acof, float_sw4 *RAJA_RESTRICT a_bope,
+		 float_sw4* RAJA_RESTRICT a_ghcof, float_sw4* RAJA_RESTRICT a_lu, float_sw4* RAJA_RESTRICT a_u,
+		 float_sw4* RAJA_RESTRICT a_mu, float_sw4* RAJA_RESTRICT a_lambda, 
+		 float_sw4 h, float_sw4* RAJA_RESTRICT a_strx, float_sw4* RAJA_RESTRICT a_stry, 
+		 float_sw4* RAJA_RESTRICT a_strz )
+{//raja fun start
+
+
+
+ // Direct reuse of fortran code by these macro definitions:
+#define mu(i,j,k)     a_mu[base+i+ni*(j)+nij*(k)]
+#define la(i,j,k) a_lambda[base+i+ni*(j)+nij*(k)]
+   // Reversed indexation
+#define u(c,i,j,k)   a_u[base3+i+ni*(j)+nij*(k)+nijk*(c)]   
+#define lu(c,i,j,k) a_lu[base3+i+ni*(j)+nij*(k)+nijk*(c)]   
+#define strx(i) a_strx[i-ifirst0]
+#define stry(j) a_stry[j-jfirst0]
+#define strz(k) a_strz[k-kfirst0]
+#define acof(i,j,k) a_acof[(i-1)+6*(j-1)+48*(k-1)]
+#define bope(i,j) a_bope[i-1+6*(j-1)]
+#define ghcof(i) a_ghcof[i-1]
+   
+   const float_sw4 a1   = 0;
+   const float_sw4 i6   = 1.0/6;
+   const float_sw4 i12  = 1.0/12;
+   const float_sw4 i144 = 1.0/144;
+   const float_sw4 tf   = 0.75;
+
+   const int ni    = ilast-ifirst+1;
+   const int nij   = ni*(jlast-jfirst+1);
+   const int nijk  = nij*(klast-kfirst+1);
+   const int base  = -(ifirst+ni*jfirst+nij*kfirst);
+   const int base3 = base-nijk;
+
+   const int nic  = 3*ni;
+   const int nijc = 3*nij;
+   const int ifirst0 = ifirst;
+   const int jfirst0 = jfirst;
+   const int kfirst0 = kfirst;
+
+
+   const float_sw4 cof = 1.0/(h*h);
+   
+   int k1 = 7; 
+   int k2 = 101;   
+   RAJA::RangeSegment k_range(k1,k2+1);
+   RAJA::RangeSegment j_range(jfirst+2,jlast-1);
+   RAJA::RangeSegment i_range(ifirst+2,ilast-1);
+
+   using POL = 
+     RAJA::KernelPolicy<
+       RAJA::statement::For<2, RAJA::omp_parallel_for_exec,
+			    RAJA::statement::For<1, RAJA::loop_exec,
+			    RAJA::statement::For<0, RAJA::simd_exec,
+						 RAJA::statement::Lambda<0> > > > >;
+
+   RAJA::kernel<POL>(RAJA::make_tuple(i_range,j_range,k_range),
+                     [=] (int i, int j, int k) {
+
+      float_sw4 mux1,mux2,mux3,mux4,muy1,muy2,muy3,muy4;
+      float_sw4 r1,r2,r3,mucof,mu1zz,mu2zz,mu3zz,lap2mu,q,u3zip2,u3zip1;
+      float_sw4 u3zim1,u3zim2,lau3zx,mu3xz,u3zjp2,u3zjp1,u3zjm1,u3zjm2,lau3zy;
+      float_sw4 mu3yz,mu1zx,u1zip2,u1zip1,u1zim1,u1zim2;
+      float_sw4 u2zjp2,u2zjp1,u2zjm1,u2zjm2,mu2zy,lau1xz,lau2yz,muz1,muz2,muz3,muz4;
+      
+/* from inner_loop_4a, 28x3 = 84 ops */
+            mux1 = mu(i-1,j,k)*strx(i-1)-
+	       tf*(mu(i,j,k)*strx(i)+mu(i-2,j,k)*strx(i-2));
+            mux2 = mu(i-2,j,k)*strx(i-2)+mu(i+1,j,k)*strx(i+1)+
+	       3*(mu(i,j,k)*strx(i)+mu(i-1,j,k)*strx(i-1));
+            mux3 = mu(i-1,j,k)*strx(i-1)+mu(i+2,j,k)*strx(i+2)+
+	       3*(mu(i+1,j,k)*strx(i+1)+mu(i,j,k)*strx(i));
+            mux4 = mu(i+1,j,k)*strx(i+1)-
+	       tf*(mu(i,j,k)*strx(i)+mu(i+2,j,k)*strx(i+2));
+
+            muy1 = mu(i,j-1,k)*stry(j-1)-
+	       tf*(mu(i,j,k)*stry(j)+mu(i,j-2,k)*stry(j-2));
+            muy2 = mu(i,j-2,k)*stry(j-2)+mu(i,j+1,k)*stry(j+1)+
+	       3*(mu(i,j,k)*stry(j)+mu(i,j-1,k)*stry(j-1));
+            muy3 = mu(i,j-1,k)*stry(j-1)+mu(i,j+2,k)*stry(j+2)+
+	       3*(mu(i,j+1,k)*stry(j+1)+mu(i,j,k)*stry(j));
+            muy4 = mu(i,j+1,k)*stry(j+1)-
+	       tf*(mu(i,j,k)*stry(j)+mu(i,j+2,k)*stry(j+2));
+
+            muz1 = mu(i,j,k-1)*strz(k-1)-
+	       tf*(mu(i,j,k)*strz(k)+mu(i,j,k-2)*strz(k-2));
+            muz2 = mu(i,j,k-2)*strz(k-2)+mu(i,j,k+1)*strz(k+1)+
+	       3*(mu(i,j,k)*strz(k)+mu(i,j,k-1)*strz(k-1));
+            muz3 = mu(i,j,k-1)*strz(k-1)+mu(i,j,k+2)*strz(k+2)+
+	       3*(mu(i,j,k+1)*strz(k+1)+mu(i,j,k)*strz(k));
+            muz4 = mu(i,j,k+1)*strz(k+1)-
+	       tf*(mu(i,j,k)*strz(k)+mu(i,j,k+2)*strz(k+2));
+/* xx, yy, and zz derivatives:*/
+/* 75 ops */
+            r1 = i6*( strx(i)*( (2*mux1+la(i-1,j,k)*strx(i-1)-
+               tf*(la(i,j,k)*strx(i)+la(i-2,j,k)*strx(i-2)))*
+                              (u(1,i-2,j,k)-u(1,i,j,k))+
+           (2*mux2+la(i-2,j,k)*strx(i-2)+la(i+1,j,k)*strx(i+1)+
+                3*(la(i,j,k)*strx(i)+la(i-1,j,k)*strx(i-1)))*
+                              (u(1,i-1,j,k)-u(1,i,j,k))+ 
+           (2*mux3+la(i-1,j,k)*strx(i-1)+la(i+2,j,k)*strx(i+2)+
+                3*(la(i+1,j,k)*strx(i+1)+la(i,j,k)*strx(i)))*
+                              (u(1,i+1,j,k)-u(1,i,j,k))+
+                (2*mux4+ la(i+1,j,k)*strx(i+1)-
+               tf*(la(i,j,k)*strx(i)+la(i+2,j,k)*strx(i+2)))*
+                (u(1,i+2,j,k)-u(1,i,j,k)) ) + stry(j)*(
+                     muy1*(u(1,i,j-2,k)-u(1,i,j,k)) + 
+                     muy2*(u(1,i,j-1,k)-u(1,i,j,k)) + 
+                     muy3*(u(1,i,j+1,k)-u(1,i,j,k)) +
+                     muy4*(u(1,i,j+2,k)-u(1,i,j,k)) ) + strz(k)*(
+                     muz1*(u(1,i,j,k-2)-u(1,i,j,k)) + 
+                     muz2*(u(1,i,j,k-1)-u(1,i,j,k)) + 
+                     muz3*(u(1,i,j,k+1)-u(1,i,j,k)) +
+                     muz4*(u(1,i,j,k+2)-u(1,i,j,k)) ) );
+
+/* 75 ops */
+            r2 = i6*( strx(i)*(mux1*(u(2,i-2,j,k)-u(2,i,j,k)) + 
+                      mux2*(u(2,i-1,j,k)-u(2,i,j,k)) + 
+                      mux3*(u(2,i+1,j,k)-u(2,i,j,k)) +
+                      mux4*(u(2,i+2,j,k)-u(2,i,j,k)) ) + stry(j)*(
+                  (2*muy1+la(i,j-1,k)*stry(j-1)-
+                      tf*(la(i,j,k)*stry(j)+la(i,j-2,k)*stry(j-2)))*
+                          (u(2,i,j-2,k)-u(2,i,j,k))+
+           (2*muy2+la(i,j-2,k)*stry(j-2)+la(i,j+1,k)*stry(j+1)+
+                     3*(la(i,j,k)*stry(j)+la(i,j-1,k)*stry(j-1)))*
+                          (u(2,i,j-1,k)-u(2,i,j,k))+ 
+           (2*muy3+la(i,j-1,k)*stry(j-1)+la(i,j+2,k)*stry(j+2)+
+                     3*(la(i,j+1,k)*stry(j+1)+la(i,j,k)*stry(j)))*
+                          (u(2,i,j+1,k)-u(2,i,j,k))+
+                  (2*muy4+la(i,j+1,k)*stry(j+1)-
+                    tf*(la(i,j,k)*stry(j)+la(i,j+2,k)*stry(j+2)))*
+                          (u(2,i,j+2,k)-u(2,i,j,k)) ) + strz(k)*(
+                     muz1*(u(2,i,j,k-2)-u(2,i,j,k)) + 
+                     muz2*(u(2,i,j,k-1)-u(2,i,j,k)) + 
+                     muz3*(u(2,i,j,k+1)-u(2,i,j,k)) +
+                     muz4*(u(2,i,j,k+2)-u(2,i,j,k)) ) );
+
+/* 75 ops */
+            r3 = i6*( strx(i)*(mux1*(u(3,i-2,j,k)-u(3,i,j,k)) + 
+                      mux2*(u(3,i-1,j,k)-u(3,i,j,k)) + 
+                      mux3*(u(3,i+1,j,k)-u(3,i,j,k)) +
+                      mux4*(u(3,i+2,j,k)-u(3,i,j,k))  ) + stry(j)*(
+                     muy1*(u(3,i,j-2,k)-u(3,i,j,k)) + 
+                     muy2*(u(3,i,j-1,k)-u(3,i,j,k)) + 
+                     muy3*(u(3,i,j+1,k)-u(3,i,j,k)) +
+                     muy4*(u(3,i,j+2,k)-u(3,i,j,k)) ) + strz(k)*(
+                  (2*muz1+la(i,j,k-1)*strz(k-1)-
+                      tf*(la(i,j,k)*strz(k)+la(i,j,k-2)*strz(k-2)))*
+                          (u(3,i,j,k-2)-u(3,i,j,k))+
+           (2*muz2+la(i,j,k-2)*strz(k-2)+la(i,j,k+1)*strz(k+1)+
+                      3*(la(i,j,k)*strz(k)+la(i,j,k-1)*strz(k-1)))*
+                          (u(3,i,j,k-1)-u(3,i,j,k))+ 
+           (2*muz3+la(i,j,k-1)*strz(k-1)+la(i,j,k+2)*strz(k+2)+
+                      3*(la(i,j,k+1)*strz(k+1)+la(i,j,k)*strz(k)))*
+                          (u(3,i,j,k+1)-u(3,i,j,k))+
+                  (2*muz4+la(i,j,k+1)*strz(k+1)-
+                    tf*(la(i,j,k)*strz(k)+la(i,j,k+2)*strz(k+2)))*
+		  (u(3,i,j,k+2)-u(3,i,j,k)) ) );
+
+
+/* Mixed derivatives: */
+/* 29ops /mixed derivative */
+/* 116 ops for r1 */
+/*   (la*v_y)_x */
+            r1 = r1 + strx(i)*stry(j)*
+                 i144*( la(i-2,j,k)*(u(2,i-2,j-2,k)-u(2,i-2,j+2,k)+
+                             8*(-u(2,i-2,j-1,k)+u(2,i-2,j+1,k))) - 8*(
+                        la(i-1,j,k)*(u(2,i-1,j-2,k)-u(2,i-1,j+2,k)+
+                             8*(-u(2,i-1,j-1,k)+u(2,i-1,j+1,k))) )+8*(
+                        la(i+1,j,k)*(u(2,i+1,j-2,k)-u(2,i+1,j+2,k)+
+                             8*(-u(2,i+1,j-1,k)+u(2,i+1,j+1,k))) ) - (
+                        la(i+2,j,k)*(u(2,i+2,j-2,k)-u(2,i+2,j+2,k)+
+                             8*(-u(2,i+2,j-1,k)+u(2,i+2,j+1,k))) )) 
+/*   (la*w_z)_x */
+               + strx(i)*strz(k)*       
+                 i144*( la(i-2,j,k)*(u(3,i-2,j,k-2)-u(3,i-2,j,k+2)+
+                             8*(-u(3,i-2,j,k-1)+u(3,i-2,j,k+1))) - 8*(
+                        la(i-1,j,k)*(u(3,i-1,j,k-2)-u(3,i-1,j,k+2)+
+                             8*(-u(3,i-1,j,k-1)+u(3,i-1,j,k+1))) )+8*(
+                        la(i+1,j,k)*(u(3,i+1,j,k-2)-u(3,i+1,j,k+2)+
+                             8*(-u(3,i+1,j,k-1)+u(3,i+1,j,k+1))) ) - (
+                        la(i+2,j,k)*(u(3,i+2,j,k-2)-u(3,i+2,j,k+2)+
+                             8*(-u(3,i+2,j,k-1)+u(3,i+2,j,k+1))) )) 
+/*   (mu*v_x)_y */
+               + strx(i)*stry(j)*       
+                 i144*( mu(i,j-2,k)*(u(2,i-2,j-2,k)-u(2,i+2,j-2,k)+
+                             8*(-u(2,i-1,j-2,k)+u(2,i+1,j-2,k))) - 8*(
+                        mu(i,j-1,k)*(u(2,i-2,j-1,k)-u(2,i+2,j-1,k)+
+                             8*(-u(2,i-1,j-1,k)+u(2,i+1,j-1,k))) )+8*(
+                        mu(i,j+1,k)*(u(2,i-2,j+1,k)-u(2,i+2,j+1,k)+
+                             8*(-u(2,i-1,j+1,k)+u(2,i+1,j+1,k))) ) - (
+                        mu(i,j+2,k)*(u(2,i-2,j+2,k)-u(2,i+2,j+2,k)+
+                             8*(-u(2,i-1,j+2,k)+u(2,i+1,j+2,k))) )) 
+/*   (mu*w_x)_z */
+               + strx(i)*strz(k)*       
+                 i144*( mu(i,j,k-2)*(u(3,i-2,j,k-2)-u(3,i+2,j,k-2)+
+                             8*(-u(3,i-1,j,k-2)+u(3,i+1,j,k-2))) - 8*(
+                        mu(i,j,k-1)*(u(3,i-2,j,k-1)-u(3,i+2,j,k-1)+
+                             8*(-u(3,i-1,j,k-1)+u(3,i+1,j,k-1))) )+8*(
+                        mu(i,j,k+1)*(u(3,i-2,j,k+1)-u(3,i+2,j,k+1)+
+                             8*(-u(3,i-1,j,k+1)+u(3,i+1,j,k+1))) ) - (
+                        mu(i,j,k+2)*(u(3,i-2,j,k+2)-u(3,i+2,j,k+2)+
+				     8*(-u(3,i-1,j,k+2)+u(3,i+1,j,k+2))) )) ;
+
+/* 116 ops for r2 */
+/*   (mu*u_y)_x */
+            r2 = r2 + strx(i)*stry(j)*
+                 i144*( mu(i-2,j,k)*(u(1,i-2,j-2,k)-u(1,i-2,j+2,k)+
+                             8*(-u(1,i-2,j-1,k)+u(1,i-2,j+1,k))) - 8*(
+                        mu(i-1,j,k)*(u(1,i-1,j-2,k)-u(1,i-1,j+2,k)+
+                             8*(-u(1,i-1,j-1,k)+u(1,i-1,j+1,k))) )+8*(
+                        mu(i+1,j,k)*(u(1,i+1,j-2,k)-u(1,i+1,j+2,k)+
+                             8*(-u(1,i+1,j-1,k)+u(1,i+1,j+1,k))) ) - (
+                        mu(i+2,j,k)*(u(1,i+2,j-2,k)-u(1,i+2,j+2,k)+
+                             8*(-u(1,i+2,j-1,k)+u(1,i+2,j+1,k))) )) 
+/* (la*u_x)_y */
+              + strx(i)*stry(j)*
+                 i144*( la(i,j-2,k)*(u(1,i-2,j-2,k)-u(1,i+2,j-2,k)+
+                             8*(-u(1,i-1,j-2,k)+u(1,i+1,j-2,k))) - 8*(
+                        la(i,j-1,k)*(u(1,i-2,j-1,k)-u(1,i+2,j-1,k)+
+                             8*(-u(1,i-1,j-1,k)+u(1,i+1,j-1,k))) )+8*(
+                        la(i,j+1,k)*(u(1,i-2,j+1,k)-u(1,i+2,j+1,k)+
+                             8*(-u(1,i-1,j+1,k)+u(1,i+1,j+1,k))) ) - (
+                        la(i,j+2,k)*(u(1,i-2,j+2,k)-u(1,i+2,j+2,k)+
+                             8*(-u(1,i-1,j+2,k)+u(1,i+1,j+2,k))) )) 
+/* (la*w_z)_y */
+               + stry(j)*strz(k)*
+                 i144*( la(i,j-2,k)*(u(3,i,j-2,k-2)-u(3,i,j-2,k+2)+
+                             8*(-u(3,i,j-2,k-1)+u(3,i,j-2,k+1))) - 8*(
+                        la(i,j-1,k)*(u(3,i,j-1,k-2)-u(3,i,j-1,k+2)+
+                             8*(-u(3,i,j-1,k-1)+u(3,i,j-1,k+1))) )+8*(
+                        la(i,j+1,k)*(u(3,i,j+1,k-2)-u(3,i,j+1,k+2)+
+                             8*(-u(3,i,j+1,k-1)+u(3,i,j+1,k+1))) ) - (
+                        la(i,j+2,k)*(u(3,i,j+2,k-2)-u(3,i,j+2,k+2)+
+                             8*(-u(3,i,j+2,k-1)+u(3,i,j+2,k+1))) ))
+/* (mu*w_y)_z */
+               + stry(j)*strz(k)*
+                 i144*( mu(i,j,k-2)*(u(3,i,j-2,k-2)-u(3,i,j+2,k-2)+
+                             8*(-u(3,i,j-1,k-2)+u(3,i,j+1,k-2))) - 8*(
+                        mu(i,j,k-1)*(u(3,i,j-2,k-1)-u(3,i,j+2,k-1)+
+                             8*(-u(3,i,j-1,k-1)+u(3,i,j+1,k-1))) )+8*(
+                        mu(i,j,k+1)*(u(3,i,j-2,k+1)-u(3,i,j+2,k+1)+
+                             8*(-u(3,i,j-1,k+1)+u(3,i,j+1,k+1))) ) - (
+                        mu(i,j,k+2)*(u(3,i,j-2,k+2)-u(3,i,j+2,k+2)+
+				     8*(-u(3,i,j-1,k+2)+u(3,i,j+1,k+2))) )) ;
+/* 116 ops for r3 */
+/*  (mu*u_z)_x */
+            r3 = r3 + strx(i)*strz(k)*
+                 i144*( mu(i-2,j,k)*(u(1,i-2,j,k-2)-u(1,i-2,j,k+2)+
+                             8*(-u(1,i-2,j,k-1)+u(1,i-2,j,k+1))) - 8*(
+                        mu(i-1,j,k)*(u(1,i-1,j,k-2)-u(1,i-1,j,k+2)+
+                             8*(-u(1,i-1,j,k-1)+u(1,i-1,j,k+1))) )+8*(
+                        mu(i+1,j,k)*(u(1,i+1,j,k-2)-u(1,i+1,j,k+2)+
+                             8*(-u(1,i+1,j,k-1)+u(1,i+1,j,k+1))) ) - (
+                        mu(i+2,j,k)*(u(1,i+2,j,k-2)-u(1,i+2,j,k+2)+
+                             8*(-u(1,i+2,j,k-1)+u(1,i+2,j,k+1))) )) 
+/* (mu*v_z)_y */
+              + stry(j)*strz(k)*
+                 i144*( mu(i,j-2,k)*(u(2,i,j-2,k-2)-u(2,i,j-2,k+2)+
+                             8*(-u(2,i,j-2,k-1)+u(2,i,j-2,k+1))) - 8*(
+                        mu(i,j-1,k)*(u(2,i,j-1,k-2)-u(2,i,j-1,k+2)+
+                             8*(-u(2,i,j-1,k-1)+u(2,i,j-1,k+1))) )+8*(
+                        mu(i,j+1,k)*(u(2,i,j+1,k-2)-u(2,i,j+1,k+2)+
+                             8*(-u(2,i,j+1,k-1)+u(2,i,j+1,k+1))) ) - (
+                        mu(i,j+2,k)*(u(2,i,j+2,k-2)-u(2,i,j+2,k+2)+
+                             8*(-u(2,i,j+2,k-1)+u(2,i,j+2,k+1))) ))
+/*   (la*u_x)_z */
+              + strx(i)*strz(k)*
+                 i144*( la(i,j,k-2)*(u(1,i-2,j,k-2)-u(1,i+2,j,k-2)+
+                             8*(-u(1,i-1,j,k-2)+u(1,i+1,j,k-2))) - 8*(
+                        la(i,j,k-1)*(u(1,i-2,j,k-1)-u(1,i+2,j,k-1)+
+                             8*(-u(1,i-1,j,k-1)+u(1,i+1,j,k-1))) )+8*(
+                        la(i,j,k+1)*(u(1,i-2,j,k+1)-u(1,i+2,j,k+1)+
+                             8*(-u(1,i-1,j,k+1)+u(1,i+1,j,k+1))) ) - (
+                        la(i,j,k+2)*(u(1,i-2,j,k+2)-u(1,i+2,j,k+2)+
+                             8*(-u(1,i-1,j,k+2)+u(1,i+1,j,k+2))) )) 
+/* (la*v_y)_z */
+              + stry(j)*strz(k)*
+                 i144*( la(i,j,k-2)*(u(2,i,j-2,k-2)-u(2,i,j+2,k-2)+
+                             8*(-u(2,i,j-1,k-2)+u(2,i,j+1,k-2))) - 8*(
+                        la(i,j,k-1)*(u(2,i,j-2,k-1)-u(2,i,j+2,k-1)+
+                             8*(-u(2,i,j-1,k-1)+u(2,i,j+1,k-1))) )+8*(
+                        la(i,j,k+1)*(u(2,i,j-2,k+1)-u(2,i,j+2,k+1)+
+                             8*(-u(2,i,j-1,k+1)+u(2,i,j+1,k+1))) ) - (
+                        la(i,j,k+2)*(u(2,i,j-2,k+2)-u(2,i,j+2,k+2)+
+				     8*(-u(2,i,j-1,k+2)+u(2,i,j+1,k+2))) )) ;
+
+/* 9 ops */
+//	    lu(1,i,j,k) = a1*lu(1,i,j,k) + cof*r1;
+//            lu(2,i,j,k) = a1*lu(2,i,j,k) + cof*r2;
+//            lu(3,i,j,k) = a1*lu(3,i,j,k) + cof*r3;
+            lu(1,i,j,k) =  cof*r1;
+            lu(2,i,j,k) =  cof*r2;
+            lu(3,i,j,k) =  cof*r3;
+
+	   });
+
+}//end brace
+
+
+
+//RAJA version
+void rhs4sg_rev_raja_For( int ifirst, int ilast, int jfirst, int jlast, int kfirst, int klast,
+		 int nk, float_sw4* RAJA_RESTRICT a_acof, float_sw4 *RAJA_RESTRICT a_bope,
+		 float_sw4* RAJA_RESTRICT a_ghcof, float_sw4* RAJA_RESTRICT a_lu, float_sw4* RAJA_RESTRICT a_u,
+		 float_sw4* RAJA_RESTRICT a_mu, float_sw4* RAJA_RESTRICT a_lambda, 
+		 float_sw4 h, float_sw4* RAJA_RESTRICT a_strx, float_sw4* RAJA_RESTRICT a_stry, 
+		 float_sw4* RAJA_RESTRICT a_strz )
+{//raja fun start
+
+
+  using POL2 = RAJA::omp_parallel_for_exec;
+  using POL1 = RAJA::loop_exec;
+  using POL0 = RAJA::simd_exec;
+
+ // Direct reuse of fortran code by these macro definitions:
+#define mu(i,j,k)     a_mu[base+i+ni*(j)+nij*(k)]
+#define la(i,j,k) a_lambda[base+i+ni*(j)+nij*(k)]
+   // Reversed indexation
+#define u(c,i,j,k)   a_u[base3+i+ni*(j)+nij*(k)+nijk*(c)]   
+#define lu(c,i,j,k) a_lu[base3+i+ni*(j)+nij*(k)+nijk*(c)]   
+#define strx(i) a_strx[i-ifirst0]
+#define stry(j) a_stry[j-jfirst0]
+#define strz(k) a_strz[k-kfirst0]
+#define acof(i,j,k) a_acof[(i-1)+6*(j-1)+48*(k-1)]
+#define bope(i,j) a_bope[i-1+6*(j-1)]
+#define ghcof(i) a_ghcof[i-1]
+   
+   const float_sw4 a1   = 0;
+   const float_sw4 i6   = 1.0/6;
+   const float_sw4 i12  = 1.0/12;
+   const float_sw4 i144 = 1.0/144;
+   const float_sw4 tf   = 0.75;
+
+   const int ni    = ilast-ifirst+1;
+   const int nij   = ni*(jlast-jfirst+1);
+   const int nijk  = nij*(klast-kfirst+1);
+   const int base  = -(ifirst+ni*jfirst+nij*kfirst);
+   const int base3 = base-nijk;
+
+   const int nic  = 3*ni;
+   const int nijc = 3*nij;
+   const int ifirst0 = ifirst;
+   const int jfirst0 = jfirst;
+   const int kfirst0 = kfirst;
+
+
+   const float_sw4 cof = 1.0/(h*h);
+   
+   int k1 = 7; 
+   int k2 = 101;   
+   RAJA::RangeSegment k_range(k1,k2+1);
+   RAJA::RangeSegment j_range(jfirst+2,jlast-1);
+   RAJA::RangeSegment i_range(ifirst+2,ilast-1);
+
+
+  RAJA::forall<POL2>(k_range, [=] (int k){
+        RAJA::forall<POL1>(j_range, [=] (int j){
+              RAJA::forall<POL0>(i_range, [=] (int i){
+
+      float_sw4 mux1,mux2,mux3,mux4,muy1,muy2,muy3,muy4;
+      float_sw4 r1,r2,r3,mucof,mu1zz,mu2zz,mu3zz,lap2mu,q,u3zip2,u3zip1;
+      float_sw4 u3zim1,u3zim2,lau3zx,mu3xz,u3zjp2,u3zjp1,u3zjm1,u3zjm2,lau3zy;
+      float_sw4 mu3yz,mu1zx,u1zip2,u1zip1,u1zim1,u1zim2;
+      float_sw4 u2zjp2,u2zjp1,u2zjm1,u2zjm2,mu2zy,lau1xz,lau2yz,muz1,muz2,muz3,muz4;
+      
+/* from inner_loop_4a, 28x3 = 84 ops */
+            mux1 = mu(i-1,j,k)*strx(i-1)-
+	       tf*(mu(i,j,k)*strx(i)+mu(i-2,j,k)*strx(i-2));
+            mux2 = mu(i-2,j,k)*strx(i-2)+mu(i+1,j,k)*strx(i+1)+
+	       3*(mu(i,j,k)*strx(i)+mu(i-1,j,k)*strx(i-1));
+            mux3 = mu(i-1,j,k)*strx(i-1)+mu(i+2,j,k)*strx(i+2)+
+	       3*(mu(i+1,j,k)*strx(i+1)+mu(i,j,k)*strx(i));
+            mux4 = mu(i+1,j,k)*strx(i+1)-
+	       tf*(mu(i,j,k)*strx(i)+mu(i+2,j,k)*strx(i+2));
+
+            muy1 = mu(i,j-1,k)*stry(j-1)-
+	       tf*(mu(i,j,k)*stry(j)+mu(i,j-2,k)*stry(j-2));
+            muy2 = mu(i,j-2,k)*stry(j-2)+mu(i,j+1,k)*stry(j+1)+
+	       3*(mu(i,j,k)*stry(j)+mu(i,j-1,k)*stry(j-1));
+            muy3 = mu(i,j-1,k)*stry(j-1)+mu(i,j+2,k)*stry(j+2)+
+	       3*(mu(i,j+1,k)*stry(j+1)+mu(i,j,k)*stry(j));
+            muy4 = mu(i,j+1,k)*stry(j+1)-
+	       tf*(mu(i,j,k)*stry(j)+mu(i,j+2,k)*stry(j+2));
+
+            muz1 = mu(i,j,k-1)*strz(k-1)-
+	       tf*(mu(i,j,k)*strz(k)+mu(i,j,k-2)*strz(k-2));
+            muz2 = mu(i,j,k-2)*strz(k-2)+mu(i,j,k+1)*strz(k+1)+
+	       3*(mu(i,j,k)*strz(k)+mu(i,j,k-1)*strz(k-1));
+            muz3 = mu(i,j,k-1)*strz(k-1)+mu(i,j,k+2)*strz(k+2)+
+	       3*(mu(i,j,k+1)*strz(k+1)+mu(i,j,k)*strz(k));
+            muz4 = mu(i,j,k+1)*strz(k+1)-
+	       tf*(mu(i,j,k)*strz(k)+mu(i,j,k+2)*strz(k+2));
+/* xx, yy, and zz derivatives:*/
+/* 75 ops */
+            r1 = i6*( strx(i)*( (2*mux1+la(i-1,j,k)*strx(i-1)-
+               tf*(la(i,j,k)*strx(i)+la(i-2,j,k)*strx(i-2)))*
+                              (u(1,i-2,j,k)-u(1,i,j,k))+
+           (2*mux2+la(i-2,j,k)*strx(i-2)+la(i+1,j,k)*strx(i+1)+
+                3*(la(i,j,k)*strx(i)+la(i-1,j,k)*strx(i-1)))*
+                              (u(1,i-1,j,k)-u(1,i,j,k))+ 
+           (2*mux3+la(i-1,j,k)*strx(i-1)+la(i+2,j,k)*strx(i+2)+
+                3*(la(i+1,j,k)*strx(i+1)+la(i,j,k)*strx(i)))*
+                              (u(1,i+1,j,k)-u(1,i,j,k))+
+                (2*mux4+ la(i+1,j,k)*strx(i+1)-
+               tf*(la(i,j,k)*strx(i)+la(i+2,j,k)*strx(i+2)))*
+                (u(1,i+2,j,k)-u(1,i,j,k)) ) + stry(j)*(
+                     muy1*(u(1,i,j-2,k)-u(1,i,j,k)) + 
+                     muy2*(u(1,i,j-1,k)-u(1,i,j,k)) + 
+                     muy3*(u(1,i,j+1,k)-u(1,i,j,k)) +
+                     muy4*(u(1,i,j+2,k)-u(1,i,j,k)) ) + strz(k)*(
+                     muz1*(u(1,i,j,k-2)-u(1,i,j,k)) + 
+                     muz2*(u(1,i,j,k-1)-u(1,i,j,k)) + 
+                     muz3*(u(1,i,j,k+1)-u(1,i,j,k)) +
+                     muz4*(u(1,i,j,k+2)-u(1,i,j,k)) ) );
+
+/* 75 ops */
+            r2 = i6*( strx(i)*(mux1*(u(2,i-2,j,k)-u(2,i,j,k)) + 
+                      mux2*(u(2,i-1,j,k)-u(2,i,j,k)) + 
+                      mux3*(u(2,i+1,j,k)-u(2,i,j,k)) +
+                      mux4*(u(2,i+2,j,k)-u(2,i,j,k)) ) + stry(j)*(
+                  (2*muy1+la(i,j-1,k)*stry(j-1)-
+                      tf*(la(i,j,k)*stry(j)+la(i,j-2,k)*stry(j-2)))*
+                          (u(2,i,j-2,k)-u(2,i,j,k))+
+           (2*muy2+la(i,j-2,k)*stry(j-2)+la(i,j+1,k)*stry(j+1)+
+                     3*(la(i,j,k)*stry(j)+la(i,j-1,k)*stry(j-1)))*
+                          (u(2,i,j-1,k)-u(2,i,j,k))+ 
+           (2*muy3+la(i,j-1,k)*stry(j-1)+la(i,j+2,k)*stry(j+2)+
+                     3*(la(i,j+1,k)*stry(j+1)+la(i,j,k)*stry(j)))*
+                          (u(2,i,j+1,k)-u(2,i,j,k))+
+                  (2*muy4+la(i,j+1,k)*stry(j+1)-
+                    tf*(la(i,j,k)*stry(j)+la(i,j+2,k)*stry(j+2)))*
+                          (u(2,i,j+2,k)-u(2,i,j,k)) ) + strz(k)*(
+                     muz1*(u(2,i,j,k-2)-u(2,i,j,k)) + 
+                     muz2*(u(2,i,j,k-1)-u(2,i,j,k)) + 
+                     muz3*(u(2,i,j,k+1)-u(2,i,j,k)) +
+                     muz4*(u(2,i,j,k+2)-u(2,i,j,k)) ) );
+
+/* 75 ops */
+            r3 = i6*( strx(i)*(mux1*(u(3,i-2,j,k)-u(3,i,j,k)) + 
+                      mux2*(u(3,i-1,j,k)-u(3,i,j,k)) + 
+                      mux3*(u(3,i+1,j,k)-u(3,i,j,k)) +
+                      mux4*(u(3,i+2,j,k)-u(3,i,j,k))  ) + stry(j)*(
+                     muy1*(u(3,i,j-2,k)-u(3,i,j,k)) + 
+                     muy2*(u(3,i,j-1,k)-u(3,i,j,k)) + 
+                     muy3*(u(3,i,j+1,k)-u(3,i,j,k)) +
+                     muy4*(u(3,i,j+2,k)-u(3,i,j,k)) ) + strz(k)*(
+                  (2*muz1+la(i,j,k-1)*strz(k-1)-
+                      tf*(la(i,j,k)*strz(k)+la(i,j,k-2)*strz(k-2)))*
+                          (u(3,i,j,k-2)-u(3,i,j,k))+
+           (2*muz2+la(i,j,k-2)*strz(k-2)+la(i,j,k+1)*strz(k+1)+
+                      3*(la(i,j,k)*strz(k)+la(i,j,k-1)*strz(k-1)))*
+                          (u(3,i,j,k-1)-u(3,i,j,k))+ 
+           (2*muz3+la(i,j,k-1)*strz(k-1)+la(i,j,k+2)*strz(k+2)+
+                      3*(la(i,j,k+1)*strz(k+1)+la(i,j,k)*strz(k)))*
+                          (u(3,i,j,k+1)-u(3,i,j,k))+
+                  (2*muz4+la(i,j,k+1)*strz(k+1)-
+                    tf*(la(i,j,k)*strz(k)+la(i,j,k+2)*strz(k+2)))*
+		  (u(3,i,j,k+2)-u(3,i,j,k)) ) );
+
+
+/* Mixed derivatives: */
+/* 29ops /mixed derivative */
+/* 116 ops for r1 */
+/*   (la*v_y)_x */
+            r1 = r1 + strx(i)*stry(j)*
+                 i144*( la(i-2,j,k)*(u(2,i-2,j-2,k)-u(2,i-2,j+2,k)+
+                             8*(-u(2,i-2,j-1,k)+u(2,i-2,j+1,k))) - 8*(
+                        la(i-1,j,k)*(u(2,i-1,j-2,k)-u(2,i-1,j+2,k)+
+                             8*(-u(2,i-1,j-1,k)+u(2,i-1,j+1,k))) )+8*(
+                        la(i+1,j,k)*(u(2,i+1,j-2,k)-u(2,i+1,j+2,k)+
+                             8*(-u(2,i+1,j-1,k)+u(2,i+1,j+1,k))) ) - (
+                        la(i+2,j,k)*(u(2,i+2,j-2,k)-u(2,i+2,j+2,k)+
+                             8*(-u(2,i+2,j-1,k)+u(2,i+2,j+1,k))) )) 
+/*   (la*w_z)_x */
+               + strx(i)*strz(k)*       
+                 i144*( la(i-2,j,k)*(u(3,i-2,j,k-2)-u(3,i-2,j,k+2)+
+                             8*(-u(3,i-2,j,k-1)+u(3,i-2,j,k+1))) - 8*(
+                        la(i-1,j,k)*(u(3,i-1,j,k-2)-u(3,i-1,j,k+2)+
+                             8*(-u(3,i-1,j,k-1)+u(3,i-1,j,k+1))) )+8*(
+                        la(i+1,j,k)*(u(3,i+1,j,k-2)-u(3,i+1,j,k+2)+
+                             8*(-u(3,i+1,j,k-1)+u(3,i+1,j,k+1))) ) - (
+                        la(i+2,j,k)*(u(3,i+2,j,k-2)-u(3,i+2,j,k+2)+
+                             8*(-u(3,i+2,j,k-1)+u(3,i+2,j,k+1))) )) 
+/*   (mu*v_x)_y */
+               + strx(i)*stry(j)*       
+                 i144*( mu(i,j-2,k)*(u(2,i-2,j-2,k)-u(2,i+2,j-2,k)+
+                             8*(-u(2,i-1,j-2,k)+u(2,i+1,j-2,k))) - 8*(
+                        mu(i,j-1,k)*(u(2,i-2,j-1,k)-u(2,i+2,j-1,k)+
+                             8*(-u(2,i-1,j-1,k)+u(2,i+1,j-1,k))) )+8*(
+                        mu(i,j+1,k)*(u(2,i-2,j+1,k)-u(2,i+2,j+1,k)+
+                             8*(-u(2,i-1,j+1,k)+u(2,i+1,j+1,k))) ) - (
+                        mu(i,j+2,k)*(u(2,i-2,j+2,k)-u(2,i+2,j+2,k)+
+                             8*(-u(2,i-1,j+2,k)+u(2,i+1,j+2,k))) )) 
+/*   (mu*w_x)_z */
+               + strx(i)*strz(k)*       
+                 i144*( mu(i,j,k-2)*(u(3,i-2,j,k-2)-u(3,i+2,j,k-2)+
+                             8*(-u(3,i-1,j,k-2)+u(3,i+1,j,k-2))) - 8*(
+                        mu(i,j,k-1)*(u(3,i-2,j,k-1)-u(3,i+2,j,k-1)+
+                             8*(-u(3,i-1,j,k-1)+u(3,i+1,j,k-1))) )+8*(
+                        mu(i,j,k+1)*(u(3,i-2,j,k+1)-u(3,i+2,j,k+1)+
+                             8*(-u(3,i-1,j,k+1)+u(3,i+1,j,k+1))) ) - (
+                        mu(i,j,k+2)*(u(3,i-2,j,k+2)-u(3,i+2,j,k+2)+
+				     8*(-u(3,i-1,j,k+2)+u(3,i+1,j,k+2))) )) ;
+
+/* 116 ops for r2 */
+/*   (mu*u_y)_x */
+            r2 = r2 + strx(i)*stry(j)*
+                 i144*( mu(i-2,j,k)*(u(1,i-2,j-2,k)-u(1,i-2,j+2,k)+
+                             8*(-u(1,i-2,j-1,k)+u(1,i-2,j+1,k))) - 8*(
+                        mu(i-1,j,k)*(u(1,i-1,j-2,k)-u(1,i-1,j+2,k)+
+                             8*(-u(1,i-1,j-1,k)+u(1,i-1,j+1,k))) )+8*(
+                        mu(i+1,j,k)*(u(1,i+1,j-2,k)-u(1,i+1,j+2,k)+
+                             8*(-u(1,i+1,j-1,k)+u(1,i+1,j+1,k))) ) - (
+                        mu(i+2,j,k)*(u(1,i+2,j-2,k)-u(1,i+2,j+2,k)+
+                             8*(-u(1,i+2,j-1,k)+u(1,i+2,j+1,k))) )) 
+/* (la*u_x)_y */
+              + strx(i)*stry(j)*
+                 i144*( la(i,j-2,k)*(u(1,i-2,j-2,k)-u(1,i+2,j-2,k)+
+                             8*(-u(1,i-1,j-2,k)+u(1,i+1,j-2,k))) - 8*(
+                        la(i,j-1,k)*(u(1,i-2,j-1,k)-u(1,i+2,j-1,k)+
+                             8*(-u(1,i-1,j-1,k)+u(1,i+1,j-1,k))) )+8*(
+                        la(i,j+1,k)*(u(1,i-2,j+1,k)-u(1,i+2,j+1,k)+
+                             8*(-u(1,i-1,j+1,k)+u(1,i+1,j+1,k))) ) - (
+                        la(i,j+2,k)*(u(1,i-2,j+2,k)-u(1,i+2,j+2,k)+
+                             8*(-u(1,i-1,j+2,k)+u(1,i+1,j+2,k))) )) 
+/* (la*w_z)_y */
+               + stry(j)*strz(k)*
+                 i144*( la(i,j-2,k)*(u(3,i,j-2,k-2)-u(3,i,j-2,k+2)+
+                             8*(-u(3,i,j-2,k-1)+u(3,i,j-2,k+1))) - 8*(
+                        la(i,j-1,k)*(u(3,i,j-1,k-2)-u(3,i,j-1,k+2)+
+                             8*(-u(3,i,j-1,k-1)+u(3,i,j-1,k+1))) )+8*(
+                        la(i,j+1,k)*(u(3,i,j+1,k-2)-u(3,i,j+1,k+2)+
+                             8*(-u(3,i,j+1,k-1)+u(3,i,j+1,k+1))) ) - (
+                        la(i,j+2,k)*(u(3,i,j+2,k-2)-u(3,i,j+2,k+2)+
+                             8*(-u(3,i,j+2,k-1)+u(3,i,j+2,k+1))) ))
+/* (mu*w_y)_z */
+               + stry(j)*strz(k)*
+                 i144*( mu(i,j,k-2)*(u(3,i,j-2,k-2)-u(3,i,j+2,k-2)+
+                             8*(-u(3,i,j-1,k-2)+u(3,i,j+1,k-2))) - 8*(
+                        mu(i,j,k-1)*(u(3,i,j-2,k-1)-u(3,i,j+2,k-1)+
+                             8*(-u(3,i,j-1,k-1)+u(3,i,j+1,k-1))) )+8*(
+                        mu(i,j,k+1)*(u(3,i,j-2,k+1)-u(3,i,j+2,k+1)+
+                             8*(-u(3,i,j-1,k+1)+u(3,i,j+1,k+1))) ) - (
+                        mu(i,j,k+2)*(u(3,i,j-2,k+2)-u(3,i,j+2,k+2)+
+				     8*(-u(3,i,j-1,k+2)+u(3,i,j+1,k+2))) )) ;
+/* 116 ops for r3 */
+/*  (mu*u_z)_x */
+            r3 = r3 + strx(i)*strz(k)*
+                 i144*( mu(i-2,j,k)*(u(1,i-2,j,k-2)-u(1,i-2,j,k+2)+
+                             8*(-u(1,i-2,j,k-1)+u(1,i-2,j,k+1))) - 8*(
+                        mu(i-1,j,k)*(u(1,i-1,j,k-2)-u(1,i-1,j,k+2)+
+                             8*(-u(1,i-1,j,k-1)+u(1,i-1,j,k+1))) )+8*(
+                        mu(i+1,j,k)*(u(1,i+1,j,k-2)-u(1,i+1,j,k+2)+
+                             8*(-u(1,i+1,j,k-1)+u(1,i+1,j,k+1))) ) - (
+                        mu(i+2,j,k)*(u(1,i+2,j,k-2)-u(1,i+2,j,k+2)+
+                             8*(-u(1,i+2,j,k-1)+u(1,i+2,j,k+1))) )) 
+/* (mu*v_z)_y */
+              + stry(j)*strz(k)*
+                 i144*( mu(i,j-2,k)*(u(2,i,j-2,k-2)-u(2,i,j-2,k+2)+
+                             8*(-u(2,i,j-2,k-1)+u(2,i,j-2,k+1))) - 8*(
+                        mu(i,j-1,k)*(u(2,i,j-1,k-2)-u(2,i,j-1,k+2)+
+                             8*(-u(2,i,j-1,k-1)+u(2,i,j-1,k+1))) )+8*(
+                        mu(i,j+1,k)*(u(2,i,j+1,k-2)-u(2,i,j+1,k+2)+
+                             8*(-u(2,i,j+1,k-1)+u(2,i,j+1,k+1))) ) - (
+                        mu(i,j+2,k)*(u(2,i,j+2,k-2)-u(2,i,j+2,k+2)+
+                             8*(-u(2,i,j+2,k-1)+u(2,i,j+2,k+1))) ))
+/*   (la*u_x)_z */
+              + strx(i)*strz(k)*
+                 i144*( la(i,j,k-2)*(u(1,i-2,j,k-2)-u(1,i+2,j,k-2)+
+                             8*(-u(1,i-1,j,k-2)+u(1,i+1,j,k-2))) - 8*(
+                        la(i,j,k-1)*(u(1,i-2,j,k-1)-u(1,i+2,j,k-1)+
+                             8*(-u(1,i-1,j,k-1)+u(1,i+1,j,k-1))) )+8*(
+                        la(i,j,k+1)*(u(1,i-2,j,k+1)-u(1,i+2,j,k+1)+
+                             8*(-u(1,i-1,j,k+1)+u(1,i+1,j,k+1))) ) - (
+                        la(i,j,k+2)*(u(1,i-2,j,k+2)-u(1,i+2,j,k+2)+
+                             8*(-u(1,i-1,j,k+2)+u(1,i+1,j,k+2))) )) 
+/* (la*v_y)_z */
+              + stry(j)*strz(k)*
+                 i144*( la(i,j,k-2)*(u(2,i,j-2,k-2)-u(2,i,j+2,k-2)+
+                             8*(-u(2,i,j-1,k-2)+u(2,i,j+1,k-2))) - 8*(
+                        la(i,j,k-1)*(u(2,i,j-2,k-1)-u(2,i,j+2,k-1)+
+                             8*(-u(2,i,j-1,k-1)+u(2,i,j+1,k-1))) )+8*(
+                        la(i,j,k+1)*(u(2,i,j-2,k+1)-u(2,i,j+2,k+1)+
+                             8*(-u(2,i,j-1,k+1)+u(2,i,j+1,k+1))) ) - (
+                        la(i,j,k+2)*(u(2,i,j-2,k+2)-u(2,i,j+2,k+2)+
+				     8*(-u(2,i,j-1,k+2)+u(2,i,j+1,k+2))) )) ;
+
+/* 9 ops */
+//	    lu(1,i,j,k) = a1*lu(1,i,j,k) + cof*r1;
+//            lu(2,i,j,k) = a1*lu(2,i,j,k) + cof*r2;
+//            lu(3,i,j,k) = a1*lu(3,i,j,k) + cof*r3;
+            lu(1,i,j,k) =  cof*r1;
+            lu(2,i,j,k) =  cof*r2;
+            lu(3,i,j,k) =  cof*r3;
+
+                 });
+              });
+        });
+
+}//end brace
+
+
+
+
+TEST(Kernel, SW4For){
+
+
+  long int kfirst=-1, klast=103;
+  long int jfirst=-1, jlast=203;
+  long int ifirst=-1, ilast=203;
+  double   h  = 0.04;
+  long int nk = 101;
+
+  long int k_len = klast-kfirst + 10;
+  long int j_len = jlast-jfirst + 10;
+  long int i_len = ilast-ifirst + 10;
+  long int arr_len = k_len*j_len*i_len;
+
+  //Allocate arrays
+  long int dim = 3;
+  double * a_lu_native  = new double[dim*arr_len]; //ref solution
+  double * a_lu_raja    = new double[dim*arr_len]; //SIMD solution
+   
+  double * a_acof       = new double[arr_len];
+  double * a_bope       = new double[arr_len];
+  double * a_ghcof      = new double[arr_len];
+  double * a_u          = new double[arr_len];
+  double * a_mu         = new double[arr_len];
+  double * a_lambda     = new double[arr_len];
+  double * a_strx       = new double[arr_len];
+  double * a_stry       = new double[arr_len];
+  double * a_strz       = new double[arr_len];
+
+   
+  for(auto i=0; i<dim*arr_len; ++i)
+    {
+      a_lu_native[i]  = 0.0; //output for the native version
+      a_lu_raja[i]    = 0.0; //output for the raja version
+    }
+
+  for(auto i=0; i<arr_len; ++i)
+    {
+      a_acof[i]  = rand() % 10 + 1;
+      a_bope[i]    = rand() % 10 + 1;
+      a_ghcof[i]   = rand() % 10 + 1;
+      a_u[i]       = rand() % 10 + 1;
+      a_mu[i]      = rand() % 10 + 1;
+      a_lambda[i]  = rand() % 10 + 1;
+      a_strx[i]    = rand() % 10 + 1;
+      a_stry[i]    = rand() % 10 + 1;
+      a_strz[i]    = rand() % 10 + 1;
+    }
+   
+   
+  std::cout<<"Calling native version..."<<std::endl;
+  //Call native version
+  rhs4sg_rev_native(ifirst, ilast, jfirst, jlast, kfirst, klast,
+		    nk, a_acof, a_bope, a_ghcof, a_lu_native, a_u,
+		    a_mu, a_lambda, h, a_strx, a_stry, a_strz );
+
+   
+
+  std::cout<<"Calling RAJA For..."<<std::endl;
+  //Call RAJA version
+  rhs4sg_rev_raja_For(ifirst, ilast, jfirst, jlast, kfirst, klast,
+		  nk, a_acof, a_bope, a_ghcof, a_lu_raja, a_u,
+		  a_mu, a_lambda, h, a_strx, a_stry, a_strz );
+
+
+  double pass = 1.0;
+
+  for(auto i=0; i<arr_len; ++i)
+    {
+      double err = abs(a_lu_native[i]-a_lu_raja[i]);
+      if(err > 1e-8){
+	pass = -1.0; 
+      }
+    }
+
+  ASSERT_FLOAT_EQ(pass, 1.0);
+  
+
+}//End of test brace
+
+
+TEST(Kernel, SW4Nested){
+
+
+  long int kfirst=-1, klast=103;
+  long int jfirst=-1, jlast=203;
+  long int ifirst=-1, ilast=203;
+  double   h  = 0.04;
+  long int nk = 101;
+
+  long int k_len = klast-kfirst + 10;
+  long int j_len = jlast-jfirst + 10;
+  long int i_len = ilast-ifirst + 10;
+  long int arr_len = k_len*j_len*i_len;
+
+  //Allocate arrays
+  long int dim = 3;
+  double * a_lu_native  = new double[dim*arr_len]; //ref solution
+  double * a_lu_raja    = new double[dim*arr_len]; //SIMD solution
+   
+  double * a_acof       = new double[arr_len];
+  double * a_bope       = new double[arr_len];
+  double * a_ghcof      = new double[arr_len];
+  double * a_u          = new double[arr_len];
+  double * a_mu         = new double[arr_len];
+  double * a_lambda     = new double[arr_len];
+  double * a_strx       = new double[arr_len];
+  double * a_stry       = new double[arr_len];
+  double * a_strz       = new double[arr_len];
+
+   
+  for(auto i=0; i<dim*arr_len; ++i)
+    {
+      a_lu_native[i]  = 0.0; //output for the native version
+      a_lu_raja[i]    = 0.0; //output for the raja version
+    }
+
+  for(auto i=0; i<arr_len; ++i)
+    {
+      a_acof[i]  = rand() % 10 + 1;
+      a_bope[i]    = rand() % 10 + 1;
+      a_ghcof[i]   = rand() % 10 + 1;
+      a_u[i]       = rand() % 10 + 1;
+      a_mu[i]      = rand() % 10 + 1;
+      a_lambda[i]  = rand() % 10 + 1;
+      a_strx[i]    = rand() % 10 + 1;
+      a_stry[i]    = rand() % 10 + 1;
+      a_strz[i]    = rand() % 10 + 1;
+    }
+   
+   
+  std::cout<<"Calling native version..."<<std::endl;
+  //Call native version
+  rhs4sg_rev_native(ifirst, ilast, jfirst, jlast, kfirst, klast,
+		    nk, a_acof, a_bope, a_ghcof, a_lu_native, a_u,
+		    a_mu, a_lambda, h, a_strx, a_stry, a_strz );
+
+   
+
+  std::cout<<"Calling RAJA Nested..."<<std::endl;
+  //Call RAJA version
+  rhs4sg_rev_raja_Nested(ifirst, ilast, jfirst, jlast, kfirst, klast,
+		  nk, a_acof, a_bope, a_ghcof, a_lu_raja, a_u,
+		  a_mu, a_lambda, h, a_strx, a_stry, a_strz );
+
+
+  double pass = 1.0;
+
+  for(auto i=0; i<arr_len; ++i)
+    {
+      double err = abs(a_lu_native[i]-a_lu_raja[i]);
+      if(err > 1e-8){
+	pass = -1.0; 
+      }
+    }
+
+  ASSERT_FLOAT_EQ(pass, 1.0);
+  
+
+}//End of test brace

--- a/test/unit/simd.cpp
+++ b/test/unit/simd.cpp
@@ -126,20 +126,6 @@ using POL =
 #define float_sw4 double
 
 
-#define mu(i,j,k)     a_mu[base+i+ni*(j)+nij*(k)]
-#define la(i,j,k) a_lambda[base+i+ni*(j)+nij*(k)]
-
-  // Reversed indexation                                                                                            
-#define u(c,i,j,k)   a_u[base3+i+ni*(j)+nij*(k)+nijk*(c)]
-#define lu(c,i,j,k) a_lu[base3+i+ni*(j)+nij*(k)+nijk*(c)]
-#define strx(i) a_strx[i-ifirst0]
-#define stry(j) a_stry[j-jfirst0]
-#define strz(k) a_strz[k-kfirst0]
-#define acof(i,j,k) a_acof[(i-1)+6*(j-1)+48*(k-1)]
-#define bope(i,j) a_bope[i-1+6*(j-1)]
-#define ghcof(i) a_ghcof[i-1]
-
-
 void rhs4sg_rev_native( int ifirst, int ilast, int jfirst, int jlast, int kfirst, int klast,
 		 int nk, float_sw4* RAJA_RESTRICT a_acof, float_sw4 *RAJA_RESTRICT a_bope,
 		 float_sw4* RAJA_RESTRICT a_ghcof, float_sw4* RAJA_RESTRICT a_lu, float_sw4* RAJA_RESTRICT a_u,
@@ -1112,17 +1098,11 @@ TEST(Kernel, SW4For){
 		  a_mu, a_lambda, h, a_strx, a_stry, a_strz );
 
 
-  double pass = 1.0;
-
   for(auto i=0; i<arr_len; ++i)
     {
-      double err = std::abs(a_lu_native[i]-a_lu_raja[i]);
-      if(err > 1e-8){
-	pass = -1.0; 
-      }
+      ASSERT_FLOAT_EQ(a_lu_native[i], a_lu_raja[i]);
     }
 
-  ASSERT_FLOAT_EQ(pass, 1.0);
   
 
 }//End of test brace
@@ -1193,17 +1173,11 @@ TEST(Kernel, SW4Nested){
 		  a_mu, a_lambda, h, a_strx, a_stry, a_strz );
 
 
-  double pass = 1.0;
-
   for(auto i=0; i<arr_len; ++i)
     {
-      double err = std::abs(a_lu_native[i]-a_lu_raja[i]);
-      if(err > 1e-8){
-	pass = -1.0; 
-      }
+      ASSERT_FLOAT_EQ(a_lu_native[i], a_lu_raja[i]);
     }
 
-  ASSERT_FLOAT_EQ(pass, 1.0);
   
 
 }//End of test brace

--- a/test/unit/simd.cpp
+++ b/test/unit/simd.cpp
@@ -182,7 +182,7 @@ void rhs4sg_rev_native( int ifirst, int ilast, int jfirst, int jlast, int kfirst
    RAJA::RangeSegment j_range(jfirst+2,jlast-1);
    RAJA::RangeSegment i_range(ifirst+2,ilast-1);
 
-   //#pragma omp parallel for                                                                                             
+#pragma omp parallel for                                                                                             
    for(int  k= k1; k <= k2 ; k++ ){
       for(int j=jfirst+2; j <= jlast-2 ; j++ ) {
 #pragma omp simd                                                                      
@@ -196,7 +196,8 @@ void rhs4sg_rev_native( int ifirst, int ilast, int jfirst, int jlast, int kfirst
       float_sw4 u3zim1,u3zim2,lau3zx,mu3xz,u3zjp2,u3zjp1,u3zjm1,u3zjm2,lau3zy;
       float_sw4 mu3yz,mu1zx,u1zip2,u1zip1,u1zim1,u1zim2;
       float_sw4 u2zjp2,u2zjp1,u2zjm1,u2zjm2,mu2zy,lau1xz,lau2yz,muz1,muz2,muz3,muz4;
-      
+
+
 /* from inner_loop_4a, 28x3 = 84 ops */
             mux1 = mu(i-1,j,k)*strx(i-1)-
 	       tf*(mu(i,j,k)*strx(i)+mu(i-2,j,k)*strx(i-2));
@@ -206,6 +207,7 @@ void rhs4sg_rev_native( int ifirst, int ilast, int jfirst, int jlast, int kfirst
 	       3*(mu(i+1,j,k)*strx(i+1)+mu(i,j,k)*strx(i));
             mux4 = mu(i+1,j,k)*strx(i+1)-
 	       tf*(mu(i,j,k)*strx(i)+mu(i+2,j,k)*strx(i+2));
+
 
             muy1 = mu(i,j-1,k)*stry(j-1)-
 	       tf*(mu(i,j,k)*stry(j)+mu(i,j-2,k)*stry(j-2));
@@ -224,6 +226,7 @@ void rhs4sg_rev_native( int ifirst, int ilast, int jfirst, int jlast, int kfirst
 	       3*(mu(i,j,k+1)*strz(k+1)+mu(i,j,k)*strz(k));
             muz4 = mu(i,j,k+1)*strz(k+1)-
 	       tf*(mu(i,j,k)*strz(k)+mu(i,j,k+2)*strz(k+2));
+
 /* xx, yy, and zz derivatives:*/
 /* 75 ops */
             r1 = i6*( strx(i)*( (2*mux1+la(i-1,j,k)*strx(i-1)-
@@ -269,6 +272,7 @@ void rhs4sg_rev_native( int ifirst, int ilast, int jfirst, int jlast, int kfirst
                      muz3*(u(2,i,j,k+1)-u(2,i,j,k)) +
                      muz4*(u(2,i,j,k+2)-u(2,i,j,k)) ) );
 
+
 /* 75 ops */
             r3 = i6*( strx(i)*(mux1*(u(3,i-2,j,k)-u(3,i,j,k)) + 
                       mux2*(u(3,i-1,j,k)-u(3,i,j,k)) + 
@@ -291,7 +295,7 @@ void rhs4sg_rev_native( int ifirst, int ilast, int jfirst, int jlast, int kfirst
                     tf*(la(i,j,k)*strz(k)+la(i,j,k+2)*strz(k+2)))*
 		  (u(3,i,j,k+2)-u(3,i,j,k)) ) );
 
-
+            //----
 /* Mixed derivatives: */
 /* 29ops /mixed derivative */
 /* 116 ops for r1 */
@@ -377,6 +381,9 @@ void rhs4sg_rev_native( int ifirst, int ilast, int jfirst, int jlast, int kfirst
                              8*(-u(3,i,j-1,k+1)+u(3,i,j+1,k+1))) ) - (
                         mu(i,j,k+2)*(u(3,i,j-2,k+2)-u(3,i,j+2,k+2)+
 				     8*(-u(3,i,j-1,k+2)+u(3,i,j+1,k+2))) )) ;
+
+
+
 /* 116 ops for r3 */
 /*  (mu*u_z)_x */
             r3 = r3 + strx(i)*strz(k)*
@@ -419,6 +426,7 @@ void rhs4sg_rev_native( int ifirst, int ilast, int jfirst, int jlast, int kfirst
                         la(i,j,k+2)*(u(2,i,j-2,k+2)-u(2,i,j+2,k+2)+
 				     8*(-u(2,i,j-1,k+2)+u(2,i,j+1,k+2))) )) ;
 
+
 /* 9 ops */
 //	    lu(1,i,j,k) = a1*lu(1,i,j,k) + cof*r1;
 //            lu(2,i,j,k) = a1*lu(2,i,j,k) + cof*r2;
@@ -433,6 +441,7 @@ void rhs4sg_rev_native( int ifirst, int ilast, int jfirst, int jlast, int kfirst
             lu(1,i,j,k) =  cof*r1;            
             lu(2,i,j,k) =  cof*r2;
             lu(3,i,j,k) =  cof*r3;
+
             }
       }
    }
@@ -1069,11 +1078,11 @@ TEST(Kernel, SW4For){
   size_t lu_arraySz = 13153412 + 10;  //padding
   double * a_lu_native  = new double[lu_arraySz]; //ref solution
   double * a_lu_raja    = new double[lu_arraySz]; //SIMD solution
-   
+  double * a_u          = new double[lu_arraySz];
+     
   double * a_acof       = new double[arr_len];
   double * a_bope       = new double[arr_len];
   double * a_ghcof      = new double[arr_len];
-  double * a_u          = new double[arr_len];
   double * a_mu         = new double[arr_len];
   double * a_lambda     = new double[arr_len];
   double * a_strx       = new double[arr_len];
@@ -1123,6 +1132,7 @@ TEST(Kernel, SW4For){
 
 
 
+
    delete[] a_lu_native;
    delete[] a_lu_raja;
 
@@ -1160,12 +1170,11 @@ TEST(Kernel, SW4Nested){
   size_t lu_arraySz = 13153412+10; 
   double * a_lu_native  = new double[lu_arraySz]; //ref solution
   double * a_lu_raja    = new double[lu_arraySz]; //SIMD solution
-
+  double * a_u          = new double[lu_arraySz];
    
   double * a_acof       = new double[arr_len];
   double * a_bope       = new double[arr_len];
   double * a_ghcof      = new double[arr_len];
-  double * a_u          = new double[arr_len];
   double * a_mu         = new double[arr_len];
   double * a_lambda     = new double[arr_len];
   double * a_strx       = new double[arr_len];
@@ -1199,8 +1208,6 @@ TEST(Kernel, SW4Nested){
 		    nk, a_acof, a_bope, a_ghcof, a_lu_native, a_u,
 		    a_mu, a_lambda, h, a_strx, a_stry, a_strz );
 
-   
-
   std::cout<<"Calling RAJA Nested..."<<std::endl;
   //Call RAJA version
   rhs4sg_rev_raja_Nested(ifirst, ilast, jfirst, jlast, kfirst, klast,
@@ -1214,6 +1221,7 @@ TEST(Kernel, SW4Nested){
     }
 
 
+  
   delete[] a_lu_native;
    delete[] a_lu_raja;
 

--- a/test/unit/simd.cpp
+++ b/test/unit/simd.cpp
@@ -67,7 +67,10 @@ TEST(Kernel, ViewNestedFor){
      {
        ASSERT_FLOAT_EQ(C[i], 1.0);
      }
-  
+
+   delete [] A;
+   delete [] B;
+   delete [] C;
    
 }
 
@@ -114,7 +117,10 @@ using POL =
      {
        ASSERT_FLOAT_EQ(C[i], 1.0);
      }
-  
+
+   delete [] A;
+   delete [] B;
+   delete [] C;
    
 }
 
@@ -1103,6 +1109,21 @@ TEST(Kernel, SW4For){
       ASSERT_FLOAT_EQ(a_lu_native[i], a_lu_raja[i]);
     }
 
+
+   delete[] a_lu_native;
+   delete[] a_lu_raja;
+
+   delete[] a_acof;
+   delete[] a_bope;
+   delete[] a_ghcof;
+   delete[] a_u;
+   delete[] a_mu;
+   delete[] a_lambda;
+   delete[] a_strx;
+   delete[] a_stry;
+   delete[] a_strz;
+
+
   
 
 }//End of test brace
@@ -1178,6 +1199,19 @@ TEST(Kernel, SW4Nested){
       ASSERT_FLOAT_EQ(a_lu_native[i], a_lu_raja[i]);
     }
 
+
+  delete[] a_lu_native;
+   delete[] a_lu_raja;
+
+   delete[] a_acof;
+   delete[] a_bope;
+   delete[] a_ghcof;
+   delete[] a_u;
+   delete[] a_mu;
+   delete[] a_lambda;
+   delete[] a_strx;
+   delete[] a_stry;
+   delete[] a_strz;
   
 
 }//End of test brace


### PR DESCRIPTION
We have found bugs when paring RAJA::Kernels with OMP parallelism, and simd compiler hints. 
In particular: 
1. Incorrect output when using RAJA view 
2. Incorrect output when using the nested branch on a SW4 Kernel 

Source code for issues are found in simd-issues folder: 
view.cpp 
sw4Kernel.cpp 

To tryout  (assuming CMAKE 3.3 or higher is available) : 
git clone -b issue/Intel-bug https://github.com/LLNL/RAJA.git intel-bug
cd intel-bug 
bash ./scripts/intel-build.sh

cd build-intel

to run code: 
./simd-issues/bin/sw4Kernel
./simd-issues/bin/view

Comments: 
1. We find that a traditional nesting of RAJA forall statements will generate the correct output, but    using the RAJA::Kernel construct will not. 

2. Each .cpp file includes a KERNEL macro. When defined the code will use the RAJA::Kernel framework. When the macro is undefined the code will use a series of nested RAJA::forall loops. 





