### PR TITLE
Fixing clang unused-loc-typedef warning

### DIFF
--- a/include/RAJA/index/IndexValue.hpp
+++ b/include/RAJA/index/IndexValue.hpp
@@ -366,8 +366,8 @@ template<typename FROM>
 using make_signed_t = typename std::conditional < 
                                   std::is_floating_point<FROM>::value,
                                     std::common_type<FROM>,
-				    std::make_signed<FROM>
-			        >::type::type;
+                                    std::make_signed<FROM>
+                               >::type::type;
 
 }  // namespace RAJA
 
@@ -394,17 +394,17 @@ using make_signed_t = typename std::conditional <
 /*!
  * \brief Helper Macro to create new Index types.
  * \param TYPE the name of the type
+ * \param IDXT the index types value type
  * \param NAME a string literal to identify this index type
  */
 #define RAJA_INDEX_VALUE_T(TYPE, IDXT, NAME)                         \
   class TYPE : public ::RAJA::IndexValue<TYPE, IDXT>                 \
   {                                                                  \
-    using parent = ::RAJA::IndexValue<TYPE, IDXT>;                   \
-                                                                     \
   public:                                                            \
-    RAJA_HOST_DEVICE RAJA_INLINE TYPE() : parent::IndexValue() {}    \
-    RAJA_HOST_DEVICE RAJA_INLINE explicit TYPE(::RAJA::Index_type v) \
-        : parent::IndexValue(v)                                      \
+    RAJA_HOST_DEVICE RAJA_INLINE TYPE()                              \
+        : RAJA::IndexValue<TYPE,IDXT>::IndexValue() {}               \
+    RAJA_HOST_DEVICE RAJA_INLINE explicit TYPE(IDXT v)               \
+        : RAJA::IndexValue<TYPE,IDXT>::IndexValue(v)                 \
     {                                                                \
     }                                                                \
     static inline std::string getName() { return NAME; }             \

--- a/test/unit/index/test-indexvalue.cpp
+++ b/test/unit/index/test-indexvalue.cpp
@@ -13,14 +13,14 @@ template<typename T>
 class IndexValueTest : public ::testing::Test {};
 
 using MyTypes = ::testing::Types<RAJA::Index_type,
-				 int,
-				 unsigned int,
-				 long,
-				 unsigned long,
-				 long int,
-				 unsigned long int,
-				 long long,
-				 unsigned long long>;
+                                 int,
+                                 unsigned int,
+                                 long,
+                                 unsigned long,
+                                 long int,
+                                 unsigned long int,
+                                 long long,
+                                 unsigned long long>;
 
 TYPED_TEST_CASE(IndexValueTest, MyTypes);
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Fixes unused-loc-typedef warning with clang generated by RAJA_INDEX_VALUE_T macro in IndexValue.hpp
  - Replaces tabs with spaces in related IndexValue files