### PR TITLE
Only set RAJA_LOADED where there actually is a PARENT_SCOPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,13 @@ endif()
 
 if (NOT RAJA_LOADED)
   set (RAJA_LOADED "${RAJA_VERSION_MAJOR}.${RAJA_VERSION_MINOR}.${RAJA_VERSION_PATCHLEVEL}")
-  set (RAJA_LOADED ${RAJA_LOADED} PARENT_SCOPE)
+
+  # Promote RAJA_LOADED to PARENT_SCOPE if it exists, which is only if we are bringing	
+  # in RAJA as a subproject to a larger CMake project
+  get_directory_property(hasParent PARENT_DIRECTORY)
+  if(hasParent)
+    set (RAJA_LOADED ${RAJA_LOADED} PARENT_SCOPE)
+  endif()
 
   mark_as_advanced(RAJA_LOADED)
 


### PR DESCRIPTION
This squashes an annoying warning you get during the CMake configure step