### PR TITLE
This PR squashes a bunch of warnings...

### DIFF
--- a/exercises/tutorial_halfday/ex1_vector-addition.cpp
+++ b/exercises/tutorial_halfday/ex1_vector-addition.cpp
@@ -37,10 +37,13 @@
 
 /*
   CUDA_BLOCK_SIZE - specifies the number of threads in a CUDA thread block
-*/
+
+                    Uncomment to use when filling in exercises. 
+
 #if defined(RAJA_ENABLE_CUDA)
 const int CUDA_BLOCK_SIZE = 256;
 #endif
+*/
 
 //
 // Functions for checking and printing arrays

--- a/exercises/tutorial_halfday/ex2_approx-pi.cpp
+++ b/exercises/tutorial_halfday/ex2_approx-pi.cpp
@@ -33,10 +33,13 @@
 
 /*
   CUDA_BLOCK_SIZE - specifies the number of threads in a CUDA thread block
-*/
+
+                    Uncomment to use when filling in exercises.
+
 #if defined(RAJA_ENABLE_CUDA)
 const int CUDA_BLOCK_SIZE = 256;
 #endif
+*/
 
 int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 {

--- a/exercises/tutorial_halfday/ex3_colored-indexset.cpp
+++ b/exercises/tutorial_halfday/ex3_colored-indexset.cpp
@@ -50,10 +50,13 @@
 
 /*
   CUDA_BLOCK_SIZE - specifies the number of threads in a CUDA thread block
-*/
+
+                    Uncomment to use when filling in exercises.
+
 #if defined(RAJA_ENABLE_CUDA)
 const int CUDA_BLOCK_SIZE = 256;
 #endif
+*/
 
 //
 // Functions to check and print result.

--- a/exercises/tutorial_halfday/ex4_atomic-histogram.cpp
+++ b/exercises/tutorial_halfday/ex4_atomic-histogram.cpp
@@ -39,10 +39,13 @@
 
 /*
   CUDA_BLOCK_SIZE - specifies the number of threads in a CUDA thread block
-*/
+
+                    Uncomment to use when filling in exercises.
+
 #if defined(RAJA_ENABLE_CUDA)
 const int CUDA_BLOCK_SIZE = 256;
 #endif
+*/
 
 //
 // Functions to check and print result.

--- a/exercises/tutorial_halfday/ex5_line-of-sight.cpp
+++ b/exercises/tutorial_halfday/ex5_line-of-sight.cpp
@@ -59,10 +59,13 @@
 
 /*
   CUDA_BLOCK_SIZE - specifies the number of threads in a CUDA thread block
-*/
+
+                    Uncomment to use when filling in exercises.
+
 #if defined(RAJA_ENABLE_CUDA)
 const int CUDA_BLOCK_SIZE = 256;
 #endif
+*/
 
 //
 // Functions to check results and print arrays.

--- a/include/RAJA/pattern/detail/reduce.hpp
+++ b/include/RAJA/pattern/detail/reduce.hpp
@@ -120,7 +120,7 @@ public:
   constexpr ValueLoc() = default;
   constexpr ValueLoc(ValueLoc const &) = default;
 
-  ValueLoc& operator=(ValueLoc const &) = default;
+  RAJA_HOST_DEVICE ValueLoc& operator=(ValueLoc const &) = default;
 
   RAJA_HOST_DEVICE constexpr ValueLoc(T const &val) : val{val}, loc{DefaultLoc<IndexType>().value()} {}
   RAJA_HOST_DEVICE constexpr ValueLoc(T const &val, IndexType const &loc)

--- a/include/RAJA/pattern/detail/reduce.hpp
+++ b/include/RAJA/pattern/detail/reduce.hpp
@@ -101,13 +101,13 @@ struct DefaultLoc {};
 template <typename T>
 struct DefaultLoc<T, false>  // any non-integral type
 {
-  RAJA_HOST_DEVICE constexpr T value() { return T(); }
+  RAJA_HOST_DEVICE constexpr T value() const { return T(); }
 };
 
 template <typename T>
 struct DefaultLoc<T, true>
 {
-  RAJA_HOST_DEVICE constexpr T value() { return -1; }
+  RAJA_HOST_DEVICE constexpr T value() const { return -1; }
 };
 
 template <typename T, typename IndexType, bool doing_min = true>
@@ -120,7 +120,7 @@ public:
   constexpr ValueLoc() = default;
   constexpr ValueLoc(ValueLoc const &) = default;
 
-  RAJA_HOST_DEVICE ValueLoc &operator=(ValueLoc const &) = default;
+  ValueLoc& operator=(ValueLoc const &) = default;
 
   RAJA_HOST_DEVICE constexpr ValueLoc(T const &val) : val{val}, loc{DefaultLoc<IndexType>().value()} {}
   RAJA_HOST_DEVICE constexpr ValueLoc(T const &val, IndexType const &loc)

--- a/include/RAJA/pattern/detail/reduce.hpp
+++ b/include/RAJA/pattern/detail/reduce.hpp
@@ -120,7 +120,10 @@ public:
   constexpr ValueLoc() = default;
   constexpr ValueLoc(ValueLoc const &) = default;
 
-  RAJA_HOST_DEVICE ValueLoc& operator=(ValueLoc const &) = default;
+#if defined(CUDART_VERSION) && CUDART_VERSION < 9020
+  RAJA_HOST_DEVICE
+#endif
+  ValueLoc& operator=(ValueLoc const &) = default;
 
   RAJA_HOST_DEVICE constexpr ValueLoc(T const &val) : val{val}, loc{DefaultLoc<IndexType>().value()} {}
   RAJA_HOST_DEVICE constexpr ValueLoc(T const &val, IndexType const &loc)

--- a/scripts/lc-builds/blueos_nvcc9.1_clang-coral-2018.08.08.sh
+++ b/scripts/lc-builds/blueos_nvcc9.1_clang-coral-2018.08.08.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-BUILD_SUFFIX=lc_blueos-nvcc9-clang6.0.0
+BUILD_SUFFIX=lc_blueos-nvcc9.1-clang-coral-2018.08.08
 
 rm -rf build_${BUILD_SUFFIX} >/dev/null
 mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
@@ -16,13 +16,12 @@ module load cmake/3.9.2
 
 cmake \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CXX_COMPILER=/usr/tce/packages/clang/clang-6.0.0/bin/clang++ \
-  -C ../host-configs/lc-builds/blueos/nvcc_clang_X.cmake \
+  -C ../host-configs/lc-builds/blueos/nvcc_clang_coral_2018_08_08.cmake \
   -DENABLE_OPENMP=On \
   -DENABLE_CUDA=On \
-  -DCUDA_TOOLKIT_ROOT_DIR=/usr/tce/packages/cuda/cuda-9.2.148 \
-  -DCMAKE_CUDA_COMPILER=/usr/tce/packages/cuda/cuda-9.2.148/bin/nvcc \
-  -DCUDA_ARCH=sm_70 \
+  -DCUDA_TOOLKIT_ROOT_DIR=/usr/tce/packages/cuda/cuda-9.1.85 \
+  -DCMAKE_CUDA_COMPILER=/usr/tce/packages/cuda/cuda-9.1.85/bin/nvcc \
+  -DCUDA_ARCH=sm_60 \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
   "$@" \
   ..

--- a/test/unit/cuda/test-reduce-loc.cpp
+++ b/test/unit/cuda/test-reduce-loc.cpp
@@ -44,24 +44,24 @@ struct Index {
 
 template <typename T>
 struct LocCompare {
-   RAJA_HOST_DEVICE constexpr T defaultVal() { return T(); }
-   RAJA_HOST_DEVICE constexpr T getVal(int idx) { return T(idx); }
+   RAJA_HOST_DEVICE constexpr T defaultVal() const { return T(); }
+   RAJA_HOST_DEVICE constexpr T getVal(int idx) const { return T(idx); }
 };
 
 template <>
 struct LocCompare<Index_type> {
-   RAJA_HOST_DEVICE constexpr Index_type defaultVal() { return -1; }
-   RAJA_HOST_DEVICE constexpr Index_type getVal(int idx) { return idx; }
+   RAJA_HOST_DEVICE constexpr Index_type defaultVal() const { return -1; }
+   RAJA_HOST_DEVICE constexpr Index_type getVal(int idx) const { return idx; }
 };
 
 template <typename T>
 struct LocConvert {
-   RAJA_HOST_DEVICE constexpr T get(const T& idx) { return idx; }
+   RAJA_HOST_DEVICE constexpr T get(const T& idx) const { return idx; }
 };
 
 template <>
 struct LocConvert<Index> {
-   RAJA_HOST_DEVICE constexpr Index_type get(const Index& i) { return i.idx; }
+   RAJA_HOST_DEVICE constexpr Index_type get(const Index& i) const { return i.idx; }
 };
 
 static void reset(double* ptr, long length, double def)


### PR DESCRIPTION
...due to unused variables, and the facts that C++14 will not implictly declare 'const' non-static member functions that are marked constexpr and class member functions marked 'default' should not be marked with '__host__ __device__' because the host and device compilers will not generally emit the same simple default implementations.

Due to inconsistencies between newer and older versions of nvcc, we will live with the host/device default members until we have a better solution.  Nevertheless, this PR does squash a lot of warnings.