### PR TITLE
Removed extra semicolon

### DIFF
--- a/include/RAJA/pattern/kernel/For.hpp
+++ b/include/RAJA/pattern/kernel/For.hpp
@@ -112,7 +112,7 @@ struct Invoke_all_Lambda {
            typename Offs, typename Params>
   static RAJA_INLINE void lambda_special(camp::idx_seq<OffsetIdx...> const &,
                                          camp::idx_seq<ParamIdx...> const &, 
-                                         Data&, Offs const &, Params const &) {};
+                                         Data&, Offs const &, Params const &) {}
 
 };
 
@@ -127,7 +127,7 @@ struct Invoke_all_Lambda<LoopIdx>{
            typename Offs, typename Params>
   static RAJA_INLINE void lambda_special(camp::idx_seq<OffsetIdx...> const &,
                              camp::idx_seq<ParamIdx...> const &, 
-                                    Data&, Offs const &, Params const &) {};
+                                    Data&, Offs const &, Params const &) {}
 
 };
 


### PR DESCRIPTION
Having the extra semicolon caused warnings to spew out under certain compiler settings. 