### PR TITLE
Fix syntax of target_link_libraries

### DIFF
--- a/docs/sphinx/user_guide/using_raja.rst
+++ b/docs/sphinx/user_guide/using_raja.rst
@@ -38,4 +38,4 @@ natively by CMake to add a dependency on RAJA. For example::
   add_executable(my-app.exe
                  my-app.cpp)
 
-  target_link_libraries(my-app.exe RAJA)
+  target_link_libraries(my-app.exe PUBLIC RAJA)


### PR DESCRIPTION
# Summary

- This PR is a buffix
- It does the following:
  - Fixes incorrect syntax in documentation