### PR TITLE
Full block direct support

### DIFF
--- a/include/RAJA/policy/cuda/kernel/For.hpp
+++ b/include/RAJA/policy/cuda/kernel/For.hpp
@@ -549,6 +549,61 @@ struct CudaStatementExecutor<
 
 /*
  * Executor for block work sharing inside CudaKernel.
+ * Mapping directly from blockIdx.xyz to indicies
+ * Assigns the loop index to offset ArgumentId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          int BlockDim,
+          typename... EnclosedStmts>
+struct CudaStatementExecutor<
+    Data,
+    statement::For<ArgumentId, RAJA::cuda_block_xyz_direct<BlockDim>, EnclosedStmts...>> {
+
+  using stmt_list_t = StatementList<EnclosedStmts...>;
+
+  using enclosed_stmts_t =
+      CudaStatementListExecutor<Data, stmt_list_t>;
+
+
+  static
+  inline RAJA_DEVICE void exec(Data &data, bool thread_active)
+  {
+    auto len = segment_length<ArgumentId>(data);
+    auto i = get_cuda_dim<BlockDim>(blockIdx);
+
+    if (i < len) {
+
+      // Assign the x thread to the argument
+      data.template assign_offset<ArgumentId>(i);
+
+      // execute enclosed statements
+      enclosed_stmts_t::exec(data, thread_active);
+    }
+  }
+
+
+  static
+  inline
+  LaunchDims calculateDimensions(Data const &data)
+  {
+    auto len = segment_length<ArgumentId>(data);
+
+    // request one block per element in the segment
+    LaunchDims dims;
+    set_cuda_dim<BlockDim>(dims.blocks, len);
+
+    // since we are direct-mapping, we REQUIRE len
+    set_cuda_dim<BlockDim>(dims.min_blocks, len);
+
+    // combine with enclosed statements
+    LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);
+    return dims.max(enclosed_dims);
+  }
+};
+
+/*
+ * Executor for block work sharing inside CudaKernel.
  * Provides a grid-stride loop (stride of gridDim.xyz) for
  * each block in xyz.
  * Assigns the loop index to offset ArgumentId
@@ -601,57 +656,6 @@ struct CudaStatementExecutor<
   }
 };
 
-/*
- * Executor for block work sharing inside CudaKernel.
- * Mapping directly from blockIdx.xyz to indicies
- * Assigns the loop index to offset ArgumentId
- */
-template <typename Data,
-          camp::idx_t ArgumentId,
-          int BlockDim,
-          typename... EnclosedStmts>
-struct CudaStatementExecutor<
-    Data,
-    statement::For<ArgumentId, RAJA::cuda_block_xyz_direct<BlockDim>, EnclosedStmts...>> {
-
-  using stmt_list_t = StatementList<EnclosedStmts...>;
-
-  using enclosed_stmts_t =
-      CudaStatementListExecutor<Data, stmt_list_t>;
-
-
-  static
-  inline RAJA_DEVICE void exec(Data &data, bool thread_active)
-  {
-    auto len = segment_length<ArgumentId>(data);
-    auto i = get_cuda_dim<BlockDim>(blockIdx);
-
-    // Assign the x thread to the argument
-    data.template assign_offset<ArgumentId>(i);
-
-    // execute enclosed statements
-    enclosed_stmts_t::exec(data, thread_active && (i<len));
-  }
-
-
-  static
-  inline
-  LaunchDims calculateDimensions(Data const &data)
-  {
-    auto len = segment_length<ArgumentId>(data);
-
-    // request one block per element in the segment
-    LaunchDims dims;
-    set_cuda_dim<BlockDim>(dims.blocks, len);
-
-    // since we are direct-mapping, we REQUIRE len
-    set_cuda_dim<BlockDim>(dims.min_blocks, len);
-
-    // combine with enclosed statements
-    LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);
-    return dims.max(enclosed_dims);
-  }
-};
 
 
 /*

--- a/include/RAJA/policy/cuda/kernel/Tile.hpp
+++ b/include/RAJA/policy/cuda/kernel/Tile.hpp
@@ -126,6 +126,97 @@ struct CudaStatementExecutor<
     Data,
     statement::Tile<ArgumentId,
                     RAJA::statement::tile_fixed<chunk_size>,
+                    cuda_block_xyz_direct<BlockDim>,
+                    EnclosedStmts...>>
+  {
+
+  using stmt_list_t = StatementList<EnclosedStmts...>;
+
+  using enclosed_stmts_t = CudaStatementListExecutor<Data, stmt_list_t>;
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data, bool thread_active)
+  {
+    // Get the segment referenced by this Tile statement
+    auto &segment = camp::get<ArgumentId>(data.segment_tuple);
+
+    using segment_t = camp::decay<decltype(segment)>;
+
+    // compute trip count
+    auto len = segment.end() - segment.begin();
+    auto i = get_cuda_dim<BlockDim>(blockIdx) * chunk_size;
+
+    // check have chunk
+    if (i < len) {
+
+      // Keep copy of original segment, so we can restore it
+      segment_t orig_segment = segment;
+
+      // Assign our new tiled segment
+      segment = orig_segment.slice(i, chunk_size);
+
+      // execute enclosed statements
+      enclosed_stmts_t::exec(data, thread_active);
+
+      // Set range back to original values
+      segment = orig_segment;
+    }
+  }
+
+
+  static
+  inline
+  LaunchDims calculateDimensions(Data const &data)
+  {
+
+    // Compute how many blocks
+    int len = segment_length<ArgumentId>(data);
+    int num_blocks = len / chunk_size;
+    if (num_blocks * chunk_size < len) {
+      num_blocks++;
+    }
+
+    LaunchDims dims;
+    set_cuda_dim<BlockDim>(dims.blocks, num_blocks);
+
+    // since we are direct-mapping, we REQUIRE len
+    set_cuda_dim<BlockDim>(dims.min_blocks, num_blocks);
+
+
+    // privatize data, so we can mess with the segments
+    using data_t = camp::decay<Data>;
+    data_t private_data = data;
+
+    // Get original segment
+    auto &segment = camp::get<ArgumentId>(private_data.segment_tuple);
+
+    // restrict to first tile
+    segment = segment.slice(0, chunk_size);
+
+
+    LaunchDims enclosed_dims =
+        enclosed_stmts_t::calculateDimensions(private_data);
+
+    return dims.max(enclosed_dims);
+  }
+};
+
+/*!
+ * A specialized RAJA::kernel cuda_impl executor for statement::Tile
+ * Assigns the tile segment to segment ArgumentId
+ *
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          camp::idx_t chunk_size,
+          int BlockDim,
+          typename... EnclosedStmts>
+struct CudaStatementExecutor<
+    Data,
+    statement::Tile<ArgumentId,
+                    RAJA::statement::tile_fixed<chunk_size>,
                     cuda_block_xyz_loop<BlockDim>,
                     EnclosedStmts...>>
   {

--- a/include/RAJA/policy/cuda/kernel/TileTCount.hpp
+++ b/include/RAJA/policy/cuda/kernel/TileTCount.hpp
@@ -111,6 +111,73 @@ struct CudaStatementExecutor<
     Data,
     statement::TileTCount<ArgumentId, ParamId,
                     RAJA::statement::tile_fixed<chunk_size>,
+                    cuda_block_xyz_direct<BlockDim>,
+                    EnclosedStmts...>>
+    : public CudaStatementExecutor<
+        Data,
+        statement::Tile<ArgumentId,
+                        RAJA::statement::tile_fixed<chunk_size>,
+                        cuda_block_xyz_direct<BlockDim>,
+                        EnclosedStmts...>> {
+
+  using Base = CudaStatementExecutor<
+      Data,
+      statement::Tile<ArgumentId,
+                      RAJA::statement::tile_fixed<chunk_size>,
+                      cuda_block_xyz_direct<BlockDim>,
+                      EnclosedStmts...>>;
+
+  using typename Base::enclosed_stmts_t;
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data, bool thread_active)
+  {
+    // Get the segment referenced by this Tile statement
+    auto &segment = camp::get<ArgumentId>(data.segment_tuple);
+
+    using segment_t = camp::decay<decltype(segment)>;
+
+    // compute trip count
+    int len = segment.end() - segment.begin();
+    auto t = get_cuda_dim<BlockDim>(blockIdx);
+    auto i = t * chunk_size;
+
+    // Iterate through grid stride of chunks
+    if (i < len) {
+
+      // Keep copy of original segment, so we can restore it
+      segment_t orig_segment = segment;
+
+      // Assign our new tiled segment
+      segment = orig_segment.slice(i, chunk_size);
+      data.template assign_param<ParamId>(t);
+
+      // execute enclosed statements
+      enclosed_stmts_t::exec(data, thread_active);
+
+      // Set range back to original values
+      segment = orig_segment;
+    }
+  }
+};
+
+/*!
+ * A specialized RAJA::kernel cuda_impl executor for statement::TileTCount
+ * Assigns the tile segment to segment ArgumentId
+ * Assigns the tile index to param ParamId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          typename ParamId,
+          camp::idx_t chunk_size,
+          int BlockDim,
+          typename... EnclosedStmts>
+struct CudaStatementExecutor<
+    Data,
+    statement::TileTCount<ArgumentId, ParamId,
+                    RAJA::statement::tile_fixed<chunk_size>,
                     cuda_block_xyz_loop<BlockDim>,
                     EnclosedStmts...>>
     : public CudaStatementExecutor<

--- a/include/RAJA/policy/hip/kernel/For.hpp
+++ b/include/RAJA/policy/hip/kernel/For.hpp
@@ -597,7 +597,7 @@ struct HipStatementExecutor<
     set_hip_dim<BlockDim>(dims.blocks, len);
 
     // since we are direct-mapping, we REQUIRE len
-    set_hip_dim<ThreadDim>(dims.min_blocks, len);
+    set_hip_dim<BlockDim>(dims.min_blocks, len);
 
     // combine with enclosed statements
     LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);

--- a/include/RAJA/policy/hip/kernel/TileTCount.hpp
+++ b/include/RAJA/policy/hip/kernel/TileTCount.hpp
@@ -113,6 +113,73 @@ struct HipStatementExecutor<
     Data,
     statement::TileTCount<ArgumentId, ParamId,
                     RAJA::statement::tile_fixed<chunk_size>,
+                    hip_block_xyz_direct<BlockDim>,
+                    EnclosedStmts...>>
+    : public HipStatementExecutor<
+        Data,
+        statement::Tile<ArgumentId,
+                        RAJA::statement::tile_fixed<chunk_size>,
+                        hip_block_xyz_direct<BlockDim>,
+                        EnclosedStmts...>> {
+
+  using Base = HipStatementExecutor<
+      Data,
+      statement::Tile<ArgumentId,
+                      RAJA::statement::tile_fixed<chunk_size>,
+                      hip_block_xyz_direct<BlockDim>,
+                      EnclosedStmts...>>;
+
+  using typename Base::enclosed_stmts_t;
+
+  static
+  inline
+  RAJA_DEVICE
+  void exec(Data &data, bool thread_active)
+  {
+    // Get the segment referenced by this Tile statement
+    auto &segment = camp::get<ArgumentId>(data.segment_tuple);
+
+    using segment_t = camp::decay<decltype(segment)>;
+
+    // compute trip count
+    int len = segment.end() - segment.begin();
+    auto t = get_hip_dim<BlockDim>(dim3(blockIdx.x,blockIdx.y,blockIdx.z));
+    auto i = t * chunk_size;
+
+    // get a chunk
+    if (i < len) {
+
+      // Keep copy of original segment, so we can restore it
+      segment_t orig_segment = segment;
+
+      // Assign our new tiled segment
+      segment = orig_segment.slice(i, chunk_size);
+      data.template assign_param<ParamId>(t);
+
+      // execute enclosed statements
+      enclosed_stmts_t::exec(data, thread_active);
+
+      // Set range back to original values
+      segment = orig_segment;
+    }
+  }
+};
+
+/*!
+ * A specialized RAJA::kernel hip_impl executor for statement::TileTCount
+ * Assigns the tile segment to segment ArgumentId
+ * Assigns the tile index to param ParamId
+ */
+template <typename Data,
+          camp::idx_t ArgumentId,
+          typename ParamId,
+          camp::idx_t chunk_size,
+          int BlockDim,
+          typename... EnclosedStmts>
+struct HipStatementExecutor<
+    Data,
+    statement::TileTCount<ArgumentId, ParamId,
+                    RAJA::statement::tile_fixed<chunk_size>,
                     hip_block_xyz_loop<BlockDim>,
                     EnclosedStmts...>>
     : public HipStatementExecutor<

