### PR TITLE
build and test on forks that don't have intel key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,12 +75,14 @@ before_install: # don't try to build and run intel when it's impossible
   if [[ "x$encrypted_cd1f6303bca7_key" != "x" ]] ; then
     openssl aes-256-cbc -K $encrypted_cd1f6303bca7_key -iv $encrypted_cd1f6303bca7_iv -in ${TRAVIS_BUILD_DIR}/travis-data/intel2016.lic.enc -out ${TRAVIS_BUILD_DIR}/travis-data/intel2016.lic -d
   else
-    export DO_TEST=no DO_BUILD=no
+    if [[ $COMPILER == *"icpc"* ]] ; then
+      export DO_TEST=no DO_BUILD=no
+    fi
   fi
 - export LSAN_OPTIONS
 - export ASAN_OPTIONS
 
-script: 
+script:
 - docker run --rm --user='root' -v ${TRAVIS_BUILD_DIR}:/home/raja rajaorg/compiler:$IMG chown -R raja /home/raja
 - docker run --rm -v ${TRAVIS_BUILD_DIR}/travis-data:/opt/intel/licenses -v ${TRAVIS_BUILD_DIR}:/home/raja -e ASAN_OPTIONS -e LSAN_OPTIONS -e COMPILER -e DO_BUILD -e DO_TEST -e CMAKE_EXTRA_FLAGS rajaorg/compiler:$IMG ./scripts/travis_build_and_test.sh
 


### PR DESCRIPTION
This is what caused the issue with PR #549, since forks don't have the encrypted key, they were having both DO_BUILD and DO_TEST set to no.