### PR TITLE
Removed RAJA_HOST_DEVICE modifier from defaulted constructors.

### DIFF
--- a/cmake/SetupCompilers.cmake
+++ b/cmake/SetupCompilers.cmake
@@ -70,7 +70,7 @@ endif()
 
 if (ENABLE_CUDA)
   set(CMAKE_CUDA_STANDARD 11)
-  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -restrict -arch ${CUDA_ARCH} --expt-extended-lambda --expt-relaxed-constexpr")
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -restrict -arch ${CUDA_ARCH} --expt-extended-lambda --expt-relaxed-constexpr -Xcudafe \"--display_error_number\"")
 
   if (NOT RAJA_HOST_CONFIG_LOADED)
     set(CMAKE_CUDA_FLAGS_RELEASE "-O2")

--- a/include/RAJA/RAJA.hpp
+++ b/include/RAJA/RAJA.hpp
@@ -66,6 +66,7 @@
 
 #if defined(RAJA_ENABLE_CUDA)
 #include "RAJA/policy/cuda.hpp"
+#pragma diag_suppress 2928
 #endif
 
 #if defined(RAJA_ENABLE_HIP)

--- a/include/RAJA/RAJA.hpp
+++ b/include/RAJA/RAJA.hpp
@@ -66,7 +66,6 @@
 
 #if defined(RAJA_ENABLE_CUDA)
 #include "RAJA/policy/cuda.hpp"
-#pragma diag_suppress 2928
 #endif
 
 #if defined(RAJA_ENABLE_HIP)

--- a/include/RAJA/pattern/detail/reduce.hpp
+++ b/include/RAJA/pattern/detail/reduce.hpp
@@ -123,9 +123,8 @@ public:
   RAJA_HOST_DEVICE
   ValueLoc &operator=(ValueLoc const &other) { val = other.val; loc = other.loc; return *this;}
 #else
-  RAJA_HOST_DEVICE constexpr ValueLoc() = default;
-  RAJA_HOST_DEVICE constexpr ValueLoc(ValueLoc const &other) = default;
-  RAJA_HOST_DEVICE
+  constexpr ValueLoc() = default;
+  constexpr ValueLoc(ValueLoc const &other) = default;
   ValueLoc &operator=(ValueLoc const &other) = default;
 #endif
 

--- a/include/RAJA/policy/atomic_builtin.hpp
+++ b/include/RAJA/policy/atomic_builtin.hpp
@@ -23,6 +23,12 @@
 #include "RAJA/util/TypeConvert.hpp"
 #include "RAJA/util/macros.hpp"
 
