### PR TITLE
Functional Tests for Old Atomics

### DIFF
--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -507,8 +507,38 @@ RAJA_INLINE __device__ unsigned long long cuda_atomicXor<unsigned long long>(
 template <typename T>
 RAJA_INLINE __device__ T cuda_atomicExchange(T volatile *acc, T value)
 {
-  // attempt to use the CUDA builtin atomic, if it exists for T
-  return ::atomicExch((T *)acc, value);
+  return cuda_atomic_CAS_oper(acc, [=] __device__(T) {
+    return value;
+  });
+}
+
+template <>
+RAJA_INLINE __device__ int cuda_atomicExchange<int>(
+    int volatile *acc, int value)
+{
+  return ::atomicExch((int *)acc, value);
+}
+
+template <>
+RAJA_INLINE __device__ unsigned cuda_atomicExchange<unsigned>(
+    unsigned volatile *acc, unsigned value)
+{
+  return ::atomicExch((unsigned *)acc, value);
+}
+
+template <>
+RAJA_INLINE __device__ unsigned long long cuda_atomicExchange<unsigned long long>(
+    unsigned long long volatile *acc,
+    unsigned long long value)
+{
+  return ::atomicExch((unsigned long long *)acc, value);
+}
+
+template <>
+RAJA_INLINE __device__ float cuda_atomicExchange<float>(
+    float volatile *acc, float value)
+{
+  return ::atomicExch((float *)acc, value);
 }
 #endif
 

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -486,10 +486,45 @@ RAJA_INLINE __device__ unsigned long long hip_atomicXor<unsigned long long>(
 template <typename T>
 RAJA_INLINE __device__ T hip_atomicExchange(T volatile *acc, T value)
 {
-  // attempt to use the HIP builtin atomic, if it exists for T
-  return ::atomicExch((T *)acc, value);
+  return hip_atomic_CAS_oper(acc, [=] __device__(T) {
+    return value;
+  });
 }
 
+#if __HIP_ARCH_HAS_GLOBAL_INT32_ATOMICS__
+template <>
+RAJA_INLINE __device__ int hip_atomicExchange<int>(
+    int volatile *acc, int value)
+{
+  return ::atomicExch((int *)acc, value);
+}
+
+template <>
+RAJA_INLINE __device__ unsigned hip_atomicExchange<unsigned>(
+    unsigned volatile *acc, unsigned value)
+{
+  return ::atomicExch((unsigned *)acc, value);
+}
+#endif
+
+#if __HIP_ARCH_HAS_GLOBAL_INT64_ATOMICS__
+template <>
+RAJA_INLINE __device__ unsigned long long hip_atomicExchange<unsigned long long>(
+    unsigned long long volatile *acc,
+    unsigned long long value)
+{
+  return ::atomicExch((unsigned long long *)acc, value);
+}
+#endif
+
+#if __HIP_ARCH_HAS_GLOBAL_FLOAT_ATOMIC_EXCH__
+template <>
+RAJA_INLINE __device__ float hip_atomicExchange<float>(
+    float volatile *acc, float value)
+{
+  return ::atomicExch((float *)acc, value);
+}
+#endif
 
 template <typename T>
 RAJA_INLINE __device__ T hip_atomicCAS(T volatile *acc, T compare, T value)

--- a/test/functional/CMakeLists.txt
+++ b/test/functional/CMakeLists.txt
@@ -5,13 +5,5 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-include_directories(include)
-
-add_subdirectory(integration)
-
-add_subdirectory(functional)
-
-add_subdirectory(unit)
-
-add_subdirectory(old-tests)
+add_subdirectory(atomic)
 

--- a/test/functional/atomic/CMakeLists.txt
+++ b/test/functional/atomic/CMakeLists.txt
@@ -1,0 +1,31 @@
+###############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+raja_add_test(
+  NAME test-atomic-forall-basic
+  SOURCES test-atomic-forall-basic.cpp)
+
+raja_add_test(
+  NAME test-atomic-forall-view
+  SOURCES test-atomic-forall-view.cpp)
+
+raja_add_test(
+  NAME test-atomic-ref-forall-math
+  SOURCES test-atomic-ref-forall-math.cpp)
+
+raja_add_test(
+  NAME test-atomic-ref-forall-math-auto
+  SOURCES test-atomic-ref-forall-math-auto.cpp)
+
+raja_add_test(
+  NAME test-atomic-ref-forall-other
+  SOURCES test-atomic-ref-forall-other.cpp)
+
+raja_add_test(
+  NAME test-atomic-ref-forall-other-auto
+  SOURCES test-atomic-ref-forall-other-auto.cpp)
+

--- a/test/functional/atomic/test-atomic-forall-basic.cpp
+++ b/test/functional/atomic/test-atomic-forall-basic.cpp
@@ -11,28 +11,29 @@
 
 #include "test-atomic-forall-basic.hpp"
 
+
 // top layer of function templates for tests
 template <typename ExecPolicy, typename AtomicPolicy>
 void testAtomicFunctionPol()
 {
-  testAtomicFunctionBasic<ExecPolicy, AtomicPolicy, int, 10000>();
-  testAtomicFunctionBasic<ExecPolicy, AtomicPolicy, unsigned, 10000>();
-  testAtomicFunctionBasic<ExecPolicy, AtomicPolicy, long long, 10000>();
+  testAtomicFunctionBasic<ExecPolicy, AtomicPolicy, int, tenk>();
+  testAtomicFunctionBasic<ExecPolicy, AtomicPolicy, unsigned, tenk>();
+  testAtomicFunctionBasic<ExecPolicy, AtomicPolicy, long long, tenk>();
   testAtomicFunctionBasic<ExecPolicy,
                           AtomicPolicy,
                           unsigned long long,
-                          10000>();
-  testAtomicFunctionBasic<ExecPolicy, AtomicPolicy, float, 10000>();
-  testAtomicFunctionBasic<ExecPolicy, AtomicPolicy, double, 10000>();
+                          tenk>();
+  testAtomicFunctionBasic<ExecPolicy, AtomicPolicy, float, tenk>();
+  testAtomicFunctionBasic<ExecPolicy, AtomicPolicy, double, tenk>();
 }
 
 template <typename ExecPolicy, typename AtomicPolicy>
 void testAtomicLogicalPol()
 {
-  testAtomicLogical<ExecPolicy, AtomicPolicy, int, 100000>();
-  testAtomicLogical<ExecPolicy, AtomicPolicy, unsigned, 100000>();
-  testAtomicLogical<ExecPolicy, AtomicPolicy, long long, 100000>();
-  testAtomicLogical<ExecPolicy, AtomicPolicy, unsigned long long, 100000>();
+  testAtomicLogical<ExecPolicy, AtomicPolicy, int, hundredk>();
+  testAtomicLogical<ExecPolicy, AtomicPolicy, unsigned, hundredk>();
+  testAtomicLogical<ExecPolicy, AtomicPolicy, long long, hundredk>();
+  testAtomicLogical<ExecPolicy, AtomicPolicy, unsigned long long, hundredk>();
 }
 
 // test instantiations

--- a/test/functional/atomic/test-atomic-forall-basic.cpp
+++ b/test/functional/atomic/test-atomic-forall-basic.cpp
@@ -1,0 +1,119 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-19, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Source file containing basic functional tests for atomic operations with forall.
+///
+
+#include "test-atomic-forall-basic.hpp"
+
+// top layer of function templates for tests
+template <typename ExecPolicy, typename AtomicPolicy>
+void testAtomicFunctionPol()
+{
+  testAtomicFunctionBasic<ExecPolicy, AtomicPolicy, int, 10000>();
+  testAtomicFunctionBasic<ExecPolicy, AtomicPolicy, unsigned, 10000>();
+  testAtomicFunctionBasic<ExecPolicy, AtomicPolicy, long long, 10000>();
+  testAtomicFunctionBasic<ExecPolicy,
+                          AtomicPolicy,
+                          unsigned long long,
+                          10000>();
+  testAtomicFunctionBasic<ExecPolicy, AtomicPolicy, float, 10000>();
+  testAtomicFunctionBasic<ExecPolicy, AtomicPolicy, double, 10000>();
+}
+
+template <typename ExecPolicy, typename AtomicPolicy>
+void testAtomicLogicalPol()
+{
+  testAtomicLogical<ExecPolicy, AtomicPolicy, int, 100000>();
+  testAtomicLogical<ExecPolicy, AtomicPolicy, unsigned, 100000>();
+  testAtomicLogical<ExecPolicy, AtomicPolicy, long long, 100000>();
+  testAtomicLogical<ExecPolicy, AtomicPolicy, unsigned long long, 100000>();
+}
+
+// test instantiations
+#if defined(RAJA_ENABLE_OPENMP)
+
+TEST(Atomic, OpenMP_auto_AtomicFuncFunctionalTest)
+{
+  testAtomicFunctionPol<RAJA::omp_for_exec, RAJA::auto_atomic>();
+}
+TEST(Atomic, OpenMP_omp_AtomicFuncFunctionalTest)
+{
+  testAtomicFunctionPol<RAJA::omp_for_exec, RAJA::omp_atomic>();
+}
+TEST(Atomic, OpenMP_builtin_AtomicFuncFunctionalTest)
+{
+  testAtomicFunctionPol<RAJA::omp_for_exec, RAJA::builtin_atomic>();
+}
+
+
+TEST(Atomic, OpenMP_auto_AtomicLogicalFunctionalTest)
+{
+  testAtomicLogicalPol<RAJA::omp_for_exec, RAJA::auto_atomic>();
+}
+TEST(Atomic, OpenMP_omp_AtomicLogicalFunctionalTest)
+{
+  testAtomicLogicalPol<RAJA::omp_for_exec, RAJA::omp_atomic>();
+}
+TEST(Atomic, OpenMP_builtin_AtomicLogicalFunctionalTest)
+{
+  testAtomicLogicalPol<RAJA::omp_for_exec, RAJA::builtin_atomic>();
+}
+
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
+
+GPU_TEST(Atomic, CUDA_auto_AtomicFuncFunctionalTest)
+{
+  testAtomicFunctionPol<RAJA::cuda_exec<256>, RAJA::auto_atomic>();
+}
+GPU_TEST(Atomic, CUDA_cuda_AtomicFuncFunctionalTest)
+{
+  testAtomicFunctionPol<RAJA::cuda_exec<256>, RAJA::cuda_atomic>();
+}
+
+
+GPU_TEST(Atomic, CUDA_auto_AtomicLogicalFunctionalTest)
+{
+  testAtomicLogicalPol<RAJA::cuda_exec<256>, RAJA::auto_atomic>();
+}
+GPU_TEST(Atomic, CUDA_cuda_AtomicLogicalFunctionalTest)
+{
+  testAtomicLogicalPol<RAJA::cuda_exec<256>, RAJA::cuda_atomic>();
+}
+
+
+#endif
+
+TEST(Atomic, basic_auto_AtomicFuncFunctionalTest)
+{
+  testAtomicFunctionPol<RAJA::seq_exec, RAJA::auto_atomic>();
+}
+TEST(Atomic, basic_seq_AtomicFuncFunctionalTest)
+{
+  testAtomicFunctionPol<RAJA::seq_exec, RAJA::seq_atomic>();
+}
+TEST(Atomic, basic_atomic_AtomicFuncFunctionalTest)
+{
+  testAtomicFunctionPol<RAJA::seq_exec, RAJA::builtin_atomic>();
+}
+
+
+TEST(Atomic, basic_auto_AtomicLogicalFunctionalTest)
+{
+  testAtomicLogicalPol<RAJA::seq_exec, RAJA::auto_atomic>();
+}
+TEST(Atomic, basic_seq_AtomicLogicalFunctionalTest)
+{
+  testAtomicLogicalPol<RAJA::seq_exec, RAJA::seq_atomic>();
+}
+TEST(Atomic, basic_builtin_AtomicLogicalFunctionalTest)
+{
+  testAtomicLogicalPol<RAJA::seq_exec, RAJA::builtin_atomic>();
+}

--- a/test/functional/atomic/test-atomic-forall-basic.cpp
+++ b/test/functional/atomic/test-atomic-forall-basic.cpp
@@ -9,6 +9,7 @@
 /// Source file containing basic functional tests for atomic operations with forall.
 ///
 
+#include "RAJA_gtest.hpp"
 #include "test-atomic-forall-basic.hpp"
 
 
@@ -118,3 +119,35 @@ TEST(Atomic, basic_builtin_AtomicLogicalFunctionalTest)
 {
   testAtomicLogicalPol<RAJA::seq_exec, RAJA::builtin_atomic>();
 }
+
+// Type parameterized test for experimentation/discussion.
+TYPED_TEST_P(AtomicFuncBasicFunctionalTest, auto_basic_AtomicFuncFunctionalTest)
+{
+  testAtomicFunctionBasicV2<RAJA::seq_exec, RAJA::auto_atomic, TypeParam>( tenk );
+}
+TYPED_TEST_P(AtomicFuncBasicFunctionalTest, seq_basic_AtomicFuncFunctionalTest)
+{
+  testAtomicFunctionBasicV2<RAJA::seq_exec, RAJA::seq_atomic, TypeParam>( tenk );
+}
+TYPED_TEST_P(AtomicFuncBasicFunctionalTest, builtin_basic_AtomicFuncFunctionalTest)
+{
+  testAtomicFunctionBasicV2<RAJA::seq_exec, RAJA::builtin_atomic, TypeParam>( tenk );
+}
+
+REGISTER_TYPED_TEST_CASE_P( AtomicFuncBasicFunctionalTest,
+                            auto_basic_AtomicFuncFunctionalTest,
+                            seq_basic_AtomicFuncFunctionalTest,
+                            builtin_basic_AtomicFuncFunctionalTest
+                          );
+
+using seqtypes = ::testing::Types<
+                          int,
+                          unsigned,
+                          long long,
+                          unsigned long long,
+                          float,
+                          double
+                 >;
+
+INSTANTIATE_TYPED_TEST_CASE_P( AtomicBasicFunctionalTest, AtomicFuncBasicFunctionalTest, seqtypes );
+// END Type parameterized test for experimentation/discussion.

--- a/test/functional/atomic/test-atomic-forall-basic.hpp
+++ b/test/functional/atomic/test-atomic-forall-basic.hpp
@@ -11,6 +11,7 @@
 
 #include <RAJA/RAJA.hpp>
 #include "RAJA_gtest.hpp"
+#include "RAJA_value_params.hpp"
 
 
 template <typename ExecPolicy,

--- a/test/functional/atomic/test-atomic-forall-basic.hpp
+++ b/test/functional/atomic/test-atomic-forall-basic.hpp
@@ -1,0 +1,147 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-19, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Header file containing basic functional tests for atomic operations with forall.
+///
+
+#include <RAJA/RAJA.hpp>
+#include "RAJA_gtest.hpp"
+
+
+template <typename ExecPolicy,
+          typename AtomicPolicy,
+          typename T,
+          RAJA::Index_type N>
+void testAtomicFunctionBasic()
+{
+  RAJA::RangeSegment seg(0, N);
+
+// initialize an array
+#if defined(RAJA_ENABLE_CUDA)
+  T *dest = nullptr;
+  cudaErrchk(cudaMallocManaged((void **)&dest, sizeof(T) * 8));
+
+  cudaErrchk(cudaDeviceSynchronize());
+
+#else
+  T *dest = new T[8];
+#endif
+
+
+  // use atomic add to reduce the array
+  dest[0] = (T)0;
+  dest[1] = (T)N;
+  dest[2] = (T)N;
+  dest[3] = (T)0;
+  dest[4] = (T)0;
+  dest[5] = (T)0;
+  dest[6] = (T)N + 1;
+  dest[7] = (T)0;
+
+
+  RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(RAJA::Index_type i) {
+    RAJA::atomicAdd<AtomicPolicy>(dest + 0, (T)1);
+    RAJA::atomicSub<AtomicPolicy>(dest + 1, (T)1);
+
+    RAJA::atomicMin<AtomicPolicy>(dest + 2, (T)i);
+    RAJA::atomicMax<AtomicPolicy>(dest + 3, (T)i);
+    RAJA::atomicInc<AtomicPolicy>(dest + 4);
+    RAJA::atomicInc<AtomicPolicy>(dest + 5, (T)16);
+    RAJA::atomicDec<AtomicPolicy>(dest + 6);
+    RAJA::atomicDec<AtomicPolicy>(dest + 7, (T)16);
+  });
+
+#if defined(RAJA_ENABLE_CUDA)
+  cudaErrchk(cudaDeviceSynchronize());
+#endif
+
+  EXPECT_EQ((T)N, dest[0]);
+  EXPECT_EQ((T)0, dest[1]);
+  EXPECT_EQ((T)0, dest[2]);
+  EXPECT_EQ((T)N - 1, dest[3]);
+  EXPECT_EQ((T)N, dest[4]);
+  EXPECT_EQ((T)4, dest[5]);
+  EXPECT_EQ((T)1, dest[6]);
+  EXPECT_EQ((T)13, dest[7]);
+
+
+#if defined(RAJA_ENABLE_CUDA)
+  cudaErrchk(cudaFree(dest));
+#else
+  delete[] dest;
+#endif
+}
+
+
+
+
+template <typename ExecPolicy,
+          typename AtomicPolicy,
+          typename T,
+          RAJA::Index_type N>
+void testAtomicLogical()
+{
+  RAJA::RangeSegment seg(0, N * 8);
+  RAJA::RangeSegment seg_bytes(0, N);
+
+// initialize an array
+#if defined(RAJA_ENABLE_CUDA)
+  T *dest_and = nullptr;
+  cudaErrchk(cudaMallocManaged((void **)&dest_and, sizeof(T) * N));
+
+  T *dest_or = nullptr;
+  cudaErrchk(cudaMallocManaged((void **)&dest_or, sizeof(T) * N));
+
+  T *dest_xor = nullptr;
+  cudaErrchk(cudaMallocManaged((void **)&dest_xor, sizeof(T) * N));
+
+  cudaErrchk(cudaDeviceSynchronize());
+#else
+  T *dest_and = new T[N];
+  T *dest_or = new T[N];
+  T *dest_xor = new T[N];
+#endif
+
+  RAJA::forall<RAJA::seq_exec>(seg_bytes, [=](RAJA::Index_type i) {
+    dest_and[i] = (T)0;
+    dest_or[i] = (T)0;
+    dest_xor[i] = (T)0;
+  });
+
+
+  RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(RAJA::Index_type i) {
+    RAJA::Index_type offset = i / 8;
+    RAJA::Index_type bit = i % 8;
+    RAJA::atomicAnd<AtomicPolicy>(dest_and + offset,
+                                          (T)(0xFF ^ (1 << bit)));
+    RAJA::atomicOr<AtomicPolicy>(dest_or + offset, (T)(1 << bit));
+    RAJA::atomicXor<AtomicPolicy>(dest_xor + offset, (T)(1 << bit));
+  });
+
+#if defined(RAJA_ENABLE_CUDA)
+  cudaErrchk(cudaDeviceSynchronize());
+#endif
+
+  for (RAJA::Index_type i = 0; i < N; ++i) {
+    EXPECT_EQ((T)0x00, dest_and[i]);
+    EXPECT_EQ((T)0xFF, dest_or[i]);
+    EXPECT_EQ((T)0xFF, dest_xor[i]);
+  }
+
+#if defined(RAJA_ENABLE_CUDA)
+  cudaErrchk(cudaFree(dest_and));
+  cudaErrchk(cudaFree(dest_or));
+  cudaErrchk(cudaFree(dest_xor));
+#else
+  delete[] dest_and;
+  delete[] dest_or;
+  delete[] dest_xor;
+#endif
+}
+
+