--- a/include/RAJA/policy/hip/policy.hpp
+++ b/include/RAJA/policy/hip/policy.hpp
@@ -233,6 +233,19 @@ using hip_thread_z_loop = hip_thread_xyz_loop<2, 1>;
 
 
 /*!
+ * Maps segment indices to CUDA blocks.
+ * This is the lowest overhead mapping, but requires that there are enough
+ * physical blocks to fit all of the direct map requests.
+ */
+template<int dim>
+struct hip_block_xyz_direct{};
+
+using hip_block_x_direct = hip_block_xyz_direct<0>;
+using hip_block_y_direct = hip_block_xyz_direct<1>;
+using hip_block_z_direct = hip_block_xyz_direct<2>;
+
+
+/*!
  * Maps segment indices to HIP blocks.
  * Uses grid-stride looping to exceed the maximum number of blocks
  */

--- a/test/unit/test-kernel-lambda-args.cpp
+++ b/test/unit/test-kernel-lambda-args.cpp
@@ -365,19 +365,49 @@ using CUDATypes =
                >,
               RAJA::statement::CudaSyncThreads,
 
-                //Read data from shared memory
-                RAJA::statement::For<0, RAJA::cuda_thread_y_direct,
-                  RAJA::statement::For<1, RAJA::cuda_thread_x_direct,
-                  RAJA::statement::Lambda<1, Segs<0>, Segs<1>, Offsets<0>, Offsets<1>, Params<0,1> >
-                  >
-                 >,
-                RAJA::statement::CudaSyncThreads
-              > //close shared memory scope
-            >//for 2
-          >//for 3
-        > //CudaKernel
-      > //kernel policy
-    > //list
+              //Read data from shared memory
+              RAJA::statement::For<0, RAJA::cuda_thread_y_direct,
+                RAJA::statement::For<1, RAJA::cuda_thread_x_direct,
+                RAJA::statement::Lambda<1, Segs<0>, Segs<1>, Offsets<0>, Offsets<1>, Params<0,1> >
+                >
+               >,
+              RAJA::statement::CudaSyncThreads
+            > //close shared memory scope
+          >//for 2
+        >//for 3
+      > //CudaKernel
+    > //kernel policy
+  > //list
+  ,
+  RAJA::list<
+    RAJA::KernelPolicy<
+      RAJA::statement::CudaKernel<
+        RAJA::statement::Tile<1, RAJA::statement::tile_fixed<TILE_DIM>, RAJA::cuda_block_y_direct,
+        RAJA::statement::Tile<0, RAJA::statement::tile_fixed<TILE_DIM>, RAJA::cuda_block_x_direct,
+
+            RAJA::statement::InitLocalMem<RAJA::cuda_shared_mem, RAJA::ParamList<0,1>,
+
+              //Load data into shared memory
+              RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+                RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                  RAJA::statement::Lambda<0, Segs<0>, Segs<1>, Offsets<0>, Offsets<1>, Params<0,1> >
+                 >
+               >,
+              RAJA::statement::CudaSyncThreads,
+
+              //Read data from shared memory
+              RAJA::statement::For<0, RAJA::cuda_thread_y_direct,
+                RAJA::statement::For<1, RAJA::cuda_thread_x_direct,
+                RAJA::statement::Lambda<1, Segs<0>, Segs<1>, Offsets<0>, Offsets<1>, Params<0,1> >
+                >
+               >,
+              RAJA::statement::CudaSyncThreads
+            > //close shared memory scope
+          >//for 2
+        >//for 3
+      > //CudaKernel
+    > //kernel policy
+  > //list
   >; //types
 INSTANTIATE_TYPED_TEST_SUITE_P(CUDA, MatTranspose, CUDATypes);
 #endif
