### PR TITLE
Update test-reductions.cpp

### DIFF
--- a/test/unit/cpu/test-reductions.cpp
+++ b/test/unit/cpu/test-reductions.cpp
@@ -106,9 +106,8 @@ protected:
   {
     array_length = 102;
 
-    array = RAJA::allocate_aligned_type<double>(RAJA::DATA_ALIGN,
-                                                array_length * sizeof(double));
-
+    array = RAJA::allocate_aligned_type<RAJA::Real_type>(RAJA::DATA_ALIGN,
+                                                         array_length * sizeof(RAJA::Real_type));
     for (int i = 1; i < array_length - 1; ++i) {
       array[i] = (RAJA::Real_type)i;
     }


### PR DESCRIPTION
This fixes a compilation error when RAJA_FP is set to "RAJA_USE_FLOAT" and "RAJA_USE_FLOAT" is set to "On". I am assuming that when RAJA_USE_FLOAT is On, RAJA_USE_DOUBLE must be Off and RAJA_USE_COMPLEX does not matter.