### PR TITLE
Improving cache use in CudaKernel launcher

### DIFF
--- a/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
+++ b/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
@@ -349,8 +349,24 @@ struct CudaLaunchHelper<cuda_launch<async0, num_blocks, num_threads>,StmtList,Da
       //
       // determine blocks at runtime
       //
-      internal::cuda_occupancy_max_blocks<Self>(
-          func, shmem_size, max_blocks, actual_threads);
+      if (num_threads <= 0 ||
+          num_threads != actual_threads) {
+
+        //
+        // determine blocks when actual_threads != num_threads
+        //
+        internal::cuda_occupancy_max_blocks<Self>(
+            func, shmem_size, max_blocks, actual_threads);
+
+      } else {
+
+        //
+        // determine blocks when actual_threads == num_threads
+        //
+        internal::cuda_occupancy_max_blocks<Self, num_threads>(
+            func, shmem_size, max_blocks);
+
+      }
 
     } else {
 


### PR DESCRIPTION


# Summary

- This PR improves caching of cuda occupancy calculator results in the CudaKernel launcher.
