### PR TITLE
Use loop scan in openmp scan impl

### DIFF
--- a/include/RAJA/policy/openmp/scan.hpp
+++ b/include/RAJA/policy/openmp/scan.hpp
@@ -29,7 +29,7 @@
 #include <omp.h>
 
 #include "RAJA/policy/openmp/policy.hpp"
-#include "RAJA/policy/sequential/scan.hpp"
+#include "RAJA/policy/loop/scan.hpp"
 
 namespace RAJA
 {
@@ -65,12 +65,12 @@ concepts::enable_if<type_traits::is_openmp_policy<Policy>> inclusive_inplace(
     const int pid = omp_get_thread_num();
     const int i0 = firstIndex(n, p, pid);
     const int i1 = firstIndex(n, p, pid + 1);
-    inclusive_inplace(::RAJA::seq_exec{}, begin + i0, begin + i1, f);
+    inclusive_inplace(::RAJA::loop_exec{}, begin + i0, begin + i1, f);
     sums[pid] = *(begin + i1 - 1);
 #pragma omp barrier
 #pragma omp single
     exclusive_inplace(
-        ::RAJA::seq_exec{}, sums.data(), sums.data() + p, f, BinFn::identity());
+        ::RAJA::loop_exec{}, sums.data(), sums.data() + p, f, BinFn::identity());
     for (int i = i0; i < i1; ++i) {
       *(begin + i) = f(*(begin + i), sums[pid]);
     }
@@ -101,12 +101,12 @@ concepts::enable_if<type_traits::is_openmp_policy<Policy>> exclusive_inplace(
     const int i1 = firstIndex(n, p, pid + 1);
     const Value init = ((pid == 0) ? v : *(begin + i0 - 1));
 #pragma omp barrier
-    exclusive_inplace(seq_exec{}, begin + i0, begin + i1, f, init);
+    exclusive_inplace(loop_exec{}, begin + i0, begin + i1, f, init);
     sums[pid] = *(begin + i1 - 1);
 #pragma omp barrier
 #pragma omp single
     exclusive_inplace(
-        seq_exec{}, sums.data(), sums.data() + p, f, BinFn::identity());
+        loop_exec{}, sums.data(), sums.data() + p, f, BinFn::identity());
     for (int i = i0; i < i1; ++i) {
       *(begin + i) = f(*(begin + i), sums[pid]);
     }


### PR DESCRIPTION
Use the loop scan implementation instead of the sequential scan
implementation in the openmp policy

# Summary

- This PR is a bugfix
- It does the following:
  - Modifies the openmp scan implementation