### PR TITLE
DO NOT MERGE (Yet) Feature/kernel perf

### DIFF
--- a/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
+++ b/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
@@ -51,6 +51,8 @@ namespace RAJA
 namespace cuda
 {
 
+
+
 //! Allocator for pinned memory for use in basic_mempool
 struct PinnedAllocator {
 
@@ -250,6 +252,32 @@ RAJA_INLINE typename std::remove_reference<LOOP_BODY>::type make_launch_body(
   using return_type = typename std::remove_reference<LOOP_BODY>::type;
   return return_type(std::forward<LOOP_BODY>(loop_body));
 }
+
+
+
+namespace internal
+{
+
+RAJA_INLINE
+int getMaxBlocks(){
+  static int max_blocks = -1;
+
+  if(max_blocks <= 0){
+    int cur_device = -1;
+    cudaGetDevice(&cur_device);
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, cur_device);
+    int s_num_sm = prop.multiProcessorCount;
+    int s_max_threads_per_sm = prop.maxThreadsPerMultiProcessor;
+    max_blocks = s_num_sm * (s_max_threads_per_sm/1024);
+    //printf("MAX_BLOCKS=%d\n", max_blocks);
+  }
+
+  return max_blocks;
+}
+
+} // namespace internal
+
 
 }  // closing brace for cuda namespace
 

--- a/include/RAJA/policy/cuda/kernel/Collapse.hpp
+++ b/include/RAJA/policy/cuda/kernel/Collapse.hpp
@@ -80,11 +80,16 @@ struct CudaStatementExecutor<Data,
   }
 
 
-  inline RAJA_DEVICE void initBlocks(Data &data,
+  inline RAJA_HOST_DEVICE void initBlocks(Data &data,
                                      int num_logical_blocks,
                                      int block_stride)
   {
     enclosed_stmts.initBlocks(data, num_logical_blocks, block_stride);
+  }
+
+  inline RAJA_DEVICE void initThread(Data &data)
+  {
+    enclosed_stmts.initThread(data);
   }
 
   RAJA_INLINE
@@ -131,11 +136,16 @@ struct CudaStatementExecutor<Data,
   }
 
 
-  inline RAJA_DEVICE void initBlocks(Data &data,
+  inline RAJA_HOST_DEVICE void initBlocks(Data &data,
                                      int num_logical_blocks,
                                      int block_stride)
   {
     enclosed_stmts.initBlocks(data, num_logical_blocks, block_stride);
+  }
+
+  inline RAJA_DEVICE void initThread(Data &data)
+  {
+    enclosed_stmts.initThread(data);
   }
 
   RAJA_INLINE

--- a/include/RAJA/policy/cuda/kernel/Conditional.hpp
+++ b/include/RAJA/policy/cuda/kernel/Conditional.hpp
@@ -48,11 +48,16 @@ struct CudaStatementExecutor<Data,
   }
 
 
-  inline RAJA_DEVICE void initBlocks(Data &data,
+  inline RAJA_HOST_DEVICE void initBlocks(Data &data,
                                      int num_logical_blocks,
                                      int block_stride)
   {
     enclosed_stmts.initBlocks(data, num_logical_blocks, block_stride);
+  }
+
+  inline RAJA_DEVICE void initThread(Data &data)
+  {
+    enclosed_stmts.initThread(data);
   }
 
   RAJA_INLINE

--- a/include/RAJA/policy/cuda/kernel/For.hpp
+++ b/include/RAJA/policy/cuda/kernel/For.hpp
@@ -70,11 +70,16 @@ struct CudaStatementExecutor<Data,
   }
 
 
-  inline RAJA_DEVICE void initBlocks(Data &data,
+  inline RAJA_HOST_DEVICE void initBlocks(Data &data,
                                      int num_logical_blocks,
                                      int block_stride)
   {
     enclosed_stmts.initBlocks(data, num_logical_blocks, block_stride);
+  }
+
+  inline RAJA_DEVICE void initThread(Data &data)
+  {
+    enclosed_stmts.initThread(data);
   }
 
   RAJA_INLINE
@@ -119,12 +124,17 @@ struct CudaStatementExecutor<Data,
   }
 
 