--- a/test/functional/atomic/test-atomic-forall-view.cpp
+++ b/test/functional/atomic/test-atomic-forall-view.cpp
@@ -15,12 +15,12 @@
 template <typename ExecPolicy, typename AtomicPolicy>
 void testAtomicViewPol()
 {
-  testAtomicViewBasic<ExecPolicy, AtomicPolicy, int, 100000>();
-  testAtomicViewBasic<ExecPolicy, AtomicPolicy, unsigned, 100000>();
-  testAtomicViewBasic<ExecPolicy, AtomicPolicy, long long, 100000>();
-  testAtomicViewBasic<ExecPolicy, AtomicPolicy, unsigned long long, 100000>();
-  testAtomicViewBasic<ExecPolicy, AtomicPolicy, float, 100000>();
-  testAtomicViewBasic<ExecPolicy, AtomicPolicy, double, 100000>();
+  testAtomicViewBasic<ExecPolicy, AtomicPolicy, int, hundredk>();
+  testAtomicViewBasic<ExecPolicy, AtomicPolicy, unsigned, hundredk>();
+  testAtomicViewBasic<ExecPolicy, AtomicPolicy, long long, hundredk>();
+  testAtomicViewBasic<ExecPolicy, AtomicPolicy, unsigned long long, hundredk>();
+  testAtomicViewBasic<ExecPolicy, AtomicPolicy, float, hundredk>();
+  testAtomicViewBasic<ExecPolicy, AtomicPolicy, double, hundredk>();
 }
 
 // test instantiations