@@ -388,8 +418,8 @@ using HIPTypes =
   RAJA::list<
     RAJA::KernelPolicy<
       RAJA::statement::HipKernel<
-        RAJA::statement::Tile<1, RAJA::statement::tile_fixed<TILE_DIM>, RAJA::hip_block_y_loop,
-        RAJA::statement::Tile<0, RAJA::statement::tile_fixed<TILE_DIM>, RAJA::hip_block_x_loop,
+        RAJA::statement::Tile<1, RAJA::statement::tile_fixed<TILE_DIM>, RAJA::hip_block_y_direct,
+          RAJA::statement::Tile<0, RAJA::statement::tile_fixed<TILE_DIM>, RAJA::hip_block_x_direct,
 
             RAJA::statement::InitLocalMem<RAJA::hip_shared_mem, RAJA::ParamList<0,1>,
 
@@ -397,23 +427,53 @@ using HIPTypes =
               RAJA::statement::For<1, RAJA::hip_thread_y_direct,
                 RAJA::statement::For<0, RAJA::hip_thread_x_direct,
                   RAJA::statement::Lambda<0, Segs<0>, Segs<1>, Offsets<0>, Offsets<1>, Params<0,1> >
-                 >
-               >,
+                >
+              >,
               RAJA::statement::HipSyncThreads,
 
-                //Read data from shared memory
-                RAJA::statement::For<0, RAJA::hip_thread_y_direct,
-                  RAJA::statement::For<1, RAJA::hip_thread_x_direct,
+              //Read data from shared memory
+              RAJA::statement::For<0, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<1, RAJA::hip_thread_x_direct,
                   RAJA::statement::Lambda<1, Segs<0>, Segs<1>, Offsets<0>, Offsets<1>, Params<0,1> >
-                  >
-                 >,
-                RAJA::statement::HipSyncThreads
-              > //close shared memory scope
-            >//for 2
-          >//for 3
-        > //HipKernel
-      > //kernel policy
-    > //list
+                >
+              >,
+              RAJA::statement::HipSyncThreads
+            > //close shared memory scope
+          >//for 2
+        >//for 3
+      > //HipKernel
+    > //kernel policy
+  > //list
+  ,
+  RAJA::list<
+    RAJA::KernelPolicy<
+      RAJA::statement::HipKernel<
+        RAJA::statement::Tile<1, RAJA::statement::tile_fixed<TILE_DIM>, RAJA::hip_block_y_loop,
+          RAJA::statement::Tile<0, RAJA::statement::tile_fixed<TILE_DIM>, RAJA::hip_block_x_loop,
+
+            RAJA::statement::InitLocalMem<RAJA::hip_shared_mem, RAJA::ParamList<0,1>,
+
+              //Load data into shared memory
+              RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                  RAJA::statement::Lambda<0, Segs<0>, Segs<1>, Offsets<0>, Offsets<1>, Params<0,1> >
+                >
+              >,
+              RAJA::statement::HipSyncThreads,
+
+              //Read data from shared memory
+              RAJA::statement::For<0, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<1, RAJA::hip_thread_x_direct,
+                  RAJA::statement::Lambda<1, Segs<0>, Segs<1>, Offsets<0>, Offsets<1>, Params<0,1> >
+                >
+              >,
+              RAJA::statement::HipSyncThreads
+            > //close shared memory scope
+          >//for 2
+        >//for 3
+      > //HipKernel
+    > //kernel policy
+  > //list
   >; //types
 INSTANTIATE_TYPED_TEST_SUITE_P(HIP, MatTranspose_gpu, HIPTypes);
 #endif
@@ -851,10 +911,10 @@ using CudaTypes2 =
               RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
                 RAJA::statement::Lambda<0, Segs<0,1>, Params<2> >
               >
-             >,
+            >,
 
             //Slide window across matrix
-             RAJA::statement::For<2, RAJA::seq_exec,
+            RAJA::statement::For<2, RAJA::seq_exec,
 
               //Load matrix into tile
               RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
@@ -877,13 +937,13 @@ using CudaTypes2 =
               RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
                 RAJA::statement::Lambda<3, Segs<0,1, 3, 4>, Params<2> >
               >
-             >
-         > //Create shared memory
+            >
+          > //Create shared memory
         >//For 3
-       >//For 4
-        > //CudaKernel
-      > //close kernel policy
-    > //close list
+      >//For 4
+      > //CudaKernel
+    > //close kernel policy
+  > //close list
   ,
   RAJA::list<
     RAJA::SizeList<TILE_DIM, TILE_DIM>,
@@ -898,22 +958,22 @@ using CudaTypes2 =
               RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
                 RAJA::statement::Lambda<0, Segs<0,1>, Params<2> >
               >
-             >,
+            >,
 
             //Slide window across matrix
-             RAJA::statement::For<2, RAJA::seq_exec,
+            RAJA::statement::For<2, RAJA::seq_exec,
 
               //Load matrix into tile
               RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
                 RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