-  inline RAJA_DEVICE void initBlocks(Data &data,
+  inline RAJA_HOST_DEVICE void initBlocks(Data &data,
                                      int num_logical_blocks,
                                      int block_stride)
   {
     int len = segment_length<ArgumentId>(data);
     initBlockLoop(enclosed_stmts, data, len, num_logical_blocks, block_stride);
+  }
+
+  inline RAJA_DEVICE void initThread(Data &data)
+  {
+    enclosed_stmts.initThread(data);
   }
 
 
@@ -175,12 +185,18 @@ struct CudaStatementExecutor<Data,
   }
 
 
-  inline RAJA_DEVICE void initBlocks(Data &data,
+  inline RAJA_HOST_DEVICE void initBlocks(Data &data,
                                      int num_logical_blocks,
                                      int block_stride)
   {
     int len = segment_length<ArgumentId>(data);
     initBlockLoop(enclosed_stmts, data, len, num_logical_blocks, block_stride);
+  }
+
+
+  inline RAJA_DEVICE void initThread(Data &data)
+  {
+    enclosed_stmts.initThread(data);
   }
 
   RAJA_INLINE
@@ -236,11 +252,16 @@ struct CudaStatementExecutor<Data,
   }
 
 
-  inline RAJA_DEVICE void initBlocks(Data &data,
+  inline RAJA_HOST_DEVICE void initBlocks(Data &data,
                                      int num_logical_blocks,
                                      int block_stride)
   {
     enclosed_stmts.initBlocks(data, num_logical_blocks, block_stride);
+  }
+
+  inline RAJA_DEVICE void initThread(Data &data)
+  {
+    enclosed_stmts.initThread(data);
   }
 
   RAJA_INLINE
@@ -284,11 +305,16 @@ struct CudaStatementExecutor<Data,
   }
 
 
-  inline RAJA_DEVICE void initBlocks(Data &data,
+  inline RAJA_HOST_DEVICE void initBlocks(Data &data,
                                      int num_logical_blocks,
                                      int block_stride)
   {
     enclosed_stmts.initBlocks(data, num_logical_blocks, block_stride);
+  }
+
+  inline RAJA_DEVICE void initThread(Data &data)
+  {
+    enclosed_stmts.initThread(data);
   }
 
   RAJA_INLINE
@@ -338,11 +364,16 @@ struct CudaStatementExecutor<Data,
   }
 
 
-  inline RAJA_DEVICE void initBlocks(Data &data,
+  inline RAJA_HOST_DEVICE void initBlocks(Data &data,
                                      int num_logical_blocks,
                                      int block_stride)
   {
     enclosed_stmts.initBlocks(data, num_logical_blocks, block_stride);
+  }
+
+  inline RAJA_DEVICE void initThread(Data &data)
+  {
+    enclosed_stmts.initThread(data);
   }
 
   RAJA_INLINE

--- a/include/RAJA/policy/cuda/kernel/Hyperplane.hpp
+++ b/include/RAJA/policy/cuda/kernel/Hyperplane.hpp
@@ -98,11 +98,16 @@ struct CudaStatementExecutor<Data,
   }
 
 