--- a/test/functional/atomic/test-atomic-forall-view.cpp
+++ b/test/functional/atomic/test-atomic-forall-view.cpp
@@ -1,0 +1,69 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-19, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Source file containing basic functional tests for atomic operations with forall and views.
+///
+
+#include "test-atomic-forall-view.hpp"
+
+// top layer of function templates for tests
+template <typename ExecPolicy, typename AtomicPolicy>
+void testAtomicViewPol()
+{
+  testAtomicViewBasic<ExecPolicy, AtomicPolicy, int, 100000>();
+  testAtomicViewBasic<ExecPolicy, AtomicPolicy, unsigned, 100000>();
+  testAtomicViewBasic<ExecPolicy, AtomicPolicy, long long, 100000>();
+  testAtomicViewBasic<ExecPolicy, AtomicPolicy, unsigned long long, 100000>();
+  testAtomicViewBasic<ExecPolicy, AtomicPolicy, float, 100000>();
+  testAtomicViewBasic<ExecPolicy, AtomicPolicy, double, 100000>();
+}
+
+// test instantiations
+#if defined(RAJA_ENABLE_OPENMP)
+
+TEST(Atomic, OpenMP_auto_AtomicViewFunctionalTest)
+{
+  testAtomicViewPol<RAJA::omp_for_exec, RAJA::auto_atomic>();
+}
+TEST(Atomic, OpenMP_omp_AtomicViewFunctionalTest)
+{
+  testAtomicViewPol<RAJA::omp_for_exec, RAJA::omp_atomic>();
+}
+TEST(Atomic, OpenMP_builtin_AtomicViewFunctionalTest)
+{
+  testAtomicViewPol<RAJA::omp_for_exec, RAJA::builtin_atomic>();
+}
+
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
+
+GPU_TEST(Atomic, CUDA_auto_AtomicViewFunctionalTest)
+{
+  testAtomicViewPol<RAJA::cuda_exec<256>, RAJA::auto_atomic>();
+}
+GPU_TEST(Atomic, CUDA_cuda_AtomicViewFunctionalTest)
+{
+  testAtomicViewPol<RAJA::cuda_exec<256>, RAJA::cuda_atomic>();
+}
+
+#endif
+
+TEST(Atomic, basic_auto_AtomicViewFunctionalTest)
+{
+  testAtomicViewPol<RAJA::seq_exec, RAJA::auto_atomic>();
+}
+TEST(Atomic, basic_seq_AtomicViewFunctionalTest)
+{
+  testAtomicViewPol<RAJA::seq_exec, RAJA::seq_atomic>();
+}
+TEST(Atomic, basic_builtin_AtomicViewFunctionalTest)
+{
+  testAtomicViewPol<RAJA::seq_exec, RAJA::builtin_atomic>();
+}
+

--- a/test/functional/atomic/test-atomic-forall-view.hpp
+++ b/test/functional/atomic/test-atomic-forall-view.hpp
@@ -1,0 +1,76 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-19, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Header file containing basic functional tests for atomic operations with forall and views.
+///
+
+#include <RAJA/RAJA.hpp>
+#include "RAJA_gtest.hpp"
+
+
+template <typename ExecPolicy,
+          typename AtomicPolicy,
+          typename T,
+          RAJA::Index_type N>
+void testAtomicViewBasic()
+{
+  RAJA::RangeSegment seg(0, N);
+  RAJA::RangeSegment seg_half(0, N / 2);
+
+// initialize an array
+#if defined(RAJA_ENABLE_CUDA)
+  T *source = nullptr;
+  cudaErrchk(cudaMallocManaged((void **)&source, sizeof(T) * N));
+
+  T *dest = nullptr;
+  cudaErrchk(cudaMallocManaged((void **)&dest, sizeof(T) * N / 2));
+
+  cudaErrchk(cudaDeviceSynchronize());
+#else
+  T *source = new T[N];
+  T *dest = new T[N / 2];
+#endif
+
+  RAJA::forall<RAJA::seq_exec>(seg,
+                               [=](RAJA::Index_type i) { source[i] = (T)1; });
+
+  // use atomic add to reduce the array
+  RAJA::View<T, RAJA::Layout<1>> vec_view(source, N);
+
+  RAJA::View<T, RAJA::Layout<1>> sum_view(dest, N);
+  auto sum_atomic_view = RAJA::make_atomic_view<AtomicPolicy>(sum_view);
+
+
+  // Zero out dest using atomic view
+  RAJA::forall<ExecPolicy>(seg_half, [=] RAJA_HOST_DEVICE(RAJA::Index_type i) {
+    sum_atomic_view(i) = (T)0;
+  });
+
+  // Assign values to dest using atomic view
+  RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(RAJA::Index_type i) {
+    sum_atomic_view(i / 2) += vec_view(i);
+  });
+
+#if defined(RAJA_ENABLE_CUDA)
+  cudaErrchk(cudaDeviceSynchronize());
+#endif
+
+  for (RAJA::Index_type i = 0; i < N / 2; ++i) {
+    EXPECT_EQ((T)2, dest[i]);
+  }
+
+#if defined(RAJA_ENABLE_CUDA)
+  cudaErrchk(cudaFree(source));
+  cudaErrchk(cudaFree(dest));
+#else
+  delete[] source;
+  delete[] dest;
+#endif
+}
+
+

