### PR TITLE
Removed 'atomic' namespace.

### DIFF
--- a/docs/sphinx/user_guide/feature/atomic.rst
+++ b/docs/sphinx/user_guide/feature/atomic.rst
@@ -19,7 +19,7 @@ in this section.
 A complete working example code that shows RAJA atomic usage can be found in 
 :ref:`atomichist-label`.
 
-.. note:: * All RAJA atomic operations are in the namespace ``RAJA::atomic``.
+.. note:: * All RAJA atomic operations are in the namespace ``RAJA``.
 
 -----------------
 Atomic Operations
@@ -96,7 +96,7 @@ an integral sum on a CUDA GPU device::
   RAJA::forall< RAJA::cuda_exec >(RAJA::RangeSegment(0, N), 
     [=] RAJA_DEVICE (RAJA::Index_type i) {
 
-    RAJA::atomic::atomicAdd< RAJA::cuda_atomic >(sum, 1);
+    RAJA::atomicAdd< RAJA::cuda_atomic >(sum, 1);
 
   });
 
@@ -108,11 +108,11 @@ AtomicRef
 
 RAJA also provides an atomic interface similar to the C++20 'std::atomic_ref', 
 but which works for arbitrary memory locations. The class 
-``RAJA::atomic::AtomicRef`` provides an object-oriented interface to the 
+``RAJA::AtomicRef`` provides an object-oriented interface to the 
 atomic methods described above. For example, after the following operations:: 
 
   double val = 2.0;
-  RAJA::atomic::AtomicRef<double,  RAJA::omp_atomic > sum(&val);
+  RAJA::AtomicRef<double,  RAJA::omp_atomic > sum(&val);
 
   sum++;
   ++sum;

--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -346,7 +346,7 @@ Here is an example illustrating use of the ``auto_atomic`` policy::
   RAJA::forall< RAJA::cuda_exec >(RAJA::RangeSegment seg(0, N),
     [=] RAJA_DEVICE (RAJA::Index_type i) {
 
-    RAJA::atomic::atomicAdd< RAJA::auto_atomic >(&sum, 1);
+    RAJA::atomicAdd< RAJA::auto_atomic >(&sum, 1);
 
   });
 

--- a/docs/sphinx/user_guide/tutorial/atomic_binning.rst
+++ b/docs/sphinx/user_guide/tutorial/atomic_binning.rst
@@ -47,7 +47,7 @@ Here is the OpenMP version:
                     :lines: 90-97
 
 Each slot in the 'bins' array is incremented by one when a value associated 
-with that slot is encountered. Note that the ``RAJA::atomic::atomicAdd`` 
+with that slot is encountered. Note that the ``RAJA::atomicAdd`` 
 operation uses an OpenMP atomic policy, which is compatible with the OpenMP 
 loop execution policy.
 

--- a/examples/pi-reduce_vs_atomic.cpp
+++ b/examples/pi-reduce_vs_atomic.cpp
@@ -76,11 +76,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   *atomic_pi = 0;
 
-  using ATOMIC_POL1 = RAJA::atomic::seq_atomic;
+  using ATOMIC_POL1 = RAJA::seq_atomic;
 
   RAJA::forall<EXEC_POL1>(bins, [=](int i) {
       double x = (double(i) + 0.5) / num_bins;
-      RAJA::atomic::atomicAdd<ATOMIC_POL1>(atomic_pi, 4.0 / (1.0 + x * x));
+      RAJA::atomicAdd<ATOMIC_POL1>(atomic_pi, 4.0 / (1.0 + x * x));
   });
 
   std::cout << "\tpi = " << std::setprecision(prec) 
@@ -111,11 +111,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   *atomic_pi = 0;
 
-  using ATOMIC_POL2 = RAJA::atomic::omp_atomic;
+  using ATOMIC_POL2 = RAJA::omp_atomic;
 
   RAJA::forall<EXEC_POL2>(bins, [=](int i) {
       double x = (double(i) + 0.5) / num_bins;
-      RAJA::atomic::atomicAdd<ATOMIC_POL2>(atomic_pi, 4.0 / (1.0 + x * x));
+      RAJA::atomicAdd<ATOMIC_POL2>(atomic_pi, 4.0 / (1.0 + x * x));
   });
 
   std::cout << "\tpi = " << std::setprecision(prec)
@@ -148,11 +148,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   *atomic_pi = 0;
 
-  using ATOMIC_POL3 = RAJA::atomic::cuda_atomic;
+  using ATOMIC_POL3 = RAJA::cuda_atomic;
 
   RAJA::forall<EXEC_POL3>(bins, [=] RAJA_DEVICE (int i) {
       double x = (double(i) + 0.5) / num_bins;
-      RAJA::atomic::atomicAdd<ATOMIC_POL3>(atomic_pi, 4.0 / (1.0 + x * x));
+      RAJA::atomicAdd<ATOMIC_POL3>(atomic_pi, 4.0 / (1.0 + x * x));
   });
 
   std::cout << "\tpi = " << std::setprecision(prec)

--- a/examples/tut_atomic-binning.cpp
+++ b/examples/tut_atomic-binning.cpp
@@ -62,11 +62,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::memset(bins, 0, M * sizeof(int));
 
   using EXEC_POL1 = RAJA::seq_exec;
-  using ATOMIC_POL1 = RAJA::atomic::seq_atomic;
+  using ATOMIC_POL1 = RAJA::seq_atomic;
 
   RAJA::forall<EXEC_POL1>(array_range, [=](int i) {
                                                       
-    RAJA::atomic::atomicAdd<ATOMIC_POL1>(&bins[array[i]], 1);
+    RAJA::atomicAdd<ATOMIC_POL1>(&bins[array[i]], 1);
 
   });
 
