### PR TITLE
Remotes/origin/bugfix/chen59/omptargetfixes

### DIFF
--- a/include/RAJA/policy/openmp/policy.hpp
+++ b/include/RAJA/policy/openmp/policy.hpp
@@ -54,28 +54,6 @@ template <unsigned int ChunkSize>
 struct Static : std::integral_constant<unsigned int, ChunkSize> {
 };
 
-#if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-// Max number of CUDA reduction threads per block possible.
-// Required for allocating omp target data before execution policy.
-// Used in target_parallel_for, aliased in target_reduce.
-static constexpr int MAXNUMTHREADS = 1024;
-
-template <unsigned int TeamSize>
-struct Teams : std::integral_constant<unsigned int, TeamSize> {
-};
-
-template <unsigned int ThreadCount>
-struct Threads : std::integral_constant<unsigned int, ThreadCount> {
-};
-
-struct Target {
-};
-
-struct Distribute {
-};
-
-#endif
 
 //
 //////////////////////////////////////////////////////////////////////
@@ -133,24 +111,6 @@ struct omp_parallel_for_static : omp_parallel_exec<omp_for_static<N>> {
 };
 
 
-#if defined(RAJA_ENABLE_TARGET_OPENMP)
-template <size_t ThreadsPerTeam>
-struct omp_target_parallel_for_exec
-    : make_policy_pattern_t<Policy::target_openmp,
-                            Pattern::forall,
-                            omp::Target,
-                            omp::Threads<ThreadsPerTeam>,
-                            omp::Distribute> {
-};
-
-struct omp_target_parallel_for_exec_nt
-    : make_policy_pattern_t<Policy::target_openmp,
-                            Pattern::forall,
-                            omp::Target,
-                            omp::Distribute> {
-};
-#endif
-
 ///
 /// Index set segment iteration policies
 ///
@@ -177,12 +137,6 @@ struct omp_taskgraph_interval_segit
 
 struct omp_reduce : make_policy_pattern_t<Policy::openmp, Pattern::reduce> {
 };
-
-#if defined(RAJA_ENABLE_TARGET_OPENMP)
-struct omp_target_reduce
-    : make_policy_pattern_t<Policy::target_openmp, Pattern::reduce> {
-};
-#endif
 
 struct omp_reduce_ordered
     : make_policy_pattern_t<Policy::openmp, Pattern::reduce, reduce::ordered> {

--- a/include/RAJA/policy/openmp_target/policy.hpp
+++ b/include/RAJA/policy/openmp_target/policy.hpp
@@ -8,6 +8,11 @@ namespace RAJA {
 namespace policy {
 namespace omp {
 
+// Max number of CUDA reduction threads per block possible.
+// Required for allocating omp target data before execution policy.
+// Used in target_parallel_for, aliased in target_reduce.
+static constexpr int MAXNUMTHREADS = 1024;
+
 template <unsigned int TeamSize>
 struct Teams : std::integral_constant<unsigned int, TeamSize> {
 };
@@ -18,12 +23,12 @@ struct Target {
 struct Distribute {
 };
 
-template <size_t Teams>
+template <size_t ThreadsPerTeam>
 struct omp_target_parallel_for_exec
     : make_policy_pattern_t<Policy::target_openmp,
                             Pattern::forall,
                             omp::Target,
-                            omp::Teams<Teams>,
+                            omp::Teams<ThreadsPerTeam>,
                             omp::Distribute> {
 };
 
@@ -41,7 +46,6 @@ struct omp_target_parallel_collapse_exec
                             omp::Collapse> {
 };
 
-template <size_t Teams>
 struct omp_target_reduce
     : make_policy_pattern_t<Policy::target_openmp, Pattern::reduce> {
 };

--- a/include/RAJA/policy/openmp_target/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/reduce.hpp
@@ -20,8 +20,6 @@
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
 
-#include <cassert>
-
 #include <algorithm>
 
 #include <omp.h>
@@ -196,7 +194,6 @@ struct TargetReduce
   //! apply reduction on device upon destruction
   ~TargetReduce()
   {
-    assert ( omp_get_num_teams() <= omp::MaxNumTeams );
     if (!omp_is_initial_device()) {
 #pragma omp critical
       {
@@ -270,7 +267,6 @@ struct TargetReduceLoc
   //! apply reduction on device upon destruction
   ~TargetReduceLoc()
   {
-    assert ( omp_get_num_teams() <= omp::MaxNumTeams );
     if (!omp_is_initial_device()) {
 #pragma omp critical
       {

--- a/include/RAJA/policy/openmp_target/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/reduce.hpp
@@ -20,6 +20,8 @@
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
 
+//#include <cassert>  // Leaving out until XL is fixed 2/25/2019.
+
 #include <algorithm>
 
 #include <omp.h>
@@ -194,6 +196,7 @@ struct TargetReduce
   //! apply reduction on device upon destruction
   ~TargetReduce()
   {
+    //assert ( omp_get_num_teams() <= omp::MaxNumTeams );  // Leaving out until XL is fixed 2/25/2019.
     if (!omp_is_initial_device()) {
 #pragma omp critical
       {
@@ -267,6 +270,7 @@ struct TargetReduceLoc
   //! apply reduction on device upon destruction
   ~TargetReduceLoc()
   {
+    //assert ( omp_get_num_teams() <= omp::MaxNumTeams );  // Leaving out until XL is fixed 2/25/2019.
     if (!omp_is_initial_device()) {
 #pragma omp critical
       {


### PR DESCRIPTION
omp_target header files were not merged & tested correctly in previous PR. Moved all OpenMP target to openmp_target directory. Removed an assert in omp_target reducer to play nicely with nvcc. This PR can only be compiled with clang-coral 18.08.08 at the moment.