### PR TITLE
fully qualify _requires and SpecializationOf

### DIFF
--- a/include/RAJA/index/IndexSet.hpp
+++ b/include/RAJA/index/IndexSet.hpp
@@ -754,12 +754,12 @@ namespace type_traits
 
 template <typename T>
 struct is_index_set
-    : SpecializationOf<RAJA::TypedIndexSet, typename std::decay<T>::type> {
+    : ::RAJA::type_traits::SpecializationOf<RAJA::TypedIndexSet, typename std::decay<T>::type> {
 };
 
 template <typename T>
 struct is_indexset_policy
-    : SpecializationOf<RAJA::ExecPolicy, typename std::decay<T>::type> {
+    : ::RAJA::type_traits::SpecializationOf<RAJA::ExecPolicy, typename std::decay<T>::type> {
 };
 }  // namespace type_traits
 

--- a/include/RAJA/util/Operators.hpp
+++ b/include/RAJA/util/Operators.hpp
@@ -568,10 +568,10 @@ namespace detail
 {
 
 template <typename Fun, typename Ret, typename T, typename U>
-using is_binary_function = requires_<BinaryFunction, Ret, T, U>;
+using is_binary_function = ::RAJA::concepts::requires_<BinaryFunction, Ret, T, U>;
 
 template <typename Fun, typename Ret, typename T>
-using is_unary_function = requires_<UnaryFunction, Ret, T>;
+using is_unary_function = ::RAJA::concepts::requires_<UnaryFunction, Ret, T>;
 }  // namespace detail
 
 }  // namespace concepts


### PR DESCRIPTION
For some reason these were failing under a specific compiler as being
missing unless fully qualified.

This is a bugfix for xlc++.