-                   RAJA::statement::Lambda<1, Segs<0,1,2,3,4>, Params<0,1> >
+                  RAJA::statement::Lambda<1, Segs<0,1,2,3,4>, Params<0,1> >
                 >
               >,
-              //perform matrix multiplcation
+              //perform matrix multiplication
               RAJA::statement::CudaSyncThreads,
-                RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
-                  RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
-                   RAJA::statement::Lambda<2, Segs<0,1>, Params<0,1,2> >
+              RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+                RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                  RAJA::statement::Lambda<2, Segs<0,1>, Params<0,1,2> >
                 >
               >,
               RAJA::statement::CudaSyncThreads
@@ -924,13 +984,13 @@ using CudaTypes2 =
               RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
                 RAJA::statement::Lambda<3, Segs<0,1, 3, 4>, Params<2> >
               >
-             >
-         > //Create shared memory
+            >
+          > //Create shared memory
         >//For 3
-       >//For 4
-        > //CudaKernel
-      > //close kernel policy
-    > //close list
+      >//For 4
+      > //CudaKernel
+    > //close kernel policy
+  > //close list
   >;//close types
 
 INSTANTIATE_TYPED_TEST_SUITE_P(CUDAShmem, MatMultiply, CudaTypes2);
@@ -939,6 +999,54 @@ INSTANTIATE_TYPED_TEST_SUITE_P(CUDAShmem, MatMultiply, CudaTypes2);
 #if defined(RAJA_ENABLE_HIP)
 using HipTypes2 =
   ::testing::Types<
+
+  RAJA::list<
+    RAJA::SizeList<TILE_DIM, TILE_DIM>,
+    RAJA::SizeList<TILE_DIM, TILE_DIM>,
+    RAJA::KernelPolicy<
+      RAJA::statement::HipKernel<
+      RAJA::statement::For<4, RAJA::hip_block_y_direct,
+        RAJA::statement::For<3, RAJA::hip_block_x_direct,
+          RAJA::statement::InitLocalMem<RAJA::hip_shared_mem, RAJA::ParamList<2,1,0>,
+            //Initalize thread private value
+            RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+              RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                RAJA::statement::Lambda<0, Segs<0,1>, Params<2> >
+              >
+            >,
+
+            //Slide window across matrix
+             RAJA::statement::For<2, RAJA::seq_exec,
+
+              //Load matrix into tile
+              RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                  RAJA::statement::Lambda<1, Segs<0,1,2,3,4>, Params<0,1> >
+                >
+              >,
+              //perform matrix multiplcation
+              RAJA::statement::HipSyncThreads,
+              RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                  RAJA::statement::Lambda<2, Segs<0,1>, Params<0,1,2> >
+                >
+              >,
+              RAJA::statement::HipSyncThreads
+            >, //sliding window
+
+            //Write memory out to global matrix
+            RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+              RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                RAJA::statement::Lambda<3, Segs<0,1, 3, 4>, Params<2> >
+              >
+            >
+          > //Create shared memory
+        >//For 3
+      >//For 4
+      > //HipKernel
+    > //close kernel policy
+  > //close list
+  ,
   RAJA::list<
     RAJA::SizeList<TILE_DIM, TILE_DIM>,
     RAJA::SizeList<TILE_DIM, TILE_DIM>,
@@ -952,7 +1060,7 @@ using HipTypes2 =
               RAJA::statement::For<0, RAJA::hip_thread_x_direct,
                 RAJA::statement::Lambda<0, Segs<0,1>, Params<2> >
               >
-             >,
+            >,
 
             //Slide window across matrix
              RAJA::statement::For<2, RAJA::seq_exec,
@@ -960,14 +1068,14 @@ using HipTypes2 =
               //Load matrix into tile
               RAJA::statement::For<1, RAJA::hip_thread_y_direct,
                 RAJA::statement::For<0, RAJA::hip_thread_x_direct,
-                   RAJA::statement::Lambda<1, Segs<0,1,2,3,4>, Params<0,1> >
+                  RAJA::statement::Lambda<1, Segs<0,1,2,3,4>, Params<0,1> >
                 >
               >,
               //perform matrix multiplcation
               RAJA::statement::HipSyncThreads,
-                RAJA::statement::For<1, RAJA::hip_thread_y_direct,
-                  RAJA::statement::For<0, RAJA::hip_thread_x_direct,
-                   RAJA::statement::Lambda<2, Segs<0,1>, Params<0,1,2> >
+              RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                  RAJA::statement::Lambda<2, Segs<0,1>, Params<0,1,2> >
                 >
               >,
               RAJA::statement::HipSyncThreads
@@ -978,13 +1086,13 @@ using HipTypes2 =
               RAJA::statement::For<0, RAJA::hip_thread_x_direct,
                 RAJA::statement::Lambda<3, Segs<0,1, 3, 4>, Params<2> >
               >
-             >
-         > //Create shared memory
+            >
+          > //Create shared memory
         >//For 3
-       >//For 4
-        > //HipKernel
-      > //close kernel policy
-    > //close list
+      >//For 4
+      > //HipKernel
+    > //close kernel policy
+  > //close list
   >;//close types
 
 INSTANTIATE_TYPED_TEST_SUITE_P(HIPShmem, MatMultiply_gpu, HipTypes2);
@@ -1230,22 +1338,15 @@ using CudaTypesMult3 =
         >
       >
     >
-    >//close list
-  >;//close types
-
-INSTANTIATE_TYPED_TEST_SUITE_P(Cuda, MatMult3, CudaTypesMult3);
-#endif
-
-#if defined(RAJA_ENABLE_HIP)
-using HipTypesMult3 =
-  ::testing::Types<
+  >//close list
+  ,
   RAJA::list<
     RAJA::KernelPolicy<
-      RAJA::statement::HipKernel<
-        RAJA::statement::Tile<1, RAJA::statement::tile_fixed<16>, RAJA::hip_block_y_loop,
-          RAJA::statement::Tile<0, RAJA::statement::tile_fixed<16>, RAJA::hip_block_x_loop,
-            RAJA::statement::For<1, RAJA::hip_thread_y_loop, // row
-              RAJA::statement::For<0, RAJA::hip_thread_x_loop, // col
+      RAJA::statement::CudaKernel<
+        RAJA::statement::Tile<1, RAJA::statement::tile_fixed<16>, RAJA::cuda_block_y_direct,
+          RAJA::statement::Tile<0, RAJA::statement::tile_fixed<16>, RAJA::cuda_block_x_direct,
+            RAJA::statement::For<1, RAJA::cuda_thread_y_loop, // row
+              RAJA::statement::For<0, RAJA::cuda_thread_x_loop, // col
                 RAJA::statement::Lambda<0, Params<0>>,  // dot = 0.0
                 RAJA::statement::For<2, RAJA::seq_exec,
                   RAJA::statement::Lambda<1, Segs<0,1,2>, Params<0>> // dot += ...
@@ -1257,7 +1358,54 @@ using HipTypesMult3 =
         >
       >
     >
