### PR TITLE
Small fix for GPU_TYPED_TEST.

### DIFF
--- a/test/unit/atomic/test-atomic-ref-accessors.cpp
+++ b/test/unit/atomic/test-atomic-ref-accessors.cpp
@@ -76,7 +76,7 @@ class AtomicRefCUDAAccessorUnitTest : public ::testing::Test
 
 TYPED_TEST_CASE_P( AtomicRefCUDAAccessorUnitTest );
 
-CUDA_TYPED_TEST_P( AtomicRefCUDAAccessorUnitTest, CUDAAccessors )
+GPU_TYPED_TEST_P( AtomicRefCUDAAccessorUnitTest, CUDAAccessors )
 {
   using T = typename std::tuple_element<0, TypeParam>::type;
   using AtomicPolicy = typename std::tuple_element<1, TypeParam>::type;

--- a/test/unit/atomic/test-atomic-ref-addsub.cpp
+++ b/test/unit/atomic/test-atomic-ref-addsub.cpp
@@ -88,7 +88,7 @@ class AtomicRefCUDAAddSubUnitTest : public ::testing::Test
 
 TYPED_TEST_CASE_P( AtomicRefCUDAAddSubUnitTest );
 
-CUDA_TYPED_TEST_P( AtomicRefCUDAAddSubUnitTest, CUDAAddSubs )
+GPU_TYPED_TEST_P( AtomicRefCUDAAddSubUnitTest, CUDAAddSubs )
 {
   using T = typename std::tuple_element<0, TypeParam>::type;
   using AtomicPolicy = typename std::tuple_element<1, TypeParam>::type;

--- a/test/unit/atomic/test-atomic-ref-bitwise.cpp
+++ b/test/unit/atomic/test-atomic-ref-bitwise.cpp
@@ -108,7 +108,7 @@ class AtomicRefCUDABitwiseUnitTest : public ::testing::Test
 
 TYPED_TEST_CASE_P( AtomicRefCUDABitwiseUnitTest );
 
-CUDA_TYPED_TEST_P( AtomicRefCUDABitwiseUnitTest, CUDABitwises )
+GPU_TYPED_TEST_P( AtomicRefCUDABitwiseUnitTest, CUDABitwises )
 {
   using T = typename std::tuple_element<0, TypeParam>::type;
   using AtomicPolicy = typename std::tuple_element<1, TypeParam>::type;

--- a/test/unit/atomic/test-atomic-ref-constructor.cpp
+++ b/test/unit/atomic/test-atomic-ref-constructor.cpp
@@ -108,7 +108,7 @@ class AtomicRefCUDAConstructorUnitTest : public ::testing::Test
 
 TYPED_TEST_CASE_P(AtomicRefCUDAConstructorUnitTest);
 
-CUDA_TYPED_TEST_P( AtomicRefCUDAConstructorUnitTest, CUDAConstructors )
+GPU_TYPED_TEST_P( AtomicRefCUDAConstructorUnitTest, CUDAConstructors )
 {
   using NumericType = typename std::tuple_element<0, TypeParam>::type;
   using AtomicPolicy = typename std::tuple_element<1, TypeParam>::type;

--- a/test/unit/atomic/test-atomic-ref-exchanges.cpp
+++ b/test/unit/atomic/test-atomic-ref-exchanges.cpp
@@ -119,7 +119,7 @@ class AtomicRefCUDAExchangeUnitTest : public ::testing::Test
 
 TYPED_TEST_CASE_P( AtomicRefCUDAExchangeUnitTest );
 
-CUDA_TYPED_TEST_P( AtomicRefCUDAExchangeUnitTest, CUDAExchanges )
+GPU_TYPED_TEST_P( AtomicRefCUDAExchangeUnitTest, CUDAExchanges )
 {
   using T = typename std::tuple_element<0, TypeParam>::type;
   using AtomicPolicy = typename std::tuple_element<1, TypeParam>::type;

--- a/test/unit/atomic/test-atomic-ref-minmax.cpp
+++ b/test/unit/atomic/test-atomic-ref-minmax.cpp
@@ -76,7 +76,7 @@ class AtomicRefCUDAMinMaxUnitTest : public ::testing::Test
 
 TYPED_TEST_CASE_P( AtomicRefCUDAMinMaxUnitTest );
 
-CUDA_TYPED_TEST_P( AtomicRefCUDAMinMaxUnitTest, CUDAMinMaxs )
+GPU_TYPED_TEST_P( AtomicRefCUDAMinMaxUnitTest, CUDAMinMaxs )
 {
   using T = typename std::tuple_element<0, TypeParam>::type;
   using AtomicPolicy = typename std::tuple_element<1, TypeParam>::type;


### PR DESCRIPTION
# Summary

- This PR is bugfixin test/reorg.
- It does the following:
  - Changes CUDA_ test instantiations to GPU_ in test/unit/atomic.