### PR TITLE
PGI compilation scripts.

### DIFF
--- a/host-configs/lc-builds/blueos/pgi_X.cmake
+++ b/host-configs/lc-builds/blueos/pgi_X.cmake
@@ -1,0 +1,18 @@
+###############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+set(RAJA_COMPILER "RAJA_COMPILER_PGI" CACHE STRING "")
+
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -fast -mp" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-fast -g -mp" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -mp" CACHE STRING "")
+
+set(RAJA_RANGE_ALIGN 4 CACHE STRING "")
+set(RAJA_RANGE_MIN_LENGTH 32 CACHE STRING "")
+set(RAJA_DATA_ALIGN 64 CACHE STRING "")
+
+set(RAJA_HOST_CONFIG_LOADED On CACHE BOOL "")

--- a/scripts/lc-builds/blueos_pgi19.7.sh
+++ b/scripts/lc-builds/blueos_pgi19.7.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+BUILD_SUFFIX=lc_blueos-pgi-19.7
+RAJA_HOSTCONFIG=../host-configs/lc-builds/blueos/pgi_X.cmake
+
+rm -rf build_${BUILD_SUFFIX} 2>/dev/null
+mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
+
+module load cmake/3.14.5
+
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_COMPILER=/usr/tce/packages/pgi/pgi-19.7/bin/pgc++ \
+  -C ${RAJA_HOSTCONFIG} \
+  -DENABLE_OPENMP=On \
+  -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
+  "$@" \
+  ..


### PR DESCRIPTION
Adding PGI 19.7 compilation scripts, with their optimization flags. The following tests fail due to a double free somewhere:
test-atomic-ref
test-atomic-ref-auto