### PR TITLE
Iteration and Tile index/count

### DIFF
--- a/include/RAJA/pattern/kernel/Conditional.hpp
+++ b/include/RAJA/pattern/kernel/Conditional.hpp
@@ -29,6 +29,8 @@
 
 #include "RAJA/config.hpp"
 
+#include "RAJA/pattern/kernel/internal.hpp"
+
 #include <iostream>
 #include <type_traits>
 
@@ -55,7 +57,9 @@ struct If : public internal::Statement<camp::nil, EnclosedStmts...> {
  * RAJA::kernel execution policies.
  */
 template <camp::idx_t ParamId>
-struct Param {
+struct Param : public internal::ParamBase {
+
+  constexpr static camp::idx_t param_idx = ParamId;
 
   template <typename Data>
   RAJA_HOST_DEVICE RAJA_INLINE static auto eval(Data const &data)

--- a/include/RAJA/pattern/kernel/For.hpp
+++ b/include/RAJA/pattern/kernel/For.hpp
@@ -115,7 +115,7 @@ struct ForICountWrapper : public GenericWrapper<Data, EnclosedStmts...> {
   RAJA_INLINE void operator()(InIndexType i)
   {
     Base::data.template assign_offset<ArgumentId>(i);
-    Base::data.template assign_param<ParamId::param_idx>(i);
+    Base::data.template assign_param<ParamId>(i);
     Base::exec();
   }
 };

--- a/include/RAJA/pattern/kernel/For.hpp
+++ b/include/RAJA/pattern/kernel/For.hpp
@@ -46,7 +46,7 @@ namespace statement
 
 /*!
  * A RAJA::kernel statement that implements a single loop.
- * Assigns the iterate to argument ArgumentId
+ * Assigns the loop iterate to argument ArgumentId
  *
  */
 template <camp::idx_t ArgumentId,
@@ -63,8 +63,8 @@ struct For : public internal::ForList,
 
 /*!
  * A RAJA::kernel statement that implements a single loop.
- * Assigns the iterate to argument ArgumentId
- * Assigns the index to param ParamId
+ * Assigns the loop iterate to argument ArgumentId
+ * Assigns the loop index to param ParamId
  *
  */
 template <camp::idx_t ArgumentId,

--- a/include/RAJA/pattern/kernel/For.hpp
+++ b/include/RAJA/pattern/kernel/For.hpp
@@ -87,7 +87,11 @@ struct ForICount : public internal::ForList,
 namespace internal
 {
 
-
+/*!
+ * A generic RAJA::kernel forall_impl loop wrapper for statement::For
+ * Assigns the loop index to offset ArgumentId
+ *
+ */
 template <camp::idx_t ArgumentId, typename Data, typename... EnclosedStmts>
 struct ForWrapper : public GenericWrapper<Data, EnclosedStmts...> {
 
@@ -103,6 +107,11 @@ struct ForWrapper : public GenericWrapper<Data, EnclosedStmts...> {
   }
 };
 
+/*!
+ * A generic RAJA::kernel forall_impl loop wrapper for statement::ForICount
+ * Assigns the loop index to offset ArgumentId
+ * Assigns the loop index to param ParamId
+ */
 template <camp::idx_t ArgumentId, typename ParamId, typename Data,
           typename... EnclosedStmts>
 struct ForICountWrapper : public GenericWrapper<Data, EnclosedStmts...> {
@@ -216,7 +225,7 @@ struct Invoke_all_Lambda<LoopIdx, State, States...>
  * RAJA::kernel forall_impl executor specialization for statement::For.
  * Assumptions: RAJA::simd_exec is the inner most policy,
  * only one lambda is used, no reductions are done within the lambda.
- *
+ * Assigns the loop index to offset ArgumentId
  */
 template <camp::idx_t ArgumentId, typename... EnclosedStmts>
 struct StatementExecutor<
@@ -253,7 +262,8 @@ struct StatementExecutor<
  * RAJA::kernel forall_impl executor specialization for statement::ForICount.
  * Assumptions: RAJA::simd_exec is the inner most policy,
  * only one lambda is used, no reductions are done within the lambda.
- *
+ * Assigns the loop index to offset ArgumentId
+ * Assigns the loop index to param ParamId
  */
 template <camp::idx_t ArgumentId, typename ParamId,
           typename... EnclosedStmts>

--- a/include/RAJA/pattern/kernel/Tile.hpp
+++ b/include/RAJA/pattern/kernel/Tile.hpp
@@ -35,6 +35,7 @@
 #include "camp/concepts.hpp"
 #include "camp/tuple.hpp"
 
+#include "RAJA/pattern/kernel/internal.hpp"
 #include "RAJA/util/macros.hpp"
 #include "RAJA/util/types.hpp"
 
@@ -53,6 +54,24 @@ template <camp::idx_t ArgumentId,
           typename ExecPolicy,
           typename... EnclosedStmts>
 struct Tile : public internal::Statement<ExecPolicy, EnclosedStmts...> {
+  using tile_policy_t = TilePolicy;
+  using exec_policy_t = ExecPolicy;
+};
+
+/*!
+ * A RAJA::kernel statement that implements a tiling (or blocking) loop.
+ * Assigns the tile index to param ParamId
+ *
+ */
+template <camp::idx_t ArgumentId,
+          typename ParamId,
+          typename TilePolicy,
+          typename ExecPolicy,
+          typename... EnclosedStmts>
+struct TileTCount : public internal::Statement<ExecPolicy, EnclosedStmts...> {
+  static_assert(std::is_base_of<internal::ParamBase, ParamId>::value,
+                "Inappropriate ParamId, ParamId must be of type "
+                "RAJA::Statement::Param< # >");
   using tile_policy_t = TilePolicy;
   using exec_policy_t = ExecPolicy;
 };
@@ -77,11 +96,11 @@ struct TileWrapper : public GenericWrapper<Data, EnclosedStmts...> {
   using Base::Base;
   using privatizer = NestedPrivatizer<TileWrapper>;
 
-  template <typename InSegmentType>
-  RAJA_INLINE void operator()(InSegmentType s)
+  template <typename InSegmentIndexType>
+  RAJA_INLINE void operator()(InSegmentIndexType si)
   {
     // Assign the tile's segment to the tuple
-    camp::get<ArgumentId>(Base::data.segment_tuple) = s;
+    camp::get<ArgumentId>(Base::data.segment_tuple) = si.s;
 
     // Assign the beginning index to the index_tuple for proper use
     // in shmem windows
@@ -93,9 +112,42 @@ struct TileWrapper : public GenericWrapper<Data, EnclosedStmts...> {
 };
 
 
+template <camp::idx_t ArgumentId, typename ParamId, typename Data,
+          typename... EnclosedStmts>
+struct TileTCountWrapper : public GenericWrapper<Data, EnclosedStmts...> {
+
+  using Base = GenericWrapper<Data, EnclosedStmts...>;
+  using Base::Base;
+  using privatizer = NestedPrivatizer<TileTCountWrapper>;
+
+  template <typename InSegmentIndexType>
+  RAJA_INLINE void operator()(InSegmentIndexType si)
+  {
+    // Assign the tile's segment to the tuple
+    camp::get<ArgumentId>(Base::data.segment_tuple) = si.s;
+
+    // Assign the beginning index to the index_tuple for proper use
+    // in shmem windows
+    camp::get<ArgumentId>(Base::data.offset_tuple) = 0;
+
+    // Assign the tile's index
+    camp::get<ParamId::param_idx>(Base::data.param_tuple) = si.i;
+
+    // Execute enclosed statements
+    Base::exec();
+  }
+};
+
+
 template <typename Iterable>
 struct IterableTiler {
   using value_type = camp::decay<Iterable>;
+
+  struct iterate
+  {
+    value_type s;
+    Index_type i;
+  };
 
   class iterator
   {
@@ -104,7 +156,7 @@ struct IterableTiler {
     const Index_type block_id;
 
   public:
-    using value_type = camp::decay<Iterable>;
+    using value_type = iterate;
     using difference_type = camp::idx_t;
     using pointer = value_type *;
     using reference = value_type &;
@@ -122,7 +174,7 @@ struct IterableTiler {
     value_type operator*()
     {
       auto start = block_id * itiler.block_size;
-      return itiler.it.slice(start, itiler.block_size);
+      return iterate{itiler.it.slice(start, itiler.block_size), block_id};
     }
 
     RAJA_HOST_DEVICE
@@ -218,7 +270,42 @@ struct StatementExecutor<
     IterableTiler<decltype(segment)> tiled_iterable(segment, chunk_size);
 
     // Wrap in case forall_impl needs to thread_privatize
-    TileWrapper<ArgumentId, Data, EnclosedStmts...> tile_wrapper(data);
+    TileWrapper<ArgumentId, Data,
+                EnclosedStmts...> tile_wrapper(data);
+
+    // Loop over tiles, executing enclosed statement list
+    forall_impl(EPol{}, tiled_iterable, tile_wrapper);
+
+    // Set range back to original values
+    camp::get<ArgumentId>(data.segment_tuple) = tiled_iterable.it;
+  }
+};
+
+template <camp::idx_t ArgumentId,
+          typename ParamId,
+          typename TPol,
+          typename EPol,
+          typename... EnclosedStmts>
+struct StatementExecutor<
+    statement::TileTCount<ArgumentId, ParamId, TPol, EPol, EnclosedStmts...>> {
+
+
+  template <typename Data>
+  static RAJA_INLINE void exec(Data &data)
+  {
+    // Get the segment we are going to tile
+    auto const &segment = camp::get<ArgumentId>(data.segment_tuple);
+
+    // Get the tiling policies chunk size
+    auto chunk_size = TPol::chunk_size;
+
+    // Create a tile iterator, needs to survive until the forall is
+    // done executing.
+    IterableTiler<decltype(segment)> tiled_iterable(segment, chunk_size);
+
+    // Wrap in case forall_impl needs to thread_privatize
+    TileTCountWrapper<ArgumentId, ParamId, Data,
+                      EnclosedStmts...> tile_wrapper(data);
 
     // Loop over tiles, executing enclosed statement list
     forall_impl(EPol{}, tiled_iterable, tile_wrapper);

--- a/include/RAJA/pattern/kernel/Tile.hpp
+++ b/include/RAJA/pattern/kernel/Tile.hpp
@@ -88,7 +88,11 @@ struct tile_fixed {
 namespace internal
 {
 
-
+/*!
+ * A generic RAJA::kernel forall_impl tile wrapper for statement::For
+ * Assigns the tile segment to segment ArgumentId
+ *
+ */
 template <camp::idx_t ArgumentId, typename Data, typename... EnclosedStmts>
 struct TileWrapper : public GenericWrapper<Data, EnclosedStmts...> {
 
@@ -111,7 +115,11 @@ struct TileWrapper : public GenericWrapper<Data, EnclosedStmts...> {
   }
 };
 
-
+/*!
+ * A generic RAJA::kernel forall_impl tile wrapper for statement::ForTCount
+ * Assigns the tile segment to segment ArgumentId
+ * Assigns the tile index to param ParamId
+ */
 template <camp::idx_t ArgumentId, typename ParamId, typename Data,
           typename... EnclosedStmts>
 struct TileTCountWrapper : public GenericWrapper<Data, EnclosedStmts...> {
@@ -247,7 +255,11 @@ struct IterableTiler {
   camp::idx_t dist;
 };
 
-
+/*!
+ * A generic RAJA::kernel forall_impl executor for statement::Tile
+ *
+ *
+ */
 template <camp::idx_t ArgumentId,
           typename TPol,
           typename EPol,
@@ -281,6 +293,11 @@ struct StatementExecutor<
   }
 };
 
+/*!
+ * A generic RAJA::kernel forall_impl executor for statement::TileTCount
+ *
+ *
+ */
 template <camp::idx_t ArgumentId,
           typename ParamId,
           typename TPol,

--- a/include/RAJA/pattern/kernel/internal.hpp
+++ b/include/RAJA/pattern/kernel/internal.hpp
@@ -173,10 +173,10 @@ struct LoopData {
     camp::get<Idx>(offset_tuple) = i;
   }
 
-  template <camp::idx_t ParamIdx, typename IndexT>
+  template <typename ParamId, typename IndexT>
   RAJA_HOST_DEVICE RAJA_INLINE void assign_param(IndexT const &i)
   {
-    camp::get<ParamIdx>(param_tuple) = i;
+    camp::get<ParamId::param_idx>(param_tuple) = i;
   }
 
   template <camp::idx_t Idx>

--- a/include/RAJA/pattern/kernel/internal.hpp
+++ b/include/RAJA/pattern/kernel/internal.hpp
@@ -79,6 +79,8 @@ struct ForTraitBase : public ForBase {
   using type = ForTraitBase;  // make camp::value compatible
 };
 
+struct ParamBase {
+};
 
 template <typename Iterator>
 struct iterable_difftype_getter {
@@ -171,6 +173,11 @@ struct LoopData {
     camp::get<Idx>(offset_tuple) = i;
   }
 
+  template <camp::idx_t ParamIdx, typename IndexT>
+  RAJA_HOST_DEVICE RAJA_INLINE void assign_param(IndexT const &i)
+  {
+    camp::get<ParamIdx>(param_tuple) = i;
+  }
 
   template <camp::idx_t Idx>
   RAJA_HOST_DEVICE RAJA_INLINE int assign_begin()

--- a/include/RAJA/policy/cuda/kernel/For.hpp
+++ b/include/RAJA/policy/cuda/kernel/For.hpp
@@ -97,7 +97,7 @@ struct CudaStatementExecutor<
 /*
  * Executor for thread work sharing loop inside CudaKernel.
  * Mapping directly from threadIdx.xyz to indices
- * Assigns the index to param ParamId
+ * Assigns the loop index to param ParamId
  */
 template <typename Data,
           camp::idx_t ArgumentId,
@@ -200,7 +200,7 @@ struct CudaStatementExecutor<
  * Executor for thread work sharing loop inside CudaKernel.
  * Provides a block-stride loop (stride of blockDim.xyz) for
  * each thread in xyz.
- * Assigns the index to param ParamId
+ * Assigns the loop index to param ParamId
  */
 template <typename Data,
           camp::idx_t ArgumentId,
@@ -299,7 +299,7 @@ struct CudaStatementExecutor<
  * Executor for block work sharing inside CudaKernel.
  * Provides a grid-stride loop (stride of gridDim.xyz) for
  * each block in xyz.
- * Assigns the index to param ParamId
+ * Assigns the loop index to param ParamId
  */
 template <typename Data,
           camp::idx_t ArgumentId,
@@ -389,7 +389,7 @@ struct CudaStatementExecutor<
  * Executor for sequential loops inside of a CudaKernel.
  *
  * This is specialized since it need to execute the loop immediately.
- * Assigns the index to param ParamId
+ * Assigns the loop index to param ParamId
  */
 template <typename Data,
           camp::idx_t ArgumentId,

--- a/include/RAJA/policy/cuda/kernel/For.hpp
+++ b/include/RAJA/policy/cuda/kernel/For.hpp
@@ -94,10 +94,53 @@ struct CudaStatementExecutor<
   }
 };
 
+/*
+ * Executor for thread work sharing loop inside CudaKernel.
+ * Mapping directly from threadIdx.xyz to indices
+ * Assigns the index to param ParamId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          typename ParamId,
+          int ThreadDim,
+          typename... EnclosedStmts>
+struct CudaStatementExecutor<
+    Data,
+    statement::ForICount<ArgumentId, ParamId, RAJA::cuda_thread_xyz_direct<ThreadDim>, EnclosedStmts...>>
+    : public CudaStatementExecutor<
+        Data,
+        statement::For<ArgumentId, RAJA::cuda_thread_xyz_direct<ThreadDim>, EnclosedStmts...>> {
+
+  using Base = CudaStatementExecutor<
+        Data,
+        statement::For<ArgumentId, RAJA::cuda_thread_xyz_direct<ThreadDim>, EnclosedStmts...>>;
+
+  using typename Base::enclosed_stmts_t;
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data)
+  {
+    auto len = segment_length<ArgumentId>(data);
+    auto i = get_cuda_dim<ThreadDim>(threadIdx);
+
+    // assign thread id directly to offset
+    data.template assign_offset<ArgumentId>(i);
+    data.template assign_param<ParamId>(i);
+
+    // execute enclosed statements if in bounds
+    if(i < len){
+      enclosed_stmts_t::exec(data);
+    }
+  }
+};
+
+
 
 /*
  * Executor for thread work sharing loop inside CudaKernel.
- * Provides a block-stride loop (stride of blockDim.xyz) for 
+ * Provides a block-stride loop (stride of blockDim.xyz) for
  * each thread in xyz.
  */
 template <typename Data,
@@ -153,11 +196,55 @@ struct CudaStatementExecutor<
   }
 };
 
+/*
+ * Executor for thread work sharing loop inside CudaKernel.
+ * Provides a block-stride loop (stride of blockDim.xyz) for
+ * each thread in xyz.
+ * Assigns the index to param ParamId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          typename ParamId,
+          int ThreadDim,
+          int MinThreads,
+          typename... EnclosedStmts>
+struct CudaStatementExecutor<
+    Data,
+    statement::ForICount<ArgumentId, ParamId, RAJA::cuda_thread_xyz_loop<ThreadDim, MinThreads>, EnclosedStmts...>>
+    : public CudaStatementExecutor<
+        Data,
+        statement::For<ArgumentId, RAJA::cuda_thread_xyz_loop<ThreadDim, MinThreads>, EnclosedStmts...>> {
+
+  using Base = CudaStatementExecutor<
+        Data,
+        statement::For<ArgumentId, RAJA::cuda_thread_xyz_loop<ThreadDim, MinThreads>, EnclosedStmts...>>;
+
+  using typename Base::enclosed_stmts_t;
+
+  static
+  inline RAJA_DEVICE void exec(Data &data)
+  {
+    // block stride loop
+    int len = segment_length<ArgumentId>(data);
+    auto i0 = get_cuda_dim<ThreadDim>(threadIdx);
+    auto i_stride = get_cuda_dim<ThreadDim>(blockDim);
+    for(auto i = i0;i < len;i += i_stride){
+
+      // Assign the x thread to the argument
+      data.template assign_offset<ArgumentId>(i);
+      data.template assign_param<ParamId>(i);
+
+      // execute enclosed statements
+      enclosed_stmts_t::exec(data);
+    }
+  }
+};
+
 
 
 /*
  * Executor for block work sharing inside CudaKernel.
- * Provides a grid-stride loop (stride of gridDim.xyz) for 
+ * Provides a grid-stride loop (stride of gridDim.xyz) for
  * each block in xyz.
  */
 template <typename Data,
@@ -208,6 +295,50 @@ struct CudaStatementExecutor<
   }
 };
 
+/*
+ * Executor for block work sharing inside CudaKernel.
+ * Provides a grid-stride loop (stride of gridDim.xyz) for
+ * each block in xyz.
+ * Assigns the index to param ParamId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          typename ParamId,
+          int BlockDim,
+          typename... EnclosedStmts>
+struct CudaStatementExecutor<
+    Data,
+    statement::ForICount<ArgumentId, ParamId, RAJA::cuda_block_xyz_loop<BlockDim>, EnclosedStmts...>>
+    : public CudaStatementExecutor<
+        Data,
+        statement::For<ArgumentId, RAJA::cuda_block_xyz_loop<BlockDim>, EnclosedStmts...>> {
+
+  using Base = CudaStatementExecutor<
+      Data,
+      statement::For<ArgumentId, RAJA::cuda_block_xyz_loop<BlockDim>, EnclosedStmts...>>;
+
+  using typename Base::enclosed_stmts_t;
+
+  static
+  inline RAJA_DEVICE void exec(Data &data)
+  {
+    // grid stride loop
+    int len = segment_length<ArgumentId>(data);
+    auto i0 = get_cuda_dim<BlockDim>(blockIdx);
+    auto i_stride = get_cuda_dim<BlockDim>(gridDim);
+    for(auto i = i0;i < len;i += i_stride){
+
+      // Assign the x thread to the argument
+      data.template assign_offset<ArgumentId>(i);
+      data.template assign_param<ParamId>(i);
+
+      // execute enclosed statements
+      enclosed_stmts_t::exec(data);
+    }
+  }
+};
+
+
 
 /*
  * Executor for sequential loops inside of a CudaKernel.
@@ -219,8 +350,7 @@ template <typename Data,
           typename... EnclosedStmts>
 struct CudaStatementExecutor<
     Data,
-    statement::For<ArgumentId, seq_exec, EnclosedStmts...> >
-  {
+    statement::For<ArgumentId, seq_exec, EnclosedStmts...> > {
 
   using stmt_list_t = StatementList<EnclosedStmts...>;
 
@@ -252,6 +382,49 @@ struct CudaStatementExecutor<
   LaunchDims calculateDimensions(Data const &data)
   {
     return enclosed_stmts_t::calculateDimensions(data);
+  }
+};
+
+/*
+ * Executor for sequential loops inside of a CudaKernel.
+ *
+ * This is specialized since it need to execute the loop immediately.
+ * Assigns the index to param ParamId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          typename ParamId,
+          typename... EnclosedStmts>
+struct CudaStatementExecutor<
+    Data,
+    statement::ForICount<ArgumentId, ParamId, seq_exec, EnclosedStmts...> >
+    : public CudaStatementExecutor<
+        Data,
+        statement::For<ArgumentId, seq_exec, EnclosedStmts...> > {
+
+  using Base = CudaStatementExecutor<
+      Data,
+      statement::For<ArgumentId, seq_exec, EnclosedStmts...> >;
+
+  using typename Base::enclosed_stmts_t;
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data)
+  {
+    using idx_type = camp::decay<decltype(camp::get<ArgumentId>(data.offset_tuple))>;
+
+    idx_type len = segment_length<ArgumentId>(data);
+
+    for(idx_type i = 0;i < len;++ i){
+      // Assign i to the argument
+      data.template assign_offset<ArgumentId>(i);
+      data.template assign_param<ParamId>(i);
+
+      // execute enclosed statements
+      enclosed_stmts_t::exec(data);
+    }
   }
 };
 

--- a/include/RAJA/policy/cuda/kernel/For.hpp
+++ b/include/RAJA/policy/cuda/kernel/For.hpp
@@ -42,6 +42,7 @@ namespace internal
 /*
  * Executor for thread work sharing loop inside CudaKernel.
  * Mapping directly from threadIdx.xyz to indices
+ * Assigns the loop index to offset ArgumentId
  */
 template <typename Data,
           camp::idx_t ArgumentId,
@@ -97,6 +98,7 @@ struct CudaStatementExecutor<
 /*
  * Executor for thread work sharing loop inside CudaKernel.
  * Mapping directly from threadIdx.xyz to indices
+ * Assigns the loop index to offset ArgumentId
  * Assigns the loop index to param ParamId
  */
 template <typename Data,
@@ -142,6 +144,7 @@ struct CudaStatementExecutor<
  * Executor for thread work sharing loop inside CudaKernel.
  * Provides a block-stride loop (stride of blockDim.xyz) for
  * each thread in xyz.
+ * Assigns the loop index to offset ArgumentId
  */
 template <typename Data,
           camp::idx_t ArgumentId,
@@ -200,6 +203,7 @@ struct CudaStatementExecutor<
  * Executor for thread work sharing loop inside CudaKernel.
  * Provides a block-stride loop (stride of blockDim.xyz) for
  * each thread in xyz.
+ * Assigns the loop index to offset ArgumentId
  * Assigns the loop index to param ParamId
  */
 template <typename Data,
@@ -246,6 +250,7 @@ struct CudaStatementExecutor<
  * Executor for block work sharing inside CudaKernel.
  * Provides a grid-stride loop (stride of gridDim.xyz) for
  * each block in xyz.
+ * Assigns the loop index to offset ArgumentId
  */
 template <typename Data,
           camp::idx_t ArgumentId,
@@ -299,6 +304,7 @@ struct CudaStatementExecutor<
  * Executor for block work sharing inside CudaKernel.
  * Provides a grid-stride loop (stride of gridDim.xyz) for
  * each block in xyz.
+ * Assigns the loop index to offset ArgumentId
  * Assigns the loop index to param ParamId
  */
 template <typename Data,
@@ -344,6 +350,7 @@ struct CudaStatementExecutor<
  * Executor for sequential loops inside of a CudaKernel.
  *
  * This is specialized since it need to execute the loop immediately.
+ * Assigns the loop index to offset ArgumentId
  */
 template <typename Data,
           camp::idx_t ArgumentId,
@@ -389,6 +396,7 @@ struct CudaStatementExecutor<
  * Executor for sequential loops inside of a CudaKernel.
  *
  * This is specialized since it need to execute the loop immediately.
+ * Assigns the loop index to offset ArgumentId
  * Assigns the loop index to param ParamId
  */
 template <typename Data,

--- a/include/RAJA/policy/cuda/kernel/Tile.hpp
+++ b/include/RAJA/policy/cuda/kernel/Tile.hpp
@@ -50,7 +50,11 @@ namespace RAJA
 namespace internal
 {
 
-
+/*!
+ * A specialized RAJA::kernel cuda_impl executor for statement::Tile
+ * Assigns the tile segment to segment ArgumentId
+ *
+ */
 template <typename Data,
           camp::idx_t ArgumentId,
           typename TPol,
@@ -117,6 +121,11 @@ struct CudaStatementExecutor<
   }
 };
 
+/*!
+ * A specialized RAJA::kernel cuda_impl executor for statement::TileTCount
+ * Assigns the tile segment to segment ArgumentId
+ * Assigns the tile index to param ParamId
+ */
 template <typename Data,
           camp::idx_t ArgumentId,
           typename ParamId,
@@ -167,7 +176,11 @@ struct CudaStatementExecutor<
   }
 };
 
-
+/*!
+ * A specialized RAJA::kernel cuda_impl executor for statement::Tile
+ * Assigns the tile segment to segment ArgumentId
+ *
+ */
 template <typename Data,
           camp::idx_t ArgumentId,
           camp::idx_t chunk_size,
@@ -252,6 +265,11 @@ struct CudaStatementExecutor<
   }
 };
 
+/*!
+ * A specialized RAJA::kernel cuda_impl executor for statement::TileTCount
+ * Assigns the tile segment to segment ArgumentId
+ * Assigns the tile index to param ParamId
+ */
 template <typename Data,
           camp::idx_t ArgumentId,
           typename ParamId,

--- a/test/unit/test-kernel.cpp
+++ b/test/unit/test-kernel.cpp
@@ -776,8 +776,8 @@ TEST(Kernel, TileTCount)
   for (int i = 0; i < N; ++i) {
     x[i] = 0;
   }
-  for (int i = 0; i < NT; ++i) {
-    xt[i] = 0;
+  for (int t = 0; t < NT; ++t) {
+    xt[t] = 0;
   }
 
   kernel_param<Pol>(
@@ -793,12 +793,12 @@ TEST(Kernel, TileTCount)
   for (int i = 0; i < N; ++i) {
     ASSERT_EQ(x[i], 1);
   }
-  for (int i = 0; i < NT; ++i) {
+  for (int t = 0; t < NT; ++t) {
     int expect = T;
-    if ((i+1)*T > N) {
-      expect -= (i+1)*T - N;
+    if ((t+1)*T > N) {
+      expect = N - t*T;
     }
-    ASSERT_EQ(xt[i], expect);
+    ASSERT_EQ(xt[t], expect);
   }
 
   delete[] xt;


### PR DESCRIPTION
Add support for getting iteration and tile indices via parameters.

Variant of For and Tile statements that set a member of the param tuple to the iteration or tile index respectively.
  - RAJA::statement::ForICount<Segment#, RAJA::statement::Param<#>, exec, ...>
  - RAJA::statement::TileTCount<Segment#, RAJA::statement::Param<#>, exec, ...>