### PR TITLE
Remove deprecated IndexSet type alias and references to it.

### DIFF
--- a/docs/style_guide.md
+++ b/docs/style_guide.md
@@ -133,7 +133,7 @@ Other usages can be found under:
 
 As the RAJA codebase evolves, there may come a point where features once used have been replaced with more viable options. To aid users in transitioning from an older API call to a preferred API, we introduce deprecation macros which should *cautiously* and *effectively* be used by RAJA developers.
 
-The following macros are defined by RAJA that assist with defining deprecation attributes for Functions, Types (structs/classes), `typedefs`, and type aliases:
+The following macros are defined by RAJA that assist with defining deprecation attributes for Functions, Types (structs/classes), and type aliases:
 
 * `RAJA_DEPRECATE("Message")`
 * `RAJA_DEPRECATE_ALIAS("Message")` -- this will **only** work with a C++14 - enabled compiler
@@ -175,12 +175,6 @@ int forall(Exec && p, Index1, Index2, Body &&) {
   return 0;
 }
 
-
-// Deprecating a typedef
-////////////////////////////////////////////////////////////////////////////////
-
-RAJA_DEPRECATE("RAJA::Index_type will be removed in 2019 (JK)")
-typedef unsigned long Index_type;
 
 // Deprecating a type alias (requires C++14)
 ////////////////////////////////////////////////////////////////////////////////

--- a/examples/tut_indexset-segments.cpp
+++ b/examples/tut_indexset-segments.cpp
@@ -31,7 +31,7 @@
  *    -  Index range segment 
  *    -  Index list segment 
  *    -  Strided index range segment 
- *    -  IndexSet segment container
+ *    -  TypedIndexSet segment container
  *    -  Hierarchical execution policies
  *
  * If CUDA is enabled, CUDA unified memory is used.
@@ -102,7 +102,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //----------------------------------------------------------------------------//
 //
 // In the following, we show RAJA versions of the daxpy operation and 
-// using different Segment constructs and IndexSets. These are all 
+// using different Segment constructs and TypedIndexSets. These are all 
 // run sequentially. The only thing that changes in these versions is
 // the object passed to the 'forall' method that defines the iteration
 // space.

--- a/examples/tut_vertexsum-coloring.cpp
+++ b/examples/tut_vertexsum-coloring.cpp
@@ -31,7 +31,7 @@
  *  RAJA features shown:
  *    - `forall` loop iteration template method
  *    -  Index list segment
- *    -  IndexSet segment container
+ *    -  TypedIndexSet segment container
  *    -  Hierarchical execution policies
  *
  * If CUDA is enabled, CUDA unified memory is used.
@@ -184,7 +184,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 // Since none of the elements with the same number share a common vertex,
 // we can iterate over each subset ("color") in parallel.
 //
-// We use RAJA ListSegments and a RAJA IndexSet to define the element 
+// We use RAJA ListSegments and a RAJA TypedIndexSet to define the element 
 // partitioning. 
 //
 
@@ -218,10 +218,10 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // _colorvectors_vertexsum_end
  
 // 
-// Second, create a RAJA IndexSet with four ListSegments
+// Second, create a RAJA TypedIndexSet with four ListSegments
 //
-// The IndexSet is a variadic template, where the template arguments
-// are the segment types that the IndexSet can hold. 
+// The TypedIndexSet is a variadic template, where the template arguments
+// are the segment types that the TypedIndexSet can hold. 
 // 
   // _colorindexset_vertexsum_start
   using SegmentType = RAJA::TypedListSegment<int>;
@@ -237,7 +237,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //----------------------------------------------------------------------------//
  
 //
-// RAJA vertex volume calculation - sequential IndexSet version 
+// RAJA vertex volume calculation - sequential TypedIndexSet version 
 // (sequential iteration over segments, 
 //  sequential iteration of each segment)
 //
@@ -269,7 +269,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 #if defined(RAJA_ENABLE_OPENMP)
 //
-// RAJA vertex volume calculation - OpenMP IndexSet version
+// RAJA vertex volume calculation - OpenMP TypedIndexSet version
 // (sequential iteration over segments, 
 //  OpenMP parallel iteration of each segment)
 //
@@ -297,7 +297,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 #if defined(RAJA_ENABLE_CUDA)
 //
