### PR TITLE
fixed parallel region in OpenMP region.hpp

### DIFF
--- a/include/RAJA/policy/openmp/region.hpp
+++ b/include/RAJA/policy/openmp/region.hpp
@@ -47,7 +47,9 @@ RAJA_INLINE void region_impl(const omp_parallel_region &, Func &&body)
 {
 
 #pragma omp parallel
-  body();
+    { // curly brackets to ensure body() is encapsulated in omp parallel region
+    body();
+    }
 }
 
 }  // namespace omp


### PR DESCRIPTION
Fixed the parallel region in raja/include/RAJA/policy/openmp/region.hpp to keep current XLC compilers from generating incorrect code and failing tests. Very simple change modifying

#pragma omp parallel
body();

to

#pragma omp parallel
{
body();
}