### PR TITLE
Ltimes build fix

### DIFF
--- a/examples/cpu-shmem-ltimes.cpp
+++ b/examples/cpu-shmem-ltimes.cpp
@@ -425,7 +425,7 @@ void runLTimesRajaKernelShmem(bool debug,
         SetShmemWindow<
 
           // Load shmem L
-          For<0, loop_exec, For<1, loop_exec, Lambda_LoadEll>>,
+          For<0, loop_exec, For<1, simd_exec, Lambda_LoadEll>>,
 
           For<2, loop_exec,
             statement::Tile<3, statement::tile_fixed<tile_zones>, loop_exec,

--- a/examples/omp-target-ltimes.cpp
+++ b/examples/omp-target-ltimes.cpp
@@ -445,13 +445,13 @@ void runLTimesRajaKernelShmem(bool debug,
         SetShmemWindow<
 
           // Load shmem L
-          For<0, simd_exec, For<1, simd_exec, Lambda_LoadEll>>,
+          For<0, loop_exec, For<1, simd_exec, Lambda_LoadEll>>,
 
           For<2, loop_exec,
             statement::Tile<3, statement::tile_fixed<tile_zones>, loop_exec,
               SetShmemWindow<
                 // Load Psi into shmem
-                For<1, simd_exec, For<3, simd_exec, Lambda_LoadPsi >>,
+                For<1, loop_exec, For<3, simd_exec, Lambda_LoadPsi >>,
 
                 For<0, loop_exec, //m
                   For<3, simd_exec, Lambda_LoadPhi>, //z


### PR DESCRIPTION
Removed the Simd policy on the top level loops of the l-times example. 