### PR TITLE
Suppress omp target warnings and cleaned up forall_impl.

### DIFF
--- a/host-configs/lc-builds/blueos/nvcc_xl_2019_X.cmake
+++ b/host-configs/lc-builds/blueos/nvcc_xl_2019_X.cmake
@@ -18,6 +18,11 @@ set(CMAKE_CUDA_FLAGS_RELEASE "-O3 ${HOST_OPT_FLAGS}" CACHE STRING "")
 set(CMAKE_CUDA_FLAGS_DEBUG "-g -G -O0" CACHE STRING "")
 set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-g -lineinfo -O3 ${HOST_OPT_FLAGS}" CACHE STRING "")
 
+# Suppressed XLC warnings:
+# - 1500-029 cannot inline
+# - 1500-036 nostrict optimizations may alter code semantics
+#   (can be countered with -qstrict, with less optimization)
+
 set(RAJA_RANGE_ALIGN 4 CACHE STRING "")
 set(RAJA_RANGE_MIN_LENGTH 32 CACHE STRING "")
 set(RAJA_DATA_ALIGN 64 CACHE STRING "")

--- a/host-configs/lc-builds/blueos/xl_2019_X.cmake
+++ b/host-configs/lc-builds/blueos/xl_2019_X.cmake
@@ -7,8 +7,8 @@
 
 set(RAJA_COMPILER "RAJA_COMPILER_XLC" CACHE STRING "")
 
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qsmp=omp -qhot -qnoeh" CACHE STRING "")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qsmp=omp -qhot -qnoeh" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qsmp=omp -qhot -qnoeh -qsuppress=1500-029 -qsuppress=1500-036" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qsmp=omp -qhot -qnoeh -qsuppress=1500-029 -qsuppress=1500-036" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -qsmp=omp:noopt " CACHE STRING "")
 set(CMAKE_EXE_LINKER_FLAGS "-Wl,-z,muldefs" CACHE STRING "")
 

--- a/host-configs/lc-builds/blueos/xl_2019_X.cmake
+++ b/host-configs/lc-builds/blueos/xl_2019_X.cmake
@@ -12,6 +12,11 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -qxlcompatmacros -qlanglvl=extended0x
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -qsmp=omp:noopt " CACHE STRING "")
 set(CMAKE_EXE_LINKER_FLAGS "-Wl,-z,muldefs" CACHE STRING "")
 
+# Suppressed XLC warnings:
+# - 1500-029 cannot inline
+# - 1500-036 nostrict optimizations may alter code semantics
+#   (can be countered with -qstrict, with less optimization)
+
 set(RAJA_RANGE_ALIGN 4 CACHE STRING "")
 set(RAJA_RANGE_MIN_LENGTH 32 CACHE STRING "")
 set(RAJA_DATA_ALIGN 64 CACHE STRING "")


### PR DESCRIPTION
Added OMP Target warning suppression for "can't inline" and "nostrict -O3". Macro'ed iterables in target forall_impl's for clarity. 