-// RAJA vertex volume calculation - CUDA IndexSet version
+// RAJA vertex volume calculation - CUDA TypedIndexSet version
 // (sequential iteration over segments, 
 //  CUDA parallel execution of each segment)
 //

--- a/exercises/tutorial_halfday/ex3_colored-indexset.cpp
+++ b/exercises/tutorial_halfday/ex3_colored-indexset.cpp
@@ -16,9 +16,9 @@
 #include "memoryManager.hpp"
 
 /*
- *  EXERCISE #3: Mesh vertex area with "colored" IndexSet
+ *  EXERCISE #3: Mesh vertex area with "colored" TypedIndexSet
  *
- *  In this exercise, you will use a RAJA IndexSet containing 4 
+ *  In this exercise, you will use a RAJA TypedIndexSet containing 4 
  *  ListSegments to parallelize the mesh vertex area computation.
  *  A sum is computed at each vertex on a logically-Cartesian 2D mesh
  *  where the sum represents the vertex "area" as an average of the 4
@@ -27,7 +27,7 @@
  *  contributions may be written to the same vertex value at the same time,
  *  the elements are partitioned into 4 subsets, where no two elements in
  *  each subset share a vertex. A ListSegment enumerates the elements in
- *  each subset. When the ListSegments are put into an IndexSet, the entire
+ *  each subset. When the ListSegments are put into an TypedIndexSet, the entire
  *  computation can be executed with one RAJA::forall() statement, where
  *  you iterate over the segments sequentially and execute each segment in
  *  parallel. This exercise illustrates how RAJA can be used to enable one 
@@ -42,7 +42,7 @@
  *  RAJA features you will use:
  *    - `forall` loop iteration template method
  *    -  Index list segment
- *    -  IndexSet segment container
+ *    -  TypedIndexSet segment container
  *    -  Hierarchical execution policies
  *
  * If CUDA is enabled, CUDA unified memory is used.
@@ -68,7 +68,7 @@ void printMeshData(double* v, int n, int joff);
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
 
-  std::cout << "\n\nExercise #3: Mesh vertex area with 'colored' IndexSet...\n";
+  std::cout << "\n\nExercise #3: Mesh vertex area with 'colored' TypedIndexSet...\n";
 
 //
 // 2D mesh has N^2 elements (N+1)^2 vertices.
@@ -151,7 +151,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 // Since none of the elements with the same number share a common vertex,
 // we can iterate over each subset ("color") in parallel.
 //
-// We use RAJA ListSegments and a RAJA IndexSet to define the element 
+// We use RAJA ListSegments and a RAJA TypedIndexSet to define the element 
 // partitioning. 
 //
 
@@ -215,12 +215,12 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
  
 // 
-// Create a RAJA IndexSet with four ListSegments, one for the indices of the
-// elements in each subset. This will be used in the RAJA OpenMP and CUDA 
+// Create a RAJA TypedIndexSet with four ListSegments, one for the indices of 
+// the elements in each subset. This will be used in the RAJA OpenMP and CUDA 
 // variants of the vertex sum calculation.
 //
-// The IndexSet is a variadic template, where the template arguments
-// are the segment types that the IndexSet can hold. 
+// The TypedIndexSet is a variadic template, where the template arguments
+// are the segment types that the TypedIndexSet can hold. 
 // 
 
 
@@ -234,7 +234,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 
 //----------------------------------------------------------------------------//
-// RAJA OpenMP vertex sum calculation using IndexSet (sequential iteration 
+// RAJA OpenMP vertex sum calculation using TypedIndexSet (sequential iteration 
 // over segments, OpenMP parallel iteration of each segment)
 //----------------------------------------------------------------------------//
 
@@ -266,7 +266,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 
 //----------------------------------------------------------------------------//
-// RAJA CUDA vertex sum calculation using IndexSet (sequential iteration 
+// RAJA CUDA vertex sum calculation using TypedIndexSet (sequential iteration 
 // over segments, CUDA kernel launched for each segment)
 //----------------------------------------------------------------------------//
 

--- a/exercises/tutorial_halfday/ex3_colored-indexset_solution.cpp
+++ b/exercises/tutorial_halfday/ex3_colored-indexset_solution.cpp
@@ -16,9 +16,9 @@
 #include "memoryManager.hpp"
 
 /*
- *  EXERCISE #3: Mesh vertex area with "colored" IndexSet
+ *  EXERCISE #3: Mesh vertex area with "colored" TypedIndexSet
  *
- *  In this exercise, you will use a RAJA IndexSet containing 4 
+ *  In this exercise, you will use a RAJA TypedIndexSet containing 4 
  *  ListSegments to parallelize the mesh vertex area computation.
  *  A sum is computed at each vertex on a logically-Cartesian 2D mesh
  *  where the sum represents the vertex "area" as an average of the 4
@@ -27,7 +27,7 @@
  *  contributions may be written to the same vertex value at the same time,
  *  the elements are partitioned into 4 subsets, where no two elements in
  *  each subset share a vertex. A ListSegment enumerates the elements in
- *  each subset. When the ListSegments are put into an IndexSet, the entire
+ *  each subset. When the ListSegments are put into an TypedIndexSet, the entire
  *  computation can be executed with one RAJA::forall() statement, where
  *  you iterate over the segments sequentially and execute each segment in
  *  parallel. This exercise illustrates how RAJA can be used to enable one 
@@ -42,7 +42,7 @@
  *  RAJA features you will use:
  *    - `forall` loop iteration template method
  *    -  Index list segment
- *    -  IndexSet segment container
+ *    -  TypedIndexSet segment container
  *    -  Hierarchical execution policies
  *
  * If CUDA is enabled, CUDA unified memory is used.
@@ -65,7 +65,7 @@ void printMeshData(double* v, int n, int joff);
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
 
-  std::cout << "\n\nExercise #3: Mesh vertex area with 'colored' IndexSet...\n";
+  std::cout << "\n\nExercise #3: Mesh vertex area with 'colored' TypedIndexSet...\n";
 
 //
 // 2D mesh has N^2 elements (N+1)^2 vertices.
@@ -148,7 +148,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 // Since none of the elements with the same number share a common vertex,
 // we can iterate over each subset ("color") in parallel.
 //
-// We use RAJA ListSegments and a RAJA IndexSet to define the element 
+// We use RAJA ListSegments and a RAJA TypedIndexSet to define the element 
 // partitioning. 
 //
 
@@ -212,12 +212,12 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
  
 // 
-// Create a RAJA IndexSet with four ListSegments, one for the indices of the
-// elements in each subsut. This will be used in the RAJA OpenMP and CUDA 
+// Create a RAJA TypedIndexSet with four ListSegments, one for the indices of 
+// the elements in each subsut. This will be used in the RAJA OpenMP and CUDA 
 // variants of the vertex sum calculation.
 //
-// The IndexSet is a variadic template, where the template arguments
-// are the segment types that the IndexSet can hold. 
+// The TypedIndexSet is a variadic template, where the template arguments
+// are the segment types that the TypedIndexSet can hold. 
 // 
   using SegmentType = RAJA::TypedListSegment<int>;
 
@@ -229,7 +229,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   colorset.push_back( SegmentType(&idx[3][0], idx[3].size()) ); 
 
 //----------------------------------------------------------------------------//
-// RAJA OpenMP vertex sum calculation using IndexSet (sequential iteration 
+// RAJA OpenMP vertex sum calculation using TypedIndexSet (sequential iteration 
 // over segments, OpenMP parallel iteration of each segment)
 //----------------------------------------------------------------------------//
 
@@ -258,7 +258,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 
 //----------------------------------------------------------------------------//
-// RAJA CUDA vertex sum calculation using IndexSet (sequential iteration 
+// RAJA CUDA vertex sum calculation using TypedIndexSet (sequential iteration 
 // over segments, CUDA kernel launched for each segment)
 //----------------------------------------------------------------------------//
 

--- a/include/RAJA/index/IndexSet.hpp
+++ b/include/RAJA/index/IndexSet.hpp
@@ -749,13 +749,6 @@ private:
 };
 
 
-RAJA_DEPRECATE_ALIAS(
-    "IndexSet will be deprecated soon. Please transition to TypedIndexSet")
-typedef TypedIndexSet<RAJA::RangeSegment,
-                      RAJA::ListSegment,
-                      RAJA::RangeStrideSegment>
-    IndexSet;
-
 namespace type_traits
 {
 


### PR DESCRIPTION
# Summary

- This PR is removes a deprecated feature. It may require minor RAJA usage changes to user code, depending on how they use RAJA IndexSets.
