### PR TITLE
Fixes bug to view with offset layout

### DIFF
--- a/include/RAJA/util/View.hpp
+++ b/include/RAJA/util/View.hpp
@@ -68,9 +68,9 @@ struct View {
   {
   }
 
-  //We found that the generated copy constructor does not actually copy-construct
+  //We found the compiler-generated copy constructor does not actually copy-construct
   //the object on the device in certain nvcc versions. 
-  //By specifying the copy constructor we are able ensure proper behavior.
+  //By explicitly defining the copy constructor we are able ensure proper behavior.
   //Git-hub pull request link https://github.com/LLNL/RAJA/pull/477
   RAJA_INLINE RAJA_HOST_DEVICE constexpr View(View const &V)
       : layout(V.layout), data(V.data)

--- a/include/RAJA/util/View.hpp
+++ b/include/RAJA/util/View.hpp
@@ -68,7 +68,10 @@ struct View {
   {
   }
 
-  RAJA_INLINE constexpr View(View const &) = default;
+  RAJA_INLINE RAJA_HOST_DEVICE constexpr View(View const &V)
+      : layout(V.layout), data(V.data)
+  {
+  }
 
   template <bool IsConstView = std::is_const<value_type>::value>
   RAJA_INLINE constexpr View(

--- a/include/RAJA/util/View.hpp
+++ b/include/RAJA/util/View.hpp
@@ -68,6 +68,10 @@ struct View {
   {
   }
 
+  //We found that the generated copy constructor does not actually copy-construct
+  //the object on the device in certain nvcc versions. 
+  //By specifying the copy constructor we are able ensure proper behavior.
+  //Git-hub pull request link https://github.com/LLNL/RAJA/pull/477
   RAJA_INLINE RAJA_HOST_DEVICE constexpr View(View const &V)
       : layout(V.layout), data(V.data)
   {


### PR DESCRIPTION
We found a bug when views are used in the device with offset layouts. In particular the generated copy constructor does not actually copy-construct the object.

The follows compilers generate run time errors :
CUDA 8, 9.0.176, 9.0.184, 9.1.76, 9.1.85 .

We are able to fix the bug by specifying the copy constructor. An additional unit test was added to test-cuda-forall-view.cpp to test for correct behavior. 
