### PR TITLE
Rm typedef

### DIFF
--- a/include/RAJA/util/Registry.hpp
+++ b/include/RAJA/util/Registry.hpp
@@ -45,8 +45,8 @@ namespace util {
   template <typename T>
   class Registry {
   public:
-    typedef T type;
-    typedef RegistryEntry<T> entry;
+    using type = T;
+    using entry = RegistryEntry<T>;
 
     class node;
     class iterator;

--- a/scripts/lc-builds/toss3_clang9.0.0.sh
+++ b/scripts/lc-builds/toss3_clang9.0.0.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+BUILD_SUFFIX=lc_toss3-clang-9.0.0
+
+rm -rf build_${BUILD_SUFFIX} 2>/dev/null
+mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
+
+module load cmake/3.14.5
+
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_COMPILER=/usr/tce/packages/clang/clang-9.0.0/bin/clang++ \
+  -C ../host-configs/lc-builds/toss3/clang_X.cmake \
+  -DENABLE_OPENMP=On \
+  -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
+  "$@" \
+  .. 


### PR DESCRIPTION
# Summary

- This PR converts remaining typedefs to using directives. (RAJA-184 JIRA issue)
- It also adds a build script for toss3 clang9 compiler.