-    >//close list
+  >//close list
+  >;//close types
+
+INSTANTIATE_TYPED_TEST_SUITE_P(Cuda, MatMult3, CudaTypesMult3);
+#endif
+
+#if defined(RAJA_ENABLE_HIP)
+using HipTypesMult3 =
+  ::testing::Types<
+  RAJA::list<
+    RAJA::KernelPolicy<
+      RAJA::statement::HipKernel<
+        RAJA::statement::Tile<1, RAJA::statement::tile_fixed<16>, RAJA::hip_block_y_direct,
+          RAJA::statement::Tile<0, RAJA::statement::tile_fixed<16>, RAJA::hip_block_x_direct,
+            RAJA::statement::For<1, RAJA::hip_thread_y_loop, // row
+              RAJA::statement::For<0, RAJA::hip_thread_x_loop, // col
+                RAJA::statement::Lambda<0, Params<0>>,  // dot = 0.0
+                RAJA::statement::For<2, RAJA::seq_exec,
+                  RAJA::statement::Lambda<1, Segs<0,1,2>, Params<0>> // dot += ...
+                >,
+                RAJA::statement::Lambda<2, Segs<0,1>, Params<0>>   // set C = ...
+              >
+            >
+          >
+        >
+      >
+    >
+  >//close list
+  ,
+  RAJA::list<
+    RAJA::KernelPolicy<
+      RAJA::statement::HipKernel<
+        RAJA::statement::Tile<1, RAJA::statement::tile_fixed<16>, RAJA::hip_block_y_loop,
+          RAJA::statement::Tile<0, RAJA::statement::tile_fixed<16>, RAJA::hip_block_x_loop,
+            RAJA::statement::For<1, RAJA::hip_thread_y_loop, // row
+              RAJA::statement::For<0, RAJA::hip_thread_x_loop, // col
+                RAJA::statement::Lambda<0, Params<0>>,  // dot = 0.0
+                RAJA::statement::For<2, RAJA::seq_exec,
+                  RAJA::statement::Lambda<1, Segs<0,1,2>, Params<0>> // dot += ...
+                >,
+                RAJA::statement::Lambda<2, Segs<0,1>, Params<0>>   // set C = ...
+              >
+            >
+          >
+        >
+      >
+    >
+  >//close list
   >;//close types
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Hip, MatMult3_gpu, HipTypesMult3);

--- a/test/unit/test-sharedmem.cpp
+++ b/test/unit/test-sharedmem.cpp
@@ -606,6 +606,32 @@ using CUDATypes =
   RAJA::list<
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernel<
+        RAJA::statement::For<3, RAJA::cuda_block_y_direct,
+          RAJA::statement::For<2, RAJA::cuda_block_x_direct,
+
+            RAJA::statement::InitLocalMem<RAJA::cuda_shared_mem, RAJA::ParamList<0,1>,
+
+              //Load data into shared memory
+              RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+                RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                  RAJA::statement::Lambda<0> > >,
+              RAJA::statement::CudaSyncThreads,
+
+              //Read data from shared memory
+              RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+                RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                  RAJA::statement::Lambda<1> > >,
+              RAJA::statement::CudaSyncThreads
+            > //close shared memory scope
+          >//for 2
+        >//for 3
+      > //CudaKernel
+    > //kernel policy
+  > //list
+  ,
+  RAJA::list<
+    RAJA::KernelPolicy<
+      RAJA::statement::CudaKernel<
         RAJA::statement::For<3, RAJA::cuda_block_y_loop,
           RAJA::statement::For<2, RAJA::cuda_block_x_loop,
 
@@ -617,17 +643,17 @@ using CUDATypes =
                   RAJA::statement::Lambda<0> > >,
               RAJA::statement::CudaSyncThreads,
 
-                //Read data from shared memory
-                RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
-                  RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
-                    RAJA::statement::Lambda<1> > >,
-                RAJA::statement::CudaSyncThreads
-              > //close shared memory scope
-            >//for 2
-          >//for 3
-        > //CudaKernel
-      > //kernel policy
-    > //list
+              //Read data from shared memory
+              RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+                RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                  RAJA::statement::Lambda<1> > >,
+              RAJA::statement::CudaSyncThreads
+            > //close shared memory scope
+          >//for 2
+        >//for 3
+      > //CudaKernel
+    > //kernel policy
+  > //list
   >; //types
 INSTANTIATE_TYPED_TEST_SUITE_P(CUDA, MatTranspose, CUDATypes);
 INSTANTIATE_TYPED_TEST_SUITE_P(CUDA, TypedLocalMem, CUDATypes);
@@ -641,6 +667,36 @@ using HIPTypes =
   RAJA::list<
     RAJA::KernelPolicy<
       RAJA::statement::HipKernel<
+        RAJA::statement::For<3, RAJA::hip_block_y_direct,
+          RAJA::statement::For<2, RAJA::hip_block_x_direct,
+
+            RAJA::statement::InitLocalMem<RAJA::hip_shared_mem, RAJA::ParamList<0,1>,
+
+              //Load data into shared memory
+              RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                  RAJA::statement::Lambda<0>
+                >
+              >,
+              RAJA::statement::HipSyncThreads,
+
+              //Read data from shared memory
+              RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                  RAJA::statement::Lambda<1>
+                >
+              >,
+              RAJA::statement::HipSyncThreads
+            > //close shared memory scope
+          >//for 2
+        >//for 3
+      > //HipKernel
+    > //kernel policy
+  > //list
+  ,
+  RAJA::list<
+    RAJA::KernelPolicy<
+      RAJA::statement::HipKernel<
         RAJA::statement::For<3, RAJA::hip_block_y_loop,
           RAJA::statement::For<2, RAJA::hip_block_x_loop,
 
@@ -649,20 +705,24 @@ using HIPTypes =
               //Load data into shared memory
               RAJA::statement::For<1, RAJA::hip_thread_y_direct,
                 RAJA::statement::For<0, RAJA::hip_thread_x_direct,
-                  RAJA::statement::Lambda<0> > >,
+                  RAJA::statement::Lambda<0>
+                >
+              >,
               RAJA::statement::HipSyncThreads,
 
-                //Read data from shared memory
-                RAJA::statement::For<1, RAJA::hip_thread_y_direct,
-                  RAJA::statement::For<0, RAJA::hip_thread_x_direct,
-                    RAJA::statement::Lambda<1> > >,
-                RAJA::statement::HipSyncThreads
-              > //close shared memory scope
-            >//for 2
+              //Read data from shared memory
+              RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                  RAJA::statement::Lambda<1>
+                >
+              >,
+              RAJA::statement::HipSyncThreads
+            > //close shared memory scope
+          >//for 2
         >//for 3
-        > //HipKernel
-      > //kernel policy
-    > //list
+      > //HipKernel
+    > //kernel policy
+  > //list
   >; //types
 INSTANTIATE_TYPED_TEST_SUITE_P(HIP, MatTranspose_gpu, HIPTypes);
 INSTANTIATE_TYPED_TEST_SUITE_P(HIP, TypedLocalMem_gpu, HIPTypes);