--- a/test/functional/atomic/test-atomic-forall-view.hpp
+++ b/test/functional/atomic/test-atomic-forall-view.hpp
@@ -11,6 +11,7 @@
 
 #include <RAJA/RAJA.hpp>
 #include "RAJA_gtest.hpp"
+#include "RAJA_value_params.hpp"
 
 
 template <typename ExecPolicy,

--- a/test/functional/atomic/test-atomic-ref-forall-math-auto.cpp
+++ b/test/functional/atomic/test-atomic-ref-forall-math-auto.cpp
@@ -1,0 +1,60 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-19, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-689114
+//
+// All rights reserved.
+//
+// This file is part of RAJA.
+//
+// For details about use and distribution, please read RAJA/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Source file containing tests for arithmetic atomic operations
+///
+
+#include "test-atomic-ref-forall-math.hpp"
+
+// top layer of function templates for tests
+template <typename ExecPolicy, typename AtomicPolicy>
+void testAtomicRefPol()
+{
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, int, 10000>();
+  #if defined(TEST_EXHAUSTIVE)
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned, 10000>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, long long, 10000>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned long long, 10000>();
+
+  testAtomicRefFloating<ExecPolicy, AtomicPolicy, float, 10000>();
+  #endif
+  testAtomicRefFloating<ExecPolicy, AtomicPolicy, double, 10000>();
+}
+
+// test instantiations
+#if defined(RAJA_ENABLE_OPENMP)
+
+TEST(Atomic, OpenMP_auto_AtomicRefForallFunctionalTest)
+{
+  testAtomicRefPol<RAJA::omp_for_exec, RAJA::auto_atomic>();
+}
+
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
+
+GPU_TEST(Atomic, CUDA_auto_AtomicRefForallFunctionalTest)
+{
+  testAtomicRefPol<RAJA::cuda_exec<256>, RAJA::auto_atomic>();
+}
+
+#endif
+
+TEST(Atomic, basic_auto_AtomicRefForallFunctionalTest)
+{
+  testAtomicRefPol<RAJA::seq_exec, RAJA::auto_atomic>();
+}
+

--- a/test/functional/atomic/test-atomic-ref-forall-math-auto.cpp
+++ b/test/functional/atomic/test-atomic-ref-forall-math-auto.cpp
@@ -23,15 +23,15 @@
 template <typename ExecPolicy, typename AtomicPolicy>
 void testAtomicRefPol()
 {
-  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, int, 10000>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, int, tenk>();
   #if defined(TEST_EXHAUSTIVE)
-  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned, 10000>();
-  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, long long, 10000>();
-  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned long long, 10000>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned, tenk>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, long long, tenk>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned long long, tenk>();
 
-  testAtomicRefFloating<ExecPolicy, AtomicPolicy, float, 10000>();
+  testAtomicRefFloating<ExecPolicy, AtomicPolicy, float, tenk>();
   #endif
-  testAtomicRefFloating<ExecPolicy, AtomicPolicy, double, 10000>();
+  testAtomicRefFloating<ExecPolicy, AtomicPolicy, double, tenk>();
 }
 
 // test instantiations

--- a/test/functional/atomic/test-atomic-ref-forall-math.cpp
+++ b/test/functional/atomic/test-atomic-ref-forall-math.cpp
@@ -1,0 +1,70 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-19, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-689114
+//
+// All rights reserved.
+//
+// This file is part of RAJA.
+//
+// For details about use and distribution, please read RAJA/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Source file containing tests for arithmetic atomic operations
+///
+
+#include "test-atomic-ref-forall-math.hpp"
+
+// top layer of function templates for tests
+template <typename ExecPolicy, typename AtomicPolicy>
+void testAtomicRefPol()
+{
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, int, 10000>();
+  #if defined(TEST_EXHAUSTIVE)
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned, 10000>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, long long, 10000>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned long long, 10000>();
+
+  testAtomicRefFloating<ExecPolicy, AtomicPolicy, float, 10000>();
+  #endif
+  testAtomicRefFloating<ExecPolicy, AtomicPolicy, double, 10000>();
+}
+
+// test instantiations
+#if defined(RAJA_ENABLE_OPENMP)
+TEST(Atomic, OpenMP_omp_AtomicRefForallFunctionalTest)
+{
+  testAtomicRefPol<RAJA::omp_for_exec, RAJA::omp_atomic>();
+}
+
+TEST(Atomic, OpenMP_builtin_AtomicRefForallFunctionalTest)
+{
+  testAtomicRefPol<RAJA::omp_for_exec, RAJA::builtin_atomic>();
+}
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
+
+GPU_TEST(Atomic, CUDA_cuda_AtomicRefForallFunctionalTest)
+{
+  testAtomicRefPol<RAJA::cuda_exec<256>, RAJA::cuda_atomic>();
+}
+
+#endif
+
+#if defined(TEST_EXHAUSTIVE) || !defined(RAJA_ENABLE_OPENMP)
+TEST(Atomic, basic_seq_AtomicRefForallFunctionalTest)
+{
+  testAtomicRefPol<RAJA::seq_exec, RAJA::seq_atomic>();
+}
+
+TEST(Atomic, basic_builtin_AtomicRefForallFunctionalTest)
+{
+  testAtomicRefPol<RAJA::seq_exec, RAJA::builtin_atomic>();
+}
+#endif
+

--- a/test/functional/atomic/test-atomic-ref-forall-math.cpp
+++ b/test/functional/atomic/test-atomic-ref-forall-math.cpp
@@ -23,15 +23,15 @@
 template <typename ExecPolicy, typename AtomicPolicy>
 void testAtomicRefPol()
 {
-  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, int, 10000>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, int, tenk>();
   #if defined(TEST_EXHAUSTIVE)
-  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned, 10000>();
-  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, long long, 10000>();
-  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned long long, 10000>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned, tenk>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, long long, tenk>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned long long, tenk>();
 
-  testAtomicRefFloating<ExecPolicy, AtomicPolicy, float, 10000>();
+  testAtomicRefFloating<ExecPolicy, AtomicPolicy, float, tenk>();
   #endif
-  testAtomicRefFloating<ExecPolicy, AtomicPolicy, double, 10000>();
+  testAtomicRefFloating<ExecPolicy, AtomicPolicy, double, tenk>();
 }
 
 // test instantiations

