### PR TITLE
Examples/artv3/notation-cleanup

### DIFF
--- a/examples/ex-batched-matrix-multiply.cpp
+++ b/examples/ex-batched-matrix-multiply.cpp
@@ -61,12 +61,12 @@
  * The extension to N > 2 matrices follows by direct
  * extension. By exploring different data layouts,
  * we can assess which performs best under a given
- * execution policy and architure.
+ * execution policy and architecture.
  *
  *  RAJA features shown:
  *    - `forall` loop iteration template method
  *    -  RAJA View
- *    -  RAJA make_permuted_layout method
+ *    -  RAJA make_permuted_layout
  *
  * If CUDA is enabled, CUDA unified memory is used.
  */
@@ -100,7 +100,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const int N_r = 3;
 
 // Number of matrices
-  const Index_type N = 4000000;
+  const Index_type N = 8000000;
 
 // Number of iterations
   const int NITER = 20;

--- a/examples/ex-batched-matrix-multiply.cpp
+++ b/examples/ex-batched-matrix-multiply.cpp
@@ -128,14 +128,16 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 // templated array indicating slowest to fastest stride. Dimensions are stored
 // in an array object. Here double braces are used to initialize the array and its
 // subobjects (number of entries in each component).
-// The layout generates an indexing equivalent to
-// A(e,r,c) A[c + N_c*(r + N_r*e)]
+// The layout object will index into the array as the following C macro would
+// #define Aview(e, r, c) A[c + N_c*(r + N_r*e)]
+//
   auto layout =
       RAJA::make_permuted_layout({{N, N_r, N_c}},
                                  RAJA::as_array<RAJA::Perm<0, 1, 2>>::get());
-
-// RAJA::Layout is templated on dimension, argument type, and index with unit
+//
+// RAJA::Layout objects may be templated on dimension, argument type, and index with unit
 // stride (in this case argument 2 has unit stride)
+//  
   RAJA::View<double, RAJA::Layout<3, Index_type, 2>> Aview(A, layout);
   RAJA::View<double, RAJA::Layout<3, Index_type, 2>> Bview(B, layout);
   RAJA::View<double, RAJA::Layout<3, Index_type, 2>> Cview(C, layout);
@@ -149,7 +151,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 //
 // Permuted layout - equivalent to indexing via
-// A[e + N*(c + N_c*r)]
+// #define Aview2(e, r, c) A2[e + N*(c + N_c*r)]
+//
   auto layout2 =
       RAJA::make_permuted_layout({{N, N_r, N_c}},
                                  RAJA::as_array<RAJA::Perm<1, 2, 0>>::get());

--- a/examples/ex-batched-matrix-multiply.cpp
+++ b/examples/ex-batched-matrix-multiply.cpp
@@ -125,9 +125,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 // Layout 1
 //
 // make_permuted_layout takes the number of entries in each dimension and a
-// templated array indicating slowest to fastest stride. Dimensions are stored
-// in an array object. Here double braces are used to initialize the array and its
-// subobjects (number of entries in each component).
+// templated array indicating index arguments with slowest to fastest stride.
+// Standard C++ arrays are used to hold the number of entries in each component.
+// This example uses double braces to initalize the array and its subobjects.
 // The layout object will index into the array as the following C macro would
 // #define Aview(e, r, c) A[c + N_c*(r + N_r*e)]
 //
@@ -136,7 +136,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
                                  RAJA::as_array<RAJA::Perm<0, 1, 2>>::get());
 //
 // RAJA::Layout objects may be templated on dimension, argument type, and index with unit
-// stride (in this case argument 2 has unit stride)
+// stride. In this case the column index has unit stride (argument 2). 
 //  
   RAJA::View<double, RAJA::Layout<3, Index_type, 2>> Aview(A, layout);
   RAJA::View<double, RAJA::Layout<3, Index_type, 2>> Bview(B, layout);
@@ -150,8 +150,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   double *C2 = memoryManager::allocate<double>(N_c * N_r * N);
 
 //
-// Permuted layout - equivalent to indexing via
+// Permuted layout - equivalent to indexing using the following macro
 // #define Aview2(e, r, c) A2[e + N*(c + N_c*r)]