@@ -1475,13 +1535,15 @@ using CudaTypes2 =
     RAJA::SizeList<TILE_DIM, TILE_DIM>,
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernel<
-      RAJA::statement::For<4, RAJA::cuda_block_y_loop,
-        RAJA::statement::For<3, RAJA::cuda_block_x_loop,
+      RAJA::statement::For<4, RAJA::cuda_block_y_direct,
+        RAJA::statement::For<3, RAJA::cuda_block_x_direct,
           RAJA::statement::InitLocalMem<RAJA::cuda_shared_mem, RAJA::ParamList<2,1,0>,
             //Initalize thread private value
             RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
               RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
-                RAJA::statement::Lambda<0> > >,
+                RAJA::statement::Lambda<0>
+              >
+            >,
 
             //Slide window across matrix
              RAJA::statement::For<2, RAJA::seq_exec,
@@ -1489,24 +1551,122 @@ using CudaTypes2 =
               //Load matrix into tile
               RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
                 RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
-                  RAJA::statement::Lambda<1> > >,
+                  RAJA::statement::Lambda<1>
+                >
+              >,
               //perform matrix multiplcation
               RAJA::statement::CudaSyncThreads,
               RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
                 RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
-                  RAJA::statement::Lambda<2> > >,
+                  RAJA::statement::Lambda<2>
+                >
+              >,
               RAJA::statement::CudaSyncThreads
             >, //sliding window
 
             //Write memory out to global matrix
             RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
               RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
-                RAJA::statement::Lambda<3> > >
-         > //Create shared memory
+                RAJA::statement::Lambda<3>
+              >
+            >
+          > //Create shared memory
         >//For 3
-       >//For 4
-        > //CudaKernel
-      >, //close kernel policy
+      >//For 4
+      > //CudaKernel
+    >, //close kernel policy
+    //Policy for Matrix multiply with a scalar as accumulator
+    RAJA::KernelPolicy<
+      RAJA::statement::CudaKernel<
+      RAJA::statement::For<4, RAJA::cuda_block_y_direct,
+        RAJA::statement::For<3, RAJA::cuda_block_x_direct,
+          RAJA::statement::InitLocalMem<RAJA::cuda_shared_mem, RAJA::ParamList<1,0>,
+
+            //Intialize thread private value to zero
+            RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+              RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                RAJA::statement::Lambda<0>
+              >
+            >,
+
+            //Slide window across matrix
+            RAJA::statement::For<2, RAJA::seq_exec,
+
+               //Load matrix into tile
+              RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+                RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                  RAJA::statement::Lambda<1>
+                >
+              >,
+
+              //perform matrix multiplcation
+              RAJA::statement::CudaSyncThreads,
+              RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+                RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                  RAJA::statement::Lambda<2>
+                >
+              >,
+              RAJA::statement::CudaSyncThreads
+            >, //sliding window
+
+            //Write memory out to global matrix
+            RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+              RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                RAJA::statement::Lambda<3>
+              >
+            >
+          > //Create shared memory
+        >//For 3
+      >//For 4
+      > //CudaKernel
+    > //close kernel policy
+  > //close list
+  ,
+  RAJA::list<
+    RAJA::SizeList<TILE_DIM, TILE_DIM>,
+    RAJA::SizeList<TILE_DIM, TILE_DIM>,
+    RAJA::KernelPolicy<
+      RAJA::statement::CudaKernel<
+      RAJA::statement::For<4, RAJA::cuda_block_y_loop,
+        RAJA::statement::For<3, RAJA::cuda_block_x_loop,
+          RAJA::statement::InitLocalMem<RAJA::cuda_shared_mem, RAJA::ParamList<2,1,0>,
+            //Initalize thread private value
+            RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+              RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                RAJA::statement::Lambda<0>
+              >
+            >,
+
+            //Slide window across matrix
+             RAJA::statement::For<2, RAJA::seq_exec,
+
+              //Load matrix into tile
+              RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+                RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                  RAJA::statement::Lambda<1>
+                >
+              >,
+              //perform matrix multiplcation
+              RAJA::statement::CudaSyncThreads,
+              RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+                RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                  RAJA::statement::Lambda<2>
+                >
+              >,
+              RAJA::statement::CudaSyncThreads
+            >, //sliding window
+
+            //Write memory out to global matrix
+            RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+              RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                RAJA::statement::Lambda<3>
+              >
+            >
+          > //Create shared memory
+        >//For 3
+      >//For 4
+      > //CudaKernel
+    >, //close kernel policy
     //Policy for Matrix multiply with a scalar as accumulator
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernel<
@@ -1517,7 +1677,9 @@ using CudaTypes2 =
             //Intialize thread private value to zero
             RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
               RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
-                RAJA::statement::Lambda<0> > >,
+                RAJA::statement::Lambda<0>
+              >
+            >,
 
             //Slide window across matrix
             RAJA::statement::For<2, RAJA::seq_exec,
@@ -1525,26 +1687,32 @@ using CudaTypes2 =
                //Load matrix into tile
               RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
                 RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
-                  RAJA::statement::Lambda<1> > >,
+                  RAJA::statement::Lambda<1>
+                >
+              >,
 
               //perform matrix multiplcation
               RAJA::statement::CudaSyncThreads,
               RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
                 RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
-                  RAJA::statement::Lambda<2> > >,
+                  RAJA::statement::Lambda<2>
+                >
+              >,
               RAJA::statement::CudaSyncThreads
             >, //sliding window
 
             //Write memory out to global matrix
             RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
               RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
-                RAJA::statement::Lambda<3> > >
-         > //Create shared memory
+                RAJA::statement::Lambda<3>
+              >
+            >
+          > //Create shared memory
         >//For 3
-       >//For 4
+      >//For 4
       > //CudaKernel
-     > //close kernel policy
-    > //close list
+    > //close kernel policy
+  > //close list
   >;//close types
 
 INSTANTIATE_TYPED_TEST_SUITE_P(CUDAShmem, MatMultiply, CudaTypes2);
@@ -1552,6 +1720,57 @@ INSTANTIATE_TYPED_TEST_SUITE_P(CUDAShmem, MatMultiplyScalar, CudaTypes2);
 
 using CudaTypes3 =
   ::testing::Types<
+
+  RAJA::list<
+    RAJA::SizeList<TILE_DIM, TILE_DIM>,
+    RAJA::SizeList<0,0>,
+    //Policy for Matrix multiply with a scalar
+    RAJA::KernelPolicy<
+      RAJA::statement::CudaKernel<
+      RAJA::statement::For<4, RAJA::cuda_block_y_direct,
+        RAJA::statement::For<3, RAJA::cuda_block_x_direct,
+          RAJA::statement::InitLocalMem<RAJA::cuda_shared_mem, RAJA::ParamList<0,1>,
+            RAJA::statement::InitLocalMem<RAJA::cuda_thread_mem, RAJA::ParamList<2>,
+              //Initalize thread private value
+              RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+                RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                  RAJA::statement::Lambda<0>
+                >
+              >,
+
+              //Slide window across matrix
+              RAJA::statement::For<2, RAJA::seq_exec,
+
+                //Load matrix into tile
+                RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+                  RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                    RAJA::statement::Lambda<1>
+                  >
+                >,
+                //perform matrix multiplcation
+                RAJA::statement::CudaSyncThreads,
+                RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+                  RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                    RAJA::statement::Lambda<2>
+                  >
+                >,
+                RAJA::statement::CudaSyncThreads
+              >, //sliding window
+
+              //Write memory out to global matrix
+              RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+                RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                  RAJA::statement::Lambda<3>
+                >
+              >
+            > //Create private memory
+          > //Create shared memory
+        >//For 3
+      >//For 4
+      > //CudaKernel
+    > //close kernel policy
+  > //close list
+  ,
   RAJA::list<
     RAJA::SizeList<TILE_DIM, TILE_DIM>,
     RAJA::SizeList<0,0>,
