### PR TITLE
Bugfix/artv3/align

### DIFF
--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -279,16 +279,16 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 
 template<typename T>
 RAJA_INLINE
-T align_hint(T x)
+T * align_hint(T * x)
 {
 #if defined (RAJA_COMPILER_INTEL)
   RAJA_ALIGN_DATA(x);
   return x;
 #else
-  return RAJA_ALIGN_DATA(x);
+  return reinterpret_cast<T *>(RAJA_ALIGN_DATA(x));
 #endif
 }
-  
+    
 }  // closing brace for RAJA namespace
 
 #endif // closing endif for header file include guard

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -177,7 +177,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #if defined(ENABLE_CUDA)
 #define RAJA_ALIGN_DATA(d)
 #else
-#define RAJA_ALIGN_DATA(d) __assume_aligned(d, DATA_ALIGN)
+#define RAJA_ALIGN_DATA(d) __assume_aligned(d, RAJA::DATA_ALIGN)
 #endif
 
 #if defined(_OPENMP) && (_OPENMP >= 201307)
@@ -199,7 +199,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #if defined(ENABLE_CUDA)
 #define RAJA_ALIGN_DATA(d)
 #else
-#define RAJA_ALIGN_DATA(d) __builtin_assume_aligned(d, DATA_ALIGN)
+#define RAJA_ALIGN_DATA(d) __builtin_assume_aligned(d, RAJA::DATA_ALIGN)
 #endif
 
 #if defined(_OPENMP) && (_OPENMP >= 201307)
@@ -222,7 +222,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 
 #define RAJA_INLINE inline  __attribute__((always_inline))
 
-#define RAJA_ALIGN_DATA(d) __alignx(DATA_ALIGN, d)
+#define RAJA_ALIGN_DATA(d) __alignx(RAJA::DATA_ALIGN, d)
 
 //#define RAJA_SIMD  _Pragma("simd_level(10)")
 #if defined(_OPENMP) && (_OPENMP >= 201307)
@@ -245,7 +245,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #if defined(ENABLE_CUDA)
 #define RAJA_ALIGN_DATA(d)
 #else
-#define RAJA_ALIGN_DATA(d) __builtin_assume_aligned(d, DATA_ALIGN)
+#define RAJA_ALIGN_DATA(d) __builtin_assume_aligned(d, RAJA::DATA_ALIGN)
 #endif
 
 #if defined(_OPENMP) && (_OPENMP >= 201307)

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -285,7 +285,7 @@ T * align_hint(T * x)
   RAJA_ALIGN_DATA(x);
   return x;
 #else
-  return reinterpret_cast<T *>(RAJA_ALIGN_DATA(x));
+  return static_cast<T *>(RAJA_ALIGN_DATA(x));
 #endif
 }
     

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -267,7 +267,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #pragma message("RAJA_COMPILER unknown, using default empty macros.")
 
 #define RAJA_INLINE inline
-#define RAJA_ALIGN_DATA(d)
+#define RAJA_ALIGN_DATA(d) d
 #define RAJA_SIMD
 #define RAJA_NO_SIMD
 

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -174,8 +174,8 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 
 #define RAJA_INLINE inline  __attribute__((always_inline))
 
-#if defined(ENABLE_CUDA)
-#define RAJA_ALIGN_DATA(d)
+#if defined(RAJA_ENABLE_CUDA)
+#define RAJA_ALIGN_DATA(d) d
 #else
 #define RAJA_ALIGN_DATA(d) __assume_aligned(d, RAJA::DATA_ALIGN)
 #endif
@@ -196,8 +196,8 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 
 #define RAJA_INLINE inline  __attribute__((always_inline))
 
-#if defined(ENABLE_CUDA)
-#define RAJA_ALIGN_DATA(d)
+#if defined(RAJA_ENABLE_CUDA)
+#define RAJA_ALIGN_DATA(d) d
 #else
 #define RAJA_ALIGN_DATA(d) __builtin_assume_aligned(d, RAJA::DATA_ALIGN)
 #endif
@@ -242,8 +242,8 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 
 #define RAJA_INLINE inline  __attribute__((always_inline))
 
