### PR TITLE
Prevent user from declaring non-RAJA-policy CudaSyncs.

### DIFF
--- a/include/RAJA/pattern/kernel/internal.hpp
+++ b/include/RAJA/pattern/kernel/internal.hpp
@@ -47,6 +47,8 @@ using StatementList = camp::list<Stmts...>;
 
 template <typename ExecPolicy, typename... EnclosedStmts>
 struct Statement {
+  Statement() = delete;
+
   using enclosed_statements_t = StatementList<EnclosedStmts...>;
   using execution_policy_t = ExecPolicy;
 };

--- a/include/RAJA/policy/cuda/kernel/Sync.hpp
+++ b/include/RAJA/policy/cuda/kernel/Sync.hpp
@@ -43,16 +43,12 @@ namespace statement
  * A RAJA::kernel statement that performs a CUDA __syncthreads().
  */
 struct CudaSyncThreads : public internal::Statement<camp::nil> {
-  private:
-  CudaSyncThreads() = default;
 };
 
 /*!
  * A RAJA::kernel statement that performs a CUDA __syncwarp().
  */
 struct CudaSyncWarp : public internal::Statement<camp::nil> {
-  private:
-  CudaSyncWarp() = default;
 };
 
 

--- a/include/RAJA/policy/cuda/kernel/Sync.hpp
+++ b/include/RAJA/policy/cuda/kernel/Sync.hpp
@@ -43,12 +43,16 @@ namespace statement
  * A RAJA::kernel statement that performs a CUDA __syncthreads().
  */
 struct CudaSyncThreads : public internal::Statement<camp::nil> {
+  private:
+  CudaSyncThreads() = default;
 };
 
 /*!
  * A RAJA::kernel statement that performs a CUDA __syncwarp().
  */
 struct CudaSyncWarp : public internal::Statement<camp::nil> {
+  private:
+  CudaSyncWarp() = default;
 };
 
 


### PR DESCRIPTION
Privatized the CudaSyncThreads and Warp constructors to prevent misuse in lambdas.