--- a/test/functional/atomic/test-atomic-ref-forall-math.hpp
+++ b/test/functional/atomic/test-atomic-ref-forall-math.hpp
@@ -1,0 +1,312 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-19, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-689114
+//
+// All rights reserved.
+//
+// This file is part of RAJA.
+//
+// For details about use and distribution, please read RAJA/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Source file containing basic functional tests for arithmetic atomic operations using forall
+///
+
+#include <RAJA/RAJA.hpp>
+#include "RAJA_gtest.hpp"
+#include <type_traits>
+
+template < typename T >
+RAJA_INLINE
+RAJA_HOST_DEVICE
+typename std::enable_if<sizeof(T) == 1, T>::type np2m1(T val)
+{
+  val |= val >> 1  ;
+  val |= val >> 2  ;
+  val |= val >> 4  ;
+  return val;
+}
+
+template < typename T >
+RAJA_INLINE
+RAJA_HOST_DEVICE
+typename std::enable_if<sizeof(T) == 2, T>::type np2m1(T val)
+{
+  val |= val >> 1  ;
+  val |= val >> 2  ;
+  val |= val >> 4  ;
+  val |= val >> 8  ;
+  return val;
+}
+
+template < typename T >
+RAJA_INLINE
+RAJA_HOST_DEVICE
+typename std::enable_if<sizeof(T) == 4, T>::type np2m1(T val)
+{
+  val |= val >> 1  ;
+  val |= val >> 2  ;
+  val |= val >> 4  ;
+  val |= val >> 8  ;
+  val |= val >> 16 ;
+  return val;
+}
+
+template < typename T >
+RAJA_INLINE
+RAJA_HOST_DEVICE
+typename std::enable_if<sizeof(T) == 8, T>::type np2m1(T val)
+{
+  val |= val >> 1  ;
+  val |= val >> 2  ;
+  val |= val >> 4  ;
+  val |= val >> 8  ;
+  val |= val >> 16 ;
+  val |= val >> 32 ;
+  return val;
+}
+
+template < typename T >
+RAJA_INLINE
+RAJA_HOST_DEVICE
+typename std::enable_if<sizeof(T) == 16, T>::type np2m1(T val)
+{
+  val |= val >> 1  ;
+  val |= val >> 2  ;
+  val |= val >> 4  ;
+  val |= val >> 8  ;
+  val |= val >> 16 ;
+  val |= val >> 32 ;
+  val |= val >> 64 ;
+  return val;
+}
+
+template < typename T, typename AtomicPolicy >
+struct PreIncCountOp {
+  PreIncCountOp(T* count, RAJA::RangeSegment seg)
+    : counter(count), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
+  { count[0] = (T)0; }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const {
+      return (++counter) - (T)1;
+    }
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
+  T min, max, final;
+};
+
+template < typename T, typename AtomicPolicy >
+struct PostIncCountOp {
+  PostIncCountOp(T* count, RAJA::RangeSegment seg)
+    : counter(count), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
+  { count[0] = (T)0; }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const {
+      return (counter++);
+    }
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
+  T min, max, final;
+};
+
+template < typename T, typename AtomicPolicy >
+struct AddEqCountOp {
+  AddEqCountOp(T* count, RAJA::RangeSegment seg)
+    : counter(count), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
+  { count[0] = (T)0; }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const {
+      return (counter += (T)1) - (T)1;
+    }
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
+  T min, max, final;
+};
+
+template < typename T, typename AtomicPolicy >
+struct FetchAddCountOp {
+  FetchAddCountOp(T* count, RAJA::RangeSegment seg)
+    : counter(count), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
+  { count[0] = (T)0; }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const {
+      return counter.fetch_add((T)1);
+    }
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
+  T min, max, final;
+};
+
+template < typename T, typename AtomicPolicy >
+struct PreDecCountOp {
+  PreDecCountOp(T* count, RAJA::RangeSegment seg)
+    : counter(count), min((T)0), max((T)seg.size()-(T)1), final((T)0)
+  { count[0] = (T)seg.size(); }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const {
+      return (--counter);
+    }
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
+  T min, max, final;
+};
+
+template < typename T, typename AtomicPolicy >
+struct PostDecCountOp {
+  PostDecCountOp(T* count, RAJA::RangeSegment seg)
+    : counter(count), min((T)0), max((T)seg.size()-(T)1), final((T)0)
+  { count[0] = (T)seg.size(); }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const {
+      return (counter--) - (T)1;
+    }
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
+  T min, max, final;
+};
+
+template < typename T, typename AtomicPolicy >
+struct SubEqCountOp {
+  SubEqCountOp(T* count, RAJA::RangeSegment seg)
+    : counter(count), min((T)0), max((T)seg.size()-(T)1), final((T)0)
+  { count[0] = (T)seg.size(); }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const {
+      return (counter -= (T)1);
+    }
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
+  T min, max, final;
+};
+
+template < typename T, typename AtomicPolicy >
+struct FetchSubCountOp {
+  FetchSubCountOp(T* count, RAJA::RangeSegment seg)
+    : counter(count), min((T)0), max((T)seg.size()-(T)1), final((T)0)
+  { count[0] = (T)seg.size(); }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const {
+      return counter.fetch_sub((T)1) - (T)1;
+    }
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
+  T min, max, final;
+};
+
+template <typename ExecPolicy,
+         typename AtomicPolicy,
+         typename T,
+  template <typename, typename> class CountOp>
+void testAtomicRefCount(RAJA::RangeSegment seg,
+    T* count, T* list, bool* hit)
+{
+  CountOp<T, AtomicPolicy> countop(count, seg);
+  RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(RAJA::Index_type i) {
+      list[i] = countop.max + (T)1;
+      hit[i] = false;
+      });
+  RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(RAJA::Index_type i) {
+      T val = countop(i);
+      list[i] = val;
+      hit[(RAJA::Index_type)val] = true;
+      });
+#if defined(RAJA_ENABLE_CUDA)
+  cudaErrchk(cudaDeviceSynchronize());
+#endif
+  EXPECT_EQ(countop.final, count[0]);
+  for (RAJA::Index_type i = 0; i < seg.size(); i++) {
+    EXPECT_LE(countop.min, list[i]);
+    EXPECT_GE(countop.max, list[i]);
+    EXPECT_TRUE(hit[i]);
+  }
+}
+
+
+template <typename ExecPolicy,
+         typename AtomicPolicy,
+         typename T,
+  RAJA::Index_type N>
+void testAtomicRefIntegral()
+{
+  RAJA::RangeSegment seg(0, N);
+
+  // initialize an array
+#if defined(RAJA_ENABLE_CUDA)
+  T *count = nullptr;
+  cudaErrchk(cudaMallocManaged((void **)&count, sizeof(T) * 1));
+  T *list;
+  cudaErrchk(cudaMallocManaged((void **)&list, sizeof(T) * N));
+  bool *hit;
+  cudaErrchk(cudaMallocManaged((void **)&hit, sizeof(bool) * N));
+  cudaErrchk(cudaDeviceSynchronize());
+#else
+  T *count  = new T[1];
+  T *list   = new T[N];
+  bool *hit = new bool[N];
+#endif
+
+  testAtomicRefCount<ExecPolicy, AtomicPolicy, T, PreIncCountOp  >(seg, count, list, hit);
+  testAtomicRefCount<ExecPolicy, AtomicPolicy, T, PostIncCountOp >(seg, count, list, hit);
+  testAtomicRefCount<ExecPolicy, AtomicPolicy, T, AddEqCountOp   >(seg, count, list, hit);
+  testAtomicRefCount<ExecPolicy, AtomicPolicy, T, FetchAddCountOp>(seg, count, list, hit);
+
+  testAtomicRefCount<ExecPolicy, AtomicPolicy, T, PreDecCountOp  >(seg, count, list, hit);
+  testAtomicRefCount<ExecPolicy, AtomicPolicy, T, PostDecCountOp >(seg, count, list, hit);
+  testAtomicRefCount<ExecPolicy, AtomicPolicy, T, SubEqCountOp   >(seg, count, list, hit);
+  testAtomicRefCount<ExecPolicy, AtomicPolicy, T, FetchSubCountOp>(seg, count, list, hit);
+
+#if defined(RAJA_ENABLE_CUDA)
+  cudaErrchk(cudaFree(hit));
+  cudaErrchk(cudaFree(list));
+  cudaErrchk(cudaFree(count));
+#else
+  delete[] hit;
+  delete[] list;
+  delete[] count;
+#endif
+}
+
+
+
+template <typename ExecPolicy,
+         typename AtomicPolicy,
+         typename T,
+  RAJA::Index_type N>
+void testAtomicRefFloating()
+{
+  RAJA::RangeSegment seg(0, N);
+
+  // initialize an array
+#if defined(RAJA_ENABLE_CUDA)
+  T *count = nullptr;
+  cudaErrchk(cudaMallocManaged((void **)&count, sizeof(T) * 1));
+  T *list;
+  cudaErrchk(cudaMallocManaged((void **)&list, sizeof(T) * N));
+  bool *hit;
+  cudaErrchk(cudaMallocManaged((void **)&hit, sizeof(bool) * N));
+  cudaErrchk(cudaDeviceSynchronize());
+#else
+  T *count  = new T[1];
+  T *list   = new T[N];
+  bool *hit = new bool[N];
+#endif
+
+  testAtomicRefCount<ExecPolicy, AtomicPolicy, T, PreIncCountOp  >(seg, count, list, hit);
+  testAtomicRefCount<ExecPolicy, AtomicPolicy, T, PostIncCountOp >(seg, count, list, hit);
+  testAtomicRefCount<ExecPolicy, AtomicPolicy, T, AddEqCountOp   >(seg, count, list, hit);
+  testAtomicRefCount<ExecPolicy, AtomicPolicy, T, FetchAddCountOp>(seg, count, list, hit);
+
+  testAtomicRefCount<ExecPolicy, AtomicPolicy, T, PreDecCountOp  >(seg, count, list, hit);
+  testAtomicRefCount<ExecPolicy, AtomicPolicy, T, PostDecCountOp >(seg, count, list, hit);
+  testAtomicRefCount<ExecPolicy, AtomicPolicy, T, SubEqCountOp   >(seg, count, list, hit);
+  testAtomicRefCount<ExecPolicy, AtomicPolicy, T, FetchSubCountOp>(seg, count, list, hit);
+
+#if defined(RAJA_ENABLE_CUDA)
+  cudaErrchk(cudaFree(hit));
+  cudaErrchk(cudaFree(list));
+  cudaErrchk(cudaFree(count));
+#else
+  delete[] hit;
+  delete[] list;
+  delete[] count;
+#endif
+}
+
+

--- a/test/functional/atomic/test-atomic-ref-forall-math.hpp
+++ b/test/functional/atomic/test-atomic-ref-forall-math.hpp
@@ -20,6 +20,7 @@
 #include <RAJA/RAJA.hpp>
 #include "RAJA_gtest.hpp"
 #include <type_traits>
+#include "RAJA_value_params.hpp"
 
 template < typename T >
 RAJA_INLINE