-#if defined(ENABLE_CUDA)
-#define RAJA_ALIGN_DATA(d)
+#if defined(RAJA_ENABLE_CUDA)
+#define RAJA_ALIGN_DATA(d) d
 #else
 #define RAJA_ALIGN_DATA(d) __builtin_assume_aligned(d, RAJA::DATA_ALIGN)
 #endif

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -277,6 +277,18 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #cmakedefine RAJA_HAVE_ALIGNED_ALLOC
 #cmakedefine RAJA_HAVE_MM_MALLOC
 
+template<typename T>
+RAJA_INLINE
+T align_hint(T x)
+{
+#if defined (RAJA_COMPILER_INTEL)
+  RAJA_ALIGN_DATA(x);
+  return x;
+#else
+  return RAJA_ALIGN_DATA(x);
+#endif
+}
+  
 }  // closing brace for RAJA namespace
 
 #endif // closing endif for header file include guard

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -277,6 +277,13 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #cmakedefine RAJA_HAVE_ALIGNED_ALLOC
 #cmakedefine RAJA_HAVE_MM_MALLOC
 
+//
+//Creates a general framework for compiler alignment hints
+//
+// Example usage:
+// double *a = RAJA::allocate_aligned_type<double>(RAJA::DATA_ALIGN,10*sizeof(double));
+// double *y = RAJA::align_hint
+
 template<typename T>
 RAJA_INLINE
 T * align_hint(T * x)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -58,6 +58,10 @@ raja_add_test(
   NAME test-multipolicy
   SOURCES test-multipolicy.cpp)
 
+raja_add_test(
+  NAME test-simd
+  SOURCES test-simd.cpp)
+
 add_subdirectory(cpu)
 
 if(ENABLE_CUDA)

--- a/test/unit/test-simd.cpp
+++ b/test/unit/test-simd.cpp
@@ -26,19 +26,6 @@
 using namespace RAJA;
 using namespace RAJA::statement;
 
-template<typename T>
-RAJA_INLINE
-T alignHint(T x)
-{
-#if defined (RAJA_COMPILER_INTEL)
-  RAJA_ALIGN_DATA(x);
-  return x;
-#else
-  return RAJA_ALIGN_DATA(x);
-#endif
-}
-
-
 TEST(SIMD, align){
 
   int N = 1024;
@@ -53,8 +40,8 @@ TEST(SIMD, align){
     }
 
 
-  double *y = alignHint(a);
-  double *x = alignHint(b);
+  double *y = RAJA::align_hint(a);
+  double *x = RAJA::align_hint(b);
 
   RAJA::forall<RAJA::simd_exec>(RAJA::RangeSegment(0, N), [=] (int i) {
       y[i] += x[i] * c;

--- a/test/unit/test-simd.cpp
+++ b/test/unit/test-simd.cpp
@@ -1,0 +1,68 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
+// 
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-689114
+//
+// All rights reserved.
+//
+// This file is part of RAJA.
+//
+// For details about use and distribution, please read RAJA/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "RAJA/RAJA.hpp"
+#include "RAJA_gtest.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <cmath>
+#include <cassert>
+
+
+using namespace RAJA;
+using namespace RAJA::statement;
+
+template<typename T>
+RAJA_INLINE
+T alignHint(T x)
+{
+#if defined (RAJA_COMPILER_INTEL)
+  RAJA_ALIGN_DATA(x);
+  return x;
+#else
+  return RAJA_ALIGN_DATA(x);
+#endif
+}
+
+
+TEST(SIMD, align){
+
+  int N = 1024;
+  double c = 0.5;
+  double *a = RAJA::allocate_aligned_type<double>(RAJA::DATA_ALIGN,N*sizeof(double));
+  double *b = RAJA::allocate_aligned_type<double>(RAJA::DATA_ALIGN,N*sizeof(double));
+    
+  for(int i=0; i<N; ++i) 
+    {
+      a[i] = 0; 
+      b[i] = 2.0;
+    }
+
+
+  double *y = alignHint(a);
+  double *x = alignHint(b);
+
+  RAJA::forall<RAJA::simd_exec>(RAJA::RangeSegment(0, N), [=] (int i) {
+      y[i] += x[i] * c;
+    });
+
+  for(int i=0; i<N; ++i)
+    {
+      ASSERT_FLOAT_EQ(y[i], 1.0);
+    }
+
+}


### PR DESCRIPTION
Fixed bug in align. Created common interface for GCC/Clang/Intel. GCC/Clang returns void * while Intel returns nothing. 