@@ -1562,32 +1781,38 @@ using CudaTypes3 =
         RAJA::statement::For<3, RAJA::cuda_block_x_loop,
           RAJA::statement::InitLocalMem<RAJA::cuda_shared_mem, RAJA::ParamList<0,1>,
             RAJA::statement::InitLocalMem<RAJA::cuda_thread_mem, RAJA::ParamList<2>,
-            //Initalize thread private value
-            RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
-              RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
-                                   RAJA::statement::Lambda<0> > >,
-
-            //Slide window across matrix
-            RAJA::statement::For<2, RAJA::seq_exec,
-
-              //Load matrix into tile
+              //Initalize thread private value
               RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
                 RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
-                  RAJA::statement::Lambda<1>
-                                   >
-                                 >,
-              //perform matrix multiplcation
-              RAJA::statement::CudaSyncThreads,
+                  RAJA::statement::Lambda<0>
+                >
+              >,
+
+              //Slide window across matrix
+              RAJA::statement::For<2, RAJA::seq_exec,
+
+                //Load matrix into tile
+                RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+                  RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                    RAJA::statement::Lambda<1>
+                  >
+                >,
+                //perform matrix multiplcation
+                RAJA::statement::CudaSyncThreads,
+                RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+                  RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+                    RAJA::statement::Lambda<2>
+                  >
+                >,
+                RAJA::statement::CudaSyncThreads
+              >, //sliding window
+
+              //Write memory out to global matrix
               RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
                 RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
-                  RAJA::statement::Lambda<2> > >,
-              RAJA::statement::CudaSyncThreads
-            >, //sliding window
-
-            //Write memory out to global matrix
-            RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
-              RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
-                RAJA::statement::Lambda<3> > >
+                  RAJA::statement::Lambda<3>
+                >
+              >
             > //Create private memory
           > //Create shared memory
         >//For 3
@@ -1610,39 +1835,134 @@ using HipTypes2 =
     RAJA::SizeList<TILE_DIM, TILE_DIM>,
     RAJA::KernelPolicy<
       RAJA::statement::HipKernel<
+      RAJA::statement::For<4, RAJA::hip_block_y_direct,
+        RAJA::statement::For<3, RAJA::hip_block_x_direct,
+          RAJA::statement::InitLocalMem<RAJA::hip_shared_mem, RAJA::ParamList<2,1,0>,
+            //Initalize thread private value
+            RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+              RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                RAJA::statement::Lambda<0>
+              >
+            >,
+
+            //Slide window across matrix
+            RAJA::statement::For<2, RAJA::seq_exec,
+
+              //Load matrix into tile
+              RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                  RAJA::statement::Lambda<1>
+                >
+              >,
+             //perform matrix multiplcation
+              RAJA::statement::HipSyncThreads,
+              RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                  RAJA::statement::Lambda<2>
+                >
+              >,
+              RAJA::statement::HipSyncThreads
+            >, //sliding window
+            //Write memory out to global matrix
+            RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+              RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                RAJA::statement::Lambda<3>
+              >
+            >
+          > //Create shared memory
+        >//For 3
+      >//For 4
+      > //HipKernel
+    >, //close kernel policy
+    //Policy for Matrix multiply with a scalar as accumulator
+    RAJA::KernelPolicy<
+      RAJA::statement::HipKernel<
+      RAJA::statement::For<4, RAJA::hip_block_y_direct,
+        RAJA::statement::For<3, RAJA::hip_block_x_direct,
+          RAJA::statement::InitLocalMem<RAJA::hip_shared_mem, RAJA::ParamList<1,0>,
+
+            //Intialize thread private value to zero
+            RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+              RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                RAJA::statement::Lambda<0>
+              >
+            >,
+
+            //Slide window across matrix
+            RAJA::statement::For<2, RAJA::seq_exec,
+
+               //Load matrix into tile
+              RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                  RAJA::statement::Lambda<1>
+                >
+              >,
+             //perform matrix multiplcation
+              RAJA::statement::HipSyncThreads,
+              RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                  RAJA::statement::Lambda<2>
+                >
+              >,
+              RAJA::statement::HipSyncThreads
+            >, //sliding window
+            //Write memory out to global matrix
+            RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+              RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                RAJA::statement::Lambda<3>
+              >
+            >
+          > //Create shared memory
+        >//For 3
+      >//For 4
+      > //HipKernel
+    > //close kernel policy
+  > //close list
+  ,
+  RAJA::list<
+    RAJA::SizeList<TILE_DIM, TILE_DIM>,
+    RAJA::SizeList<TILE_DIM, TILE_DIM>,
+    RAJA::KernelPolicy<
+      RAJA::statement::HipKernel<
       RAJA::statement::For<4, RAJA::hip_block_y_loop,
         RAJA::statement::For<3, RAJA::hip_block_x_loop,
           RAJA::statement::InitLocalMem<RAJA::hip_shared_mem, RAJA::ParamList<2,1,0>,
             //Initalize thread private value
             RAJA::statement::For<1, RAJA::hip_thread_y_direct,
               RAJA::statement::For<0, RAJA::hip_thread_x_direct,
-                                   RAJA::statement::Lambda<0> > >,
+                RAJA::statement::Lambda<0>
+              >
+            >,
 
             //Slide window across matrix
-             RAJA::statement::For<2, RAJA::seq_exec,
+            RAJA::statement::For<2, RAJA::seq_exec,
 
-               //Load matrix into tile
+              //Load matrix into tile
               RAJA::statement::For<1, RAJA::hip_thread_y_direct,
                 RAJA::statement::For<0, RAJA::hip_thread_x_direct,
                   RAJA::statement::Lambda<1>
-                                   >
-                                 >,
+                >
+              >,
              //perform matrix multiplcation
               RAJA::statement::HipSyncThreads,
-                RAJA::statement::For<1, RAJA::hip_thread_y_direct,
-                  RAJA::statement::For<0, RAJA::hip_thread_x_direct,
-                    RAJA::statement::Lambda<2> > >
-                     ,RAJA::statement::HipSyncThreads
+              RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                  RAJA::statement::Lambda<2>
+                >
+              >,
+              RAJA::statement::HipSyncThreads
             >, //sliding window
             //Write memory out to global matrix
             RAJA::statement::For<1, RAJA::hip_thread_y_direct,
               RAJA::statement::For<0, RAJA::hip_thread_x_direct,
-                                   RAJA::statement::Lambda<3> > >
-         > //Create shared memory
+                RAJA::statement::Lambda<3>
+              >
+            >
+          > //Create shared memory
         >//For 3