@@ -80,11 +80,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::memset(bins, 0, M * sizeof(int));
 
   using EXEC_POL2 = RAJA::omp_parallel_for_exec;
-  using ATOMIC_POL2 = RAJA::atomic::omp_atomic;
+  using ATOMIC_POL2 = RAJA::omp_atomic;
 
   RAJA::forall<EXEC_POL2>(array_range, [=](int i) {
                           
-    RAJA::atomic::atomicAdd<ATOMIC_POL2>(&bins[array[i]], 1);
+    RAJA::atomicAdd<ATOMIC_POL2>(&bins[array[i]], 1);
                                            
   });
 
@@ -96,11 +96,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::memset(bins, 0, M * sizeof(int));
 
   using EXEC_POL2 = RAJA::omp_parallel_for_exec;
-  using ATOMIC_POL3 = RAJA::atomic::auto_atomic;
+  using ATOMIC_POL3 = RAJA::auto_atomic;
 
   RAJA::forall<EXEC_POL2>(array_range, [=](int i) {
   
-    RAJA::atomic::atomicAdd<ATOMIC_POL3>(&bins[array[i]], 1);
+    RAJA::atomicAdd<ATOMIC_POL3>(&bins[array[i]], 1);
   
   });
 
@@ -116,11 +116,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::memset(bins, 0, M * sizeof(int));
 
   using EXEC_POL4 = RAJA::cuda_exec<CUDA_BLOCK_SIZE>;
-  using ATOMIC_POL4 = RAJA::atomic::cuda_atomic;
+  using ATOMIC_POL4 = RAJA::cuda_atomic;
 
   RAJA::forall<EXEC_POL4>(array_range, [=] RAJA_DEVICE(int i) {
                           
-    RAJA::atomic::atomicAdd<ATOMIC_POL4>(&bins[array[i]], 1);
+    RAJA::atomicAdd<ATOMIC_POL4>(&bins[array[i]], 1);
                                                  
   });
 
@@ -131,11 +131,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::cout << "\n\nRunning RAJA CUDA binning with auto atomic" << std::endl;
   std::memset(bins, 0, M * sizeof(int));
 
-  using ATOMIC_POL5 = RAJA::atomic::auto_atomic;
+  using ATOMIC_POL5 = RAJA::auto_atomic;
 
   RAJA::forall<EXEC_POL4>(array_range, [=] RAJA_DEVICE(int i) {
 
-    RAJA::atomic::atomicAdd<ATOMIC_POL5>(&bins[array[i]], 1);
+    RAJA::atomicAdd<ATOMIC_POL5>(&bins[array[i]], 1);
 
   });
 

