### PR TITLE
 CUDA: Adding missing executors and bitmasked policies

### DIFF
--- a/include/RAJA/RAJA.hpp
+++ b/include/RAJA/RAJA.hpp
@@ -119,6 +119,10 @@
 //
 #include "RAJA/pattern/atomic.hpp"
 
+//
+// Bit masking operators
+//
+#include "RAJA/util/BitMask.hpp"
 
 //
 // Reduction objects

--- a/include/RAJA/policy/cuda/kernel/For.hpp
+++ b/include/RAJA/policy/cuda/kernel/For.hpp
@@ -464,7 +464,7 @@ struct CudaStatementExecutor<
   LaunchDims calculateDimensions(Data const &data)
   {
     // Get enclosed statements
-    LaunchDims dims = enclosed_stmts_t::calculateDimensions(data);
+    LaunchDims dims;
 
     // we need to allocate enough threads for the segment size, and the
     // shifted off bits
@@ -476,7 +476,8 @@ struct CudaStatementExecutor<
     // since we are direct-mapping, we REQUIRE len
     set_cuda_dim<0>(dims.min_threads, len);
 
-    return(dims);
+    LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);
+    return(dims.max(enclosed_dims));
   }
 };
 
@@ -537,7 +538,7 @@ struct CudaStatementExecutor<
   LaunchDims calculateDimensions(Data const &data)
   {
     // Get enclosed statements
-    LaunchDims dims = enclosed_stmts_t::calculateDimensions(data);
+    LaunchDims dims;
 
     // we need to allocate enough threads for the segment size, and the
     // shifted off bits
@@ -549,7 +550,8 @@ struct CudaStatementExecutor<
     // since we are direct-mapping, we REQUIRE len
     set_cuda_dim<0>(dims.min_threads, len);
 
-    return(dims);
+    LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);
+    return(dims.max(enclosed_dims));
   }
 };
 

