### PR TITLE
Fix for seg fault in OMP Target when running PerfSuite. 

### DIFF
--- a/include/RAJA/policy/openmp_target/forall.hpp
+++ b/include/RAJA/policy/openmp_target/forall.hpp
@@ -60,9 +60,9 @@ RAJA_INLINE void forall_impl(const omp_target_parallel_for_exec<ThreadsPerTeam>&
     numteams = tperteam;
   }
 
+// thread_limit(tperteam) unused due to XL seg fault (when tperteam != distance)
 #pragma omp target teams distribute parallel for num_teams(numteams) \
-    thread_limit(tperteam) schedule(static, 1) map(to              \
-                                                    : body)
+    schedule(static, 1) map(to : body)
   for (Index_type i = 0; i < distance; ++i) {
     Body ib = body;
     ib(begin[i]);


### PR DESCRIPTION
When running Polybench_ADI and Polybench_GESUMMV, RAJA OpenMP Target seg faults when the thread_limit(tperteam) clause does not match the number of thread iterations. Removing the clause staves off the "Warp Illegal Address" errors and allows them to run to completion, albeit with faulty checksums. A single-file non-RAJA reproducer is in the works, but it is difficult to reproduce in a non-RAJA environment. Will iterate with Johann and Roy on this (separately from this PR).