-  inline RAJA_DEVICE void initBlocks(Data &data,
+  inline RAJA_HOST_DEVICE void initBlocks(Data &data,
                                      int num_logical_blocks,
                                      int block_stride)
   {
     enclosed_stmts.initBlocks(data, num_logical_blocks, block_stride);
+  }
+
+  inline RAJA_DEVICE void initThread(Data &data)
+  {
+    enclosed_stmts.initThread(data);
   }
 
   RAJA_INLINE
@@ -151,7 +156,7 @@ struct CudaStatementExecutor<Data,
     if (block_carry <= 0) {
       // set indices to beginning of each segment, and increment
       // to this threads first iteration
-      bool done = index_calc.assignBegin(data, threadIdx.x, blockDim.x);
+      bool done = index_calc.reset(data, threadIdx.x);
 
       while (!done) {
 
@@ -180,11 +185,18 @@ struct CudaStatementExecutor<Data,
   }
 
 
-  inline RAJA_DEVICE void initBlocks(Data &data,
+  inline RAJA_HOST_DEVICE void initBlocks(Data &data,
                                      int num_logical_blocks,
                                      int block_stride)
   {
     enclosed_stmts.initBlocks(data, num_logical_blocks, block_stride);
+  }
+
+
+  inline RAJA_DEVICE void initThread(Data &data)
+  {
+    index_calc.initThread(data, threadIdx.x);
+    enclosed_stmts.initThread(data);
   }
 
   RAJA_INLINE

--- a/include/RAJA/policy/cuda/kernel/Lambda.hpp
+++ b/include/RAJA/policy/cuda/kernel/Lambda.hpp
@@ -61,7 +61,7 @@ struct CudaStatementExecutor<Data, statement::Lambda<LoopIndex>, IndexCalc> {
     if (block_carry <= 0) {
       // set indices to beginning of each segment, and increment
       // to this threads first iteration
-      bool done = index_calc.assignBegin(data, threadIdx.x, blockDim.x);
+      bool done = index_calc.reset(data, threadIdx.x);
 
       while (!done) {
 
@@ -73,11 +73,16 @@ struct CudaStatementExecutor<Data, statement::Lambda<LoopIndex>, IndexCalc> {
   }
 
 
-  inline RAJA_DEVICE void initBlocks(Data &data,
+  inline RAJA_HOST_DEVICE void initBlocks(Data &data,
                                      int num_logical_blocks,
                                      int block_stride)
   {
     // nop
+  }
+
+  inline RAJA_DEVICE void initThread(Data &data)
+  {
+    index_calc.initThread(data, threadIdx.x);
   }
 
 
@@ -105,9 +110,14 @@ struct CudaStatementExecutor<Data,
     }
   }
 
-  inline RAJA_DEVICE void initBlocks(Data &data,
+  inline RAJA_HOST_DEVICE void initBlocks(Data &data,
                                      int num_logical_blocks,
                                      int block_stride)
+  {
+    // nop
+  }
+
+  inline RAJA_DEVICE void initThread(Data &data)
   {
     // nop
   }

--- a/include/RAJA/policy/cuda/kernel/ShmemWindow.hpp
+++ b/include/RAJA/policy/cuda/kernel/ShmemWindow.hpp
@@ -73,12 +73,20 @@ struct CudaStatementExecutor<Data,
   }
 
 
-  inline RAJA_DEVICE void initBlocks(Data &data,
+  inline RAJA_HOST_DEVICE void initBlocks(Data &data,
                                      int num_logical_blocks,
                                      int block_stride)
   {
     enclosed_stmts.initBlocks(data, num_logical_blocks, block_stride);
   }
+
+
+  inline RAJA_DEVICE void initThread(Data &data)
+  {
+    enclosed_stmts.initThread(data);
+  }
+
+
 
   RAJA_INLINE
   LaunchDim calculateDimensions(Data const &data, LaunchDim const &max_physical)

--- a/include/RAJA/policy/cuda/kernel/Sync.hpp
+++ b/include/RAJA/policy/cuda/kernel/Sync.hpp
@@ -65,9 +65,14 @@ struct CudaStatementExecutor<Data, statement::CudaSyncThreads, IndexCalc> {
 
   inline __device__ void exec(Data &, int, int) { __syncthreads(); }
 
-  inline RAJA_DEVICE void initBlocks(Data &data,
+  inline RAJA_HOST_DEVICE void initBlocks(Data &data,
                                      int num_logical_blocks,
                                      int block_stride)
+  {
+    // nop
+  }
+
+  inline RAJA_DEVICE void initThread(Data &data)
   {
     // nop
   }

--- a/include/RAJA/policy/cuda/kernel/Thread.hpp
+++ b/include/RAJA/policy/cuda/kernel/Thread.hpp
@@ -76,7 +76,7 @@ struct CudaStatementExecutor<Data,
     if (block_carry <= 0) {
       // set indices to beginning of each segment, and increment
       // to this threads first iteration
-      bool done = index_calc.assignBegin(data, threadIdx.x, blockDim.x);
+      bool done = index_calc.reset(data, threadIdx.x);
 
       while (!done) {
 
@@ -89,11 +89,17 @@ struct CudaStatementExecutor<Data,
   }
 
 
-  inline RAJA_DEVICE void initBlocks(Data &data,
+  inline RAJA_HOST_DEVICE void initBlocks(Data &data,
                                      int num_logical_blocks,
                                      int block_stride)
   {
     enclosed_stmts.initBlocks(data, num_logical_blocks, block_stride);
+  }
+
+  inline RAJA_DEVICE void initThread(Data &data)
+  {
+    index_calc.initThread(data, threadIdx.x);
+    enclosed_stmts.initThread(data);
   }
 
   RAJA_INLINE

--- a/include/RAJA/policy/cuda/kernel/Tile.hpp
+++ b/include/RAJA/policy/cuda/kernel/Tile.hpp
@@ -90,6 +90,9 @@ struct CudaStatementExecutor<Data,
       // Assign our new tiled segment
       segment = orig_segment.slice(i, chunk_size);
 
+      // Reinitialize thread calculations (TODO: optimize this)
+      enclosed_stmts.initThread(data);
+
       // execute enclosed statements
       enclosed_stmts.exec(data, num_logical_blocks, block_carry);
     }
@@ -100,11 +103,16 @@ struct CudaStatementExecutor<Data,
   }
 
 
-  inline RAJA_DEVICE void initBlocks(Data &data,
+  inline RAJA_HOST_DEVICE void initBlocks(Data &data,
                                      int num_logical_blocks,
                                      int block_stride)
   {
     enclosed_stmts.initBlocks(data, num_logical_blocks, block_stride);
+  }
+
+  inline RAJA_DEVICE void initThread(Data &data)
+  {
+    enclosed_stmts.initThread(data);
   }
 
 

--- a/test/unit/kernel.cpp
+++ b/test/unit/kernel.cpp
@@ -2142,7 +2142,7 @@ TEST(Kernel, IndexCalc_seq){
   for(int init = 1;init < 5;++ init){
     int i = 0;
 
-    ASSERT_EQ(ic.setInitial(data, init) > 0, init > 0);
+    ASSERT_EQ(ic.reset(data, init) > 0, init > 0);
     ASSERT_EQ(RAJA::get<0>(data.offset_tuple), i);
 
     for(int inc = 1;inc < 7;++ inc){
@@ -2179,11 +2179,15 @@ TEST(Kernel, IndexCalc_thread){
 
   RAJA::internal::CudaIndexCalc_Policy<0, RAJA::cuda_thread_exec> ic;
 
+
+
   for(int init = 1;init < 5;++ init){
     //printf("init=%d\n", init);
     int i = init;
 
-    ASSERT_EQ(ic.setInitial(data, init) > 0, false);
+    ic.initIteration(data, init);
+
+    ASSERT_EQ(ic.reset(data, init) > 0, false);
     ASSERT_EQ(RAJA::get<0>(data.offset_tuple), i);
 
     for(int inc = 1;inc < 3*N;++ inc){


### PR DESCRIPTION
Trying to accomplish some cleanup/performance enhancements with RAJA::kernel and CUDA

1) Move away from using occupancy calculator by default
2) Move as much index calculations (aka. integer divides) from the GPU back up to the CPU before launch
3) Improve Collapse over thread-blocks
4) General semantics issues