+// In this case the element index has unit stride (argument 0). 
 //
   auto layout2 =
       RAJA::make_permuted_layout({{N, N_r, N_c}},

--- a/examples/ex-offset.cpp
+++ b/examples/ex-offset.cpp
@@ -40,7 +40,7 @@
  *
  *  We assume a lattice has N x N interior nodes 
  *  and a padded edge of zeros for a lattice
- *  of size (N + 2) x (N + 2).  
+ *  of size (N_r + 2) x (N_c + 2).  
  *
  *  In the case of N = 3, the input lattice generated
  *  takes the form
@@ -75,7 +75,8 @@
  * In this example, we use RAJA's make_offset_layout
  * method and view object to simplify applying
  * the stencil to interior cells.
- * A make_offset_layout enables developers to offset
+ * The make_offset_layout method enables developers
+ * to create layouts which offset
  * the enumeration of values in an array. Here we
  * choose to enumerate the lattice in the following manner:
  *
@@ -111,7 +112,7 @@
 //
 // Functions for printing and checking results
 //
-void printLattice(int* lattice, int iCellsInRow, int iCellsInCol);
+void printLattice(int* lattice, int N_r, int N_c);
 void checkResult(int* compLattice, int* refLattice, int totCells);
 
 int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
@@ -122,14 +123,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 //
 // Define num of interior cells in row/cols in a lattice
 //
-  const int iCellsInRow = 3;
-  const int iCellsInCol = 3;
+  const int N_r = 3;
+  const int N_c = 3;
 
 //
 // Define total num of cells in rows/cols in a lattice
 //
-  const int totCellsInRow = iCellsInRow + 2;
-  const int totCellsInCol = iCellsInCol + 2;
+  const int totCellsInRow = N_r + 2;
+  const int totCellsInCol = N_c + 2;
 
 //
 // Define total num of cells in a lattice
@@ -150,8 +151,8 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 //
 // C-Style intialization
 //
-  for (int row = 1; row <= iCellsInRow; ++row) {
-    for (int col = 1; col <= iCellsInCol; ++col) {
+  for (int row = 1; row <= N_r; ++row) {
+    for (int col = 1; col <= N_c; ++col) {
       int id = col + totCellsInCol * row;
       input_lattice[id] = 1;
     }
@@ -161,8 +162,8 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 //
 // Generate reference solution
 //
-  for (int row = 1; row <= iCellsInRow; ++row) {
-    for (int col = 1; col <= iCellsInCol; ++col) {
+  for (int row = 1; row <= N_r; ++row) {
+    for (int col = 1; col <= N_c; ++col) {
 
       int id = col + totCellsInCol * row;
       lattice_ref[id] = input_lattice[id] + input_lattice[id + 1]
@@ -178,8 +179,8 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 //
 // Create loop bounds
 //
-  RAJA::RangeSegment col_range(0, iCellsInRow);
-  RAJA::RangeSegment row_range(0, iCellsInCol);
+  RAJA::RangeSegment col_range(0, N_r);
+  RAJA::RangeSegment row_range(0, N_c);
 
 //
 // Specify the dimension of the lattice
@@ -196,7 +197,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 // subobjects.
 //
   RAJA::OffsetLayout<DIM> layout =
-      RAJA::make_offset_layout<DIM>({{-1, -1}}, {{iCellsInRow, iCellsInCol}});
+      RAJA::make_offset_layout<DIM>({{-1, -1}}, {{N_r, N_c}});
   RAJA::View<int, RAJA::OffsetLayout<DIM>> input_latticeView(input_lattice, layout);
   RAJA::View<int, RAJA::OffsetLayout<DIM>> output_latticeView(output_lattice, layout);
 

--- a/examples/ex-offset.cpp
+++ b/examples/ex-offset.cpp
@@ -30,7 +30,7 @@
  *
  *  The five-cell stencil accumulates values of a cell 
  *  and its four neighbors. Assuming the cells of a 
- *  lattice may be accessed through a row/col fashion, 
+ *  lattice may be accessed in a row/col fashion, 
  *  the stencil may be expressed as the following sum
  * 
  *  output_lattice(row, col)
@@ -38,11 +38,11 @@
  *         + input_lattice(row - 1, col) + input_lattice(row + 1, col)
  *         + input_lattice(row, col - 1) + input_lattice(row, col + 1)
  *
- *  We assume a lattice has N x N interior nodes 
- *  and a padded edge of zeros for a lattice
- *  of size (N + 2) x (N + 2).  
+ *  We assume a lattice has N_r x N_c interior nodes
+ *  with unit values and a padded edge of zeros for a lattice
+ *  of size (N_r + 2) x (N_c + 2).  
  *
- *  In the case of N = 3, the input lattice generated
+ *  In the case of N_r = N_c = 3, the input lattice generated
  *  takes the form
  *
  *  ---------------------
@@ -57,7 +57,7 @@
  *  | 0 | 0 | 0 | 0 | 0 |
  *  ---------------------
  *
- *  after the computation, we expect the output
+ *  After applying the stencil, we expect the output
  *  lattice to take the form
  *
  *  ---------------------
@@ -75,7 +75,8 @@
  * In this example, we use RAJA's make_offset_layout
  * method and view object to simplify applying
  * the stencil to interior cells.
- * A make_offset_layout enables developers to offset
+ * The make_offset_layout method enables developers
+ * to create layouts which offset
  * the enumeration of values in an array. Here we
  * choose to enumerate the lattice in the following manner:
  *
@@ -111,7 +112,7 @@
 //
 // Functions for printing and checking results
 //
-void printLattice(int* lattice, int iCellsInRow, int iCellsInCol);
+void printLattice(int* lattice, int N_r, int N_c);
 void checkResult(int* compLattice, int* refLattice, int totCells);
 
 int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
@@ -122,14 +123,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 //
 // Define num of interior cells in row/cols in a lattice
 //
-  const int iCellsInRow = 3;
-  const int iCellsInCol = 3;
+  const int N_r = 3;
+  const int N_c = 3;
 
 //
 // Define total num of cells in rows/cols in a lattice
 //
-  const int totCellsInRow = iCellsInRow + 2;
-  const int totCellsInCol = iCellsInCol + 2;
+  const int totCellsInRow = N_r + 2;
+  const int totCellsInCol = N_c + 2;
 
 //
 // Define total num of cells in a lattice
@@ -150,8 +151,8 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 //
 // C-Style intialization
 //
-  for (int row = 1; row <= iCellsInRow; ++row) {
-    for (int col = 1; col <= iCellsInCol; ++col) {
+  for (int row = 1; row <= N_r; ++row) {
+    for (int col = 1; col <= N_c; ++col) {
       int id = col + totCellsInCol * row;
       input_lattice[id] = 1;
     }
@@ -161,8 +162,8 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 //
 // Generate reference solution
 //
-  for (int row = 1; row <= iCellsInRow; ++row) {
-    for (int col = 1; col <= iCellsInCol; ++col) {
+  for (int row = 1; row <= N_r; ++row) {
+    for (int col = 1; col <= N_c; ++col) {
 
       int id = col + totCellsInCol * row;
       lattice_ref[id] = input_lattice[id] + input_lattice[id + 1]
@@ -178,8 +179,8 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 //
 // Create loop bounds
 //
-  RAJA::RangeSegment col_range(0, iCellsInRow);
-  RAJA::RangeSegment row_range(0, iCellsInCol);
+  RAJA::RangeSegment row_range(0, N_r);
+  RAJA::RangeSegment col_range(0, N_c);
 
 //
 // Specify the dimension of the lattice
@@ -196,7 +197,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 // subobjects.
 //
   RAJA::OffsetLayout<DIM> layout =
-      RAJA::make_offset_layout<DIM>({{-1, -1}}, {{iCellsInRow, iCellsInCol}});
+      RAJA::make_offset_layout<DIM>({{-1, -1}}, {{N_r, N_c}});
   RAJA::View<int, RAJA::OffsetLayout<DIM>> input_latticeView(input_lattice, layout);
   RAJA::View<int, RAJA::OffsetLayout<DIM>> output_latticeView(output_lattice, layout);
 

--- a/examples/ex-offset.cpp
+++ b/examples/ex-offset.cpp
@@ -30,7 +30,7 @@
  *
  *  The five-cell stencil accumulates values of a cell 
  *  and its four neighbors. Assuming the cells of a 
- *  lattice may be accessed in a row/col fashion, 
+ *  lattice may be accessed through a row/col fashion, 
  *  the stencil may be expressed as the following sum
  * 
  *  output_lattice(row, col)
@@ -38,11 +38,11 @@
  *         + input_lattice(row - 1, col) + input_lattice(row + 1, col)
  *         + input_lattice(row, col - 1) + input_lattice(row, col + 1)
  *
- *  We assume a lattice has N_r x N_c interior nodes
- *  with unit values and a padded edge of zeros for a lattice
- *  of size (N_r + 2) x (N_c + 2).  
+ *  We assume a lattice has N x N interior nodes 
+ *  and a padded edge of zeros for a lattice
+ *  of size (N + 2) x (N + 2).  
  *
- *  In the case of N_r = N_c = 3, the input lattice generated
+ *  In the case of N = 3, the input lattice generated
  *  takes the form
  *
  *  ---------------------
@@ -57,7 +57,7 @@
  *  | 0 | 0 | 0 | 0 | 0 |
  *  ---------------------
  *
- *  After applying the stencil, we expect the output
+ *  after the computation, we expect the output
  *  lattice to take the form
  *
  *  ---------------------
@@ -75,8 +75,7 @@
  * In this example, we use RAJA's make_offset_layout
  * method and view object to simplify applying
  * the stencil to interior cells.
- * The make_offset_layout method enables developers
- * to create layouts which offset
+ * A make_offset_layout enables developers to offset
  * the enumeration of values in an array. Here we
  * choose to enumerate the lattice in the following manner:
  *
@@ -112,7 +111,7 @@
 //
 // Functions for printing and checking results
 //
-void printLattice(int* lattice, int N_r, int N_c);
+void printLattice(int* lattice, int iCellsInRow, int iCellsInCol);
 void checkResult(int* compLattice, int* refLattice, int totCells);
 
 int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
@@ -123,14 +122,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 //
 // Define num of interior cells in row/cols in a lattice
 //
-  const int N_r = 3;
-  const int N_c = 3;
+  const int iCellsInRow = 3;
+  const int iCellsInCol = 3;
 
 //
 // Define total num of cells in rows/cols in a lattice
 //
-  const int totCellsInRow = N_r + 2;
-  const int totCellsInCol = N_c + 2;
+  const int totCellsInRow = iCellsInRow + 2;
+  const int totCellsInCol = iCellsInCol + 2;
 
 //
 // Define total num of cells in a lattice
@@ -151,8 +150,8 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 //
 // C-Style intialization
 //
-  for (int row = 1; row <= N_r; ++row) {
-    for (int col = 1; col <= N_c; ++col) {
+  for (int row = 1; row <= iCellsInRow; ++row) {
+    for (int col = 1; col <= iCellsInCol; ++col) {
       int id = col + totCellsInCol * row;
       input_lattice[id] = 1;
     }
@@ -162,8 +161,8 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 //
 // Generate reference solution
 //
-  for (int row = 1; row <= N_r; ++row) {
-    for (int col = 1; col <= N_c; ++col) {
+  for (int row = 1; row <= iCellsInRow; ++row) {
+    for (int col = 1; col <= iCellsInCol; ++col) {
 
       int id = col + totCellsInCol * row;
       lattice_ref[id] = input_lattice[id] + input_lattice[id + 1]
@@ -179,8 +178,8 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 //
 // Create loop bounds
 //
-  RAJA::RangeSegment row_range(0, N_r);
-  RAJA::RangeSegment col_range(0, N_c);
+  RAJA::RangeSegment col_range(0, iCellsInRow);
+  RAJA::RangeSegment row_range(0, iCellsInCol);
 
 //
 // Specify the dimension of the lattice
@@ -197,7 +196,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 // subobjects.
 //
   RAJA::OffsetLayout<DIM> layout =
-      RAJA::make_offset_layout<DIM>({{-1, -1}}, {{N_r, N_c}});
+      RAJA::make_offset_layout<DIM>({{-1, -1}}, {{iCellsInRow, iCellsInCol}});
   RAJA::View<int, RAJA::OffsetLayout<DIM>> input_latticeView(input_lattice, layout);
   RAJA::View<int, RAJA::OffsetLayout<DIM>> output_latticeView(output_lattice, layout);
 


### PR DESCRIPTION
Simplifies notation and addresses a few grammar issues to be consistent with the docs. 