### PR TITLE
__syncwarp NOP alternative

### DIFF
--- a/include/RAJA/policy/cuda/kernel/Sync.hpp
+++ b/include/RAJA/policy/cuda/kernel/Sync.hpp
@@ -54,13 +54,11 @@ namespace statement
 struct CudaSyncThreads : public internal::Statement<camp::nil> {
 };
 
-#if CUDART_VERSION >= 9000
 /*!
  * A RAJA::kernel statement that performs a CUDA __syncwarp().
  */
 struct CudaSyncWarp : public internal::Statement<camp::nil> {
 };
-#endif
 
 
 }  // namespace statement
@@ -85,14 +83,17 @@ struct CudaStatementExecutor<Data, statement::CudaSyncThreads> {
   }
 };
 
-#if CUDART_VERSION >= 9000
 template <typename Data>
 struct CudaStatementExecutor<Data, statement::CudaSyncWarp> {
 
   static
   inline
   RAJA_DEVICE
+#if CUDART_VERSION >= 9000
   void exec(Data &, bool) { __syncwarp(); }
+#else
+  void exec(Data &, bool) {  }
+#endif
 
 
   static
@@ -102,7 +103,6 @@ struct CudaStatementExecutor<Data, statement::CudaSyncWarp> {
     return LaunchDims();
   }
 };
-#endif
 
 
 }  // namespace internal


### PR DESCRIPTION
Tests with __syncwarp were failing to compile with CUDA 8.0. Added NOP alternative to __syncwarp.