### PR TITLE
Fixed initialization of tuple_storage to use (...) instead of {...}

### DIFF
--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -80,7 +80,11 @@ namespace internal
     CAMP_HOST_DEVICE constexpr tuple_storage() : val(){};
 
     CAMP_SUPPRESS_HD_WARN
-    CAMP_HOST_DEVICE constexpr tuple_storage(Type const& v) : val{v} {}
+    CAMP_HOST_DEVICE constexpr tuple_storage(Type const& v) :
+    // initializing with (...) instead of {...} for compiler compatability
+    // some compilers complain when Type has no members and we use {...} to
+    // initialize val
+    val(v) {}
 
     CAMP_SUPPRESS_HD_WARN
     CAMP_HOST_DEVICE constexpr tuple_storage(Type&& v)


### PR DESCRIPTION
Was causing issues with some compilers when the storage type had no data memebers

This appears to fix things on rzhasgpu.llnl.gov with gcc 4.9.3 + CUDA 9.1, and with clang 4.0.0 + CUDA 9.1.