### PR TITLE
HIP Constructor Fix

### DIFF
--- a/include/RAJA/pattern/detail/reduce.hpp
+++ b/include/RAJA/pattern/detail/reduce.hpp
@@ -117,13 +117,17 @@ public:
   T val = doing_min ? operators::limits<T>::max() : operators::limits<T>::min();
   IndexType loc = DefaultLoc<IndexType>().value();
 
+#if __NVCC__ && defined(CUDART_VERSION) && CUDART_VERSION < 9020
   RAJA_HOST_DEVICE constexpr ValueLoc() {}
   RAJA_HOST_DEVICE constexpr ValueLoc(ValueLoc const &other) : val{other.val}, loc{other.loc} {}
-
-#if (defined(CUDART_VERSION) && CUDART_VERSION < 9020) || defined(__HIPCC__)
   RAJA_HOST_DEVICE
-#endif
   ValueLoc &operator=(ValueLoc const &other) { val = other.val; loc = other.loc; return *this;}
+#else
+  RAJA_HOST_DEVICE constexpr ValueLoc() = default;
+  RAJA_HOST_DEVICE constexpr ValueLoc(ValueLoc const &other) = default;
+  RAJA_HOST_DEVICE
+  ValueLoc &operator=(ValueLoc const &other) = default;
+#endif
 
   RAJA_HOST_DEVICE constexpr ValueLoc(T const &val) : val{val}, loc{DefaultLoc<IndexType>().value()} {}
   RAJA_HOST_DEVICE constexpr ValueLoc(T const &val, IndexType const &loc)

--- a/scripts/lc-builds/corona_hipcc.sh
+++ b/scripts/lc-builds/corona_hipcc.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+BUILD_SUFFIX=lc_corona-hipcc
+
+rm -rf build_${BUILD_SUFFIX} >/dev/null
+mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
+
+#============= For LC Corona ONLY =============
+export PATH=/usr/workspace/wsb/raja-dev/opt/hip-clang/bin:$PATH
+export HIP_CLANG_PATH=/usr/workspace/wsb/raja-dev/opt/llvm/bin
+export DEVICE_LIB_PATH=/usr/workspace/wsb/raja-dev/opt/lib
+export HCC_AMDGPU_TARGET=gfx900
+module load opt
+module load dts/7.1
+module load rocm
+#==============================================
+
+module load cmake/3.14.5
+
+cmake \
+  -C ../host-configs/hip.cmake \
+  ..


### PR DESCRIPTION
# Summary

- This PR is a bugfix.
- It does the following (modify list as needed):
  - Fixes build failure of nvcc10+gcc7.3.1. Compiler was unable to modify ValueLoc operator= with RAJA_HOST_DEVICE. Now, uses default constructors for nvcc > 9.2 and HIP.
  - Adds HIP build script for Corona.