### PR TITLE
Use CudaKernelLauncherFixed with compile-time num_threads

### DIFF
--- a/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
+++ b/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
@@ -186,7 +186,7 @@ __global__ void CudaKernelLauncher(Data data)
 
 /*!
  * CUDA global function for launching CudaKernel policies
- * This is annotated to gaurantee that device code generated
+ * This is annotated to guarantee that device code generated
  * can be launched by a kernel with BlockSize number of threads.
  *
  * This launcher is used by the CudaKerelFixed policies.
@@ -202,6 +202,41 @@ __launch_bounds__(BlockSize, 1) __global__
   // execute the the object
   Exec::exec(private_data, true);
 }
+
+
+/*!
+ * Helper class that handles getting the correct global function for
+ * CudaKernel policies.
+ */
+template<size_t BlockSize, typename Data, typename executor_t, bool fixed = (BlockSize > 0)>
+struct CudaKernelLauncherGetter;
+
+/*!
+ * Helper class specialization for unknown number of threads.
+ */
+template<size_t BlockSize, typename Data, typename executor_t>
+struct CudaKernelLauncherGetter<BlockSize, Data, executor_t, false>
+{
+  using type = camp::decay<decltype(&internal::CudaKernelLauncher<Data, executor_t>)>;
+  static constexpr type get() noexcept
+  {
+    return internal::CudaKernelLauncher<Data, executor_t>;
+  }
+};
+
+/*!
+ * Helper class specialization for maximum number of threads.
+ */
+template<size_t BlockSize, typename Data, typename executor_t>
+struct CudaKernelLauncherGetter<BlockSize, Data, executor_t, true>
+{
+  using type = camp::decay<decltype(&internal::CudaKernelLauncherFixed<BlockSize, Data, executor_t>)>;
+  static constexpr type get() noexcept
+  {
+    return internal::CudaKernelLauncherFixed<BlockSize, Data, executor_t>;
+  }
+};
+
 
 /*!
  * Helper class that handles CUDA kernel launching, and computing
@@ -225,10 +260,12 @@ struct CudaLaunchHelper<cuda_launch<async0, num_blocks, num_threads>,StmtList,Da
 
   using executor_t = internal::cuda_statement_list_executor_t<StmtList, Data>;
 
+  using kernelGetter_t = CudaKernelLauncherGetter<(num_threads <= 0) ? 0 : num_threads, Data, executor_t>;
+
   inline static void recommended_blocks_threads(int shmem_size,
       int &recommended_blocks, int &recommended_threads)
   {
-    auto func = internal::CudaKernelLauncher<Data, executor_t>;
+    auto func = kernelGetter_t::get();
 
     if (num_blocks <= 0) {
 
@@ -304,7 +341,7 @@ struct CudaLaunchHelper<cuda_launch<async0, num_blocks, num_threads>,StmtList,Da
   inline static void max_blocks(int shmem_size,
       int &max_blocks, int actual_threads)
   {
-    auto func = internal::CudaKernelLauncher<Data, executor_t>;
+    auto func = kernelGetter_t::get();
 
     if (num_blocks <= 0) {
 
@@ -329,7 +366,7 @@ struct CudaLaunchHelper<cuda_launch<async0, num_blocks, num_threads>,StmtList,Da
                      size_t shmem,
                      cudaStream_t stream)
   {
-    auto func = internal::CudaKernelLauncher<Data, executor_t>;
+    auto func = kernelGetter_t::get();
 
     void *args[] = {(void*)&data};
     RAJA::cuda::launch((const void*)func, launch_dims.blocks, launch_dims.threads, args, shmem, stream);

--- a/test/unit/test-kernel.cpp
+++ b/test/unit/test-kernel.cpp
@@ -2642,6 +2642,7 @@ CUDA_TEST(Kernel, CudaExec_fixedspillexec)
 
 
   constexpr long N = (long)2048;
+  constexpr long M = (long)32;
 
   // Loop Fusion
   using Pol = KernelPolicy<CudaKernelFixed<1024,
@@ -2655,7 +2656,7 @@ CUDA_TEST(Kernel, CudaExec_fixedspillexec)
 
 
   long *x = nullptr;
-  cudaErrchk(cudaMallocManaged(&x, (N+32) * sizeof(long)));
+  cudaErrchk(cudaMallocManaged(&x, (N+M) * sizeof(long)));
   long *y = x;
 
   RAJA::ReduceSum<cuda_reduce, long> trip_count(0);
@@ -2665,13 +2666,14 @@ CUDA_TEST(Kernel, CudaExec_fixedspillexec)
       RAJA::make_tuple(RangeSegment(0, N)),
 
       [=] __device__(Index_type i) {
-        long a[32];
-        for (int j = 0; j < 32; ++j) {
+        constexpr long M = (long)32; // M must be constexpr on the device
+        long a[M];
+        for (int j = 0; j < M; ++j) {
           a[j] = x[i+j];
           y[i+j] = a[j];
         }
         trip_count += 1;
-        for (int j = 0; j < 32; ++j) {
+        for (int j = 0; j < M; ++j) {
           x[i+j] = a[j];
         }
       });

--- a/test/unit/test-kernel.cpp
+++ b/test/unit/test-kernel.cpp
@@ -2634,4 +2634,56 @@ CUDA_TEST(Kernel, CudaExec_1threadexec)
   ASSERT_EQ(result, N * N * N * N);
 }
 
+
+
+CUDA_TEST(Kernel, CudaExec_fixedspillexec)
+{
+  using namespace RAJA;
+
+
+  constexpr long N = (long)2048;
+
+  // Loop Fusion
+  using Pol = KernelPolicy<CudaKernelFixed<1024,
+      statement::Tile<0, statement::tile_fixed<1024>, cuda_block_x_loop,
+        For<0, cuda_thread_x_direct,
+          Lambda<0>
+        >
+      >
+    >
+  >;
+
+
+  long *x = nullptr;
+  cudaErrchk(cudaMallocManaged(&x, (N+32) * sizeof(long)));
+  long *y = x;
+
+  RAJA::ReduceSum<cuda_reduce, long> trip_count(0);
+
+  kernel<Pol>(
+
+      RAJA::make_tuple(RangeSegment(0, N)),
+
+      [=] __device__(Index_type i) {
+        long a[32];
+        for (int j = 0; j < 32; ++j) {
+          a[j] = x[i+j];
+          y[i+j] = a[j];
+        }
+        trip_count += 1;
+        for (int j = 0; j < 32; ++j) {
+          x[i+j] = a[j];
+        }
+      });
+
+  cudaErrchk(cudaDeviceSynchronize());
+
+
+  long result = (long)trip_count;
+
+  ASSERT_EQ(result, N);
+
+  cudaErrchk(cudaFree(x));
+}
+
 #endif


### PR DESCRIPTION
Pick the correct global function used with cuda kernel policies.
Previously the global function used with unknown num_threads was
always being used.