### PR TITLE
Guards for cuda enabled RAJA

### DIFF
--- a/include/RAJA/index/ListSegment.hpp
+++ b/include/RAJA/index/ListSegment.hpp
@@ -38,7 +38,7 @@
 #include "RAJA/util/macros.hpp"
 #include "RAJA/util/types.hpp"
 
-#if defined(RAJA_ENABLE_CUDA)
+#if defined(__NVCC__) && defined(RAJA_ENABLE_CUDA)
 #include "RAJA/policy/cuda/raja_cudaerrchk.hpp"
 #else
 #define cudaErrchk(...)
@@ -64,7 +64,7 @@ template <typename T>
 class TypedListSegment
 {
 
-#if defined(RAJA_ENABLE_CUDA)
+#if defined(__NVCC__) && defined(RAJA_ENABLE_CUDA)
   static constexpr bool Has_CUDA = true;
 #else
   static constexpr bool Has_CUDA = false;
@@ -99,7 +99,7 @@ class TypedListSegment
   //! specialization for allocation of CPU_memory
   void allocate(CPU_memory) { m_data = new T[m_size]; }
 
-#if defined(RAJA_ENABLE_CUDA)
+#if defined(__NVCC__) && defined(RAJA_ENABLE_CUDA)
   //! copy data from container using BlockCopy
   template <typename Container>
   void copy(Container&& src, BlockCopy)

--- a/include/RAJA/index/ListSegment.hpp
+++ b/include/RAJA/index/ListSegment.hpp
@@ -38,7 +38,7 @@
 #include "RAJA/util/macros.hpp"
 #include "RAJA/util/types.hpp"
 
-#if defined(__NVCC__) && defined(RAJA_ENABLE_CUDA)
+#if (defined(__NVCC__) || (defined(__clang__) && defined(__CUDA__))) && defined(RAJA_ENABLE_CUDA)
 #include "RAJA/policy/cuda/raja_cudaerrchk.hpp"
 #else
 #define cudaErrchk(...)
@@ -64,7 +64,7 @@ template <typename T>
 class TypedListSegment
 {
 
-#if defined(__NVCC__) && defined(RAJA_ENABLE_CUDA)
+#if (defined(__NVCC__) || (defined(__clang__) && defined(__CUDA__))) && defined(RAJA_ENABLE_CUDA)
   static constexpr bool Has_CUDA = true;
 #else
   static constexpr bool Has_CUDA = false;
@@ -99,7 +99,7 @@ class TypedListSegment
   //! specialization for allocation of CPU_memory
   void allocate(CPU_memory) { m_data = new T[m_size]; }
 
-#if defined(__NVCC__) && defined(RAJA_ENABLE_CUDA)
+#if (defined(__NVCC__) || (defined(__clang__) && defined(__CUDA__))) && defined(RAJA_ENABLE_CUDA)
   //! copy data from container using BlockCopy
   template <typename Container>
   void copy(Container&& src, BlockCopy)

--- a/include/RAJA/policy/cuda.hpp
+++ b/include/RAJA/policy/cuda.hpp
@@ -30,7 +30,7 @@
 
 #include "RAJA/config.hpp"
 
-#if defined(RAJA_ENABLE_CUDA)
+#if defined(__NVCC__) && defined(RAJA_ENABLE_CUDA)
 
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/include/RAJA/policy/cuda.hpp
+++ b/include/RAJA/policy/cuda.hpp
@@ -30,7 +30,7 @@
 
 #include "RAJA/config.hpp"
 
-#if defined(__NVCC__) && defined(RAJA_ENABLE_CUDA)
+#if (defined(__NVCC__) || (defined(__clang__) && defined(__CUDA__))) && defined(RAJA_ENABLE_CUDA)
 
 #include <cuda.h>
 #include <cuda_runtime.h>


### PR DESCRIPTION
By adding a few checks, this PR enables users to maintain one build of RAJA and be compatible with strict device code and CUDA code. This was motivated by an application which compiled packages which depended on RAJA with both nvcc and host compilers.