### PR TITLE
Changed plumbing in RAJA::kernel to defer masking off threads until lambda is called

### DIFF
--- a/include/RAJA/policy/cuda/kernel/Conditional.hpp
+++ b/include/RAJA/policy/cuda/kernel/Conditional.hpp
@@ -57,13 +57,12 @@ struct CudaStatementExecutor<Data,
   static
   inline
   RAJA_DEVICE
-  void exec(Data &data)
+  void exec(Data &data, bool thread_active)
   {
-
     if (Conditional::eval(data)) {
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data);
+      enclosed_stmts_t::exec(data, thread_active);
     }
   }
 

--- a/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
+++ b/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
@@ -150,7 +150,7 @@ __global__ void CudaKernelLauncher(Data data)
   using data_t = camp::decay<Data>;
   data_t private_data = data;
 
-  Exec::exec(private_data);
+  Exec::exec(private_data, true);
 }
 
 
@@ -170,7 +170,7 @@ __launch_bounds__(BlockSize, 1) __global__
   data_t private_data = data;
 
   // execute the the object
-  Exec::exec(private_data);
+  Exec::exec(private_data, true);
 }
 
 /*!

--- a/include/RAJA/policy/cuda/kernel/ForICount.hpp
+++ b/include/RAJA/policy/cuda/kernel/ForICount.hpp
@@ -67,7 +67,7 @@ struct CudaStatementExecutor<
   static
   inline
   RAJA_DEVICE
-  void exec(Data &data)
+  void exec(Data &data, bool thread_active)
   {
     auto len = segment_length<ArgumentId>(data);
     auto i = get_cuda_dim<ThreadDim>(threadIdx);
@@ -77,9 +77,8 @@ struct CudaStatementExecutor<
     data.template assign_param<ParamId>(i);
 
     // execute enclosed statements if in bounds
-    if(i < len){
-      enclosed_stmts_t::exec(data);
-    }
+    enclosed_stmts_t::exec(data, thread_active && (i<len));
+
   }
 };
 
@@ -113,20 +112,29 @@ struct CudaStatementExecutor<
   using typename Base::enclosed_stmts_t;
 
   static
-  inline RAJA_DEVICE void exec(Data &data)
+  inline RAJA_DEVICE void exec(Data &data, bool thread_active)
   {
     // block stride loop
     int len = segment_length<ArgumentId>(data);
     auto i0 = get_cuda_dim<ThreadDim>(threadIdx);
     auto i_stride = get_cuda_dim<ThreadDim>(blockDim);
-    for(auto i = i0;i < len;i += i_stride){
+    auto i = i0;
+    for(;i < len;i += i_stride){
 
       // Assign the x thread to the argument
       data.template assign_offset<ArgumentId>(i);
       data.template assign_param<ParamId>(i);
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data);
+      enclosed_stmts_t::exec(data, thread_active);
+    }
+    // do we need one more masked iteration?
+    if(i - i0 < len)
+    {
+      // execute enclosed statements one more time, but masking them off
+      // this is because there's at least one thread that isn't masked off
+      // that is still executing the above loop
+      enclosed_stmts_t::exec(data, false);
     }
   }
 };
@@ -160,7 +168,7 @@ struct CudaStatementExecutor<
   using typename Base::enclosed_stmts_t;
 
   static
-  inline RAJA_DEVICE void exec(Data &data)
+  inline RAJA_DEVICE void exec(Data &data, bool thread_active)
   {
     // grid stride loop
     int len = segment_length<ArgumentId>(data);
@@ -173,7 +181,7 @@ struct CudaStatementExecutor<
       data.template assign_param<ParamId>(i);
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data);
+      enclosed_stmts_t::exec(data, thread_active);
     }
   }
 };
@@ -206,7 +214,7 @@ struct CudaStatementExecutor<
   static
   inline
   RAJA_DEVICE
-  void exec(Data &data)
+  void exec(Data &data, bool thread_active)
   {
     using idx_type = camp::decay<decltype(camp::get<ArgumentId>(data.offset_tuple))>;
 
@@ -218,7 +226,7 @@ struct CudaStatementExecutor<
       data.template assign_param<ParamId>(i);
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data);
+      enclosed_stmts_t::exec(data, thread_active);
     }
   }
 };

--- a/include/RAJA/policy/cuda/kernel/Hyperplane.hpp
+++ b/include/RAJA/policy/cuda/kernel/Hyperplane.hpp
@@ -50,7 +50,7 @@ template <typename Data,
           typename... EnclosedStmts>
 struct CudaStatementExecutor<Data,
                              statement::Hyperplane<HpArgumentId,
-                                                   cuda_seq_syncthreads_exec,
+                                                   seq_exec,
                                                    ArgList<Args...>,
                                                    EnclosedStmts...>> {
 
@@ -60,7 +60,7 @@ struct CudaStatementExecutor<Data,
   static
   inline
   RAJA_DEVICE
-  void exec(Data &data)
+  void exec(Data &data, bool thread_active)
   {
     // compute Manhattan distance of iteration space to determine
     // as:  hp_len = l0 + l1 + l2 + ...
@@ -78,7 +78,7 @@ struct CudaStatementExecutor<Data,
     /*
      * Execute the loop over hyperplanes
      *
-     * We reject the iterations that lie outsize of the specified rectangular
+     * We reject the iterations that lie outside of the specified rectangular
      * region we are sweeping.
      */
     for (int h = 0; h < hp_len; ++h) {
@@ -87,17 +87,10 @@ struct CudaStatementExecutor<Data,
       // as:  i0 = h - (i1 + i2 + i3 + ...)
       idx_t i = h - h_args;
 
-      // execute enclosed statements
-      if (i >= 0 && i < i_len) {
-
-        // assign i to the hp arg
-        data.template assign_offset<HpArgumentId>(i);
-
-        enclosed_stmts_t::exec(data);
-      }
-
-      // sync
-      __syncthreads();
+      // execute enclosed statements, masking off threads that are out of
+      // bounds
+      data.template assign_offset<HpArgumentId>(i);
+      enclosed_stmts_t::exec(data, thread_active && (i >= 0 && i < i_len));
     }
   }
 