+#if defined(RAJA_ENABLE_HIP)
+#define RAJA_DEVICE_HIP RAJA_HOST_DEVICE
+#else
+#define RAJA_DEVICE_HIP
+#endif
+
 namespace RAJA
 {
 
@@ -36,7 +42,7 @@ namespace detail
 
 #if defined(RAJA_COMPILER_MSVC)
 
-RAJA_HOST_DEVICE
+RAJA_DEVICE_HIP
 RAJA_INLINE unsigned builtin_atomic_CAS(
                                unsigned volatile *acc,
                                unsigned compare,
@@ -51,7 +57,7 @@ RAJA_INLINE unsigned builtin_atomic_CAS(
   return RAJA::util::reinterp_A_as_B<long, unsigned>(old);
 }
 
-RAJA_HOST_DEVICE
+RAJA_DEVICE_HIP
 RAJA_INLINE unsigned long long builtin_atomic_CAS(
                                          unsigned long long volatile *acc,
                                          unsigned long long compare,
@@ -72,9 +78,7 @@ RAJA_INLINE unsigned long long builtin_atomic_CAS(
 
 #else   // RAJA_COMPILER_MSVC
 
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE unsigned builtin_atomic_CAS(
                               unsigned volatile *acc,
                               unsigned compare,
@@ -85,9 +89,7 @@ RAJA_INLINE unsigned builtin_atomic_CAS(
   return compare;
 }
 
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE unsigned long long builtin_atomic_CAS(
                               unsigned long long volatile *acc,
                               unsigned long long compare,
@@ -102,9 +104,7 @@ RAJA_INLINE unsigned long long builtin_atomic_CAS(
 
 
 template <typename T>
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE typename std::enable_if<sizeof(T) == sizeof(unsigned), T>::type
 builtin_atomic_CAS(T volatile *acc, T compare, T value)
 {
@@ -115,9 +115,7 @@ builtin_atomic_CAS(T volatile *acc, T compare, T value)
 }
 
 template <typename T>
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE typename std::enable_if<sizeof(T) == sizeof(unsigned long long), T>::type
 builtin_atomic_CAS(T volatile *acc, T compare, T value)
 {
@@ -146,9 +144,7 @@ struct BuiltinAtomicCAS<4> {
    * Returns the OLD value that was replaced by the result of this operation.
    */
   template <typename T, typename OPER, typename ShortCircuit>
-  #if defined(RAJA_ENABLE_HIP)
-  RAJA_HOST_DEVICE
-  #endif
+  RAJA_DEVICE_HIP
   RAJA_INLINE T operator()(T volatile *acc,
                            OPER const &oper,
                            ShortCircuit const &sc) const
@@ -179,9 +175,7 @@ struct BuiltinAtomicCAS<8> {
    * Returns the OLD value that was replaced by the result of this operation.
    */
   template <typename T, typename OPER, typename ShortCircuit>
-  #if defined(RAJA_ENABLE_HIP)
-  RAJA_HOST_DEVICE
-  #endif
+  RAJA_DEVICE_HIP
   RAJA_INLINE T operator()(T volatile *acc,
                            OPER const &oper,
                            ShortCircuit const &sc) const
@@ -211,9 +205,7 @@ struct BuiltinAtomicCAS<8> {
  * Returns the OLD value that was replaced by the result of this operation.
  */
 template <typename T, typename OPER>
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE T builtin_atomic_CAS_oper(T volatile *acc, OPER &&oper)
 {
   BuiltinAtomicCAS<sizeof(T)> cas;
@@ -221,9 +213,7 @@ RAJA_INLINE T builtin_atomic_CAS_oper(T volatile *acc, OPER &&oper)
 }
 
 template <typename T, typename OPER, typename ShortCircuit>
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE T builtin_atomic_CAS_oper_sc(T volatile *acc,
                                          OPER &&oper,
                                          ShortCircuit const &sc)
@@ -237,9 +227,7 @@ RAJA_INLINE T builtin_atomic_CAS_oper_sc(T volatile *acc,
 
 
 template <typename T>
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE T atomicAdd(builtin_atomic, T volatile *acc, T value)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T a) { return a + value; });
@@ -247,18 +235,14 @@ RAJA_INLINE T atomicAdd(builtin_atomic, T volatile *acc, T value)
 
 
 template <typename T>
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE T atomicSub(builtin_atomic, T volatile *acc, T value)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T a) { return a - value; });
 }
 
 template <typename T>
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE T atomicMin(builtin_atomic, T volatile *acc, T value)
 {
   if (*acc < value) {
@@ -274,9 +258,7 @@ RAJA_INLINE T atomicMin(builtin_atomic, T volatile *acc, T value)
 }
 
 template <typename T>
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE T atomicMax(builtin_atomic, T volatile *acc, T value)
 {
   if (*acc > value) {
@@ -292,18 +274,14 @@ RAJA_INLINE T atomicMax(builtin_atomic, T volatile *acc, T value)
 }
 
 template <typename T>
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE T atomicInc(builtin_atomic, T volatile *acc)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T a) { return a + 1; });
 }
 
 template <typename T>
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE T atomicInc(builtin_atomic, T volatile *acc, T val)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T old) {
@@ -312,18 +290,14 @@ RAJA_INLINE T atomicInc(builtin_atomic, T volatile *acc, T val)
 }
 
 template <typename T>
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE T atomicDec(builtin_atomic, T volatile *acc)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T a) { return a - 1; });
 }
 
 template <typename T>
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE T atomicDec(builtin_atomic, T volatile *acc, T val)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T old) {
@@ -332,45 +306,35 @@ RAJA_INLINE T atomicDec(builtin_atomic, T volatile *acc, T val)
 }
 
 template <typename T>
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE T atomicAnd(builtin_atomic, T volatile *acc, T value)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T a) { return a & value; });
 }
 
 template <typename T>
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE T atomicOr(builtin_atomic, T volatile *acc, T value)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T a) { return a | value; });
 }
 
 template <typename T>
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE T atomicXor(builtin_atomic, T volatile *acc, T value)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T a) { return a ^ value; });
 }
 
 template <typename T>
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE T atomicExchange(builtin_atomic, T volatile *acc, T value)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T) { return value; });
 }
 
 template <typename T>
