### PR TITLE
Fix for CUDA memcheck failures in tuple tests.

### DIFF
--- a/test/unit/cuda/test-reduce-randloc.cpp
+++ b/test/unit/cuda/test-reduce-randloc.cpp
@@ -41,7 +41,7 @@ struct funcapplier<ReduceMinLoc<cuda_reduce, NumType, Indexer>>
 {
   static NumType extremeval()
   {
-    return 1024.0;
+    return (NumType)1024;
   }
 
   RAJA_HOST_DEVICE static void apply(ReduceMinLoc<cuda_reduce, NumType, Indexer> const & r,
@@ -63,7 +63,7 @@ struct funcapplier<ReduceMinLoc<seq_reduce, NumType, Indexer>>
 {
   static NumType extremeval()
   {
-    return 1024.0;
+    return (NumType)1024;
   }
 
   static void apply(ReduceMinLoc<seq_reduce, NumType, Indexer> const & r,
@@ -79,7 +79,7 @@ struct funcapplier<ReduceMaxLoc<cuda_reduce, NumType, Indexer>>
 {
   static NumType extremeval()
   {
-    return -1024.0;
+    return (NumType)(-1024);
   }
 
   RAJA_HOST_DEVICE static void apply(ReduceMaxLoc<cuda_reduce, NumType, Indexer> const & r,
@@ -101,7 +101,7 @@ struct funcapplier<ReduceMaxLoc<seq_reduce, NumType, Indexer>>
 {
   static NumType extremeval()
   {
-    return -1024.0;
+    return (NumType)(-1024);
   }
 
   static void apply(ReduceMaxLoc<seq_reduce, NumType, Indexer> const & r,
@@ -217,6 +217,8 @@ GPU_TYPED_TEST_P(CUDAReduceLocRandTest, ReduceLocRandom)
   using applygpu = funcapplier<at_v<TypeParam, 0>>;
   using applycpu = funcapplier<at_v<TypeParam, 1>>;
 
+  int * data2 = this->data;
+
   this->equalize();
   constexpr int reps = 25;
 
@@ -235,7 +237,7 @@ GPU_TYPED_TEST_P(CUDAReduceLocRandTest, ReduceLocRandom)
 
     RAJA::forall<cuda_exec<block_size>>(RAJA::RangeSegment(0, array_length),
                              [=] RAJA_DEVICE (int ii) {
-                               applygpu::apply(minmaxloc_reducer, this->data[ii], ii);
+                               applygpu::apply(minmaxloc_reducer, data2[ii], ii);
                              });
 
     int raja_loc = minmaxloc_reducer.getLoc();
@@ -261,6 +263,8 @@ GPU_TYPED_TEST_P(CUDAReduceLocRandTest, ReduceLocSameHalves)
   cset.push_back( colrange0 );
   cset.push_back( colrange1 );
 
+  int * data2 = this->data;
+
   this->equalize();
 
   // CPU reduce loc
@@ -274,7 +278,7 @@ GPU_TYPED_TEST_P(CUDAReduceLocRandTest, ReduceLocSameHalves)
 
   RAJA::forall<ExecPolicy<seq_segit, cuda_exec<block_size>>>(
     cset, [=] RAJA_DEVICE (int ii) {
-      applygpu::apply(minmaxloc_reducer, this->data[ii], ii);
+      applygpu::apply(minmaxloc_reducer, data2[ii], ii);
     });
 
   int raja_loc = minmaxloc_reducer.getLoc();
@@ -301,6 +305,8 @@ GPU_TYPED_TEST_P(CUDAReduceLocRandTest, ReduceLocAscendingHalves)
   cset.push_back( colrange0 );
   cset.push_back( colrange1 );
 
+  int * data2 = this->data;
+
   // create ascending array
   for ( int zz = 0; zz < array_length; ++zz )
   {
@@ -318,7 +324,7 @@ GPU_TYPED_TEST_P(CUDAReduceLocRandTest, ReduceLocAscendingHalves)
 
   RAJA::forall<ExecPolicy<seq_segit, cuda_exec<block_size>>>(
     cset, [=] RAJA_DEVICE (int ii) {
-      applygpu::apply(minmaxloc_reducer, this->data[ii], ii);
+      applygpu::apply(minmaxloc_reducer, data2[ii], ii);
     });
 
   int raja_loc = minmaxloc_reducer.getLoc();
@@ -343,6 +349,8 @@ GPU_TYPED_TEST_P(CUDAReduceLocRandTest, ReduceLocRandomHalves)
   cset.push_back( colrange0 );
   cset.push_back( colrange1 );
 
+  int * data2 = this->data;
+
   this->equalize();
   constexpr int reps = 25;
 
@@ -356,7 +364,7 @@ GPU_TYPED_TEST_P(CUDAReduceLocRandTest, ReduceLocRandomHalves)
     at_v<TypeParam, 0> gpureducescaled(applygpu::extremeval(), 0);
     RAJA::forall<ExecPolicy<seq_segit, cuda_exec<block_size>>>(
       cset, [=] RAJA_DEVICE (int ii) {
-        applygpu::apply(gpureducescaled, 2*(this->data[ii]), ii);
+        applygpu::apply(gpureducescaled, 2*(data2[ii]), ii);
       });
 
     int scaled_loc = gpureducescaled.getLoc();
@@ -366,7 +374,7 @@ GPU_TYPED_TEST_P(CUDAReduceLocRandTest, ReduceLocRandomHalves)
 
     RAJA::forall<ExecPolicy<seq_segit, cuda_exec<block_size>>>(
       cset, [=] RAJA_DEVICE (int ii) {
-        applygpu::apply(minmaxloc_reducer, this->data[ii], ii);
+        applygpu::apply(minmaxloc_reducer, data2[ii], ii);
       });
 
     int raja_loc = minmaxloc_reducer.getLoc();
@@ -396,6 +404,8 @@ GPU_TYPED_TEST_P(CUDAReduceLocRandTest, ReduceLocRandomDisjoint)
   cset.push_back( colrange2 );
   cset.push_back( colrange3 );
 
+  int * data2 = this->data;
+
   this->equalize();
   constexpr int reps = 25;
 
@@ -412,7 +422,7 @@ GPU_TYPED_TEST_P(CUDAReduceLocRandTest, ReduceLocRandomDisjoint)
     at_v<TypeParam, 0> gpureducescaled(applygpu::extremeval(), 0);
     RAJA::forall<ExecPolicy<seq_segit, cuda_exec<block_size>>>(
       cset, [=] RAJA_DEVICE (int ii) {
-        applygpu::apply(gpureducescaled, 2*(this->data[ii]), ii);
+        applygpu::apply(gpureducescaled, 2*(data2[ii]), ii);
       });
 
     int scaled_loc = gpureducescaled.getLoc();
@@ -422,7 +432,7 @@ GPU_TYPED_TEST_P(CUDAReduceLocRandTest, ReduceLocRandomDisjoint)
 
     RAJA::forall<ExecPolicy<seq_segit, cuda_exec<block_size>>>(
       cset, [=] RAJA_DEVICE (int ii) {
-        applygpu::apply(minmaxloc_reducer, this->data[ii], ii);
+        applygpu::apply(minmaxloc_reducer, data2[ii], ii);
       });
 
     int raja_loc = minmaxloc_reducer.getLoc();

--- a/test/unit/cuda/test-reduce-tupleloc.cpp
+++ b/test/unit/cuda/test-reduce-tupleloc.cpp
@@ -37,7 +37,7 @@ struct funcapplier<ReduceMinLoc<cuda_reduce, NumType, Indexer>>   // GPU minloc
 {
   static NumType extremeval()
   {
-    return 1024.0;
+    return (NumType)(1024);
   }
 
   RAJA_HOST_DEVICE static void apply(ReduceMinLoc<cuda_reduce, NumType, Indexer> const & r,
@@ -59,7 +59,7 @@ struct funcapplier<ReduceMinLoc<seq_reduce, NumType, Indexer>>    // CPU minloc
 {
   static NumType extremeval()
   {
-    return 1024.0;
+    return (NumType)(1024);
   }
 
   static void apply(ReduceMinLoc<seq_reduce, NumType, Indexer> const & r,
@@ -75,7 +75,7 @@ struct funcapplier<ReduceMaxLoc<cuda_reduce, NumType, Indexer>>   // GPU maxloc
 {
   static NumType extremeval()
   {
-    return -1024.0;
+    return (NumType)(-1024);
   }
 
   RAJA_HOST_DEVICE static void apply(ReduceMaxLoc<cuda_reduce, NumType, Indexer> const & r,
@@ -97,7 +97,7 @@ struct funcapplier<ReduceMaxLoc<seq_reduce, NumType, Indexer>>    // CPU maxloc
 {
   static NumType extremeval()
   {
-    return -1024.0;
+    return (NumType)(-1024);
   }
 
   static void apply(ReduceMaxLoc<seq_reduce, NumType, Indexer> const & r,
@@ -260,12 +260,14 @@ GPU_TYPED_TEST_P(CUDAReduceLocTest, ReduceLoc2DIndexTupleViewKernel)
   RAJA::RangeSegment colrange(0, ydim);
   RAJA::RangeSegment rowrange(0, xdim);
 
+  RAJA::View<double, RAJA::Layout<2>> dataview2 = this->dataview;
+
   // FIRST TEST: original unequal values
   at_v<TypeParam, 0> minmaxloc_reducer(applygpu::extremeval(), RAJA::make_tuple(0, 0));
 
   RAJA::kernel<ExecutionPol>(RAJA::make_tuple(colrange, rowrange),
                            [=] RAJA_DEVICE (int c, int r) {
-                             applygpu::apply(minmaxloc_reducer, this->dataview(r, c), RAJA::make_tuple(c, r));
+                             applygpu::apply(minmaxloc_reducer, dataview2(r, c), RAJA::make_tuple(c, r));
                            });
 
   RAJA::tuple<int, int> raja_loc = minmaxloc_reducer.getLoc();
@@ -282,7 +284,7 @@ GPU_TYPED_TEST_P(CUDAReduceLocTest, ReduceLoc2DIndexTupleViewKernel)
 
   RAJA::kernel<ExecutionPol>(RAJA::make_tuple(colrange, rowrange),
                            [=] RAJA_DEVICE (int c, int r) {
-                             applygpu::apply(minmaxloc_reducer2, this->dataview(r, c), RAJA::make_tuple(c, r));
+                             applygpu::apply(minmaxloc_reducer2, dataview2(r, c), RAJA::make_tuple(c, r));
                            });
 
   ASSERT_FLOAT_EQ(this->getminormax(applygpu::minormax()), (double)minmaxloc_reducer2.get());
@@ -321,6 +323,8 @@ GPU_TYPED_TEST_P(CUDAReduceLocTest, ReduceLoc2DIndexTupleViewKernelRandom)
   RAJA::RangeSegment colrange(0, ydim);
   RAJA::RangeSegment rowrange(0, xdim);
 
+  RAJA::View<double, RAJA::Layout<2>> dataview2 = this->dataview;
+
   this->equalize();
   constexpr int reps = 25;
 
@@ -335,7 +339,7 @@ GPU_TYPED_TEST_P(CUDAReduceLocTest, ReduceLoc2DIndexTupleViewKernelRandom)
 
     RAJA::kernel<ExecutionPol>(RAJA::make_tuple(colrange, rowrange),
                              [=] RAJA_DEVICE (int c, int r) {
-                               applygpu::apply(minmaxloc_reducer, this->dataview(r, c), RAJA::make_tuple(c, r));
+                               applygpu::apply(minmaxloc_reducer, dataview2(r, c), RAJA::make_tuple(c, r));
                              });
 
     RAJA::tuple<int, int> raja_loc = minmaxloc_reducer.getLoc();

--- a/test/unit/hip/test-reduce-randloc.cpp
+++ b/test/unit/hip/test-reduce-randloc.cpp
@@ -41,7 +41,7 @@ struct funcapplier<ReduceMinLoc<hip_reduce, NumType, Indexer>>
 {
   static NumType extremeval()
   {
-    return 1024.0;
+    return (NumType)1024;
   }
 
   RAJA_HOST_DEVICE static void apply(ReduceMinLoc<hip_reduce, NumType, Indexer> const & r,
@@ -63,7 +63,7 @@ struct funcapplier<ReduceMinLoc<seq_reduce, NumType, Indexer>>
 {
   static NumType extremeval()
   {
-    return 1024.0;
+    return (NumType)1024;
   }
 
   static void apply(ReduceMinLoc<seq_reduce, NumType, Indexer> const & r,
@@ -79,7 +79,7 @@ struct funcapplier<ReduceMaxLoc<hip_reduce, NumType, Indexer>>
 {
   static NumType extremeval()
   {
-    return -1024.0;
+    return (NumType)(-1024);
   }
 
   RAJA_HOST_DEVICE static void apply(ReduceMaxLoc<hip_reduce, NumType, Indexer> const & r,
@@ -101,7 +101,7 @@ struct funcapplier<ReduceMaxLoc<seq_reduce, NumType, Indexer>>
 {
   static NumType extremeval()
   {
-    return -1024.0;
+    return (NumType)(-1024);
   }
 
   static void apply(ReduceMaxLoc<seq_reduce, NumType, Indexer> const & r,

--- a/test/unit/hip/test-reduce-tupleloc.cpp
+++ b/test/unit/hip/test-reduce-tupleloc.cpp
@@ -37,7 +37,7 @@ struct funcapplier<ReduceMinLoc<hip_reduce, NumType, Indexer>>   // GPU minloc
 {
   static NumType extremeval()
   {
-    return 1024.0;
+    return (NumType)1024;
   }
 
   RAJA_HOST_DEVICE static void apply(ReduceMinLoc<hip_reduce, NumType, Indexer> const & r,
@@ -59,7 +59,7 @@ struct funcapplier<ReduceMinLoc<seq_reduce, NumType, Indexer>>    // CPU minloc
 {
   static NumType extremeval()
   {
-    return 1024.0;
+    return (NumType)1024;
   }
 
   static void apply(ReduceMinLoc<seq_reduce, NumType, Indexer> const & r,
@@ -75,7 +75,7 @@ struct funcapplier<ReduceMaxLoc<hip_reduce, NumType, Indexer>>   // GPU maxloc
 {
   static NumType extremeval()
   {
-    return -1024.0;
+    return (NumType)(-1024);
   }
 
   RAJA_HOST_DEVICE static void apply(ReduceMaxLoc<hip_reduce, NumType, Indexer> const & r,
@@ -97,7 +97,7 @@ struct funcapplier<ReduceMaxLoc<seq_reduce, NumType, Indexer>>    // CPU maxloc
 {
   static NumType extremeval()
   {
-    return -1024.0;
+    return (NumType)(-1024);
   }
 
   static void apply(ReduceMaxLoc<seq_reduce, NumType, Indexer> const & r,


### PR DESCRIPTION
# Summary

- This PR is a bug fix.
  - Mohammed Nafees at NVIDIA found that although the tuple tests pass, they fail when run under cuda-memcheck.

- It does the following:
  - Fixes this issue: the problem was that nvcc did not properly translate a "this->" to a member variable. This is solved by creating a local variable which points to the member.
  - Also corrected some return casts.