--- a/include/RAJA/policy/cuda/kernel/For.hpp
+++ b/include/RAJA/policy/cuda/kernel/For.hpp
@@ -285,6 +285,276 @@ struct CudaStatementExecutor<
 
 
 /*
+ * Executor for thread work sharing loop inside CudaKernel.
+ * Mapping directly from a warp lane
+ * Assigns the loop index to offset ArgumentId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          typename Mask,
+          typename ... EnclosedStmts>
+struct CudaStatementExecutor<
+  Data,
+  statement::For<ArgumentId, RAJA::cuda_warp_masked_direct<Mask>,
+                 EnclosedStmts ...> > {
+
+  using stmt_list_t = StatementList<EnclosedStmts ...>;
+
+  using enclosed_stmts_t =
+          CudaStatementListExecutor<Data, stmt_list_t>;
+
+  using mask_t = Mask;
+
+  static_assert(mask_t::max_masked_size <= RAJA::policy::cuda::WARP_SIZE,
+                "BitMask is too large for CUDA warp size");
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data, bool thread_active)
+  {
+    auto len = segment_length<ArgumentId>(data);
+
+    auto i = mask_t::maskValue(threadIdx.x);
+
+    // assign thread id directly to offset
+    data.template assign_offset<ArgumentId>(i);
+
+    // execute enclosed statements if in bounds
+    enclosed_stmts_t::exec(data, thread_active && (i<len));
+  }
+
+
+  static
+  inline
+  LaunchDims calculateDimensions(Data const &data)
+  {
+    // Get enclosed statements
+    LaunchDims dims = enclosed_stmts_t::calculateDimensions(data);
+
+    // we always get EXACTLY one warp by allocating one warp in the X
+    // dimension
+    int len = RAJA::policy::cuda::WARP_SIZE;
+
+    // request one thread per element in the segment
+    set_cuda_dim<0>(dims.threads, len);
+
+    // since we are direct-mapping, we REQUIRE len
+    set_cuda_dim<0>(dims.min_threads, len);
+
+    return(dims);
+  }
+};
+
+
+
+/*
+ * Executor for thread work sharing loop inside CudaKernel.
+ * Mapping directly from a warp lane
+ * Assigns the loop index to offset ArgumentId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          typename Mask,
+          typename ... EnclosedStmts>
+struct CudaStatementExecutor<
+  Data,
+  statement::For<ArgumentId, RAJA::cuda_warp_masked_loop<Mask>,
+                 EnclosedStmts ...> > {
+
+  using stmt_list_t = StatementList<EnclosedStmts ...>;
+
+  using enclosed_stmts_t =
+          CudaStatementListExecutor<Data, stmt_list_t>;
+
+  using mask_t = Mask;
+
+  static_assert(mask_t::max_masked_size <= RAJA::policy::cuda::WARP_SIZE,
+                "BitMask is too large for CUDA warp size");
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data, bool thread_active)
+  {
+    // masked size strided loop
+    int len = segment_length<ArgumentId>(data);
+    int i = mask_t::maskValue(threadIdx.x);
+    for( ; i < len; i += (int) mask_t::max_masked_size){
+
+      // Assign the x thread to the argument
+      data.template assign_offset<ArgumentId>(i);
+
+      // execute enclosed statements
+      enclosed_stmts_t::exec(data, thread_active);
+    }
+    // do we need one more masked iteration?
+    if(i - mask_t::maskValue(threadIdx.x) < len){
+      // execute enclosed statements one more time, but masking them off
+      // this is because there's at least one thread that isn't masked off
+      // that is still executing the above loop
+      enclosed_stmts_t::exec(data, false);
+    }
+
+  }
+
+
+  static
+  inline
+  LaunchDims calculateDimensions(Data const &data)
+  {
+    // Get enclosed statements
+    LaunchDims dims = enclosed_stmts_t::calculateDimensions(data);
+
+    // we always get EXACTLY one warp by allocating one warp in the X
+    // dimension
+    int len = RAJA::policy::cuda::WARP_SIZE;
+
+    // request one thread per element in the segment
+    set_cuda_dim<0>(dims.threads, len);
+
+    // since we are direct-mapping, we REQUIRE len
+    set_cuda_dim<0>(dims.min_threads, len);
+
+    return(dims);
+  }
+};
+
+
+/*
+ * Executor for thread work sharing loop inside CudaKernel.
+ * Mapping directly from raw threadIdx.x
+ * Assigns the loop index to offset ArgumentId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          typename Mask,
+          typename ... EnclosedStmts>
+struct CudaStatementExecutor<
+  Data,
+  statement::For<ArgumentId, RAJA::cuda_thread_masked_direct<Mask>,
+                 EnclosedStmts ...> > {
+
+  using stmt_list_t = StatementList<EnclosedStmts ...>;
+
+  using enclosed_stmts_t =
+          CudaStatementListExecutor<Data, stmt_list_t>;
+
+  using mask_t = Mask;
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data, bool thread_active)
+  {
+    auto len = segment_length<ArgumentId>(data);
+
+    auto i = mask_t::maskValue(threadIdx.x);
+
+    // assign thread id directly to offset
+    data.template assign_offset<ArgumentId>(i);
+
+    // execute enclosed statements if in bounds
+    enclosed_stmts_t::exec(data, thread_active && (i<len));
+  }
+
+
+  static
+  inline
+  LaunchDims calculateDimensions(Data const &data)
+  {
+    // Get enclosed statements
+    LaunchDims dims = enclosed_stmts_t::calculateDimensions(data);
+
+    // we need to allocate enough threads for the segment size, and the
+    // shifted off bits
+    int len = mask_t::max_input_size;
+
+    // request one thread per element in the segment
+    set_cuda_dim<0>(dims.threads, len);
+
+    // since we are direct-mapping, we REQUIRE len
+    set_cuda_dim<0>(dims.min_threads, len);
+
+    return(dims);
+  }
+};
+
+
+
+
+/*
+ * Executor for thread work sharing loop inside CudaKernel.
+ * Mapping directly from a warp lane
+ * Assigns the loop index to offset ArgumentId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          typename Mask,
+          typename ... EnclosedStmts>
+struct CudaStatementExecutor<
+  Data,
+  statement::For<ArgumentId, RAJA::cuda_thread_masked_loop<Mask>,
+                 EnclosedStmts ...> > {
+
+  using stmt_list_t = StatementList<EnclosedStmts ...>;
+
+  using enclosed_stmts_t =
+          CudaStatementListExecutor<Data, stmt_list_t>;
+
+  using mask_t = Mask;
+
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data, bool thread_active)
+  {
+    // masked size strided loop
+    int len = segment_length<ArgumentId>(data);
+    int i = mask_t::maskValue(threadIdx.x);
+    for( ; i < len; i += (int) mask_t::max_masked_size){
+
+      // Assign the x thread to the argument
+      data.template assign_offset<ArgumentId>(i);
+
+      // execute enclosed statements
+      enclosed_stmts_t::exec(data, thread_active);
+    }
+    // do we need one more masked iteration?
+    if(i - mask_t::maskValue(threadIdx.x) < len){
+      // execute enclosed statements one more time, but masking them off
+      // this is because there's at least one thread that isn't masked off
+      // that is still executing the above loop
+      enclosed_stmts_t::exec(data, false);
+    }
+
+  }
+
+
+  static
+  inline
+  LaunchDims calculateDimensions(Data const &data)
+  {
+    // Get enclosed statements
+    LaunchDims dims = enclosed_stmts_t::calculateDimensions(data);
+
+    // we need to allocate enough threads for the segment size, and the
+    // shifted off bits
+    int len = mask_t::max_input_size;
+
+    // request one thread per element in the segment
+    set_cuda_dim<0>(dims.threads, len);
+
+    // since we are direct-mapping, we REQUIRE len
+    set_cuda_dim<0>(dims.min_threads, len);
+
+    return(dims);
+  }
+};
+
+
+/*
  * Executor for block work sharing inside CudaKernel.
  * Provides a grid-stride loop (stride of gridDim.xyz) for
  * each block in xyz.

--- a/include/RAJA/policy/cuda/kernel/ForICount.hpp
+++ b/include/RAJA/policy/cuda/kernel/ForICount.hpp
@@ -85,6 +85,351 @@ struct CudaStatementExecutor<
 
 
 
+
+/*
+ * Executor for thread work sharing loop inside CudaKernel.
+ * Mapping directly from threadIdx.xyz to indices
+ * Assigns the loop iterate to offset ArgumentId
+ * Assigns the loop count to param ParamId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          typename ParamId,
+          typename ... EnclosedStmts>
+struct CudaStatementExecutor<
+  Data,
+  statement::ForICount<ArgumentId, ParamId, RAJA::cuda_warp_direct,
+                       EnclosedStmts ...> >
+  : public CudaStatementExecutor<
+    Data,
+    statement::For<ArgumentId, RAJA::cuda_warp_direct,
+                   EnclosedStmts ...> > {
+
+  using Base = CudaStatementExecutor<
+          Data,
+          statement::For<ArgumentId, RAJA::cuda_warp_direct,
+                         EnclosedStmts ...> >;
+
+  using typename Base::enclosed_stmts_t;
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data, bool thread_active)
+  {
+    auto len = segment_length<ArgumentId>(data);
+    auto i = get_cuda_dim<0>(threadIdx);
+
+    // assign thread id directly to offset
+    data.template assign_offset<ArgumentId>(i);
+    data.template assign_param<ParamId>(i);
+
+    // execute enclosed statements if in bounds
+    enclosed_stmts_t::exec(data, thread_active && (i<len));
+
+  }
+};
+
+
+/*
+ * Executor for thread work sharing loop inside CudaKernel.
+ * Mapping directly from threadIdx.xyz to indices
+ * Assigns the loop iterate to offset ArgumentId
+ * Assigns the loop count to param ParamId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          typename ParamId,
+          typename ... EnclosedStmts>
+struct CudaStatementExecutor<
+  Data,
+  statement::ForICount<ArgumentId, ParamId, RAJA::cuda_warp_loop,
+                       EnclosedStmts ...> >
+  : public CudaStatementExecutor<
+    Data,
+    statement::For<ArgumentId, RAJA::cuda_warp_loop,
+                   EnclosedStmts ...> > {
+
+  using Base = CudaStatementExecutor<
+          Data,
+          statement::For<ArgumentId, RAJA::cuda_warp_loop,
+                         EnclosedStmts ...> >;
+
+  using typename Base::enclosed_stmts_t;
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data, bool thread_active)
+  {
+    // block stride loop
+    int len = segment_length<ArgumentId>(data);
+    //auto i0 = threadIdx.x;
+    //auto i_stride = RAJA::policy::cuda::WARP_SIZE;
+    //auto i = i0;
+    auto &i = camp::get<ArgumentId>(data.offset_tuple);
+    i = threadIdx.x;
+    for( ; i < len; i += RAJA::policy::cuda::WARP_SIZE){
+
+      // Assign the x thread to the argument
+      //  data.template assign_offset<ArgumentId>(i);
+      data.template assign_param<ParamId>(i);
+
+      // execute enclosed statements
+      enclosed_stmts_t::exec(data, thread_active);
+    }
+    // do we need one more masked iteration?
+    if(i - threadIdx.x < len){
+      // execute enclosed statements one more time, but masking them off
+      // this is because there's at least one thread that isn't masked off
+      // that is still executing the above loop
+      enclosed_stmts_t::exec(data, false);
+    }
+  }
+};
+
+
+/*
+ * Executor for thread work sharing loop inside CudaKernel.
+ * Mapping directly from a warp lane
+ * Assigns the loop index to offset ArgumentId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          typename ParamId,
+          typename Mask,
+          typename ... EnclosedStmts>
+struct CudaStatementExecutor<
+  Data,
+  statement::ForICount<ArgumentId, ParamId,
+                       RAJA::cuda_warp_masked_direct<Mask>,
+                       EnclosedStmts ...> >
+  : public CudaStatementExecutor<
+    Data,
+    statement::For<ArgumentId, RAJA::cuda_warp_masked_direct<Mask>,
+                   EnclosedStmts ...> > {
+
+  using Base = CudaStatementExecutor<
+          Data,
+          statement::For<ArgumentId, RAJA::cuda_warp_masked_direct<Mask>,
+                         EnclosedStmts ...> >;
+
+  using stmt_list_t = StatementList<EnclosedStmts ...>;
+
+  using enclosed_stmts_t =
+          CudaStatementListExecutor<Data, stmt_list_t>;
+
+  using mask_t = Mask;
+
+  static_assert(mask_t::max_masked_size <= RAJA::policy::cuda::WARP_SIZE,
+                "BitMask is too large for CUDA warp size");
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data, bool thread_active)
+  {
+    auto len = segment_length<ArgumentId>(data);
+
+    auto i = mask_t::maskValue(threadIdx.x);
+
+    // assign thread id directly to offset
+    data.template assign_offset<ArgumentId>(i);
+    data.template assign_param<ParamId>(i);
+
+    // execute enclosed statements if in bounds
+    enclosed_stmts_t::exec(data, thread_active && (i<len));
+  }
+
+};
+
+
+
+/*
+ * Executor for thread work sharing loop inside CudaKernel.
+ * Mapping directly from a warp lane
+ * Assigns the loop index to offset ArgumentId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          typename ParamId,
+          typename Mask,
+          typename ... EnclosedStmts>
+struct CudaStatementExecutor<
+  Data,
+  statement::ForICount<ArgumentId, ParamId,
+                       RAJA::cuda_warp_masked_loop<Mask>,
+                       EnclosedStmts ...> >
+  : public CudaStatementExecutor<
+    Data,
+    statement::For<ArgumentId, RAJA::cuda_warp_masked_loop<Mask>,
+                   EnclosedStmts ...> > {
+
+  using Base = CudaStatementExecutor<
+          Data,
+          statement::For<ArgumentId, RAJA::cuda_warp_masked_loop<Mask>,
+                         EnclosedStmts ...> >;
+
+  using stmt_list_t = StatementList<EnclosedStmts ...>;
+
+  using enclosed_stmts_t =
+          CudaStatementListExecutor<Data, stmt_list_t>;
+
+  using mask_t = Mask;
+
+  static_assert(mask_t::max_masked_size <= RAJA::policy::cuda::WARP_SIZE,
+                "BitMask is too large for CUDA warp size");
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data, bool thread_active)
+  {
+    // masked size strided loop
+    int len = segment_length<ArgumentId>(data);
+    auto i = mask_t::maskValue(threadIdx.x);
+    for( ; i < len; i += (int) mask_t::max_masked_size){
+
+      // Assign the x thread to the argument and param
+      data.template assign_offset<ArgumentId>(i);
+      data.template assign_param<ParamId>(i);
+
+      // execute enclosed statements
+      enclosed_stmts_t::exec(data, thread_active);
+    }
+    // do we need one more masked iteration?
+    if(i - mask_t::maskValue(threadIdx.x) < len){
+      // execute enclosed statements one more time, but masking them off
+      // this is because there's at least one thread that isn't masked off
+      // that is still executing the above loop
+      enclosed_stmts_t::exec(data, false);
+    }
+  }
+
+};
+
+
+
+
+/*
+ * Executor for thread work sharing loop inside CudaKernel.
+ * Mapping directly from a warp lane
+ * Assigns the loop index to offset ArgumentId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          typename ParamId,
+          typename Mask,
+          typename ... EnclosedStmts>
+struct CudaStatementExecutor<
+  Data,
+  statement::ForICount<ArgumentId, ParamId,
+                       RAJA::cuda_thread_masked_direct<Mask>,
+                       EnclosedStmts ...> >
+  : public CudaStatementExecutor<
+    Data,
+    statement::For<ArgumentId, RAJA::cuda_thread_masked_direct<Mask>,
+                   EnclosedStmts ...> > {
+
+  using Base = CudaStatementExecutor<
+          Data,
+          statement::For<ArgumentId, RAJA::cuda_thread_masked_direct<Mask>,
+                         EnclosedStmts ...> >;
+
+  using stmt_list_t = StatementList<EnclosedStmts ...>;
+
+  using enclosed_stmts_t =
+          CudaStatementListExecutor<Data, stmt_list_t>;
+
+  using mask_t = Mask;
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data, bool thread_active)
+  {
+    auto len = segment_length<ArgumentId>(data);
+
+    auto i = mask_t::maskValue(threadIdx.x);
+
+    // assign thread id directly to offset
+    data.template assign_offset<ArgumentId>(i);
+    data.template assign_param<ParamId>(i);
+
+    // execute enclosed statements if in bounds
+    enclosed_stmts_t::exec(data, thread_active && (i<len));
+  }
+
+};
+
+
+
+
+
+/*
+ * Executor for thread work sharing loop inside CudaKernel.
+ * Mapping directly from a warp lane
+ * Assigns the loop index to offset ArgumentId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          typename ParamId,
+          typename Mask,
+          typename ... EnclosedStmts>
+struct CudaStatementExecutor<
+  Data,
+  statement::ForICount<ArgumentId, ParamId,
+                       RAJA::cuda_thread_masked_loop<Mask>,
+                       EnclosedStmts ...> >
+  : public CudaStatementExecutor<
+    Data,
+    statement::For<ArgumentId, RAJA::cuda_thread_masked_loop<Mask>,
+                   EnclosedStmts ...> > {
+
+  using Base = CudaStatementExecutor<
+          Data,
+          statement::For<ArgumentId, RAJA::cuda_thread_masked_loop<Mask>,
+                         EnclosedStmts ...> >;
+
+  using stmt_list_t = StatementList<EnclosedStmts ...>;
+
+  using enclosed_stmts_t =
+          CudaStatementListExecutor<Data, stmt_list_t>;
+
+  using mask_t = Mask;
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data, bool thread_active)
+  {
+    // masked size strided loop
+    int len = segment_length<ArgumentId>(data);
+    int i = mask_t::maskValue(threadIdx.x);
+    for( ; i < len; i += (int) mask_t::max_masked_size){
+
+      // Assign the x thread to the argument
+      data.template assign_offset<ArgumentId>(i);
+      data.template assign_param<ParamId>(i);
+
+      // execute enclosed statements
+      enclosed_stmts_t::exec(data, thread_active);
+    }
+    // do we need one more masked iteration?
+    if(i - mask_t::maskValue(threadIdx.x) < len){
+      // execute enclosed statements one more time, but masking them off
+      // this is because there's at least one thread that isn't masked off
+      // that is still executing the above loop
+      enclosed_stmts_t::exec(data, false);
+    }
+  }
+
+};
+
+
+
+
+
 /*
  * Executor for thread work sharing loop inside CudaKernel.
  * Provides a block-stride loop (stride of blockDim.xyz) for

--- a/include/RAJA/policy/cuda/kernel/Tile.hpp
+++ b/include/RAJA/policy/cuda/kernel/Tile.hpp
@@ -295,6 +295,99 @@ struct CudaStatementExecutor<
 };
 
 
+/*!
+ * A specialized RAJA::kernel cuda_impl executor for statement::Tile
+ * Assigns the tile segment to segment ArgumentId
+ *
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          camp::idx_t chunk_size,
+          int ThreadDim,
+          int MinThreads,
+          typename ... EnclosedStmts>
+struct CudaStatementExecutor<
+  Data,
+  statement::Tile<ArgumentId,
+                  RAJA::statement::tile_fixed<chunk_size>,
+                  cuda_thread_xyz_loop<ThreadDim, MinThreads>,
+                  EnclosedStmts ...> >{
+
+  using stmt_list_t = StatementList<EnclosedStmts ...>;
+
+  using enclosed_stmts_t = CudaStatementListExecutor<Data, stmt_list_t>;
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data, bool thread_active)
+  {
+    // Get the segment referenced by this Tile statement
+    auto &segment = camp::get<ArgumentId>(data.segment_tuple);
+
+    // Keep copy of original segment, so we can restore it
+    using segment_t = camp::decay<decltype(segment)>;
+    segment_t orig_segment = segment;
+
+    // compute trip count
+    auto i0 = get_cuda_dim<ThreadDim>(threadIdx) * chunk_size;
+
+    // Get our stride from the dimension
+    auto i_stride = get_cuda_dim<ThreadDim>(blockDim) * chunk_size;
+
+    // Iterate through grid stride of chunks
+    int len = segment_length<ArgumentId>(data);
+    for (int i = i0; i < len; i += i_stride) {
+
+      // Assign our new tiled segment
+      segment = orig_segment.slice(i, chunk_size);
+
+      // execute enclosed statements
+      enclosed_stmts_t::exec(data, thread_active);
+    }
+
+    // Set range back to original values
+    segment = orig_segment;
+  }
+
+
+  static
+  inline
+  LaunchDims calculateDimensions(Data const &data)
+  {
+
+    // Compute how many blocks
+    int len = segment_length<ArgumentId>(data);
+    int num_threads = len / chunk_size;
+    if(num_threads * chunk_size < len){
+      num_threads++;
+    }
+    num_threads = std::max(num_threads, MinThreads);
+
+    LaunchDims dims;
+    set_cuda_dim<ThreadDim>(dims.threads, num_threads);
+    set_cuda_dim<ThreadDim>(dims.min_threads, MinThreads);
+
+    // privatize data, so we can mess with the segments
+    using data_t = camp::decay<Data>;
+    data_t private_data = data;
+
+    // Get original segment
+    auto &segment = camp::get<ArgumentId>(private_data.segment_tuple);
+
+    // restrict to first tile
+    segment = segment.slice(0, chunk_size);
+
+
+    LaunchDims enclosed_dims =
+      enclosed_stmts_t::calculateDimensions(private_data);
+
+    return(dims.max(enclosed_dims));
+  }
+};
+
+
+
 
 }  // end namespace internal
 }  // end namespace RAJA

--- a/include/RAJA/policy/cuda/kernel/Tile.hpp
+++ b/include/RAJA/policy/cuda/kernel/Tile.hpp
@@ -212,6 +212,90 @@ struct CudaStatementExecutor<
 };
 
 
+
+/*!
+ * A specialized RAJA::kernel cuda_impl executor for statement::Tile
+ * Assigns the tile segment to segment ArgumentId
+ *
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          camp::idx_t chunk_size,
+          int ThreadDim,
+          typename ... EnclosedStmts>
+struct CudaStatementExecutor<
+  Data,
+  statement::Tile<ArgumentId,
+                  RAJA::statement::tile_fixed<chunk_size>,
+                  cuda_thread_xyz_direct<ThreadDim>,
+                  EnclosedStmts ...> >{
+
+  using stmt_list_t = StatementList<EnclosedStmts ...>;
+
+  using enclosed_stmts_t = CudaStatementListExecutor<Data, stmt_list_t>;
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data, bool thread_active)
+  {
+    // Get the segment referenced by this Tile statement
+    auto &segment = camp::get<ArgumentId>(data.segment_tuple);
+
+    // Keep copy of original segment, so we can restore it
+    using segment_t = camp::decay<decltype(segment)>;
+    segment_t orig_segment = segment;
+
+    // compute trip count
+    auto i0 = get_cuda_dim<ThreadDim>(threadIdx) * chunk_size;
+
+    // Assign our new tiled segment
+    segment = orig_segment.slice(i0, chunk_size);
+
+    // execute enclosed statements
+    enclosed_stmts_t::exec(data, thread_active);
+
+    // Set range back to original values
+    segment = orig_segment;
+  }
+
+
+  static
+  inline
+  LaunchDims calculateDimensions(Data const &data)
+  {
+
+    // Compute how many blocks
+    int len = segment_length<ArgumentId>(data);
+    int num_threads = len / chunk_size;
+    if(num_threads * chunk_size < len){
+      num_threads++;
+    }
+
+    LaunchDims dims;
+    set_cuda_dim<ThreadDim>(dims.threads, num_threads);
+
+
+    // privatize data, so we can mess with the segments
+    using data_t = camp::decay<Data>;
+    data_t private_data = data;
+
+    // Get original segment
+    auto &segment = camp::get<ArgumentId>(private_data.segment_tuple);
+
+    // restrict to first tile
+    segment = segment.slice(0, chunk_size);
+
+
+    LaunchDims enclosed_dims =
+      enclosed_stmts_t::calculateDimensions(private_data);
+
+    return(dims.max(enclosed_dims));
+  }
+};
+
+
+
 }  // end namespace internal
 }  // end namespace RAJA
 

--- a/include/RAJA/policy/cuda/kernel/TileTCount.hpp
+++ b/include/RAJA/policy/cuda/kernel/TileTCount.hpp
@@ -175,6 +175,70 @@ struct CudaStatementExecutor<
 };
 
 
+
+/*!
+ * A specialized RAJA::kernel cuda_impl executor for statement::TileTCount
+ * Assigns the tile segment to segment ArgumentId
+ * Assigns the tile index to param ParamId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          typename ParamId,
+          camp::idx_t chunk_size,
+          int ThreadDim,
+          typename ... EnclosedStmts>
+struct CudaStatementExecutor<
+  Data,
+  statement::TileTCount<ArgumentId, ParamId,
+                        RAJA::statement::tile_fixed<chunk_size>,
+                        cuda_thread_xyz_direct<ThreadDim>,
+                        EnclosedStmts ...> >
+  : public CudaStatementExecutor<
+    Data,
+    statement::Tile<ArgumentId,
+                    RAJA::statement::tile_fixed<chunk_size>,
+                    cuda_thread_xyz_direct<ThreadDim>,
+                    EnclosedStmts ...> > {
+
+  using Base = CudaStatementExecutor<
+          Data,
+          statement::Tile<ArgumentId,
+                          RAJA::statement::tile_fixed<chunk_size>,
+                          cuda_thread_xyz_direct<ThreadDim>,
+                          EnclosedStmts ...> >;
+
+  using typename Base::enclosed_stmts_t;
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data, bool thread_active)
+  {
+    // Get the segment referenced by this Tile statement
+    auto &segment = camp::get<ArgumentId>(data.segment_tuple);
+
+    // Keep copy of original segment, so we can restore it
+    using segment_t = camp::decay<decltype(segment)>;
+    segment_t orig_segment = segment;
+
+    // compute trip count
+    int len = segment.end() - segment.begin();
+    auto t0 = get_cuda_dim<ThreadDim>(threadIdx);
+    auto t_stride = get_cuda_dim<ThreadDim>(blockDim);
+    auto i0 = t0 * chunk_size;
+
+    // Assign our new tiled segment
+    segment = orig_segment.slice(i0, chunk_size);
+    data.template assign_param<ParamId>(t0);
+
+    // execute enclosed statements
+    enclosed_stmts_t::exec(data, thread_active);
+
+    // Set range back to original values
+    segment = orig_segment;
+  }
+};
+
 }  // end namespace internal
 }  // end namespace RAJA
 

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -138,6 +138,31 @@ struct cuda_warp_loop{};
 
 
 
+// Policy to map work to threads within a warp using a bit mask
+// Cannot be used in conjunction with cuda_thread_x_*
+// Multiple warps have to be created by using cuda_thread_{yz}_*
+// Since we are masking specific threads, multiple nested
+// cuda_warp_masked
+// can be used to create complex thread interleaving patterns
+template<typename Mask>
+struct cuda_warp_masked_direct {};
+
+// Policy to map work to threads within a warp using a bit mask
+// Cannot be used in conjunction with cuda_thread_x_*
+// Multiple warps have to be created by using cuda_thread_{yz}_*
+// Since we are masking specific threads, multiple nested
+// cuda_warp_masked
+// can be used to create complex thread interleaving patterns
+template<typename Mask>
+struct cuda_warp_masked_loop {};
+
+
+template<typename Mask>
+struct cuda_thread_masked_direct {};
+
+template<typename Mask>
+struct cuda_thread_masked_loop {};
+
 
 
 //
@@ -175,6 +200,12 @@ using policy::cuda::cuda_warp_reduce;
 
 using policy::cuda::cuda_warp_direct;
 using policy::cuda::cuda_warp_loop;
+
+using policy::cuda::cuda_warp_masked_direct;
+using policy::cuda::cuda_warp_masked_loop;
+
+using policy::cuda::cuda_thread_masked_direct;
+using policy::cuda::cuda_thread_masked_loop;
 
 using policy::cuda::cuda_synchronize;
 

--- a/include/RAJA/util/BitMask.hpp
+++ b/include/RAJA/util/BitMask.hpp
@@ -1,0 +1,65 @@
+/*!
+ ******************************************************************************
+ *
+ * \file
+ *
+ * \brief   RAJA header file defining a bit masking operator
+ *
+ ******************************************************************************
+ */
+
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-19, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-689114
+//
+// All rights reserved.
+//
+// This file is part of RAJA.
+//
+// For details about use and distribution, please read RAJA/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef RAJA_util_BitMask_HPP
+#define RAJA_util_BitMask_HPP
+
+#include "RAJA/config.hpp"
+
+
+namespace RAJA
+{
+
+
+  /*!
+   * A bit-masking operator
+   *
+   * Provides an operator that shifts and masks in input value to extract
+   * a value contiguous set of bits.
+   *
+   * result = (input >> Shift) & (Mask)
+   *
+   * Where mask is (1<<Width)-1, or the number of bits defined by Width.
+   *
+   *
+   */
+  template<size_t Width, size_t Shift>
+  struct BitMask {
+    static constexpr size_t shift = Shift;
+    static constexpr size_t width = Width;
+    static constexpr size_t max_input_size = 1<<(Shift+Width);
+    static constexpr size_t max_masked_size = 1<<Width;
+    static constexpr size_t max_shifted_size = 1<<Shift;
+
+    template<typename T>
+    RAJA_HOST_DEVICE
+    static constexpr T maskValue(T input) {
+      return( (input>>((T) Shift)) & (T) ((1<<(Width))-1));
+    }
+  };
+
+}  // namespace RAJA
+
+#endif //RAJA_util_BitMask_HPP


### PR DESCRIPTION

Adding missing executors for existing CUDA warp/thread policies, and bitmasked policies that allow dividing up a warp or block based on bitmasks.

Also, added a bunch of unit tests