-#if defined(RAJA_ENABLE_HIP)
-RAJA_HOST_DEVICE
-#endif
+RAJA_DEVICE_HIP
 RAJA_INLINE T atomicCAS(builtin_atomic, T volatile *acc, T compare, T value)
 {
   return detail::builtin_atomic_CAS(acc, compare, value);

--- a/include/RAJA/policy/atomic_builtin.hpp
+++ b/include/RAJA/policy/atomic_builtin.hpp
@@ -72,7 +72,9 @@ RAJA_INLINE unsigned long long builtin_atomic_CAS(
 
 #else   // RAJA_COMPILER_MSVC
 
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE unsigned builtin_atomic_CAS(
                               unsigned volatile *acc,
                               unsigned compare,
@@ -83,7 +85,9 @@ RAJA_INLINE unsigned builtin_atomic_CAS(
   return compare;
 }
 
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE unsigned long long builtin_atomic_CAS(
                               unsigned long long volatile *acc,
                               unsigned long long compare,
@@ -98,7 +102,9 @@ RAJA_INLINE unsigned long long builtin_atomic_CAS(
 
 
 template <typename T>
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE typename std::enable_if<sizeof(T) == sizeof(unsigned), T>::type
 builtin_atomic_CAS(T volatile *acc, T compare, T value)
 {
@@ -109,7 +115,9 @@ builtin_atomic_CAS(T volatile *acc, T compare, T value)
 }
 
 template <typename T>
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE typename std::enable_if<sizeof(T) == sizeof(unsigned long long), T>::type
 builtin_atomic_CAS(T volatile *acc, T compare, T value)
 {
@@ -138,7 +146,9 @@ struct BuiltinAtomicCAS<4> {
    * Returns the OLD value that was replaced by the result of this operation.
    */
   template <typename T, typename OPER, typename ShortCircuit>
+  #if defined(RAJA_ENABLE_HIP)
   RAJA_HOST_DEVICE
+  #endif
   RAJA_INLINE T operator()(T volatile *acc,
                            OPER const &oper,
                            ShortCircuit const &sc) const
@@ -169,7 +179,9 @@ struct BuiltinAtomicCAS<8> {
    * Returns the OLD value that was replaced by the result of this operation.
    */
   template <typename T, typename OPER, typename ShortCircuit>
+  #if defined(RAJA_ENABLE_HIP)
   RAJA_HOST_DEVICE
+  #endif
   RAJA_INLINE T operator()(T volatile *acc,
                            OPER const &oper,
                            ShortCircuit const &sc) const
@@ -199,7 +211,9 @@ struct BuiltinAtomicCAS<8> {
  * Returns the OLD value that was replaced by the result of this operation.
  */
 template <typename T, typename OPER>
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE T builtin_atomic_CAS_oper(T volatile *acc, OPER &&oper)
 {
   BuiltinAtomicCAS<sizeof(T)> cas;
@@ -207,7 +221,9 @@ RAJA_INLINE T builtin_atomic_CAS_oper(T volatile *acc, OPER &&oper)
 }
 
 template <typename T, typename OPER, typename ShortCircuit>
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE T builtin_atomic_CAS_oper_sc(T volatile *acc,
                                          OPER &&oper,
                                          ShortCircuit const &sc)
@@ -221,7 +237,9 @@ RAJA_INLINE T builtin_atomic_CAS_oper_sc(T volatile *acc,
 
 
 template <typename T>
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE T atomicAdd(builtin_atomic, T volatile *acc, T value)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T a) { return a + value; });
@@ -229,14 +247,18 @@ RAJA_INLINE T atomicAdd(builtin_atomic, T volatile *acc, T value)
 
 
 template <typename T>
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE T atomicSub(builtin_atomic, T volatile *acc, T value)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T a) { return a - value; });
 }
 
 template <typename T>
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE T atomicMin(builtin_atomic, T volatile *acc, T value)
 {
   if (*acc < value) {
@@ -252,7 +274,9 @@ RAJA_INLINE T atomicMin(builtin_atomic, T volatile *acc, T value)
 }
 
 template <typename T>
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE T atomicMax(builtin_atomic, T volatile *acc, T value)
 {
   if (*acc > value) {
@@ -268,14 +292,18 @@ RAJA_INLINE T atomicMax(builtin_atomic, T volatile *acc, T value)
 }
 
 template <typename T>
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE T atomicInc(builtin_atomic, T volatile *acc)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T a) { return a + 1; });
 }
 
 template <typename T>
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE T atomicInc(builtin_atomic, T volatile *acc, T val)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T old) {
@@ -284,14 +312,18 @@ RAJA_INLINE T atomicInc(builtin_atomic, T volatile *acc, T val)
 }
 
 template <typename T>
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE T atomicDec(builtin_atomic, T volatile *acc)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T a) { return a - 1; });
 }
 
 template <typename T>
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE T atomicDec(builtin_atomic, T volatile *acc, T val)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T old) {
@@ -300,35 +332,45 @@ RAJA_INLINE T atomicDec(builtin_atomic, T volatile *acc, T val)
 }
 
 template <typename T>
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE T atomicAnd(builtin_atomic, T volatile *acc, T value)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T a) { return a & value; });
 }
 
 template <typename T>
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE T atomicOr(builtin_atomic, T volatile *acc, T value)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T a) { return a | value; });
 }
 
 template <typename T>
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE T atomicXor(builtin_atomic, T volatile *acc, T value)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T a) { return a ^ value; });
 }
 
 template <typename T>
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE T atomicExchange(builtin_atomic, T volatile *acc, T value)
 {
   return detail::builtin_atomic_CAS_oper(acc, [=](T) { return value; });
 }
 
 template <typename T>
+#if defined(RAJA_ENABLE_HIP)
 RAJA_HOST_DEVICE
+#endif
 RAJA_INLINE T atomicCAS(builtin_atomic, T volatile *acc, T compare, T value)
 {
   return detail::builtin_atomic_CAS(acc, compare, value);


### PR DESCRIPTION
# Summary

- This PR is a bugfix.
- It does the following:
  - Removes RAJA_HOST_DEVICE from defaulted constructors to prevent NVCC warnings.