--- a/include/RAJA/pattern/atomic.hpp
+++ b/include/RAJA/pattern/atomic.hpp
@@ -27,8 +27,6 @@
 
 namespace RAJA
 {
-namespace atomic
-{
 
 
 /*!
@@ -92,7 +90,7 @@ RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicAdd(T volatile *acc, T value)
 {
-  return RAJA::atomic::atomicAdd(Policy{}, acc, value);
+  return RAJA::atomicAdd(Policy{}, acc, value);
 }
 
 
@@ -106,7 +104,7 @@ RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicSub(T volatile *acc, T value)
 {
-  return RAJA::atomic::atomicSub(Policy{}, acc, value);
+  return RAJA::atomicSub(Policy{}, acc, value);
 }
 
 
@@ -120,7 +118,7 @@ RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicMin(T volatile *acc, T value)
 {
-  return RAJA::atomic::atomicMin(Policy{}, acc, value);
+  return RAJA::atomicMin(Policy{}, acc, value);
 }
 
 
@@ -134,7 +132,7 @@ RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicMax(T volatile *acc, T value)
 {
-  return RAJA::atomic::atomicMax(Policy{}, acc, value);
+  return RAJA::atomicMax(Policy{}, acc, value);
 }
 
 
@@ -147,7 +145,7 @@ RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicInc(T volatile *acc)
 {
-  return RAJA::atomic::atomicInc(Policy{}, acc);
+  return RAJA::atomicInc(Policy{}, acc);
 }
 
 
@@ -163,7 +161,7 @@ RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicInc(T volatile *acc, T compare)
 {
-  return RAJA::atomic::atomicInc(Policy{}, acc, compare);
+  return RAJA::atomicInc(Policy{}, acc, compare);
 }
 
 
@@ -176,7 +174,7 @@ RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicDec(T volatile *acc)
 {
-  return RAJA::atomic::atomicDec(Policy{}, acc);
+  return RAJA::atomicDec(Policy{}, acc);
 }
 
 
@@ -192,7 +190,7 @@ RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicDec(T volatile *acc, T compare)
 {
-  return RAJA::atomic::atomicDec(Policy{}, acc, compare);
+  return RAJA::atomicDec(Policy{}, acc, compare);
 }
 
 
@@ -209,7 +207,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicAnd(T volatile *acc, T value)
 {
   static_assert(std::is_integral<T>::value,
                 "atomicAnd can only be used on integral types");
-  return RAJA::atomic::atomicAnd(Policy{}, acc, value);
+  return RAJA::atomicAnd(Policy{}, acc, value);
 }
 
 
@@ -226,7 +224,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicOr(T volatile *acc, T value)
 {
   static_assert(std::is_integral<T>::value,
                 "atomicOr can only be used on integral types");
-  return RAJA::atomic::atomicOr(Policy{}, acc, value);
+  return RAJA::atomicOr(Policy{}, acc, value);
 }
 
 
@@ -243,7 +241,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicXor(T volatile *acc, T value)
 {
   static_assert(std::is_integral<T>::value,
                 "atomicXor can only be used on integral types");
-  return RAJA::atomic::atomicXor(Policy{}, acc, value);
+  return RAJA::atomicXor(Policy{}, acc, value);
 }
 
 
@@ -257,7 +255,7 @@ RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicExchange(T volatile *acc, T value)
 {
-  return RAJA::atomic::atomicExchange(Policy{}, acc, value);
+  return RAJA::atomicExchange(Policy{}, acc, value);
 }
 
 
@@ -273,7 +271,7 @@ RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicCAS(T volatile *acc, T compare, T value)
 {
-  return RAJA::atomic::atomicCAS(Policy{}, acc, compare, value);
+  return RAJA::atomicCAS(Policy{}, acc, compare, value);
 }
 
 /*!
@@ -283,7 +281,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicCAS(T volatile *acc, T compare, T value)
  * arbitrary memory location.
  *
  * This object provides an OO interface to the global function calls provided
- * as RAJA::atomic::atomicXXX
+ * as RAJA::atomicXXX
  */
 template <typename T, typename Policy = auto_atomic>
 class AtomicRef
@@ -340,14 +338,14 @@ public:
   RAJA_HOST_DEVICE
   value_type exchange(value_type rhs) const
   {
-    return RAJA::atomic::atomicExchange<Policy>(m_value_ptr, rhs);
+    return RAJA::atomicExchange<Policy>(m_value_ptr, rhs);
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   value_type CAS(value_type compare, value_type rhs) const
   {
-    return RAJA::atomic::atomicCAS<Policy>(m_value_ptr, compare, rhs);
+    return RAJA::atomicCAS<Policy>(m_value_ptr, compare, rhs);
   }
 
   RAJA_INLINE
@@ -355,7 +353,7 @@ public:
   bool compare_exchange_strong(value_type& expect, value_type rhs) const
   {
     value_type compare = expect;
-    value_type old = RAJA::atomic::atomicCAS<Policy>(m_value_ptr, compare, rhs);
+    value_type old = RAJA::atomicCAS<Policy>(m_value_ptr, compare, rhs);
     if (compare == old) {
       return true;
     } else {
@@ -375,70 +373,70 @@ public:
   RAJA_HOST_DEVICE
   value_type operator++() const
   {
-    return RAJA::atomic::atomicInc<Policy>(m_value_ptr) + 1;
+    return RAJA::atomicInc<Policy>(m_value_ptr) + 1;
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   value_type operator++(int) const
   {
-    return RAJA::atomic::atomicInc<Policy>(m_value_ptr);
+    return RAJA::atomicInc<Policy>(m_value_ptr);
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   value_type operator--() const
   {
-    return RAJA::atomic::atomicDec<Policy>(m_value_ptr) - 1;
+    return RAJA::atomicDec<Policy>(m_value_ptr) - 1;
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   value_type operator--(int) const
   {
-    return RAJA::atomic::atomicDec<Policy>(m_value_ptr);
+    return RAJA::atomicDec<Policy>(m_value_ptr);
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   value_type fetch_add(value_type rhs) const
   {
-    return RAJA::atomic::atomicAdd<Policy>(m_value_ptr, rhs);
+    return RAJA::atomicAdd<Policy>(m_value_ptr, rhs);
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   value_type operator+=(value_type rhs) const
   {
-    return RAJA::atomic::atomicAdd<Policy>(m_value_ptr, rhs) + rhs;
+    return RAJA::atomicAdd<Policy>(m_value_ptr, rhs) + rhs;
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   value_type fetch_sub(value_type rhs) const
   {
-    return RAJA::atomic::atomicSub<Policy>(m_value_ptr, rhs);
+    return RAJA::atomicSub<Policy>(m_value_ptr, rhs);
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   value_type operator-=(value_type rhs) const
   {
-    return RAJA::atomic::atomicSub<Policy>(m_value_ptr, rhs) - rhs;
+    return RAJA::atomicSub<Policy>(m_value_ptr, rhs) - rhs;
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   value_type fetch_min(value_type rhs) const
   {
-    return RAJA::atomic::atomicMin<Policy>(m_value_ptr, rhs);
+    return RAJA::atomicMin<Policy>(m_value_ptr, rhs);
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   value_type min(value_type rhs) const
   {
-    value_type old = RAJA::atomic::atomicMin<Policy>(m_value_ptr, rhs);
+    value_type old = RAJA::atomicMin<Policy>(m_value_ptr, rhs);
     return old < rhs ? old : rhs;
   }
 
@@ -446,14 +444,14 @@ public:
   RAJA_HOST_DEVICE
   value_type fetch_max(value_type rhs) const
   {
-    return RAJA::atomic::atomicMax<Policy>(m_value_ptr, rhs);
+    return RAJA::atomicMax<Policy>(m_value_ptr, rhs);
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   value_type max(value_type rhs) const
   {
-    value_type old = RAJA::atomic::atomicMax<Policy>(m_value_ptr, rhs);
+    value_type old = RAJA::atomicMax<Policy>(m_value_ptr, rhs);
     return old > rhs ? old : rhs;
   }
 
@@ -461,42 +459,42 @@ public:
   RAJA_HOST_DEVICE
   value_type fetch_and(value_type rhs) const
   {
-    return RAJA::atomic::atomicAnd<Policy>(m_value_ptr, rhs);
+    return RAJA::atomicAnd<Policy>(m_value_ptr, rhs);
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   value_type operator&=(value_type rhs) const
   {
-    return RAJA::atomic::atomicAnd<Policy>(m_value_ptr, rhs) & rhs;
+    return RAJA::atomicAnd<Policy>(m_value_ptr, rhs) & rhs;
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   value_type fetch_or(value_type rhs) const
   {
-    return RAJA::atomic::atomicOr<Policy>(m_value_ptr, rhs);
+    return RAJA::atomicOr<Policy>(m_value_ptr, rhs);
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   value_type operator|=(value_type rhs) const
   {
-    return RAJA::atomic::atomicOr<Policy>(m_value_ptr, rhs) | rhs;
+    return RAJA::atomicOr<Policy>(m_value_ptr, rhs) | rhs;
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   value_type fetch_xor(value_type rhs) const
   {
-    return RAJA::atomic::atomicXor<Policy>(m_value_ptr, rhs);
+    return RAJA::atomicXor<Policy>(m_value_ptr, rhs);
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   value_type operator^=(value_type rhs) const
   {
-    return RAJA::atomic::atomicXor<Policy>(m_value_ptr, rhs) ^ rhs;
+    return RAJA::atomicXor<Policy>(m_value_ptr, rhs) ^ rhs;
   }
 
 private:
@@ -504,7 +502,6 @@ private:
 };
 
 
-}  // namespace atomic
 }  // namespace RAJA
 
 #endif

--- a/include/RAJA/policy/atomic_auto.hpp
+++ b/include/RAJA/policy/atomic_auto.hpp
@@ -38,19 +38,17 @@
  */
 #if defined(__CUDA_ARCH__)
 #define RAJA_AUTO_ATOMIC \
-  RAJA::atomic::cuda_atomic {}
+  RAJA::cuda_atomic {}
 #elif defined(RAJA_ENABLE_OPENMP)
 #define RAJA_AUTO_ATOMIC \
-  RAJA::atomic::omp_atomic {}
+  RAJA::omp_atomic {}
 #else
 #define RAJA_AUTO_ATOMIC \
-  RAJA::atomic::seq_atomic {}
+  RAJA::seq_atomic {}
 #endif
 
 
 namespace RAJA
-{
-namespace atomic
 {
 
 //! Atomic policy that automatically does "the right thing"
@@ -145,7 +143,6 @@ atomicCAS(auto_atomic, T volatile *acc, T compare, T value)
 }
 
 
-}  // namespace atomic
 }  // namespace RAJA
 
 // make sure this define doesn't bleed out of this header

--- a/include/RAJA/policy/atomic_builtin.hpp
+++ b/include/RAJA/policy/atomic_builtin.hpp
@@ -25,8 +25,6 @@
 
 namespace RAJA
 {
-namespace atomic
-{
 
 
 //! Atomic policy that uses the compilers builtin __atomic_XXX routines
@@ -314,7 +312,6 @@ RAJA_INLINE T atomicCAS(builtin_atomic, T volatile *acc, T compare, T value)
 }
 
 
-}  // namespace atomic
 }  // namespace RAJA
 
 // make sure this define doesn't bleed out of this header

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -32,8 +32,6 @@
 
 namespace RAJA
 {
-namespace atomic
-{
 
 
 namespace detail
@@ -736,7 +734,6 @@ atomicCAS(cuda_atomic, T volatile *acc, T compare, T value)
 #endif
 }
 
-}  // namespace atomic
 }  // namespace RAJA
 
 

--- a/include/RAJA/policy/cuda/reduce.hpp
+++ b/include/RAJA/policy/cuda/reduce.hpp
@@ -59,7 +59,7 @@ template <typename T>
 struct atomic<sum<T>> {
   RAJA_DEVICE RAJA_INLINE void operator()(T& val, const T v)
   {
-    RAJA::atomic::atomicAdd<T>(RAJA::atomic::cuda_atomic{}, &val, v);
+    RAJA::atomicAdd<T>(RAJA::cuda_atomic{}, &val, v);
   }
 };
 
@@ -67,7 +67,7 @@ template <typename T>
 struct atomic<min<T>> {
   RAJA_DEVICE RAJA_INLINE void operator()(T& val, const T v)
   {
-    RAJA::atomic::atomicMin<T>(RAJA::atomic::cuda_atomic{}, &val, v);
+    RAJA::atomicMin<T>(RAJA::cuda_atomic{}, &val, v);
   }
 };
 
@@ -75,7 +75,7 @@ template <typename T>
 struct atomic<max<T>> {
   RAJA_DEVICE RAJA_INLINE void operator()(T& val, const T v)
   {
-    RAJA::atomic::atomicMax<T>(RAJA::atomic::cuda_atomic{}, &val, v);
+    RAJA::atomicMax<T>(RAJA::cuda_atomic{}, &val, v);
   }
 };
 

--- a/include/RAJA/policy/loop/atomic.hpp
+++ b/include/RAJA/policy/loop/atomic.hpp
@@ -26,12 +26,8 @@
 
 namespace RAJA
 {
-namespace atomic
-{
 
 using loop_atomic = seq_atomic;
-
-}  // namespace atomic
 
 }  // namespace RAJA
 

--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -30,8 +30,6 @@
 
 namespace RAJA
 {
-namespace atomic
-{
 
 #if defined(RAJA_COMPILER_MSVC)
 
@@ -111,7 +109,7 @@ template <typename T>
 RAJA_INLINE T atomicInc(omp_atomic, T volatile *acc, T val)
 {
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
-  return RAJA::atomic::atomicInc(builtin_atomic{}, acc, val);
+  return RAJA::atomicInc(builtin_atomic{}, acc, val);
 }
 
 
@@ -134,7 +132,7 @@ template <typename T>
 RAJA_INLINE T atomicDec(omp_atomic, T volatile *acc, T val)
 {
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
-  return RAJA::atomic::atomicDec(builtin_atomic{}, acc, val);
+  return RAJA::atomicDec(builtin_atomic{}, acc, val);
 }
 
 RAJA_SUPPRESS_HD_WARN
@@ -194,13 +192,12 @@ template <typename T>
 RAJA_INLINE T atomicCAS(omp_atomic, T volatile *acc, T compare, T value)
 {
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
-  return RAJA::atomic::atomicCAS(builtin_atomic{}, acc, compare, value);
+  return RAJA::atomicCAS(builtin_atomic{}, acc, compare, value);
 }
 
 #endif  // not defined RAJA_COMPILER_MSVC
 
 
-}  // namespace atomic
 }  // namespace RAJA
 
 #endif  // RAJA_ENABLE_OPENMP

--- a/include/RAJA/policy/sequential/atomic.hpp
+++ b/include/RAJA/policy/sequential/atomic.hpp
@@ -24,8 +24,6 @@
 
 namespace RAJA
 {
-namespace atomic
-{
 
 struct seq_atomic {
 };
@@ -152,7 +150,6 @@ RAJA_INLINE T atomicCAS(seq_atomic, T volatile *acc, T compare, T value)
 }
 
 
-}  // namespace atomic
 }  // namespace RAJA
 
 

--- a/include/RAJA/util/LocalArray.hpp
+++ b/include/RAJA/util/LocalArray.hpp
@@ -81,7 +81,7 @@ struct AtomicTypedLocalArray<AtomicPolicy, DataType, camp::idx_seq<Perm ...>,
                              RAJA::SizeList<Sizes ...>, IndexTypes ...>{
   DataType *m_arrayPtr = nullptr;
   using element_t = DataType;
-  using atomic_ref_t = RAJA::atomic::AtomicRef<element_t, AtomicPolicy>;
+  using atomic_ref_t = RAJA::AtomicRef<element_t, AtomicPolicy>;
   using layout_t = RAJA::StaticLayout<camp::idx_seq<Perm ...>, Sizes ...>;
   static const camp::idx_t NumElem = layout_t::size();
 

--- a/include/RAJA/util/View.hpp
+++ b/include/RAJA/util/View.hpp
@@ -137,12 +137,12 @@ using TypedManagedArrayView = TypedViewBase<ValueType,
 #endif
 
 
-template <typename ViewType, typename AtomicPolicy = RAJA::atomic::auto_atomic>
+template <typename ViewType, typename AtomicPolicy = RAJA::auto_atomic>
 struct AtomicViewWrapper {
   using base_type = ViewType;
   using pointer_type = typename base_type::pointer_type;
   using value_type = typename base_type::value_type;
-  using atomic_type = RAJA::atomic::AtomicRef<value_type, AtomicPolicy>;
+  using atomic_type = RAJA::AtomicRef<value_type, AtomicPolicy>;
 
   base_type base_;
 
@@ -164,12 +164,11 @@ struct AtomicViewWrapper {
  * for performance
  */
 template <typename ViewType>
-struct AtomicViewWrapper<ViewType, RAJA::atomic::seq_atomic> {
+struct AtomicViewWrapper<ViewType, RAJA::seq_atomic> {
   using base_type = ViewType;
   using pointer_type = typename base_type::pointer_type;
   using value_type = typename base_type::value_type;
-  using atomic_type =
-      RAJA::atomic::AtomicRef<value_type, RAJA::atomic::seq_atomic>;
+  using atomic_type = RAJA::AtomicRef<value_type, RAJA::seq_atomic>;
 
   base_type base_;
 

--- a/test/unit/test-atomic-ref-auto.cpp
+++ b/test/unit/test-atomic-ref-auto.cpp
@@ -23,7 +23,7 @@
 
 TEST(Atomic, basic_OpenMP_AtomicRef)
 {
-  testAtomicRefPol<RAJA::omp_for_exec, RAJA::atomic::auto_atomic>();
+  testAtomicRefPol<RAJA::omp_for_exec, RAJA::auto_atomic>();
 }
 
 #endif
@@ -32,13 +32,13 @@ TEST(Atomic, basic_OpenMP_AtomicRef)
 
 CUDA_TEST(Atomic, basic_CUDA_AtomicRef)
 {
-  testAtomicRefPol<RAJA::cuda_exec<256>, RAJA::atomic::auto_atomic>();
+  testAtomicRefPol<RAJA::cuda_exec<256>, RAJA::auto_atomic>();
 }
 
 #endif
 
 TEST(Atomic, basic_seq_AtomicRef)
 {
-  testAtomicRefPol<RAJA::seq_exec, RAJA::atomic::auto_atomic>();
+  testAtomicRefPol<RAJA::seq_exec, RAJA::auto_atomic>();
 }
 

--- a/test/unit/test-atomic-ref.cpp
+++ b/test/unit/test-atomic-ref.cpp
@@ -23,8 +23,8 @@
 
 TEST(Atomic, basic_OpenMP_AtomicRef)
 {
-  testAtomicRefPol<RAJA::omp_for_exec, RAJA::atomic::omp_atomic>();
-  testAtomicRefPol<RAJA::omp_for_exec, RAJA::atomic::builtin_atomic>();
+  testAtomicRefPol<RAJA::omp_for_exec, RAJA::omp_atomic>();
+  testAtomicRefPol<RAJA::omp_for_exec, RAJA::builtin_atomic>();
 }
 
 #endif
@@ -33,7 +33,7 @@ TEST(Atomic, basic_OpenMP_AtomicRef)
 
 CUDA_TEST(Atomic, basic_CUDA_AtomicRef)
 {
-  testAtomicRefPol<RAJA::cuda_exec<256>, RAJA::atomic::cuda_atomic>();
+  testAtomicRefPol<RAJA::cuda_exec<256>, RAJA::cuda_atomic>();
 }
 
 #endif
@@ -41,8 +41,8 @@ CUDA_TEST(Atomic, basic_CUDA_AtomicRef)
 #if defined(TEST_EXHAUSTIVE) || !defined(RAJA_ENABLE_OPENMP)
 TEST(Atomic, basic_seq_AtomicRef)
 {
-  testAtomicRefPol<RAJA::seq_exec, RAJA::atomic::seq_atomic>();
-  testAtomicRefPol<RAJA::seq_exec, RAJA::atomic::builtin_atomic>();
+  testAtomicRefPol<RAJA::seq_exec, RAJA::seq_atomic>();
+  testAtomicRefPol<RAJA::seq_exec, RAJA::builtin_atomic>();
 }
 #endif
 

--- a/test/unit/test-atomic-ref.hpp
+++ b/test/unit/test-atomic-ref.hpp
@@ -95,7 +95,7 @@ struct AndEqOtherOp {
   RAJA_HOST_DEVICE
     T operator()(RAJA::Index_type i) const
     { return other &= (T)i; }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
@@ -108,7 +108,7 @@ struct FetchAndOtherOp {
   RAJA_HOST_DEVICE
     T operator()(RAJA::Index_type i) const
     { return other.fetch_and((T)i); }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
@@ -121,7 +121,7 @@ struct OrEqOtherOp {
   RAJA_HOST_DEVICE
     T operator()(RAJA::Index_type i) const
     { return other |= (T)i; }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
@@ -134,7 +134,7 @@ struct FetchOrOtherOp {
   RAJA_HOST_DEVICE
     T operator()(RAJA::Index_type i) const
     { return other.fetch_or((T)i); }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
@@ -150,7 +150,7 @@ struct XorEqOtherOp {
   RAJA_HOST_DEVICE
     T operator()(RAJA::Index_type i) const
     { return other ^= (T)i; }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
@@ -166,7 +166,7 @@ struct FetchXorOtherOp {
   RAJA_HOST_DEVICE
     T operator()(RAJA::Index_type i) const
     { return other.fetch_xor((T)i); }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
@@ -179,7 +179,7 @@ struct LoadOtherOp {
   RAJA_HOST_DEVICE
     T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const
     { return other.load(); }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
@@ -192,7 +192,7 @@ struct OperatorTOtherOp {
   RAJA_HOST_DEVICE
     T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const
     { return other; }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
@@ -205,7 +205,7 @@ struct StoreOtherOp {
   RAJA_HOST_DEVICE
     T operator()(RAJA::Index_type i) const
     { other.store((T)i); return (T)i; }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
@@ -218,7 +218,7 @@ struct AssignOtherOp {
   RAJA_HOST_DEVICE
     T operator()(RAJA::Index_type i) const
     { return (other = (T)i); }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
@@ -237,7 +237,7 @@ struct CASOtherOp {
       }
       return received;
     }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
@@ -254,7 +254,7 @@ struct CompareExchangeWeakOtherOp {
       while (!other.compare_exchange_weak(expect, (T)i)) {}
       return expect;
     }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
@@ -271,7 +271,7 @@ struct CompareExchangeStrongOtherOp {
       while (!other.compare_exchange_strong(expect, (T)i)) {}
       return expect;
     }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
@@ -284,7 +284,7 @@ struct PreIncCountOp {
     T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const {
       return (++counter) - (T)1;
     }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> counter;
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
   T min, max, final;
 };
 
@@ -297,7 +297,7 @@ struct PostIncCountOp {
     T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const {
       return (counter++);
     }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> counter;
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
   T min, max, final;
 };
 
@@ -310,7 +310,7 @@ struct AddEqCountOp {
     T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const {
       return (counter += (T)1) - (T)1;
     }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> counter;
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
   T min, max, final;
 };
 
@@ -323,7 +323,7 @@ struct FetchAddCountOp {
     T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const {
       return counter.fetch_add((T)1);
     }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> counter;
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
   T min, max, final;
 };
 
@@ -336,7 +336,7 @@ struct PreDecCountOp {
     T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const {
       return (--counter);
     }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> counter;
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
   T min, max, final;
 };
 
@@ -349,7 +349,7 @@ struct PostDecCountOp {
     T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const {
       return (counter--) - (T)1;
     }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> counter;
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
   T min, max, final;
 };
 
@@ -362,7 +362,7 @@ struct SubEqCountOp {
     T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const {
       return (counter -= (T)1);
     }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> counter;
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
   T min, max, final;
 };
 
@@ -375,7 +375,7 @@ struct FetchSubCountOp {
     T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const {
       return counter.fetch_sub((T)1) - (T)1;
     }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> counter;
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
   T min, max, final;
 };
 
@@ -388,7 +388,7 @@ struct MaxEqOtherOp {
   RAJA_HOST_DEVICE
     T operator()(RAJA::Index_type i) const
     { return other.max((T)i); }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
@@ -401,7 +401,7 @@ struct FetchMaxOtherOp {
   RAJA_HOST_DEVICE
     T operator()(RAJA::Index_type i) const
     { return other.fetch_max((T)i); }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
@@ -414,7 +414,7 @@ struct MinEqOtherOp {
   RAJA_HOST_DEVICE
     T operator()(RAJA::Index_type i) const
     { return other.min((T)i); }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
@@ -427,7 +427,7 @@ struct FetchMinOtherOp {
   RAJA_HOST_DEVICE
     T operator()(RAJA::Index_type i) const
     { return other.fetch_min((T)i); }
-  RAJA::atomic::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 

--- a/test/unit/test-atomic.cpp
+++ b/test/unit/test-atomic.cpp
@@ -45,15 +45,15 @@ void testAtomicFunctionBasic()
 
 
   RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(RAJA::Index_type i) {
-    RAJA::atomic::atomicAdd<AtomicPolicy>(dest + 0, (T)1);
-    RAJA::atomic::atomicSub<AtomicPolicy>(dest + 1, (T)1);
+    RAJA::atomicAdd<AtomicPolicy>(dest + 0, (T)1);
+    RAJA::atomicSub<AtomicPolicy>(dest + 1, (T)1);
 
-    RAJA::atomic::atomicMin<AtomicPolicy>(dest + 2, (T)i);
-    RAJA::atomic::atomicMax<AtomicPolicy>(dest + 3, (T)i);
-    RAJA::atomic::atomicInc<AtomicPolicy>(dest + 4);
-    RAJA::atomic::atomicInc<AtomicPolicy>(dest + 5, (T)16);
-    RAJA::atomic::atomicDec<AtomicPolicy>(dest + 6);
-    RAJA::atomic::atomicDec<AtomicPolicy>(dest + 7, (T)16);
+    RAJA::atomicMin<AtomicPolicy>(dest + 2, (T)i);
+    RAJA::atomicMax<AtomicPolicy>(dest + 3, (T)i);
+    RAJA::atomicInc<AtomicPolicy>(dest + 4);
+    RAJA::atomicInc<AtomicPolicy>(dest + 5, (T)16);
+    RAJA::atomicDec<AtomicPolicy>(dest + 6);
+    RAJA::atomicDec<AtomicPolicy>(dest + 7, (T)16);
   });
 
 #if defined(RAJA_ENABLE_CUDA)
@@ -204,10 +204,10 @@ void testAtomicLogical()
   RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(RAJA::Index_type i) {
     RAJA::Index_type offset = i / 8;
     RAJA::Index_type bit = i % 8;
-    RAJA::atomic::atomicAnd<AtomicPolicy>(dest_and + offset,
+    RAJA::atomicAnd<AtomicPolicy>(dest_and + offset,
                                           (T)(0xFF ^ (1 << bit)));
-    RAJA::atomic::atomicOr<AtomicPolicy>(dest_or + offset, (T)(1 << bit));
-    RAJA::atomic::atomicXor<AtomicPolicy>(dest_xor + offset, (T)(1 << bit));
+    RAJA::atomicOr<AtomicPolicy>(dest_or + offset, (T)(1 << bit));
+    RAJA::atomicXor<AtomicPolicy>(dest_xor + offset, (T)(1 << bit));
   });
 
 #if defined(RAJA_ENABLE_CUDA)
@@ -246,25 +246,25 @@ void testAtomicLogicalPol()
 
 TEST(Atomic, basic_OpenMP_AtomicFunction)
 {
-  testAtomicFunctionPol<RAJA::omp_for_exec, RAJA::atomic::auto_atomic>();
-  testAtomicFunctionPol<RAJA::omp_for_exec, RAJA::atomic::omp_atomic>();
-  testAtomicFunctionPol<RAJA::omp_for_exec, RAJA::atomic::builtin_atomic>();
+  testAtomicFunctionPol<RAJA::omp_for_exec, RAJA::auto_atomic>();
+  testAtomicFunctionPol<RAJA::omp_for_exec, RAJA::omp_atomic>();
+  testAtomicFunctionPol<RAJA::omp_for_exec, RAJA::builtin_atomic>();
 }
 
 
 TEST(Atomic, basic_OpenMP_AtomicView)
 {
-  testAtomicViewPol<RAJA::omp_for_exec, RAJA::atomic::auto_atomic>();
-  testAtomicViewPol<RAJA::omp_for_exec, RAJA::atomic::omp_atomic>();
-  testAtomicViewPol<RAJA::omp_for_exec, RAJA::atomic::builtin_atomic>();
+  testAtomicViewPol<RAJA::omp_for_exec, RAJA::auto_atomic>();
+  testAtomicViewPol<RAJA::omp_for_exec, RAJA::omp_atomic>();
+  testAtomicViewPol<RAJA::omp_for_exec, RAJA::builtin_atomic>();
 }
 
 
 TEST(Atomic, basic_OpenMP_Logical)
 {
-  testAtomicLogicalPol<RAJA::omp_for_exec, RAJA::atomic::auto_atomic>();
-  testAtomicLogicalPol<RAJA::omp_for_exec, RAJA::atomic::omp_atomic>();
-  testAtomicLogicalPol<RAJA::omp_for_exec, RAJA::atomic::builtin_atomic>();
+  testAtomicLogicalPol<RAJA::omp_for_exec, RAJA::auto_atomic>();
+  testAtomicLogicalPol<RAJA::omp_for_exec, RAJA::omp_atomic>();
+  testAtomicLogicalPol<RAJA::omp_for_exec, RAJA::builtin_atomic>();
 }
 
 #endif
@@ -273,21 +273,21 @@ TEST(Atomic, basic_OpenMP_Logical)
 
 CUDA_TEST(Atomic, basic_CUDA_AtomicFunction)
 {
-  testAtomicFunctionPol<RAJA::cuda_exec<256>, RAJA::atomic::auto_atomic>();
-  testAtomicFunctionPol<RAJA::cuda_exec<256>, RAJA::atomic::cuda_atomic>();
+  testAtomicFunctionPol<RAJA::cuda_exec<256>, RAJA::auto_atomic>();
+  testAtomicFunctionPol<RAJA::cuda_exec<256>, RAJA::cuda_atomic>();
 }
 
 CUDA_TEST(Atomic, basic_CUDA_AtomicView)
 {
-  testAtomicViewPol<RAJA::cuda_exec<256>, RAJA::atomic::auto_atomic>();
-  testAtomicViewPol<RAJA::cuda_exec<256>, RAJA::atomic::cuda_atomic>();
+  testAtomicViewPol<RAJA::cuda_exec<256>, RAJA::auto_atomic>();
+  testAtomicViewPol<RAJA::cuda_exec<256>, RAJA::cuda_atomic>();
 }
 
 
 CUDA_TEST(Atomic, basic_CUDA_Logical)
 {
-  testAtomicLogicalPol<RAJA::cuda_exec<256>, RAJA::atomic::auto_atomic>();
-  testAtomicLogicalPol<RAJA::cuda_exec<256>, RAJA::atomic::cuda_atomic>();
+  testAtomicLogicalPol<RAJA::cuda_exec<256>, RAJA::auto_atomic>();
+  testAtomicLogicalPol<RAJA::cuda_exec<256>, RAJA::cuda_atomic>();
 }
 
 
@@ -295,22 +295,22 @@ CUDA_TEST(Atomic, basic_CUDA_Logical)
 
 TEST(Atomic, basic_seq_AtomicFunction)
 {
-  testAtomicFunctionPol<RAJA::seq_exec, RAJA::atomic::auto_atomic>();
-  testAtomicFunctionPol<RAJA::seq_exec, RAJA::atomic::seq_atomic>();
-  testAtomicFunctionPol<RAJA::seq_exec, RAJA::atomic::builtin_atomic>();
+  testAtomicFunctionPol<RAJA::seq_exec, RAJA::auto_atomic>();
+  testAtomicFunctionPol<RAJA::seq_exec, RAJA::seq_atomic>();
+  testAtomicFunctionPol<RAJA::seq_exec, RAJA::builtin_atomic>();
 }
 
 TEST(Atomic, basic_seq_AtomicView)
 {
-  testAtomicViewPol<RAJA::seq_exec, RAJA::atomic::auto_atomic>();
-  testAtomicViewPol<RAJA::seq_exec, RAJA::atomic::seq_atomic>();
-  testAtomicViewPol<RAJA::seq_exec, RAJA::atomic::builtin_atomic>();
+  testAtomicViewPol<RAJA::seq_exec, RAJA::auto_atomic>();
+  testAtomicViewPol<RAJA::seq_exec, RAJA::seq_atomic>();
+  testAtomicViewPol<RAJA::seq_exec, RAJA::builtin_atomic>();
 }
 
 
 TEST(Atomic, basic_seq_Logical)
 {
-  testAtomicLogicalPol<RAJA::seq_exec, RAJA::atomic::auto_atomic>();
-  testAtomicLogicalPol<RAJA::seq_exec, RAJA::atomic::seq_atomic>();
-  testAtomicLogicalPol<RAJA::seq_exec, RAJA::atomic::builtin_atomic>();
+  testAtomicLogicalPol<RAJA::seq_exec, RAJA::auto_atomic>();
+  testAtomicLogicalPol<RAJA::seq_exec, RAJA::seq_atomic>();
+  testAtomicLogicalPol<RAJA::seq_exec, RAJA::builtin_atomic>();
 }

--- a/test/unit/test-kernel.cpp
+++ b/test/unit/test-kernel.cpp
@@ -376,14 +376,14 @@ CUDA_TEST(Kernel, CudaCollapse2)
   RAJA::kernel<Pol>(
       RAJA::make_tuple(RAJA::RangeSegment(1, N), RAJA::RangeSegment(1, N)),
       [=] RAJA_DEVICE(Index_type i, Index_type j) {
-        RAJA::atomic::atomicAdd<RAJA::atomic::cuda_atomic>(sum1, i);
-        RAJA::atomic::atomicAdd<RAJA::atomic::cuda_atomic>(sum2, j);
+        RAJA::atomicAdd<RAJA::cuda_atomic>(sum1, i);
+        RAJA::atomicAdd<RAJA::cuda_atomic>(sum2, j);
 
         if (i >= 41) {
-          RAJA::atomic::atomicAdd<RAJA::atomic::cuda_atomic>(err, 1);
+          RAJA::atomicAdd<RAJA::cuda_atomic>(err, 1);
         }
         if (j >= 41) {
-          RAJA::atomic::atomicAdd<RAJA::atomic::cuda_atomic>(err + 1, 1);
+          RAJA::atomicAdd<RAJA::cuda_atomic>(err + 1, 1);
         }
       });
 
@@ -514,7 +514,7 @@ CUDA_TEST(Kernel, SubRange_Complex)
                        RAJA::RangeSegment(0, 16),
                        RAJA::RangeSegment(0, 32)),
       [=] RAJA_HOST_DEVICE(Index_type i, Index_type j, Index_type k) {
-        RAJA::atomic::atomicAdd<RAJA::atomic::cuda_atomic>(ptr + i, 1.0);
+        RAJA::atomicAdd<RAJA::cuda_atomic>(ptr + i, 1.0);
       });
 
 
@@ -2169,7 +2169,7 @@ CUDA_TEST(Kernel, CudaComplexNested)
                      RAJA::Index_type j,
                      RAJA::Index_type k) {
         trip_count += 1;
-        RAJA::atomic::atomicAdd<RAJA::atomic::auto_atomic>(ptr + i, (int)1);
+        RAJA::atomicAdd<RAJA::auto_atomic>(ptr + i, (int)1);
       });
   cudaErrchk(cudaDeviceSynchronize());
 

--- a/test/unit/test-sharedmem.cpp
+++ b/test/unit/test-sharedmem.cpp
@@ -74,7 +74,7 @@ CUDA_TYPED_TEST_P(TypedLocalMem, Basic)
     }
   }
 
-  using SharedTile = AtomicTypedLocalArray<RAJA::atomic::auto_atomic, double, RAJA::PERM_IJ, RAJA::SizeList<TILE_DIM,TILE_DIM>, TY, TX>;
+  using SharedTile = AtomicTypedLocalArray<RAJA::auto_atomic, double, RAJA::PERM_IJ, RAJA::SizeList<TILE_DIM,TILE_DIM>, TY, TX>;
   SharedTile myTile, myTile2;
 
   const TX TX_TILE_DIM(16);


### PR DESCRIPTION
This makes use of RAJA atomic operations consistent with other RAJA capabilities; e.g., reductions, scans, etc.

I discussed with several code teams and all are OK with this.