### PR TITLE
Fixed naming of example executable

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -59,7 +59,7 @@ raja_add_executable(
   SOURCES ex9-scan.cpp)
 
 raja_add_executable(
-  NAME ex10-binning.cpp
+  NAME ex10-binning
   SOURCES ex10-binning.cpp)
 
 raja_add_executable(


### PR DESCRIPTION
We have an email submitted bug from Ron Green (@greenrongreen) on our email list, we're naming an example executable ExampleName.cpp rather than ExampleName.