--- a/test/functional/atomic/test-atomic-ref-forall-other-auto.cpp
+++ b/test/functional/atomic/test-atomic-ref-forall-other-auto.cpp
@@ -23,15 +23,15 @@
 template <typename ExecPolicy, typename AtomicPolicy>
 void testAtomicRefPol()
 {
-  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, int, 10000>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, int, tenk>();
   #if defined(TEST_EXHAUSTIVE)
-  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned, 10000>();
-  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, long long, 10000>();
-  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned long long, 10000>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned, tenk>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, long long, tenk>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned long long, tenk>();
 
-  testAtomicRefFloating<ExecPolicy, AtomicPolicy, float, 10000>();
+  testAtomicRefFloating<ExecPolicy, AtomicPolicy, float, tenk>();
   #endif
-  testAtomicRefFloating<ExecPolicy, AtomicPolicy, double, 10000>();
+  testAtomicRefFloating<ExecPolicy, AtomicPolicy, double, tenk>();
 }
 
 // test instantiations

--- a/test/functional/atomic/test-atomic-ref-forall-other-auto.cpp
+++ b/test/functional/atomic/test-atomic-ref-forall-other-auto.cpp
@@ -1,0 +1,56 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-19, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-689114
+//
+// All rights reserved.
+//
+// This file is part of RAJA.
+//
+// For details about use and distribution, please read RAJA/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Source file containing tests for atomic operations
+///
+
+#include "test-atomic-ref-forall-other.hpp"
+
+// top layer of function templates for tests
+template <typename ExecPolicy, typename AtomicPolicy>
+void testAtomicRefPol()
+{
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, int, 10000>();
+  #if defined(TEST_EXHAUSTIVE)
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned, 10000>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, long long, 10000>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned long long, 10000>();
+
+  testAtomicRefFloating<ExecPolicy, AtomicPolicy, float, 10000>();
+  #endif
+  testAtomicRefFloating<ExecPolicy, AtomicPolicy, double, 10000>();
+}
+
+// test instantiations
+#if defined(RAJA_ENABLE_OPENMP)
+TEST(Atomic, OpenMP_auto_AtomicRefOtherFunctionalTest)
+{
+  testAtomicRefPol<RAJA::omp_for_exec, RAJA::auto_atomic>();
+}
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
+GPU_TEST(Atomic, CUDA_auto_AtomicRefOtherFunctionalTest)
+{
+  testAtomicRefPol<RAJA::cuda_exec<256>, RAJA::auto_atomic>();
+}
+#endif
+
+TEST(Atomic, basic_auto_AtomicRefOtherFunctionalTest)
+{
+  testAtomicRefPol<RAJA::seq_exec, RAJA::auto_atomic>();
+}
+

--- a/test/functional/atomic/test-atomic-ref-forall-other.cpp
+++ b/test/functional/atomic/test-atomic-ref-forall-other.cpp
@@ -23,15 +23,15 @@
 template <typename ExecPolicy, typename AtomicPolicy>
 void testAtomicRefPol()
 {
-  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, int, 10000>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, int, tenk>();
   #if defined(TEST_EXHAUSTIVE)
-  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned, 10000>();
-  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, long long, 10000>();
-  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned long long, 10000>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned, tenk>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, long long, tenk>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned long long, tenk>();
 
-  testAtomicRefFloating<ExecPolicy, AtomicPolicy, float, 10000>();
+  testAtomicRefFloating<ExecPolicy, AtomicPolicy, float, tenk>();
   #endif
-  testAtomicRefFloating<ExecPolicy, AtomicPolicy, double, 10000>();
+  testAtomicRefFloating<ExecPolicy, AtomicPolicy, double, tenk>();
 }
 
 

--- a/test/functional/atomic/test-atomic-ref-forall-other.cpp
+++ b/test/functional/atomic/test-atomic-ref-forall-other.cpp
@@ -1,0 +1,69 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-19, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-689114
+//
+// All rights reserved.
+//
+// This file is part of RAJA.
+//
+// For details about use and distribution, please read RAJA/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Source file containing tests for logical, accessor, min/max, and cas atomic operations
+///
+
+#include "test-atomic-ref-forall-other.hpp"
+
+// top layer of function templates for tests
+template <typename ExecPolicy, typename AtomicPolicy>
+void testAtomicRefPol()
+{
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, int, 10000>();
+  #if defined(TEST_EXHAUSTIVE)
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned, 10000>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, long long, 10000>();
+  testAtomicRefIntegral<ExecPolicy, AtomicPolicy, unsigned long long, 10000>();
+
+  testAtomicRefFloating<ExecPolicy, AtomicPolicy, float, 10000>();
+  #endif
+  testAtomicRefFloating<ExecPolicy, AtomicPolicy, double, 10000>();
+}
+
+
+// test instantiations
+#if defined(RAJA_ENABLE_OPENMP)
+TEST(Atomic, OpenMP_omp_AtomicRefOtherFunctionalTest)
+{
+  testAtomicRefPol<RAJA::omp_for_exec, RAJA::omp_atomic>();
+}
+
+TEST(Atomic, OpenMP_builtin_AtomicRefOtherFunctionalTest)
+{
+  testAtomicRefPol<RAJA::omp_for_exec, RAJA::builtin_atomic>();
+}
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
+GPU_TEST(Atomic, CUDA_cuda_AtomicRefOtherFunctionalTest)
+{
+  testAtomicRefPol<RAJA::cuda_exec<256>, RAJA::cuda_atomic>();
+}
+#endif
+
+#if defined(TEST_EXHAUSTIVE) || !defined(RAJA_ENABLE_OPENMP)
+TEST(Atomic, basic_seq_AtomicRefOtherFunctionalTest)
+{
+  testAtomicRefPol<RAJA::seq_exec, RAJA::seq_atomic>();
+}
+
+TEST(Atomic, basic_builtin_AtomicRefOtherFunctionalTest)
+{
+  testAtomicRefPol<RAJA::seq_exec, RAJA::builtin_atomic>();
+}
+#endif
+

--- a/test/functional/atomic/test-atomic-ref-forall-other.hpp
+++ b/test/functional/atomic/test-atomic-ref-forall-other.hpp
@@ -21,6 +21,7 @@
 #include <RAJA/RAJA.hpp>
 #include "RAJA_gtest.hpp"
 #include <type_traits>
+#include "RAJA_value_params.hpp"
 
 template < typename T >
 RAJA_INLINE

