### PR TITLE
Fix files so GitHub automatically picks up license and shows in banner.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -26,25 +26,3 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
 OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Additional BSD Notice
-
-1. This notice is required to be provided under our contract with the U.S.
-Department of Energy (DOE). This work was produced at Lawrence Livermore
-National Laboratory under Contract No. DE-AC52-07NA27344 with the DOE.
-
-2. Neither the United States Government nor Lawrence Livermore National
-Security, LLC nor any of their employees, makes any warranty, express or
-implied, or assumes any liability or responsibility for the accuracy,
-completeness, or usefulness of any information, apparatus, product, or
-process disclosed, or represents that its use would not infringe
-privately-owned rights.
-
-3. Also, reference herein to any specific commercial products, process,
-or services by trade name, trademark, manufacturer or otherwise does not
-necessarily constitute or imply its endorsement, recommendation, or favoring
-by the United States Government or Lawrence Livermore National Security, LLC.
-The views and opinions of authors expressed herein do not necessarily state
-or reflect those of the United States Government or Lawrence Livermore
-National Security, LLC, and shall not be used for advertising or product
-endorsement purposes.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,21 @@
+Additional BSD Notice
+
+1. This notice is required to be provided under our contract with the U.S.
+Department of Energy (DOE). This work was produced at Lawrence Livermore
+National Laboratory under Contract No. DE-AC52-07NA27344 with the DOE.
+
+2. Neither the United States Government nor Lawrence Livermore National
+Security, LLC nor any of their employees, makes any warranty, express or
+implied, or assumes any liability or responsibility for the accuracy,
+completeness, or usefulness of any information, apparatus, product, or
+process disclosed, or represents that its use would not infringe
+privately-owned rights.
+
+3. Also, reference herein to any specific commercial products, process,
+or services by trade name, trademark, manufacturer or otherwise does not
+necessarily constitute or imply its endorsement, recommendation, or favoring
+by the United States Government or Lawrence Livermore National Security, LLC.
+The views and opinions of authors expressed herein do not necessarily state
+or reflect those of the United States Government or Lawrence Livermore
+National Security, LLC, and shall not be used for advertising or product
+endorsement purposes.

--- a/README.md
+++ b/README.md
@@ -125,21 +125,51 @@ The original developers of RAJA are:
 Please see the [RAJA Contributors Page](https://github.com/LLNL/RAJA/graphs/contributors), to see the full list of contributors to the project.
 
 
-Release
+License
 -----------
 
-Copyright (c) 2016-2019, Lawrence Livermore National Security, LLC.
+RAJA is licensed under the BSD 3-Clause license,
+(BSD-3-Clause or https://opensource.org/licenses/BSD-3-Clause).
 
-Produced at the Lawrence Livermore National Laboratory.
+Copyrights and patents in the RAJA project are retained by contributors.
+No copyright assignment is required to contribute to RAJA.
 
-All rights reserved.
-
+Unlimited Open Source - BSD 3-clause Distribution
 `LLNL-CODE-689114`  `OCEC-16-063`
 
-Unlimited Open Source - BSD Distribution
-
-For release details and restrictions, please read the RELEASE, LICENSE,
-and NOTICE files, also linked here:
+For release details and restrictions, please see the information in the
+following:
 - [RELEASE](./RELEASE)
 - [LICENSE](./LICENSE)
 - [NOTICE](./NOTICE)
+
+
+SPDX usage
+------------
+
+Individual files contain SPDX tags instead of the full license text.
+This enables machine processing of license information based on the SPDX
+License Identifiers that are available here: https://spdx.org/licenses/
+
+Files that are licensed as BSD 3-Clause contain the following
+text in the license header:
+
+    SPDX-License-Identifier: (BSD-3-Clause)
+
+External Packages
+-------------------
+RAJA bundles its external dependencies as submodules in the git repository.
+These packages are covered by various permissive licenses.  A summary listing
+follows. See the license included with each package for full details.
+
+PackageName: BLT  
+PackageHomePage: https://github.com/LLNL/blt
+PackageLicenseDeclared: BSD-3-Clause  
+
+PackageName: camp
+PackageHomePage: https://github.com/LLNL/camp  
+PackageLicenseDeclared: BSD-3-Clause
+
+PackageName: CUB  
+PackageHomePage: https://github.com/NVlabs/cub
+PackageLicenseDeclared: BSD-3-Clause  

--- a/RELEASE
+++ b/RELEASE
@@ -1,6 +1,6 @@
 *******************************************************************************
 
-RAJA: ................................, version 0.8.0
+RAJA: ................................, version 0.9.0
 
 Copyright (c) 2016-19, Lawrence Livermore National Security, LLC. 
 Produced at the Lawrence Livermore National Laboratory.
@@ -16,7 +16,8 @@ Rich Hornung (hornung1@llnl.gov)
 David Beckingsale (beckingsale1@llnl.gov)
 Jason Burmark (burmark1@llnl.gov)
 Robert Chen (chen59@llnl.gov)
-Matt Cordery (cordery1@llnl.gov)
+Matt Cordery (mcorder@us.ibm.com)
+Mike Davis (davis291@llnl.gov)
 Jeff Hammond (jeff.science@gmail.com)
 Holger Jones (jones19@llnl.gov)
 Jeff Keasler (keasler1@llnl.gov)


### PR DESCRIPTION

# Summary

- This PR is a minor documentation fix
- It does the following:
  - enables GitHub to automatically pick up license information and show it in the top banner of the project home page.