--- a/include/RAJA/policy/cuda/kernel/InitLocalMem.hpp
+++ b/include/RAJA/policy/cuda/kernel/InitLocalMem.hpp
@@ -57,7 +57,7 @@ struct CudaStatementExecutor<Data, statement::InitLocalMem<RAJA::cuda_shared_mem
   static
   inline
   RAJA_DEVICE
-  void initMem(Data &data)
+  void initMem(Data &data, bool thread_active)
   {
     using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::element_t;
     const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::NumElem;
@@ -65,7 +65,7 @@ struct CudaStatementExecutor<Data, statement::InitLocalMem<RAJA::cuda_shared_mem
     __shared__ varType Array[NumElem];
     camp::get<Pos>(data.param_tuple).m_arrayPtr = Array;
 
-    enclosed_stmts_t::exec(data);
+    enclosed_stmts_t::exec(data, thread_active);
   }
   
   //Intialize local array
@@ -74,14 +74,14 @@ struct CudaStatementExecutor<Data, statement::InitLocalMem<RAJA::cuda_shared_mem
   static
   inline
   RAJA_DEVICE
-  void initMem(Data &data)
+  void initMem(Data &data, bool thread_active)
   {
     using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::element_t;
     const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::NumElem;
     
     __shared__ varType Array[NumElem];
     camp::get<Pos>(data.param_tuple).m_arrayPtr = Array;
-    initMem<others...>(data);
+    initMem<others...>(data, thread_active);
   }
 
   //Set pointer to null base case
@@ -112,11 +112,11 @@ struct CudaStatementExecutor<Data, statement::InitLocalMem<RAJA::cuda_shared_mem
   static
   inline
   RAJA_DEVICE