-       >//For 4
-        > //HipKernel
-      >, //close kernel policy
+      >//For 4
+      > //HipKernel
+    >, //close kernel policy
     //Policy for Matrix multiply with a scalar as accumulator
     RAJA::KernelPolicy<
       RAJA::statement::HipKernel<
@@ -1653,34 +1973,40 @@ using HipTypes2 =
             //Intialize thread private value to zero
             RAJA::statement::For<1, RAJA::hip_thread_y_direct,
               RAJA::statement::For<0, RAJA::hip_thread_x_direct,
-                                   RAJA::statement::Lambda<0> > >,
+                RAJA::statement::Lambda<0>
+              >
+            >,
 
             //Slide window across matrix
-             RAJA::statement::For<2, RAJA::seq_exec,
+            RAJA::statement::For<2, RAJA::seq_exec,
 
                //Load matrix into tile
               RAJA::statement::For<1, RAJA::hip_thread_y_direct,
                 RAJA::statement::For<0, RAJA::hip_thread_x_direct,
                   RAJA::statement::Lambda<1>
-                                   >
-                                 >,
+                >
+              >,
              //perform matrix multiplcation
               RAJA::statement::HipSyncThreads,
-                RAJA::statement::For<1, RAJA::hip_thread_y_direct,
-                  RAJA::statement::For<0, RAJA::hip_thread_x_direct,
-                    RAJA::statement::Lambda<2> > >
-                     ,RAJA::statement::HipSyncThreads
-           >, //sliding window
+              RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                  RAJA::statement::Lambda<2>
+                >
+              >,
+              RAJA::statement::HipSyncThreads
+            >, //sliding window
             //Write memory out to global matrix
             RAJA::statement::For<1, RAJA::hip_thread_y_direct,
               RAJA::statement::For<0, RAJA::hip_thread_x_direct,
-                                   RAJA::statement::Lambda<3> > >
-         > //Create shared memory
+                RAJA::statement::Lambda<3>
+              >
+            >
+          > //Create shared memory
         >//For 3
-       >//For 4
+      >//For 4
       > //HipKernel
-     > //close kernel policy
-    > //close list
+    > //close kernel policy
+  > //close list
   >;//close types
 
 INSTANTIATE_TYPED_TEST_SUITE_P(HIPShmem, MatMultiply_gpu, HipTypes2);
@@ -1694,42 +2020,97 @@ using HipTypes3 =
     //Policy for Matrix multiply with a scalar
     RAJA::KernelPolicy<
       RAJA::statement::HipKernel<
+      RAJA::statement::For<4, RAJA::hip_block_y_direct,
+        RAJA::statement::For<3, RAJA::hip_block_x_direct,
+          RAJA::statement::InitLocalMem<RAJA::hip_shared_mem, RAJA::ParamList<0,1>,
+            RAJA::statement::InitLocalMem<RAJA::hip_thread_mem, RAJA::ParamList<2>,
+              //Initalize thread private value
+              RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                  RAJA::statement::Lambda<0>
+                >
+              >,
+
+              //Slide window across matrix
+              RAJA::statement::For<2, RAJA::seq_exec,
+
+                //Load matrix into tile
+                RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                  RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                    RAJA::statement::Lambda<1>
+                  >
+                >,
+                //perform matrix multiplcation
+                RAJA::statement::HipSyncThreads,
+                RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                  RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                    RAJA::statement::Lambda<2>
+                  >
+                >,
+                RAJA::statement::HipSyncThreads
+              >, //sliding window
+              //Write memory out to global matrix
+              RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                  RAJA::statement::Lambda<3>
+                >
+              >
+            > //Create private memory
+          > //Create shared memory
+        >//For 3
+      >//For 4
+      > //HipKernel
+    > //close kernel policy
+  > //close list
+  ,
+  RAJA::list<
+    RAJA::SizeList<TILE_DIM, TILE_DIM>,
+    RAJA::SizeList<0,0>,
+    //Policy for Matrix multiply with a scalar
+    RAJA::KernelPolicy<
+      RAJA::statement::HipKernel<
       RAJA::statement::For<4, RAJA::hip_block_y_loop,
         RAJA::statement::For<3, RAJA::hip_block_x_loop,
           RAJA::statement::InitLocalMem<RAJA::hip_shared_mem, RAJA::ParamList<0,1>,
             RAJA::statement::InitLocalMem<RAJA::hip_thread_mem, RAJA::ParamList<2>,
-            //Initalize thread private value
-            RAJA::statement::For<1, RAJA::hip_thread_y_direct,
-              RAJA::statement::For<0, RAJA::hip_thread_x_direct,
-                                   RAJA::statement::Lambda<0> > >,
-
-            //Slide window across matrix
-             RAJA::statement::For<2, RAJA::seq_exec,
-
-               //Load matrix into tile
+              //Initalize thread private value
               RAJA::statement::For<1, RAJA::hip_thread_y_direct,
                 RAJA::statement::For<0, RAJA::hip_thread_x_direct,
-                  RAJA::statement::Lambda<1>
-                                   >
-                                 >,
-             //perform matrix multiplcation
-              RAJA::statement::HipSyncThreads,
+                  RAJA::statement::Lambda<0>
+                >
+              >,
+
+              //Slide window across matrix
+              RAJA::statement::For<2, RAJA::seq_exec,
+
+                //Load matrix into tile
                 RAJA::statement::For<1, RAJA::hip_thread_y_direct,
                   RAJA::statement::For<0, RAJA::hip_thread_x_direct,
-                    RAJA::statement::Lambda<2> > >
-                     ,RAJA::statement::HipSyncThreads
-            >, //sliding window
-            //Write memory out to global matrix
-            RAJA::statement::For<1, RAJA::hip_thread_y_direct,
-              RAJA::statement::For<0, RAJA::hip_thread_x_direct,
-                                   RAJA::statement::Lambda<3> > >
-         > //Create private memory
-        > //Create shared memory
+                    RAJA::statement::Lambda<1>
+                  >
+                >,
+                //perform matrix multiplcation
+                RAJA::statement::HipSyncThreads,
+                RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                  RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                    RAJA::statement::Lambda<2>
+                  >
+                >,
+                RAJA::statement::HipSyncThreads
+              >, //sliding window
+              //Write memory out to global matrix
+              RAJA::statement::For<1, RAJA::hip_thread_y_direct,
+                RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+                  RAJA::statement::Lambda<3>
+                >
+              >
+            > //Create private memory
+          > //Create shared memory
         >//For 3
-       >//For 4
-       > //HipKernel
-      > //close kernel policy
-    > //close list
+      >//For 4
+      > //HipKernel
+    > //close kernel policy
+  > //close list
   >;//close types
 
 INSTANTIATE_TYPED_TEST_SUITE_P(HIPShmemPriv, MatMultiply_gpu, HipTypes3);


### PR DESCRIPTION
# Summary

- This PR is adds full block direct support in kernel
- It does the following:
  - Fixes #744 
  - Adds block_direct support for cuda and hip kernel statements For, ForIcount, Tile, and TileTcount

Deficiencies:
- ForIcount tests
- TileTcount tests