### PR TITLE
Example 1: Fix Typo

### DIFF
--- a/exercises/tutorial_halfday/ex1_vector-addition.cpp
+++ b/exercises/tutorial_halfday/ex1_vector-addition.cpp
@@ -186,7 +186,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   }
 
   checkResult(c, c_ref, N);
-//printArray(c, N); 
+//printArray(c, N);
 
 #endif
 
@@ -200,7 +200,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   std::memset(c, 0, N * sizeof(int));
 
-  std::cout << "\n Running RAJA OpenMP multthreaded vector addition...\n";
+  std::cout << "\n Running RAJA OpenMP multithreaded vector addition...\n";
 
   ///
   /// TODO...

--- a/exercises/tutorial_halfday/ex1_vector-addition_solution.cpp
+++ b/exercises/tutorial_halfday/ex1_vector-addition_solution.cpp
@@ -160,7 +160,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   }
 
   checkResult(c, c_ref, N);
-//printArray(c, N); 
+//printArray(c, N);
 
 #endif
 
@@ -174,7 +174,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   std::memset(c, 0, N * sizeof(int));
 
-  std::cout << "\n Running RAJA OpenMP multthreaded vector addition...\n";
+  std::cout << "\n Running RAJA OpenMP multithreaded vector addition...\n";
 
   using EXEC_POL4 = RAJA::omp_parallel_for_exec;
 


### PR DESCRIPTION
Fix a small typo in the first example's output.
Also removes some end-of-line white spaces.