### PR TITLE
Ensure foralls always call wrap::forall

### DIFF
--- a/include/RAJA/pattern/forall.hpp
+++ b/include/RAJA/pattern/forall.hpp
@@ -463,7 +463,7 @@ RAJA_INLINE void forall(Args&&... args)
   util::callPreLaunchPlugins(context); 
 
   RAJA_FORCEINLINE_RECURSIVE
-  forall(ExecutionPolicy(), std::forward<Args>(args)...);
+  wrap::forall(ExecutionPolicy(), std::forward<Args>(args)...);
 
   util::callPostLaunchPlugins(context);
 }

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -3,10 +3,8 @@
 # and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
-###############################################################################
+################################################################################
 
-include_directories(include)
-
-add_subdirectory(unit)
-
-add_subdirectory(integration)
+raja_add_test(
+  NAME test-plugin
+  SOURCES test_plugin.cpp plugin_for_test.cpp)

--- a/test/integration/counter.hpp
+++ b/test/integration/counter.hpp
@@ -1,0 +1,13 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-19, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+#ifndef  RAJA_counter_HPP
+#define  RAJA_counter_HPP
+
+extern int plugin_test_counter_pre;
+extern int plugin_test_counter_post;
+
+#endif  // RAJA_counter_HPP

--- a/test/integration/plugin_for_test.cpp
+++ b/test/integration/plugin_for_test.cpp
@@ -1,0 +1,27 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-19, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+#include "RAJA/util/PluginStrategy.hpp"
+
+#include <iostream>
+
+#include "counter.hpp"
+
+class CounterPlugin :
+  public RAJA::util::PluginStrategy
+{
+  public:
+  void preLaunch(RAJA::util::PluginContext RAJA_UNUSED_ARG(p)) {
+    plugin_test_counter_pre++;
+  }
+
+  void postLaunch(RAJA::util::PluginContext RAJA_UNUSED_ARG(p)) {
+    plugin_test_counter_post++;
+  }
+};
+
+// Regiser plugin with the PluginRegistry
+static RAJA::util::PluginRegistry::Add<CounterPlugin> P("counter-plugin", "Counter");

--- a/test/integration/test_plugin.cpp
+++ b/test/integration/test_plugin.cpp
@@ -1,0 +1,33 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-19, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+#include "RAJA/RAJA.hpp"
+#include "counter.hpp"
+
+#include "gtest/gtest.h"
+
+int plugin_test_counter_pre{0};
+int plugin_test_counter_post{0};
+
+// Check that the plugin is called the correct number of times, once before and
+// after each kernel invocation
+TEST(PluginTest, Counter)
+{
+  int* a = new int[10];
+
+  for (int i = 0; i < 10; i++) {
+    RAJA::forall<RAJA::seq_exec>(
+      RAJA::RangeSegment(0,10), 
+      [=] (int i) {
+        a[i] = 0;
+    });
+  }
+
+  ASSERT_EQ(plugin_test_counter_pre, 10);
+  ASSERT_EQ(plugin_test_counter_post, 10);
+
+  delete[] a;
+}


### PR DESCRIPTION
This addresses an issue where plugins can be triggered multiple times

# Summary

- This PR is a bugfix
- It does the following:
  - Fixes #691 
  - Modifies one `RAJA::forall` to call `wrap::forall` internally, rather than the generic `forall` again.
  - Adds a test to ensure this won't happen again.
