### PR TITLE
Added check to not launch CUDA kernels for RAJA::kernel if the iteration space is 0

### DIFF
--- a/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
+++ b/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
@@ -173,70 +173,61 @@ struct StatementExecutor<statement::CudaKernelExt<LaunchConfig,
     cudaStream_t stream = 0;
 
 
-    //
     // Compute the MAX physical kernel dimensions
-    //
-
     using data_t = camp::decay<Data>;
     LaunchDim max_physical = LaunchConfig::calc_max_physical(
         CudaKernelLauncher<StatementList<EnclosedStmts...>, data_t>, shmem);
 
-    //    printf("Physical limits: %d blocks, %d threads\n",
-    //        (int)max_physical.blocks, (int)max_physical.threads);
 
-
-    //
-    // Compute the Logical kernel dimensions
-    //
+    printf("Max: blocks=%d, threads=%d\n", (int)max_physical.blocks, (int)max_physical.threads);
 
     // Privatize the LoopData, using make_launch_body to setup reductions
     auto cuda_data = RAJA::cuda::make_launch_body(
         max_physical.blocks, max_physical.threads, shmem, stream, data);
-    //    printf("Data size=%d\n", (int)sizeof(cuda_data));
 
-
-    // Compute logical dimensions
-    using SegmentTuple = decltype(data.segment_tuple);
 
     // Instantiate an executor object
     using executor_t = cuda_statement_list_executor_t<stmt_list_t, data_t>;
     executor_t executor;
 
+
     // Compute logical dimensions
     LaunchDim logical_dims = executor.calculateDimensions(data, max_physical);
 
 
-    //    printf("Logical dims: %d blocks, %d threads\n",
-    //        (int)logical_dims.blocks, (int)logical_dims.threads);
+    printf("Logical: blocks=%d, threads=%d\n", (int)logical_dims.blocks, (int)logical_dims.threads);
 
-
-    //
     // Compute the actual physical kernel dimensions
-    //
-
     LaunchDim launch_dims;
     launch_dims.blocks = std::min(max_physical.blocks, logical_dims.blocks);
     launch_dims.threads = std::min(max_physical.threads, logical_dims.threads);
 
-    //    printf("Launch dims: %d blocks, %d threads\n",
-    //        (int)launch_dims.blocks, (int)launch_dims.threads);
+    printf("Launch: blocks=%d, threads=%d\n", (int)launch_dims.blocks, (int)launch_dims.threads);
+
+    // Only launch kernel if we have something to iterate over
+    bool at_least_one_iter = launch_dims.blocks > 0 || launch_dims.threads > 0;
+    bool is_degenerate =     launch_dims.blocks < 0 || launch_dims.threads < 0;
+    if (at_least_one_iter && !is_degenerate) {
+
+      // Make sure that having either 0 blocks or 0 threads get bumped to 1
+      launch_dims.blocks = std::max(launch_dims.blocks, (int)1);
+      launch_dims.threads = std::max(launch_dims.threads, (int)1);
 
 
-    //
-    // Launch the kernels
-    //
-    CudaKernelLauncher<StatementList<EnclosedStmts...>>
-        <<<launch_dims.blocks, launch_dims.threads, shmem, stream>>>(
-            cuda_data, logical_dims.blocks);
+      // Launch the kernels
+      CudaKernelLauncher<StatementList<EnclosedStmts...>>
+          <<<launch_dims.blocks, launch_dims.threads, shmem, stream>>>(
+              cuda_data, logical_dims.blocks);
 
 
-    // Check for errors
-    RAJA::cuda::peekAtLastError();
+      // Check for errors
+      RAJA::cuda::peekAtLastError();
 
-    RAJA::cuda::launch(stream);
+      RAJA::cuda::launch(stream);
 
-    if (!LaunchConfig::async) {
-      RAJA::cuda::synchronize(stream);
+      if (!LaunchConfig::async) {
+        RAJA::cuda::synchronize(stream);
+      }
     }
   }
 };

--- a/include/RAJA/policy/cuda/kernel/For.hpp
+++ b/include/RAJA/policy/cuda/kernel/For.hpp
@@ -83,7 +83,7 @@ struct CudaStatementExecutor<Data,
 
     LaunchDim dim = enclosed_stmts.calculateDimensions(data, max_physical);
 
-    dim.threads *= segment_length<ArgumentId>(data);
+    dim.addThreads(segment_length<ArgumentId>(data));
 
     return dim;
   }
@@ -134,7 +134,7 @@ struct CudaStatementExecutor<Data,
 
     LaunchDim dim = enclosed_stmts.calculateDimensions(data, max_physical);
 
-    dim.blocks *= segment_length<ArgumentId>(data);
+    dim.addBlocks(segment_length<ArgumentId>(data));
 
     return dim;
   }
@@ -196,8 +196,8 @@ struct CudaStatementExecutor<Data,
       num_blocks++;
     }
 
-    dim.blocks *= num_blocks;
-    dim.threads *= max_threads;
+    dim.addBlocks(num_blocks);
+    dim.addThreads(max_threads);
 
     return dim;
   }


### PR DESCRIPTION
This check is already in forall<cuda_exec>, but not for RAJA::kernel... so we just get a kernel launch failure when the number of threads or blocks is 0.

This PR add logic to skip the kernel invocation when there is nothing to iterate over.