--- a/test/functional/atomic/test-atomic-ref-forall-other.hpp
+++ b/test/functional/atomic/test-atomic-ref-forall-other.hpp
@@ -1,0 +1,461 @@
+
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-19, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-689114
+//
+// All rights reserved.
+//
+// This file is part of RAJA.
+//
+// For details about use and distribution, please read RAJA/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Source file containing basic functional tests for non-arithmetic atomic operations using forall
+///
+
+#include <RAJA/RAJA.hpp>
+#include "RAJA_gtest.hpp"
+#include <type_traits>
+
+template < typename T >
+RAJA_INLINE
+RAJA_HOST_DEVICE
+typename std::enable_if<sizeof(T) == 1, T>::type np2m1(T val)
+{
+  val |= val >> 1  ;
+  val |= val >> 2  ;
+  val |= val >> 4  ;
+  return val;
+}
+
+template < typename T >
+RAJA_INLINE
+RAJA_HOST_DEVICE
+typename std::enable_if<sizeof(T) == 2, T>::type np2m1(T val)
+{
+  val |= val >> 1  ;
+  val |= val >> 2  ;
+  val |= val >> 4  ;
+  val |= val >> 8  ;
+  return val;
+}
+
+template < typename T >
+RAJA_INLINE
+RAJA_HOST_DEVICE
+typename std::enable_if<sizeof(T) == 4, T>::type np2m1(T val)
+{
+  val |= val >> 1  ;
+  val |= val >> 2  ;
+  val |= val >> 4  ;
+  val |= val >> 8  ;
+  val |= val >> 16 ;
+  return val;
+}
+
+template < typename T >
+RAJA_INLINE
+RAJA_HOST_DEVICE
+typename std::enable_if<sizeof(T) == 8, T>::type np2m1(T val)
+{
+  val |= val >> 1  ;
+  val |= val >> 2  ;
+  val |= val >> 4  ;
+  val |= val >> 8  ;
+  val |= val >> 16 ;
+  val |= val >> 32 ;
+  return val;
+}
+
+template < typename T >
+RAJA_INLINE
+RAJA_HOST_DEVICE
+typename std::enable_if<sizeof(T) == 16, T>::type np2m1(T val)
+{
+  val |= val >> 1  ;
+  val |= val >> 2  ;
+  val |= val >> 4  ;
+  val |= val >> 8  ;
+  val |= val >> 16 ;
+  val |= val >> 32 ;
+  val |= val >> 64 ;
+  return val;
+}
+
+template < typename T, typename AtomicPolicy >
+struct AndEqOtherOp {
+  AndEqOtherOp(T* count, RAJA::RangeSegment seg)
+    : other(count), min(T(0)), max((T)seg.size()),
+    final_min(min), final_max(min)
+  { count[0] = np2m1((T)seg.size()); }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type i) const
+    { return other &= (T)i; }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
+  T min, max, final_min, final_max;
+};
+
+template < typename T, typename AtomicPolicy >
+struct FetchAndOtherOp {
+  FetchAndOtherOp(T* count, RAJA::RangeSegment seg)
+    : other(count), min(T(0)), max(np2m1((T)seg.size())),
+    final_min(min), final_max(min)
+  { count[0] = max; }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type i) const
+    { return other.fetch_and((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
+  T min, max, final_min, final_max;
+};
+
+template < typename T, typename AtomicPolicy >
+struct OrEqOtherOp {
+  OrEqOtherOp(T* count, RAJA::RangeSegment seg)
+    : other(count), min(T(0)), max(np2m1((T)seg.size())),
+    final_min(max), final_max(max)
+  { count[0] = T(0); }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type i) const
+    { return other |= (T)i; }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
+  T min, max, final_min, final_max;
+};
+
+template < typename T, typename AtomicPolicy >
+struct FetchOrOtherOp {
+  FetchOrOtherOp(T* count, RAJA::RangeSegment seg)
+    : other(count), min(T(0)), max(np2m1((T)seg.size())),
+    final_min(max), final_max(max)
+  { count[0] = T(0); }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type i) const
+    { return other.fetch_or((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
+  T min, max, final_min, final_max;
+};
+
+template < typename T, typename AtomicPolicy >
+struct XorEqOtherOp {
+  XorEqOtherOp(T* count, RAJA::RangeSegment seg)
+    : other(count), min(T(0)), max(np2m1((T)seg.size())),
+    final_min(min), final_max(min)
+  { count[0] = T(0);
+    for (RAJA::Index_type i = 0; i < seg.size(); ++i) {
+      final_min ^= (T)i; final_max ^= (T)i;
+    } }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type i) const
+    { return other ^= (T)i; }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
+  T min, max, final_min, final_max;
+};
+
+template < typename T, typename AtomicPolicy >
+struct FetchXorOtherOp {
+  FetchXorOtherOp(T* count, RAJA::RangeSegment seg)
+    : other(count), min(T(0)), max(np2m1((T)seg.size())),
+    final_min(min), final_max(min)
+  { count[0] = T(0);
+    for (RAJA::Index_type i = 0; i < seg.size(); ++i) {
+      final_min ^= (T)i; final_max ^= (T)i;
+    } }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type i) const
+    { return other.fetch_xor((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
+  T min, max, final_min, final_max;
+};
+
+template < typename T, typename AtomicPolicy >
+struct LoadOtherOp {
+  LoadOtherOp(T* count, RAJA::RangeSegment seg)
+    : other(count), min((T)seg.size()), max(min),
+    final_min(min), final_max(min)
+  { count[0] = min; }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const
+    { return other.load(); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
+  T min, max, final_min, final_max;
+};
+
+template < typename T, typename AtomicPolicy >
+struct OperatorTOtherOp {
+  OperatorTOtherOp(T* count, RAJA::RangeSegment RAJA_UNUSED_ARG(seg))
+    : other(count), min(T(0)), max(min),
+    final_min(min), final_max(min)
+  { count[0] = min; }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type RAJA_UNUSED_ARG(i)) const
+    { return other; }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
+  T min, max, final_min, final_max;
+};
+
+template < typename T, typename AtomicPolicy >
+struct StoreOtherOp {
+  StoreOtherOp(T* count, RAJA::RangeSegment seg)
+    : other(count), min((T)0), max((T)seg.size() - (T)1),
+    final_min(min), final_max(max)
+  { count[0] = (T)seg.size(); }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type i) const
+    { other.store((T)i); return (T)i; }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
+  T min, max, final_min, final_max;
+};
+
+template < typename T, typename AtomicPolicy >
+struct AssignOtherOp {
+  AssignOtherOp(T* count, RAJA::RangeSegment seg)
+    : other(count), min(T(0)), max((T)seg.size() - (T)1),
+    final_min(min), final_max(max)
+  { count[0] = (T)seg.size(); }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type i) const
+    { return (other = (T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
+  T min, max, final_min, final_max;
+};
+
+template < typename T, typename AtomicPolicy >
+struct CASOtherOp {
+  CASOtherOp(T* count, RAJA::RangeSegment seg)
+    : other(count), min((T)0), max((T)seg.size() - (T)1),
+    final_min(min), final_max(max)
+  { count[0] = (T)0; }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type i) const
+    {
+      T received, expect = (T)0;
+      while ((received = other.CAS(expect, (T)i)) != expect) {
+        expect = received;
+      }
+      return received;
+    }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
+  T min, max, final_min, final_max;
+};
+
+template < typename T, typename AtomicPolicy >
+struct CompareExchangeWeakOtherOp {
+  CompareExchangeWeakOtherOp(T* count, RAJA::RangeSegment seg)
+    : other(count), min((T)0), max((T)seg.size() - (T)1),
+    final_min(min), final_max(max)
+  { count[0] = (T)0; }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type i) const
+    {
+      T expect = (T)0;
+      while (!other.compare_exchange_weak(expect, (T)i)) {}
+      return expect;
+    }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
+  T min, max, final_min, final_max;
+};
+
+template < typename T, typename AtomicPolicy >
+struct CompareExchangeStrongOtherOp {
+  CompareExchangeStrongOtherOp(T* count, RAJA::RangeSegment seg)
+    : other(count), min((T)0), max((T)seg.size() - (T)1),
+    final_min(min), final_max(max)
+  { count[0] = (T)0; }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type i) const
+    {
+      T expect = (T)0;
+      while (!other.compare_exchange_strong(expect, (T)i)) {}
+      return expect;
+    }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
+  T min, max, final_min, final_max;
+};
+
+template < typename T, typename AtomicPolicy >
+struct MaxEqOtherOp {
+  MaxEqOtherOp(T* count, RAJA::RangeSegment seg)
+    : other(count), min(T(0)), max((T)seg.size() - (T)1),
+    final_min(max), final_max(max)
+  { count[0] = (T)0; }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type i) const
+    { return other.max((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
+  T min, max, final_min, final_max;
+};
+
+template < typename T, typename AtomicPolicy >
+struct FetchMaxOtherOp {
+  FetchMaxOtherOp(T* count, RAJA::RangeSegment seg)
+    : other(count), min(T(0)), max((T)seg.size() - (T)1),
+    final_min(max), final_max(max)
+  { count[0] = (T)0; }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type i) const
+    { return other.fetch_max((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
+  T min, max, final_min, final_max;
+};
+
+template < typename T, typename AtomicPolicy >
+struct MinEqOtherOp {
+  MinEqOtherOp(T* count, RAJA::RangeSegment seg)
+    : other(count), min(T(0)), max((T)seg.size() - (T)1),
+    final_min(min), final_max(min)
+  { count[0] = (T)seg.size(); }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type i) const
+    { return other.min((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
+  T min, max, final_min, final_max;
+};
+
+template < typename T, typename AtomicPolicy >
+struct FetchMinOtherOp {
+  FetchMinOtherOp(T* count, RAJA::RangeSegment seg)
+    : other(count), min(T(0)), max((T)seg.size()),
+    final_min(min), final_max(min)
+  { count[0] = (T)seg.size(); }
+  RAJA_HOST_DEVICE
+    T operator()(RAJA::Index_type i) const
+    { return other.fetch_min((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
+  T min, max, final_min, final_max;
+};
+
+
+template <typename ExecPolicy,
+         typename AtomicPolicy,
+         typename T,
+  template <typename, typename> class OtherOp>
+void testAtomicRefOther(RAJA::RangeSegment seg, T* count, T* list)
+{
+  OtherOp<T, AtomicPolicy> otherop(count, seg);
+  RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(RAJA::Index_type i) {
+      list[i] = otherop.max + (T)1;
+      });
+  RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(RAJA::Index_type i) {
+      T val = otherop(i);
+      list[i] = val;
+      });
+#if defined(RAJA_ENABLE_CUDA)
+  cudaErrchk(cudaDeviceSynchronize());
+#endif
+  EXPECT_LE(otherop.final_min, count[0]);
+  EXPECT_GE(otherop.final_max, count[0]);
+  for (RAJA::Index_type i = 0; i < seg.size(); i++) {
+    EXPECT_LE(otherop.min, list[i]);
+    EXPECT_GE(otherop.max, list[i]);
+  }
+}
+
+
+
+template <typename ExecPolicy,
+         typename AtomicPolicy,
+         typename T,
+  RAJA::Index_type N>
+void testAtomicRefIntegral()
+{
+  RAJA::RangeSegment seg(0, N);
+
+  // initialize an array
+#if defined(RAJA_ENABLE_CUDA)
+  T *count = nullptr;
+  cudaErrchk(cudaMallocManaged((void **)&count, sizeof(T) * 1));
+  T *list;
+  cudaErrchk(cudaMallocManaged((void **)&list, sizeof(T) * N));
+  bool *hit;
+  cudaErrchk(cudaMallocManaged((void **)&hit, sizeof(bool) * N));
+  cudaErrchk(cudaDeviceSynchronize());
+#else
+  T *count  = new T[1];
+  T *list   = new T[N];
+  bool *hit = new bool[N];
+#endif
+
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, LoadOtherOp     >(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, OperatorTOtherOp>(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, StoreOtherOp    >(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, AssignOtherOp   >(seg, count, list);
+
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, CASOtherOp                  >(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, CompareExchangeWeakOtherOp  >(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, CompareExchangeStrongOtherOp>(seg, count, list);
+
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, MaxEqOtherOp   >(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, FetchMaxOtherOp>(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, MinEqOtherOp   >(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, FetchMinOtherOp>(seg, count, list);
+
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, AndEqOtherOp   >(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, FetchAndOtherOp>(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, OrEqOtherOp    >(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, FetchOrOtherOp >(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, XorEqOtherOp   >(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, FetchXorOtherOp>(seg, count, list);
+
+#if defined(RAJA_ENABLE_CUDA)
+  cudaErrchk(cudaFree(hit));
+  cudaErrchk(cudaFree(list));
+  cudaErrchk(cudaFree(count));
+#else
+  delete[] hit;
+  delete[] list;
+  delete[] count;
+#endif
+}
+
+template <typename ExecPolicy,
+         typename AtomicPolicy,
+         typename T,
+  RAJA::Index_type N>
+void testAtomicRefFloating()
+{
+  RAJA::RangeSegment seg(0, N);
+
+  // initialize an array
+#if defined(RAJA_ENABLE_CUDA)
+  T *count = nullptr;
+  cudaErrchk(cudaMallocManaged((void **)&count, sizeof(T) * 1));
+  T *list;
+  cudaErrchk(cudaMallocManaged((void **)&list, sizeof(T) * N));
+  bool *hit;
+  cudaErrchk(cudaMallocManaged((void **)&hit, sizeof(bool) * N));
+  cudaErrchk(cudaDeviceSynchronize());
+#else
+  T *count  = new T[1];
+  T *list   = new T[N];
+  bool *hit = new bool[N];
+#endif
+
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, LoadOtherOp     >(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, OperatorTOtherOp>(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, StoreOtherOp    >(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, AssignOtherOp   >(seg, count, list);
+
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, CASOtherOp                  >(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, CompareExchangeWeakOtherOp  >(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, CompareExchangeStrongOtherOp>(seg, count, list);
+
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, MaxEqOtherOp   >(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, FetchMaxOtherOp>(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, MinEqOtherOp   >(seg, count, list);
+  testAtomicRefOther<ExecPolicy, AtomicPolicy, T, FetchMinOtherOp>(seg, count, list);
+
+#if defined(RAJA_ENABLE_CUDA)
+  cudaErrchk(cudaFree(hit));
+  cudaErrchk(cudaFree(list));
+  cudaErrchk(cudaFree(count));
+#else
+  delete[] hit;
+  delete[] list;
+  delete[] count;
+#endif
+}
+

--- a/test/include/RAJA_value_params.hpp
+++ b/test/include/RAJA_value_params.hpp
@@ -1,0 +1,13 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Header file of value parameter macros for tests.
+///
+
+#define tenk 10000
+#define hundredk 100000

--- a/test/unit/atomic/test-atomic-ref-accessors.cpp
+++ b/test/unit/atomic/test-atomic-ref-accessors.cpp
@@ -76,7 +76,7 @@ class AtomicRefCUDAAccessorUnitTest : public ::testing::Test
 
 TYPED_TEST_CASE_P( AtomicRefCUDAAccessorUnitTest );
 
-CUDA_TYPED_TEST_P( AtomicRefCUDAAccessorUnitTest, CUDAAccessors )
+GPU_TYPED_TEST_P( AtomicRefCUDAAccessorUnitTest, CUDAAccessors )
 {
   using T = typename std::tuple_element<0, TypeParam>::type;
   using AtomicPolicy = typename std::tuple_element<1, TypeParam>::type;

--- a/test/unit/atomic/test-atomic-ref-addsub.cpp
+++ b/test/unit/atomic/test-atomic-ref-addsub.cpp
@@ -88,7 +88,7 @@ class AtomicRefCUDAAddSubUnitTest : public ::testing::Test
 
 TYPED_TEST_CASE_P( AtomicRefCUDAAddSubUnitTest );
 
-CUDA_TYPED_TEST_P( AtomicRefCUDAAddSubUnitTest, CUDAAddSubs )
+GPU_TYPED_TEST_P( AtomicRefCUDAAddSubUnitTest, CUDAAddSubs )
 {
   using T = typename std::tuple_element<0, TypeParam>::type;
   using AtomicPolicy = typename std::tuple_element<1, TypeParam>::type;

--- a/test/unit/atomic/test-atomic-ref-bitwise.cpp
+++ b/test/unit/atomic/test-atomic-ref-bitwise.cpp
@@ -108,7 +108,7 @@ class AtomicRefCUDABitwiseUnitTest : public ::testing::Test
 
 TYPED_TEST_CASE_P( AtomicRefCUDABitwiseUnitTest );
 
-CUDA_TYPED_TEST_P( AtomicRefCUDABitwiseUnitTest, CUDABitwises )
+GPU_TYPED_TEST_P( AtomicRefCUDABitwiseUnitTest, CUDABitwises )
 {
   using T = typename std::tuple_element<0, TypeParam>::type;
   using AtomicPolicy = typename std::tuple_element<1, TypeParam>::type;

--- a/test/unit/atomic/test-atomic-ref-constructor.cpp
+++ b/test/unit/atomic/test-atomic-ref-constructor.cpp
@@ -108,7 +108,7 @@ class AtomicRefCUDAConstructorUnitTest : public ::testing::Test
 
 TYPED_TEST_CASE_P(AtomicRefCUDAConstructorUnitTest);
 
-CUDA_TYPED_TEST_P( AtomicRefCUDAConstructorUnitTest, CUDAConstructors )
+GPU_TYPED_TEST_P( AtomicRefCUDAConstructorUnitTest, CUDAConstructors )
 {
   using NumericType = typename std::tuple_element<0, TypeParam>::type;
   using AtomicPolicy = typename std::tuple_element<1, TypeParam>::type;

--- a/test/unit/atomic/test-atomic-ref-exchanges.cpp
+++ b/test/unit/atomic/test-atomic-ref-exchanges.cpp
@@ -119,7 +119,7 @@ class AtomicRefCUDAExchangeUnitTest : public ::testing::Test
 
 TYPED_TEST_CASE_P( AtomicRefCUDAExchangeUnitTest );
 
-CUDA_TYPED_TEST_P( AtomicRefCUDAExchangeUnitTest, CUDAExchanges )
+GPU_TYPED_TEST_P( AtomicRefCUDAExchangeUnitTest, CUDAExchanges )
 {
   using T = typename std::tuple_element<0, TypeParam>::type;
   using AtomicPolicy = typename std::tuple_element<1, TypeParam>::type;

--- a/test/unit/atomic/test-atomic-ref-minmax.cpp
+++ b/test/unit/atomic/test-atomic-ref-minmax.cpp
@@ -76,7 +76,7 @@ class AtomicRefCUDAMinMaxUnitTest : public ::testing::Test
 
 TYPED_TEST_CASE_P( AtomicRefCUDAMinMaxUnitTest );
 
-CUDA_TYPED_TEST_P( AtomicRefCUDAMinMaxUnitTest, CUDAMinMaxs )
+GPU_TYPED_TEST_P( AtomicRefCUDAMinMaxUnitTest, CUDAMinMaxs )
 {
   using T = typename std::tuple_element<0, TypeParam>::type;
   using AtomicPolicy = typename std::tuple_element<1, TypeParam>::type;


### PR DESCRIPTION
# Summary

- This PR re-organizes the old atomic tests into the functional test directory.
- It does the following:
  - Fixes unit/atomic/ tests for HIP.
  - Splits old tests into slightly smaller chunks.
  - Separates test instantiation in *.cpp files. This uses existing function templates to control test type combinatorial explosion, and AVOIDS template parameterization.
  - TODO: Split -other- tests further.
  - TODO: Add HIP tests.

# Design review

On 12/17/2019, we discussed the design ideas:

1. Parameterized functional tests. Need to list every combination of test parameters.
2. Function templated functional tests (non-parameterized). Can avoid lists of test params, but need hierarchy of test function templates (see *.cpp files).

This PR implements 2, and we should discuss whether this is the right course for our functional tests. 
