### PR TITLE
Fix RAJA cuda reducers with host device lambdas

### DIFF
--- a/include/RAJA/policy/cuda/reduce.hpp
+++ b/include/RAJA/policy/cuda/reduce.hpp
@@ -638,11 +638,14 @@ struct Reduce_Data {
   {
   }
 
+  //! initialize output to identity to ensure never read
+  //  uninitialized memory
   void init_grid_val(T* output)
   {
     *output = identity;
   }
 
+  //! reduce values in grid to single value, store in output
   RAJA_DEVICE
   void grid_reduce(T* output)
   {
@@ -726,11 +729,14 @@ struct ReduceAtomic_Data {
   {
   }
 
+  //! initialize output to identity to ensure never read
+  //  uninitialized memory
   void init_grid_val(T* output)
   {
     *output = identity;
   }
 
+  //! reduce values in grid to single value, store in output
   RAJA_DEVICE
   void grid_reduce(T* output)
   {
@@ -795,6 +801,8 @@ public:
   }
 
   //! copy and on host attempt to setup for device
+  //  init val_ptr to avoid uninitialized read caused by host copy of
+  //  reducer in host device lambda not being used on device.
   RAJA_HOST_DEVICE
   Reduce(const Reduce& other)
 #if !defined(__CUDA_ARCH__)

--- a/include/RAJA/policy/cuda/reduce.hpp
+++ b/include/RAJA/policy/cuda/reduce.hpp
@@ -605,7 +605,7 @@ struct Reduce_Data {
 
   Reduce_Data()
     : Reduce_Data(T(),T()){};
-  
+
   /*! \brief create from a default value and offload information
    *
    *  allocates PinnedTally to hold device values
@@ -636,6 +636,11 @@ struct Reduce_Data {
         device{other.device},
         own_device_ptr{false}
   {
+  }
+
+  void init_grid_val(T* output)
+  {
+    *output = identity;
   }
 
   RAJA_DEVICE
@@ -692,7 +697,7 @@ struct ReduceAtomic_Data {
 
   ReduceAtomic_Data()
     : ReduceAtomic_Data(T(),T()) {};
-  
+
   ReduceAtomic_Data(T initValue, T identity_)
     : value{initValue},
     identity{identity_},
@@ -719,6 +724,11 @@ struct ReduceAtomic_Data {
         device{other.device},
         own_device_ptr{false}
   {
+  }
+
+  void init_grid_val(T* output)
+  {
+    *output = identity;
   }
 
   RAJA_DEVICE
@@ -800,6 +810,7 @@ public:
       if (val.setupForDevice()) {
         tally_or_val_ptr.val_ptr =
             tally_or_val_ptr.list->new_value(currentStream());
+        val.init_grid_val(tally_or_val_ptr.val_ptr);
         parent = nullptr;
       }
     }

--- a/test/unit/cuda/test-forall-view.cpp
+++ b/test/unit/cuda/test-forall-view.cpp
@@ -67,8 +67,8 @@ CUDA_TEST_F(ForallViewCUDA, ForallViewLayout)
   const RAJA::Layout<1> my_layout(alen);
   RAJA::View<double, RAJA::Layout<1> > view(arr_d, my_layout);
 
-  forall<RAJA::cuda_exec<block_size>>(RAJA::RangeSegment(0, alen), 
-    [=] __device__ (Index_type i) {
+  forall<RAJA::cuda_exec<block_size>>(RAJA::RangeSegment(0, alen),
+    [=] RAJA_HOST_DEVICE (Index_type i) {
     view(i) = test_val;
   });
 
@@ -88,12 +88,12 @@ CUDA_TEST_F(ForallViewCUDA, ForallViewOffsetLayout)
   double* arr_d = ::arr_d;
   double test_val = ::test_val;
 
-  RAJA::OffsetLayout<1> my_layout = 
-                        RAJA::make_offset_layout<1>({{1}}, {{alen+1}}); 
+  RAJA::OffsetLayout<1> my_layout =
+                        RAJA::make_offset_layout<1>({{1}}, {{alen+1}});
   RAJA::View<double, RAJA::OffsetLayout<1> > view(arr_d, my_layout);
 
-  forall<RAJA::cuda_exec<block_size>>(RAJA::RangeSegment(1, alen+1), 
-  [=] __device__(Index_type i) { 
+  forall<RAJA::cuda_exec<block_size>>(RAJA::RangeSegment(1, alen+1),
+  [=] RAJA_HOST_DEVICE(Index_type i) {
     view(i) = test_val;
   });
 
@@ -108,21 +108,21 @@ CUDA_TEST_F(ForallViewCUDA, ForallViewOffsetLayout)
 
 CUDA_TEST_F(ForallViewCUDA, ForallViewOffsetLayout2D)
 {
-  
+
   using RAJA::Index_type;
   Index_type *box;
   const Index_type DIM = 2;
   const Index_type N = 2;
   const Index_type boxSize = (N+2)*(N+2);
-  
+
   cudaMallocManaged((void**)&box, boxSize*sizeof(Index_type), cudaMemAttachGlobal);
 
   RAJA::OffsetLayout<DIM> layout = RAJA::make_offset_layout<DIM>({{-1,-1}}, {{2,2}});
   RAJA::View<Index_type, RAJA::OffsetLayout<DIM>>boxview(box,layout);
 
   forall<RAJA::cuda_exec<256>>
-    (RAJA::RangeSegment(0, N*N), 
-     [=] __device__(Index_type i) { 
+    (RAJA::RangeSegment(0, N*N),
+     [=] RAJA_HOST_DEVICE(Index_type i) {
       const int col = i%N;
       const int row = i/N;
       boxview(row,col) = 1000;

--- a/test/unit/cuda/test-forall-view.cpp
+++ b/test/unit/cuda/test-forall-view.cpp
@@ -93,7 +93,7 @@ CUDA_TEST_F(ForallViewCUDA, ForallViewOffsetLayout)
   RAJA::View<double, RAJA::OffsetLayout<1> > view(arr_d, my_layout);
 
   forall<RAJA::cuda_exec<block_size>>(RAJA::RangeSegment(1, alen+1),
-  [=] RAJA_HOST_DEVICE(Index_type i) {
+  [=] RAJA_DEVICE(Index_type i) {
     view(i) = test_val;
   });
 

--- a/test/unit/cuda/test-forall.cpp
+++ b/test/unit/cuda/test-forall.cpp
@@ -192,7 +192,7 @@ CUDA_TEST_F(ForallCUDA, forall_range)
   }
 
   RAJA::forall<RAJA::cuda_exec<block_size>>(
-      RAJA::make_range(0, array_length), [=] __device__(RAJA::Index_type idx) {
+      RAJA::make_range(0, array_length), [=] RAJA_HOST_DEVICE(RAJA::Index_type idx) {
         test_array[idx] = parent[idx] * parent[idx];
       });
 
@@ -224,7 +224,7 @@ CUDA_TEST_F(ForallCUDA, forall_icount_range)
   RAJA::forall_Icount<RAJA::cuda_exec<block_size>>(
       RAJA::make_range(0, array_length),
       0,
-      [=] __device__(RAJA::Index_type icount, RAJA::Index_type idx) {
+      [=] RAJA_HOST_DEVICE(RAJA::Index_type icount, RAJA::Index_type idx) {
         test_array[icount] = parent[idx] * parent[idx];
       });
 
@@ -254,7 +254,7 @@ CUDA_TEST_F(ForallCUDA, forall_indexset)
   }
 
   RAJA::forall<RAJA::ExecPolicy<RAJA::seq_segit, RAJA::cuda_exec<block_size>>>(
-      iset, [=] __device__(RAJA::Index_type idx) {
+      iset, [=] RAJA_HOST_DEVICE(RAJA::Index_type idx) {
         test_array[idx] = parent[idx] * parent[idx];
       });
 
@@ -282,7 +282,7 @@ CUDA_TEST_F(ForallCUDA, forall_icount_indexset)
 
   RAJA::forall_Icount<RAJA::ExecPolicy<RAJA::seq_segit,
                                        RAJA::cuda_exec<block_size>>>(
-      iset, [=] __device__(RAJA::Index_type icount, RAJA::Index_type idx) {
+      iset, [=] RAJA_HOST_DEVICE(RAJA::Index_type icount, RAJA::Index_type idx) {
         test_array[icount] = parent[idx] * parent[idx];
       });
 

--- a/test/unit/cuda/test-forall.cpp
+++ b/test/unit/cuda/test-forall.cpp
@@ -224,7 +224,7 @@ CUDA_TEST_F(ForallCUDA, forall_icount_range)
   RAJA::forall_Icount<RAJA::cuda_exec<block_size>>(
       RAJA::make_range(0, array_length),
       0,
-      [=] RAJA_HOST_DEVICE(RAJA::Index_type icount, RAJA::Index_type idx) {
+      [=] RAJA_DEVICE(RAJA::Index_type icount, RAJA::Index_type idx) {
         test_array[icount] = parent[idx] * parent[idx];
       });
 
@@ -282,7 +282,7 @@ CUDA_TEST_F(ForallCUDA, forall_icount_indexset)
 
   RAJA::forall_Icount<RAJA::ExecPolicy<RAJA::seq_segit,
                                        RAJA::cuda_exec<block_size>>>(
-      iset, [=] RAJA_HOST_DEVICE(RAJA::Index_type icount, RAJA::Index_type idx) {
+      iset, [=] RAJA_DEVICE(RAJA::Index_type icount, RAJA::Index_type idx) {
         test_array[icount] = parent[idx] * parent[idx];
       });
 

--- a/test/unit/cuda/test-nested-strided.cpp
+++ b/test/unit/cuda/test-nested-strided.cpp
@@ -58,7 +58,7 @@ static void stride_test(int stride, bool reverse = false)
                                 cuda_block_x_exec,
                                 cuda_thread_y_exec>,
                        Permute<PERM_IJK>>>(seg_x, seg_y, seg_z,
-                                           [=] RAJA_DEVICE(Index_type i,
+                                           [=] RAJA_HOST_DEVICE(Index_type i,
                                                            Index_type j,
                                                            Index_type k) {
                                              Index_type val = (i*y*z) + (j*z) + k;

--- a/test/unit/cuda/test-nested.cpp
+++ b/test/unit/cuda/test-nested.cpp
@@ -346,7 +346,7 @@ CUDA_TEST(NestedCUDA, NegativeRange)
 
   forallN<NestedPolicy<
       ExecList<cuda_threadblock_y_exec<16>, cuda_threadblock_x_exec<16>>>>(
-      RangeSegment(-2, 8), RangeSegment(-2, 8), [=] RAJA_HOST_DEVICE(int k, int j) {
+      RangeSegment(-2, 8), RangeSegment(-2, 8), [=] RAJA_DEVICE(int k, int j) {
         const int idx = ((k - -2) * 10) + (j - -2);
         data[idx] = idx * 1.0;
       });

--- a/test/unit/cuda/test-nested.cpp
+++ b/test/unit/cuda/test-nested.cpp
@@ -137,7 +137,7 @@ static void runLTimesTest(Index_type num_moments,
       RangeSegment(0, num_directions),
       RangeSegment(0, num_groups),
       RangeSegment(0, num_zones),
-      [=] __device__(IMoment m, IDirection d, IGroup g, IZone z) {
+      [=] RAJA_HOST_DEVICE(IMoment m, IDirection d, IGroup g, IZone z) {
         // printf("%d,%d,%d,%d\n", *m, *d, *g, *z);
         double val = ell(m, d) * psi(d, g, z);
         phi(m, g, z) += val;
@@ -346,7 +346,7 @@ CUDA_TEST(NestedCUDA, NegativeRange)
 
   forallN<NestedPolicy<
       ExecList<cuda_threadblock_y_exec<16>, cuda_threadblock_x_exec<16>>>>(
-      RangeSegment(-2, 8), RangeSegment(-2, 8), [=] RAJA_DEVICE(int k, int j) {
+      RangeSegment(-2, 8), RangeSegment(-2, 8), [=] RAJA_HOST_DEVICE(int k, int j) {
         const int idx = ((k - -2) * 10) + (j - -2);
         data[idx] = idx * 1.0;
       });
@@ -373,7 +373,7 @@ CUDA_TEST(NestedCUDA, PositiveRange)
 
   forallN<NestedPolicy<
       ExecList<cuda_threadblock_y_exec<16>, cuda_threadblock_x_exec<16>>>>(
-      RangeSegment(2, 12), RangeSegment(2, 12), [=] RAJA_DEVICE(int k, int j) {
+      RangeSegment(2, 12), RangeSegment(2, 12), [=] RAJA_HOST_DEVICE(int k, int j) {
         const int idx = ((k - 2) * 10) + (j - 2);
         data[idx] = idx * 1.0;
       });

--- a/test/unit/cuda/test-reduce-loc.cpp
+++ b/test/unit/cuda/test-reduce-loc.cpp
@@ -167,7 +167,7 @@ CUDA_TYPED_TEST_P(ReduceCUDA, generic)
       reduce::detail::ValueLoc<double> randval(droll, index);
       applier::updatedvalue(dvalue, randval, dcurrent);
 
-      forall<cuda_exec<block_size>>(RAJA::RangeSegment(0, TEST_VEC_LEN), [=] RAJA_HOST_DEVICE(int i) {
+      forall<cuda_exec<block_size>>(RAJA::RangeSegment(0, TEST_VEC_LEN), [=] RAJA_DEVICE(int i) {
         applier::apply(dmin0, dvalue[i], i);
         applier::apply(dmin1, 2 * dvalue[i], i);
         applier::apply(dmin2, dvalue[i], i);
@@ -274,7 +274,7 @@ CUDA_TYPED_TEST_P(ReduceCUDA, indexset_noalign)
     applier::updatedvalue(dvalue, randval, dcurrent);
 
     forall<ExecPolicy<seq_segit, cuda_exec<block_size>>>(
-        iset, [=] RAJA_HOST_DEVICE(int i) {
+        iset, [=] RAJA_DEVICE(int i) {
           applier::apply(dmin0, dvalue[i], i);
           applier::apply(dmin1, 2 * dvalue[i], i);
         });

--- a/test/unit/cuda/test-reduce-loc.cpp
+++ b/test/unit/cuda/test-reduce-loc.cpp
@@ -64,7 +64,7 @@ struct reduce_applier<ReduceMinLoc<T, U>> {
       apply(dcurrent, randval);
     }
   }
-  RAJA_DEVICE static void apply(ReduceMinLoc<T, U> const& r,
+  RAJA_HOST_DEVICE static void apply(ReduceMinLoc<T, U> const& r,
                                 U const& val,
                                 Index_type i)
   {
@@ -98,7 +98,7 @@ struct reduce_applier<ReduceMaxLoc<T, U>> {
       apply(dcurrent, randval);
     }
   }
-  RAJA_DEVICE static void apply(ReduceMaxLoc<T, U> const& r,
+  RAJA_HOST_DEVICE static void apply(ReduceMaxLoc<T, U> const& r,
                                 U const& val,
                                 Index_type i)
   {
@@ -167,7 +167,7 @@ CUDA_TYPED_TEST_P(ReduceCUDA, generic)
       reduce::detail::ValueLoc<double> randval(droll, index);
       applier::updatedvalue(dvalue, randval, dcurrent);
 
-      forall<cuda_exec<block_size>>(RAJA::RangeSegment(0, TEST_VEC_LEN), [=] __device__(int i) {
+      forall<cuda_exec<block_size>>(RAJA::RangeSegment(0, TEST_VEC_LEN), [=] RAJA_HOST_DEVICE(int i) {
         applier::apply(dmin0, dvalue[i], i);
         applier::apply(dmin1, 2 * dvalue[i], i);
         applier::apply(dmin2, dvalue[i], i);
@@ -217,7 +217,7 @@ CUDA_TYPED_TEST_P(ReduceCUDA, indexset_align)
     applier::updatedvalue(dvalue, randval, dcurrent);
 
     forall<ExecPolicy<seq_segit, cuda_exec<block_size>>>(
-        iset, [=] __device__(int i) {
+        iset, [=] RAJA_HOST_DEVICE(int i) {
           applier::apply(dmin0, dvalue[i], i);
           applier::apply(dmin1, 2 * dvalue[i], i);
         });
@@ -274,7 +274,7 @@ CUDA_TYPED_TEST_P(ReduceCUDA, indexset_noalign)
     applier::updatedvalue(dvalue, randval, dcurrent);
 
     forall<ExecPolicy<seq_segit, cuda_exec<block_size>>>(
-        iset, [=] __device__(int i) {
+        iset, [=] RAJA_HOST_DEVICE(int i) {
           applier::apply(dmin0, dvalue[i], i);
           applier::apply(dmin1, 2 * dvalue[i], i);
         });

--- a/test/unit/cuda/test-reduce-max.cpp
+++ b/test/unit/cuda/test-reduce-max.cpp
@@ -117,7 +117,7 @@ CUDA_TEST_F(ReduceMaxCUDA, generic)
         dcurrentMax = RAJA_MAX(dcurrentMax, droll);
       }
 
-      forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] RAJA_HOST_DEVICE(int i) {
+      forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] RAJA_DEVICE(int i) {
           dmax0.max(dvalue[i]);
           dmax1.max(2 * dvalue[i]);
           dmax2.max(dvalue[i]);
@@ -224,7 +224,7 @@ CUDA_TEST_F(ReduceMaxCUDA, indexset_noalign)
     }
 
     forall<ExecPolicy<seq_segit, cuda_exec<block_size> > >(
-        iset, [=] RAJA_HOST_DEVICE(int i) {
+        iset, [=] RAJA_DEVICE(int i) {
           dmax0.max(dvalue[i]);
           dmax1.max(2 * dvalue[i]);
         });

--- a/test/unit/cuda/test-reduce-max.cpp
+++ b/test/unit/cuda/test-reduce-max.cpp
@@ -80,7 +80,7 @@ CUDA_TEST_F(ReduceMaxCUDA, generic)
     ReduceMax<cuda_reduce<block_size>, double> dmax0; dmax0.reset(DEFAULT_VAL);
     ReduceMax<cuda_reduce<block_size>, double> dmax1(DEFAULT_VAL);
     ReduceMax<cuda_reduce<block_size>, double> dmax2(BIG_VAL);
-    
+
     int loops = 16;
     for (int k = 0; k < loops; k++) {
 
@@ -91,7 +91,7 @@ CUDA_TEST_F(ReduceMaxCUDA, generic)
         dcurrentMax = RAJA_MAX(dcurrentMax, droll);
       }
 
-      forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] __device__(int i) {
+      forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] RAJA_HOST_DEVICE(int i) {
         dmax0.max(dvalue[i]);
         dmax1.max(2 * dvalue[i]);
         dmax2.max(dvalue[i]);
@@ -106,29 +106,29 @@ CUDA_TEST_F(ReduceMaxCUDA, generic)
     dmax0.reset(DEFAULT_VAL);
     dmax1.reset(DEFAULT_VAL);
     dmax2.reset(BIG_VAL);
-    
+
     loops = 16;
     for (int k = 0; k < loops; k++) {
-      
+
       double droll = dist(mt);
       int index = int(dist2(mt));
       if (droll > dvalue[index]) {
         dvalue[index] = droll;
         dcurrentMax = RAJA_MAX(dcurrentMax, droll);
       }
-      
-      forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] __device__(int i) {
+
+      forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] RAJA_HOST_DEVICE(int i) {
           dmax0.max(dvalue[i]);
           dmax1.max(2 * dvalue[i]);
           dmax2.max(dvalue[i]);
         });
-      
+
       ASSERT_FLOAT_EQ(dcurrentMax, dmax0.get());
       ASSERT_FLOAT_EQ(dcurrentMax * 2, dmax1.get());
       ASSERT_FLOAT_EQ(BIG_VAL, dmax2.get());
     }
   }
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -168,7 +168,7 @@ CUDA_TEST_F(ReduceMaxCUDA, indexset_align)
     }
 
     forall<ExecPolicy<seq_segit, cuda_exec<block_size> > >(
-        iset, [=] __device__(int i) {
+        iset, [=] RAJA_HOST_DEVICE(int i) {
           dmax0.max(dvalue[i]);
           dmax1.max(2 * dvalue[i]);
         });
@@ -224,7 +224,7 @@ CUDA_TEST_F(ReduceMaxCUDA, indexset_noalign)
     }
 
     forall<ExecPolicy<seq_segit, cuda_exec<block_size> > >(
-        iset, [=] __device__(int i) {
+        iset, [=] RAJA_HOST_DEVICE(int i) {
           dmax0.max(dvalue[i]);
           dmax1.max(2 * dvalue[i]);
         });

--- a/test/unit/cuda/test-reduce-min.cpp
+++ b/test/unit/cuda/test-reduce-min.cpp
@@ -91,7 +91,7 @@ CUDA_TEST_F(ReduceMinCUDA, generic)
         dcurrentMin = RAJA_MIN(dcurrentMin, droll);
       }
 
-      forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] __device__(int i) {
+      forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] RAJA_HOST_DEVICE(int i) {
         dmin0.min(dvalue[i]);
         dmin1.min(2 * dvalue[i]);
         dmin2.min(dvalue[i]);
@@ -116,7 +116,7 @@ CUDA_TEST_F(ReduceMinCUDA, generic)
         dcurrentMin = RAJA_MIN(dcurrentMin, droll);
       }
 
-      forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] __device__(int i) {
+      forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] RAJA_HOST_DEVICE(int i) {
         dmin0.min(dvalue[i]);
         dmin1.min(2 * dvalue[i]);
         dmin2.min(dvalue[i]);
@@ -166,7 +166,7 @@ CUDA_TEST_F(ReduceMinCUDA, indexset_align)
     }
 
     forall<ExecPolicy<seq_segit, cuda_exec<block_size> > >(
-        iset, [=] __device__(int i) {
+        iset, [=] RAJA_HOST_DEVICE(int i) {
           dmin0.min(dvalue[i]);
           dmin1.min(2 * dvalue[i]);
         });
@@ -222,7 +222,7 @@ CUDA_TEST_F(ReduceMinCUDA, indexset_noalign)
     }
 
     forall<ExecPolicy<seq_segit, cuda_exec<block_size> > >(
-        iset, [=] __device__(int i) {
+        iset, [=] RAJA_HOST_DEVICE(int i) {
           dmin0.min(dvalue[i]);
           dmin1.min(2 * dvalue[i]);
         });

--- a/test/unit/cuda/test-reduce-min.cpp
+++ b/test/unit/cuda/test-reduce-min.cpp
@@ -91,7 +91,7 @@ CUDA_TEST_F(ReduceMinCUDA, generic)
         dcurrentMin = RAJA_MIN(dcurrentMin, droll);
       }
 
-      forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] RAJA_HOST_DEVICE(int i) {
+      forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] RAJA_DEVICE(int i) {
         dmin0.min(dvalue[i]);
         dmin1.min(2 * dvalue[i]);
         dmin2.min(dvalue[i]);
@@ -166,7 +166,7 @@ CUDA_TEST_F(ReduceMinCUDA, indexset_align)
     }
 
     forall<ExecPolicy<seq_segit, cuda_exec<block_size> > >(
-        iset, [=] RAJA_HOST_DEVICE(int i) {
+        iset, [=] RAJA_DEVICE(int i) {
           dmin0.min(dvalue[i]);
           dmin1.min(2 * dvalue[i]);
         });

--- a/test/unit/cuda/test-reduce-sum.cpp
+++ b/test/unit/cuda/test-reduce-sum.cpp
@@ -150,7 +150,7 @@ CUDA_TEST_F(ReduceSumCUDA, staggered_sum2)
   int loops = 2;
   for (int k = 0; k < loops; k++) {
 
-    forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] RAJA_HOST_DEVICE(int i) {
+    forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] RAJA_DEVICE(int i) {
       dsum0 += dvalue[i];
       dsum1 += dvalue[i] * 2.0;
       dsum2 += dvalue[i] * 3.0;
@@ -252,7 +252,7 @@ CUDA_TEST_F(ReduceSumCUDA, indexset_noalign)
   ReduceSum<cuda_reduce<block_size>, int> isum3(itinit * 4);
 
   forall<ExecPolicy<seq_segit, cuda_exec<block_size> > >(
-      iset, [=] RAJA_HOST_DEVICE(int i) {
+      iset, [=] RAJA_DEVICE(int i) {
         dsum0 += dvalue[i];
         isum1 += 2 * ivalue[i];
         dsum2 += 3 * dvalue[i];
@@ -313,7 +313,7 @@ CUDA_TEST_F(ReduceSumCUDA, increasing_size)
 
     ReduceSum<cuda_reduce<block_size, true>, double> dsum0(dtinit);
 
-    forall<cuda_exec<block_size, true> >(RangeSegment(0, size), [=] RAJA_HOST_DEVICE(int i) {
+    forall<cuda_exec<block_size, true> >(RangeSegment(0, size), [=] RAJA_DEVICE(int i) {
       dsum0 += dvalue[i];
     });
 

--- a/test/unit/cuda/test-reduce-sum.cpp
+++ b/test/unit/cuda/test-reduce-sum.cpp
@@ -29,7 +29,7 @@
 
 using UnitIndexSet = RAJA::TypedIndexSet<RAJA::RangeSegment, RAJA::ListSegment, RAJA::RangeStrideSegment>;
 
-constexpr const int TEST_VEC_LEN = 1024 * 1024 * 5;
+constexpr const int TEST_VEC_LEN = 1024;
 
 using namespace RAJA;
 
@@ -99,7 +99,7 @@ CUDA_TEST_F(ReduceSumCUDA, staggered_sum)
   int loops = 2;
   for (int k = 0; k < loops; k++) {
 
-    forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] __device__(int i) {
+    forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] RAJA_HOST_DEVICE(int i) {
       dsum0 += dvalue[i];
       dsum1 += dvalue[i] * 2.0;
       dsum2 += dvalue[i] * 3.0;
@@ -137,7 +137,7 @@ CUDA_TEST_F(ReduceSumCUDA, staggered_sum2)
   ReduceSum<cuda_reduce<block_size>, double> dsum5;
   ReduceSum<cuda_reduce<block_size>, double> dsum6(5.0);
   ReduceSum<cuda_reduce<block_size>, double> dsum7;
-  
+
   dsum0.reset(0.0);
   dsum1.reset(dtinit * 1.0);
   dsum2.reset(0.0);
@@ -146,11 +146,11 @@ CUDA_TEST_F(ReduceSumCUDA, staggered_sum2)
   dsum5.reset(dtinit * 5.0);
   dsum6.reset(0.0);
   dsum7.reset(dtinit * 7.0);
-  
+
   int loops = 2;
   for (int k = 0; k < loops; k++) {
 
-    forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] __device__(int i) {
+    forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] RAJA_HOST_DEVICE(int i) {
       dsum0 += dvalue[i];
       dsum1 += dvalue[i] * 2.0;
       dsum2 += dvalue[i] * 3.0;
@@ -197,7 +197,7 @@ CUDA_TEST_F(ReduceSumCUDA, indexset_aligned)
 
   forallN<NestedPolicy<ExecList<ExecPolicy<seq_segit,
                                            cuda_exec<block_size> > > > >(
-      iset, [=] __device__(int i) {
+      iset, [=] RAJA_HOST_DEVICE(int i) {
         dsum0 += dvalue[i];
         isum1 += 2 * ivalue[i];
         dsum2 += 3 * dvalue[i];
@@ -225,11 +225,17 @@ CUDA_TEST_F(ReduceSumCUDA, indexset_noalign)
   double* dvalue = ReduceSumCUDA::dvalue;
   int* ivalue = ReduceSumCUDA::ivalue;
 
-
+#if 0
   RangeSegment seg0(1, 1230);
   RangeSegment seg1(1237, 3385);
   RangeSegment seg2(4860, 10110);
   RangeSegment seg3(20490, 32003);
+#else
+  RangeSegment seg0((int)0.0125*TEST_VEC_LEN, (int)0.2375*TEST_VEC_LEN);
+  RangeSegment seg1((int)0.2875*TEST_VEC_LEN, (int)0.4500*TEST_VEC_LEN);
+  RangeSegment seg2((int)0.5250*TEST_VEC_LEN, (int)0.7125*TEST_VEC_LEN);
+  RangeSegment seg3((int)0.7775*TEST_VEC_LEN, (int)0.9650*TEST_VEC_LEN);
+#endif
 
   UnitIndexSet iset;
   iset.push_back(seg0);
@@ -246,7 +252,7 @@ CUDA_TEST_F(ReduceSumCUDA, indexset_noalign)
   ReduceSum<cuda_reduce<block_size>, int> isum3(itinit * 4);
 
   forall<ExecPolicy<seq_segit, cuda_exec<block_size> > >(
-      iset, [=] __device__(int i) {
+      iset, [=] RAJA_HOST_DEVICE(int i) {
         dsum0 += dvalue[i];
         isum1 += 2 * ivalue[i];
         dsum2 += 3 * dvalue[i];
@@ -284,7 +290,7 @@ CUDA_TEST_F(ReduceSumCUDA, atomic_reduce)
         pos_chk_val += rand_dvalue[i];
       }
     }
-    forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] __device__(int i) {
+    forall<cuda_exec<block_size> >(RangeSegment(0, TEST_VEC_LEN), [=] RAJA_HOST_DEVICE(int i) {
       if (rand_dvalue[i] < 0.0) {
         dsumN += rand_dvalue[i];
       } else {
@@ -307,7 +313,7 @@ CUDA_TEST_F(ReduceSumCUDA, increasing_size)
 
     ReduceSum<cuda_reduce<block_size, true>, double> dsum0(dtinit);
 
-    forall<cuda_exec<block_size, true> >(RangeSegment(0, size), [=] __device__(int i) {
+    forall<cuda_exec<block_size, true> >(RangeSegment(0, size), [=] RAJA_HOST_DEVICE(int i) {
       dsum0 += dvalue[i];
     });
 

--- a/test/unit/cuda/test-reduce-sum.cpp
+++ b/test/unit/cuda/test-reduce-sum.cpp
@@ -29,7 +29,7 @@
 
 using UnitIndexSet = RAJA::TypedIndexSet<RAJA::RangeSegment, RAJA::ListSegment, RAJA::RangeStrideSegment>;
 
-constexpr const int TEST_VEC_LEN = 1024;
+constexpr const int TEST_VEC_LEN = 1024 * 1024 * 5;
 
 using namespace RAJA;
 
@@ -225,17 +225,11 @@ CUDA_TEST_F(ReduceSumCUDA, indexset_noalign)
   double* dvalue = ReduceSumCUDA::dvalue;
   int* ivalue = ReduceSumCUDA::ivalue;
 
-#if 0
+
   RangeSegment seg0(1, 1230);
   RangeSegment seg1(1237, 3385);
   RangeSegment seg2(4860, 10110);
   RangeSegment seg3(20490, 32003);
-#else
-  RangeSegment seg0((int)0.0125*TEST_VEC_LEN, (int)0.2375*TEST_VEC_LEN);
-  RangeSegment seg1((int)0.2875*TEST_VEC_LEN, (int)0.4500*TEST_VEC_LEN);
-  RangeSegment seg2((int)0.5250*TEST_VEC_LEN, (int)0.7125*TEST_VEC_LEN);
-  RangeSegment seg3((int)0.7775*TEST_VEC_LEN, (int)0.9650*TEST_VEC_LEN);
-#endif
 
   UnitIndexSet iset;
   iset.push_back(seg0);

--- a/test/unit/cuda/test-synchronize.cpp
+++ b/test/unit/cuda/test-synchronize.cpp
@@ -24,7 +24,7 @@ CUDA_TEST(SynchronizeTest, CUDA){
   double* managed_data;
   cudaMallocManaged(&managed_data, sizeof(double)*50);
 
-  RAJA::forall<RAJA::cuda_exec_async<256>>(0,50, [=] RAJA_DEVICE (RAJA::Index_type i) {
+  RAJA::forall<RAJA::cuda_exec_async<256>>(0,50, [=] RAJA_HOST_DEVICE (RAJA::Index_type i) {
       managed_data[i] = 1.0*i;
   });
   RAJA::synchronize<RAJA::cuda_synchronize>();


### PR DESCRIPTION
This fixes Raja cuda reducers to work in host device lambdas.
This pull request changes the cuda tests to use both device and  host device lambdas.

The bug was caused by reading uninitialized memory. The RAJA cuda reducers expected the gpu to write to the memory allocated for the reduction result from the device. However host device lambdas have separate copies of the captured values for the host and the device. So both copies of the reducer allocate space for the reduced value from the gpu, but no value is written to the memory allocated by the host lambda copy of the reducer. When this memory is read it causes the final result to be garbage.