-  void exec(Data &data)
+  void exec(Data &data, bool thread_active)
   {
     
     //Intialize scoped arrays + launch loops
-    initMem<Indices...>(data);
+    initMem<Indices...>(data, thread_active);
     
     //set pointers in scoped arrays to null
     setPtrToNull<Indices...>(data);
@@ -146,7 +146,7 @@ struct CudaStatementExecutor<Data, statement::InitLocalMem<RAJA::cuda_thread_mem
   static
   inline
   RAJA_DEVICE
-  void initMem(Data &data)
+  void initMem(Data &data, bool thread_active)
   {
     using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::element_t;
     const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::NumElem;
@@ -154,7 +154,7 @@ struct CudaStatementExecutor<Data, statement::InitLocalMem<RAJA::cuda_thread_mem
     varType Array[NumElem];
     camp::get<Pos>(data.param_tuple).m_arrayPtr = Array;
 
-    enclosed_stmts_t::exec(data);
+    enclosed_stmts_t::exec(data, thread_active);
   }
   
   //Intialize local array
@@ -163,14 +163,14 @@ struct CudaStatementExecutor<Data, statement::InitLocalMem<RAJA::cuda_thread_mem
   static
   inline
   RAJA_DEVICE
-  void initMem(Data &data)
+  void initMem(Data &data, bool thread_active)
   {
     using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::element_t;
     const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::NumElem;
     
     varType Array[NumElem];
     camp::get<Pos>(data.param_tuple).m_arrayPtr = Array;
-    initMem<others...>(data);
+    initMem<others...>(data, thread_active);
   }
 
   //Set pointer to null base case
@@ -201,11 +201,11 @@ struct CudaStatementExecutor<Data, statement::InitLocalMem<RAJA::cuda_thread_mem
   static
   inline
   RAJA_DEVICE
-  void exec(Data &data)
+  void exec(Data &data, bool thread_active)
   {
     
     //Intialize scoped arrays + launch loops
-    initMem<Indices...>(data);
+    initMem<Indices...>(data, thread_active);
     
     //set pointers in scoped arrays to null
     setPtrToNull<Indices...>(data);

--- a/include/RAJA/policy/cuda/kernel/Lambda.hpp
+++ b/include/RAJA/policy/cuda/kernel/Lambda.hpp
@@ -52,9 +52,12 @@ template <typename Data, camp::idx_t LoopIndex>
 struct CudaStatementExecutor<Data, statement::Lambda<LoopIndex>> {
 
   static
-  inline RAJA_DEVICE void exec(Data &data)
+  inline RAJA_DEVICE void exec(Data &data, bool thread_active)
   {
-    invoke_lambda<LoopIndex>(data);
+    // Only execute the lambda if it hasn't been masked off
+    if(thread_active){
+      invoke_lambda<LoopIndex>(data);
+    }
   }
 
 

--- a/include/RAJA/policy/cuda/kernel/Sync.hpp
+++ b/include/RAJA/policy/cuda/kernel/Sync.hpp
@@ -67,7 +67,7 @@ struct CudaStatementExecutor<Data, statement::CudaSyncThreads> {
   static
   inline
   RAJA_DEVICE
-  void exec(Data &) { __syncthreads(); }
+  void exec(Data &, bool) { __syncthreads(); }
 
 
   static

--- a/include/RAJA/policy/cuda/kernel/Tile.hpp
+++ b/include/RAJA/policy/cuda/kernel/Tile.hpp
@@ -70,7 +70,7 @@ struct CudaStatementExecutor<
   static
   inline
   RAJA_DEVICE
-  void exec(Data &data){
+  void exec(Data &data, bool thread_active){
     // Get the segment referenced by this Tile statement
     auto &segment = camp::get<ArgumentId>(data.segment_tuple);
 
@@ -90,7 +90,7 @@ struct CudaStatementExecutor<
       segment = orig_segment.slice(i, chunk_size);
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data);
+      enclosed_stmts_t::exec(data, thread_active);
     }
 
     // Set range back to original values
@@ -147,7 +147,7 @@ struct CudaStatementExecutor<
   static
   inline
   RAJA_DEVICE
-  void exec(Data &data)
+  void exec(Data &data, bool thread_active)
   {
     // Get the segment referenced by this Tile statement
     auto &segment = camp::get<ArgumentId>(data.segment_tuple);
@@ -168,7 +168,7 @@ struct CudaStatementExecutor<
       segment = orig_segment.slice(i, chunk_size);
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data);
+      enclosed_stmts_t::exec(data, thread_active);
     }
 
     // Set range back to original values

--- a/include/RAJA/policy/cuda/kernel/TileTCount.hpp
+++ b/include/RAJA/policy/cuda/kernel/TileTCount.hpp
@@ -76,7 +76,7 @@ struct CudaStatementExecutor<
   static
   inline
   RAJA_DEVICE
-  void exec(Data &data){
+  void exec(Data &data, bool thread_active){
     // Get the segment referenced by this Tile statement
     auto &segment = camp::get<ArgumentId>(data.segment_tuple);
 
@@ -97,7 +97,7 @@ struct CudaStatementExecutor<
       data.template assign_param<ParamId>(t);
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data);
+      enclosed_stmts_t::exec(data, thread_active);
     }
 
     // Set range back to original values
@@ -142,7 +142,7 @@ struct CudaStatementExecutor<
   static
   inline
   RAJA_DEVICE
-  void exec(Data &data)
+  void exec(Data &data, bool thread_active)
   {
     // Get the segment referenced by this Tile statement
     auto &segment = camp::get<ArgumentId>(data.segment_tuple);
@@ -166,7 +166,7 @@ struct CudaStatementExecutor<
       data.template assign_param<ParamId>(t);
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data);
+      enclosed_stmts_t::exec(data, thread_active);
     }
 
     // Set range back to original values

--- a/include/RAJA/policy/cuda/kernel/internal.hpp
+++ b/include/RAJA/policy/cuda/kernel/internal.hpp
@@ -193,13 +193,13 @@ struct CudaStatementListExecutorHelper {
   using cur_stmt_t = camp::at_v<StmtList, cur_stmt>;
 
   template <typename Data>
-  inline static RAJA_DEVICE void exec(Data &data)
+  inline static RAJA_DEVICE void exec(Data &data, bool thread_active)
   {
     // Execute stmt
-    cur_stmt_t::exec(data);
+    cur_stmt_t::exec(data, thread_active);
 
     // Execute next stmt
-    next_helper_t::exec(data);
+    next_helper_t::exec(data, thread_active);
   }
 
 
@@ -221,7 +221,7 @@ template <camp::idx_t num_stmts, typename StmtList>
 struct CudaStatementListExecutorHelper<num_stmts, num_stmts, StmtList> {
 
   template <typename Data>
-  inline static RAJA_DEVICE void exec(Data &)
+  inline static RAJA_DEVICE void exec(Data &, bool)
   {
     // nop terminator
   }
@@ -252,10 +252,10 @@ struct CudaStatementListExecutor<Data, StatementList<Stmts...>> {
   static
   inline
   RAJA_DEVICE
-  void exec(Data &data)
+  void exec(Data &data, bool thread_active)
   {
     // Execute statements in order with helper class
-    CudaStatementListExecutorHelper<0, num_stmts, enclosed_stmts_t>::exec(data);
+    CudaStatementListExecutorHelper<0, num_stmts, enclosed_stmts_t>::exec(data, thread_active);
   }
 
 

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -88,15 +88,6 @@ struct cuda_exec : public RAJA::make_policy_pattern_launch_platform_t<
 };
 
 
-/*
- * Policy for on-device loop with a __syncthreads() after each iteration
- */
-struct cuda_seq_syncthreads_exec
-    : public RAJA::make_policy_pattern_launch_platform_t<RAJA::Policy::cuda,
-                                                         RAJA::Pattern::forall,
-                                                         RAJA::Launch::sync,
-                                                         RAJA::Platform::cuda> {
-};
 
 //
 // NOTE: There is no Index set segment iteration policy for CUDA
@@ -151,7 +142,6 @@ using policy::cuda::cuda_exec;
 template <size_t BLOCK_SIZE>
 using cuda_exec_async = policy::cuda::cuda_exec<BLOCK_SIZE, true>;
 
-using policy::cuda::cuda_seq_syncthreads_exec;
 using policy::cuda::cuda_reduce_base;
 using policy::cuda::cuda_reduce;
 using policy::cuda::cuda_reduce_atomic;

--- a/test/unit/test-kernel.cpp
+++ b/test/unit/test-kernel.cpp
@@ -1807,8 +1807,8 @@ CUDA_TEST(Kernel, Hyperplane_cuda_2d)
   using Pol =
       RAJA::KernelPolicy<CudaKernel<
         For<1, cuda_thread_x_direct,
-          Hyperplane<0, cuda_seq_syncthreads_exec, ArgList<1>,
-                                               Lambda<0>>>>>;
+          Hyperplane<0, seq_exec, ArgList<1>,
+                                     Lambda<0>, CudaSyncThreads>>>>;
 
   constexpr long N = (long)24;
   constexpr long M = (long)11;
@@ -1854,8 +1854,8 @@ CUDA_TEST(Kernel, Hyperplane_cuda_2d_negstride)
   using Pol =
       RAJA::KernelPolicy<CudaKernel<
         For<1, cuda_thread_y_direct,
-          Hyperplane<0, cuda_seq_syncthreads_exec, ArgList<1>,
-                                               Lambda<0>>>>>;
+          Hyperplane<0, seq_exec, ArgList<1>,
+                                           Lambda<0>, CudaSyncThreads>>>>;
 
   constexpr long N = (long)24;
   constexpr long M = (long)11;
@@ -1906,9 +1906,8 @@ CUDA_TEST(Kernel, Hyperplane_cuda_3d_tiled)
           RAJA::statement::Tile<3, RAJA::statement::tile_fixed<7>, seq_exec,
             For<2, cuda_thread_x_direct,
               For<3, cuda_thread_y_direct,
-                Hyperplane<1, cuda_seq_syncthreads_exec, ArgList<2, 3>,
-
-                                               Lambda<0>>>>>>>>>;
+                Hyperplane<1, seq_exec, ArgList<2, 3>,
+                                           Lambda<0>, CudaSyncThreads>>>>>>>>;
 
   constexpr long L = (long)1;
   constexpr long N = (long)11;


### PR DESCRIPTION
Changed plumbing in RAJA::kernel to only mask off threads that are out of bounds at the Lambda invokation.

This allows threads that are masked off to still participate in syncthreads, etc., which was causing hangs with the NVidia V100's.
Also, it allowed the elimination of the cuda_seq_syncthreads_exec policy.