### PR TITLE
RangeSegment/StrideSegment test warning/failure on CUDA/HIP

### DIFF
--- a/test/unit/index/test-rangesegment.cpp
+++ b/test/unit/index/test-rangesegment.cpp
@@ -43,17 +43,19 @@ TYPED_TEST(RangeSegmentUnitTest, Constructors)
   ASSERT_EQ(moved, copied);
 
   // Test exception when begin > end
-#ifndef RAJA_ENABLE_CUDA
+#if !defined(RAJA_ENABLE_CUDA) && !defined(RAJA_ENABLE_HIP)
   ASSERT_ANY_THROW(RAJA::TypedRangeSegment<TypeParam> neg(20, 19));
 #endif
 
   if(std::is_signed<TypeParam>::value){
+#if !defined(__CUDA_ARCH__)
     RAJA::TypedRangeSegment<TypeParam> r1(-10, 7);
     RAJA::TypedRangeSegment<TypeParam> r3(-13, -1);
     ASSERT_EQ(17, r1.size());
     ASSERT_EQ(12, r3.size());
+#endif
 
-#ifndef RAJA_ENABLE_CUDA
+#if !defined(RAJA_ENABLE_CUDA) && !defined(RAJA_ENABLE_HIP)
     ASSERT_ANY_THROW(RAJA::TypedRangeSegment<TypeParam> r2(0, -50));
 #endif
   }
@@ -88,10 +90,12 @@ TYPED_TEST(RangeSegmentUnitTest, Iterators)
   ASSERT_EQ(100, std::distance(r1.begin(), r1.end()));
   ASSERT_EQ(100, r1.size());
 
+#if !defined(__CUDA_ARCH__)
   if(std::is_signed<TypeParam>::value){
     RAJA::TypedRangeSegment<TypeParam> r3(-2, 100);
     ASSERT_EQ(-2, *r3.begin());
   }
+#endif
 }
 
 TYPED_TEST(RangeSegmentUnitTest, Slices)

--- a/test/unit/index/test-rangestridesegment.cpp
+++ b/test/unit/index/test-rangestridesegment.cpp
@@ -123,6 +123,7 @@ TYPED_TEST(RangeStrideSegmentUnitTest, Sizes)
   ASSERT_EQ(segment15.size(), 0);
 
   // NEGATIVE INDICES
+#if !defined(__CUDA_ARCH__)
   if (std::is_signed<TypeParam>::value) {
     RAJA::TypedRangeStrideSegment<TypeParam> segment16(-10, -2, 2);
     ASSERT_EQ(segment16.size(), 4);
@@ -133,6 +134,7 @@ TYPED_TEST(RangeStrideSegmentUnitTest, Sizes)
     RAJA::TypedRangeStrideSegment<TypeParam> segment18(0, -5, 1);
     ASSERT_EQ(segment18.size(), 0);
   }
+#endif
 }
 
 TYPED_TEST(RangeStrideSegmentUnitTest, Slices)


### PR DESCRIPTION
Removes warnings when compiling RangeSegment/StrideSegment tests with CUDA.

Fixes RangeSegment test so it passes when compiling with HIP.