### PR TITLE
Reproducer/nvidia/offset - (DO NOT MERGE)

### DIFF
--- a/include/RAJA/util/View.hpp
+++ b/include/RAJA/util/View.hpp
@@ -36,6 +36,9 @@
 #include "chai/ManagedArray.hpp"
 #endif
 
+#define FIX_NVCC_BUG
+#undef FIX_NVCC_BUG
+
 namespace RAJA
 {
 
@@ -68,10 +71,15 @@ struct View {
   {
   }
 
+#if defined(FIX_NVCC_BUG)
   RAJA_INLINE RAJA_HOST_DEVICE constexpr View(View const &V)
       : layout(V.layout), data(V.data)
   {
   }
+#else
+
+  RAJA_INLINE constexpr View(View const &) = default;
+#endif
 
   template <bool IsConstView = std::is_const<value_type>::value>
   RAJA_INLINE constexpr View(

--- a/include/RAJA/util/View.hpp
+++ b/include/RAJA/util/View.hpp
@@ -68,7 +68,10 @@ struct View {
   {
   }
 
-  RAJA_INLINE constexpr View(View const &) = default;
+  RAJA_INLINE RAJA_HOST_DEVICE constexpr View(View const &V)
+      : layout(V.layout), data(V.data)
+  {
+  }
 
   template <bool IsConstView = std::is_const<value_type>::value>
   RAJA_INLINE constexpr View(


### PR DESCRIPTION
Reproducer for NVIDIA. We found a bug when views are used in the device with offset layouts. In particular the generated copy constructor does not actually copy-construct the object. 

The follows compilers generate run time errors : 
CUDA 8, 9.0.176, 9.0.184, 9.1.76, 9.1.85 . 

In particular the following test fails /test/unit/cuda/test/test-cuda-forall-view.exe 

By defining FIX_NVCC_BUG in nvidia-bug/include/RAJA/util/View.hpp we are able to fix the bug, i.e. specifying the copy constructor. Removing FIX_NVCC_BUG macro  will cause run-time errors. 

 git clone -b reproducer/nvidia/offset https://github.com/LLNL/RAJA.git nvcc-bug
cd nvcc-bug
git submodule init && git submodule update
mkdir build
cmake -DENABLE_CUDA=On -DCUDA_TOOLKIT_ROOT_DIR=$(PATH_TO_CUDA) ../
make -j
./test/unit/cuda/test/test-cuda-forall-view.exe 




