### PR TITLE
Fix Cuda atomicExchange

### DIFF
--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -507,8 +507,38 @@ RAJA_INLINE __device__ unsigned long long cuda_atomicXor<unsigned long long>(
 template <typename T>
 RAJA_INLINE __device__ T cuda_atomicExchange(T volatile *acc, T value)
 {
-  // attempt to use the CUDA builtin atomic, if it exists for T
-  return ::atomicExch((T *)acc, value);
+  return cuda_atomic_CAS_oper(acc, [=] __device__(T) {
+    return value;
+  });
+}
+
+template <>
+RAJA_INLINE __device__ int cuda_atomicExchange<int>(
+    int volatile *acc, int value)
+{
+  return ::atomicExch((int *)acc, value);
+}
+
+template <>
+RAJA_INLINE __device__ unsigned cuda_atomicExchange<unsigned>(
+    unsigned volatile *acc, unsigned value)
+{
+  return ::atomicExch((unsigned *)acc, value);
+}
+
+template <>
+RAJA_INLINE __device__ unsigned long long cuda_atomicExchange<unsigned long long>(
+    unsigned long long volatile *acc,
+    unsigned long long value)
+{
+  return ::atomicExch((unsigned long long *)acc, value);
+}
+
+template <>
+RAJA_INLINE __device__ float cuda_atomicExchange<float>(
+    float volatile *acc, float value)
+{
+  return ::atomicExch((float *)acc, value);
 }
 #endif
 

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -486,9 +486,45 @@ RAJA_INLINE __device__ unsigned long long hip_atomicXor<unsigned long long>(
 template <typename T>
 RAJA_INLINE __device__ T hip_atomicExchange(T volatile *acc, T value)
 {
-  // attempt to use the HIP builtin atomic, if it exists for T
-  return ::atomicExch((T *)acc, value);
+  return hip_atomic_CAS_oper(acc, [=] __device__(T) {
+    return value;
+  });
 }
+
+#if __HIP_ARCH_HAS_GLOBAL_INT32_ATOMICS__
+template <>
+RAJA_INLINE __device__ int hip_atomicExchange<int>(
+    int volatile *acc, int value)
+{
+  return ::atomicExch((int *)acc, value);
+}
+
+template <>
+RAJA_INLINE __device__ unsigned hip_atomicExchange<unsigned>(
+    unsigned volatile *acc, unsigned value)
+{
+  return ::atomicExch((unsigned *)acc, value);
+}
+#endif
+
+#if __HIP_ARCH_HAS_GLOBAL_INT64_ATOMICS__
+template <>
+RAJA_INLINE __device__ unsigned long long hip_atomicExchange<unsigned long long>(
+    unsigned long long volatile *acc,
+    unsigned long long value)
+{
+  return ::atomicExch((unsigned long long *)acc, value);
+}
+#endif
+
+#if __HIP_ARCH_HAS_GLOBAL_FLOAT_ATOMIC_EXCH__
+template <>
+RAJA_INLINE __device__ float hip_atomicExchange<float>(
+    float volatile *acc, float value)
+{
+  return ::atomicExch((float *)acc, value);
+}
+#endif
 
 
 template <typename T>

--- a/test/unit/test-atomic.cpp
+++ b/test/unit/test-atomic.cpp
@@ -24,12 +24,12 @@ void testAtomicFunctionBasic()
 // initialize an array
 #if defined(RAJA_ENABLE_CUDA)
   T *dest = nullptr;
-  cudaErrchk(cudaMallocManaged((void **)&dest, sizeof(T) * 8));
+  cudaErrchk(cudaMallocManaged((void **)&dest, sizeof(T) * 10));
 
   cudaErrchk(cudaDeviceSynchronize());
 
 #else
-  T *dest = new T[8];
+  T *dest = new T[10];
 #endif
 
 

--- a/test/unit/test-atomic.cpp
+++ b/test/unit/test-atomic.cpp
@@ -42,6 +42,8 @@ void testAtomicFunctionBasic()
   dest[5] = (T)0;
   dest[6] = (T)N + 1;
   dest[7] = (T)0;
+  dest[8] = (T)N;
+  dest[9] = (T)0;
 
 
   RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(RAJA::Index_type i) {
@@ -54,6 +56,8 @@ void testAtomicFunctionBasic()
     RAJA::atomicInc<AtomicPolicy>(dest + 5, (T)16);
     RAJA::atomicDec<AtomicPolicy>(dest + 6);
     RAJA::atomicDec<AtomicPolicy>(dest + 7, (T)16);
+    RAJA::atomicExchange<AtomicPolicy>(dest + 8, (T)i);
+    RAJA::atomicCAS<AtomicPolicy>(dest + 9, (T)i, (T)(i+1));
   });
 
 #if defined(RAJA_ENABLE_CUDA)
@@ -68,6 +72,10 @@ void testAtomicFunctionBasic()
   EXPECT_EQ((T)4, dest[5]);
   EXPECT_EQ((T)1, dest[6]);
   EXPECT_EQ((T)13, dest[7]);
+  EXPECT_LE((T)0, dest[8]);
+  EXPECT_GT((T)N, dest[8]);
+  EXPECT_LT((T)0, dest[9]);
+  EXPECT_GE((T)N, dest[9]);
 
 
 #if defined(RAJA_ENABLE_CUDA)

--- a/test/unit/test-atomic.cpp
+++ b/test/unit/test-atomic.cpp
@@ -22,14 +22,15 @@ void testAtomicFunctionBasic()
   RAJA::RangeSegment seg(0, N);
 
 // initialize an array
+  const int len = 10;
 #if defined(RAJA_ENABLE_CUDA)
   T *dest = nullptr;
-  cudaErrchk(cudaMallocManaged((void **)&dest, sizeof(T) * 10));
+  cudaErrchk(cudaMallocManaged((void **)&dest, sizeof(T) * len));
 
   cudaErrchk(cudaDeviceSynchronize());
 
 #else
-  T *dest = new T[10];
+  T *dest = new T[len];
 #endif
 
 
@@ -260,9 +261,10 @@ void testAtomicFunctionBasic_gpu()
   RAJA::RangeSegment seg(0, N);
 
   // initialize an array
-  T *dest = new T[10];
+  const int len = 10;
+  T *dest = new T[len];
   T *d_dest = nullptr;
-  hipErrchk(hipMalloc((void **)&d_dest, sizeof(T) * 10));
+  hipErrchk(hipMalloc((void **)&d_dest, sizeof(T) * len));
 
   // use atomic add to reduce the array
   dest[0] = (T)0;
@@ -276,7 +278,7 @@ void testAtomicFunctionBasic_gpu()
   dest[8] = (T)N;
   dest[9] = (T)0;
 
-  hipErrchk(hipMemcpy(d_dest, dest, 10*sizeof(T), hipMemcpyHostToDevice));
+  hipErrchk(hipMemcpy(d_dest, dest, len*sizeof(T), hipMemcpyHostToDevice));
 
   RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(RAJA::Index_type i) {
     RAJA::atomicAdd<AtomicPolicy>(d_dest + 0, (T)1);
@@ -294,7 +296,7 @@ void testAtomicFunctionBasic_gpu()
 
   hipErrchk(hipDeviceSynchronize());
 
-  hipErrchk(hipMemcpy(dest, d_dest, 10*sizeof(T), hipMemcpyDeviceToHost));
+  hipErrchk(hipMemcpy(dest, d_dest, len*sizeof(T), hipMemcpyDeviceToHost));
 
   EXPECT_EQ((T)N, dest[0]);
   EXPECT_EQ((T)0, dest[1]);

--- a/test/unit/test-atomic.cpp
+++ b/test/unit/test-atomic.cpp
@@ -50,7 +50,6 @@ void testAtomicFunctionBasic()
   RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(RAJA::Index_type i) {
     RAJA::atomicAdd<AtomicPolicy>(dest + 0, (T)1);
     RAJA::atomicSub<AtomicPolicy>(dest + 1, (T)1);
-
     RAJA::atomicMin<AtomicPolicy>(dest + 2, (T)i);
     RAJA::atomicMax<AtomicPolicy>(dest + 3, (T)i);
     RAJA::atomicInc<AtomicPolicy>(dest + 4);
@@ -283,7 +282,6 @@ void testAtomicFunctionBasic_gpu()
   RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(RAJA::Index_type i) {
     RAJA::atomicAdd<AtomicPolicy>(d_dest + 0, (T)1);
     RAJA::atomicSub<AtomicPolicy>(d_dest + 1, (T)1);
-
     RAJA::atomicMin<AtomicPolicy>(d_dest + 2, (T)i);
     RAJA::atomicMax<AtomicPolicy>(d_dest + 3, (T)i);
     RAJA::atomicInc<AtomicPolicy>(d_dest + 4);

--- a/test/unit/test-atomic.cpp
+++ b/test/unit/test-atomic.cpp
@@ -260,7 +260,7 @@ void testAtomicFunctionBasic_gpu()
   RAJA::RangeSegment seg(0, N);
 
   // initialize an array
-  T *dest = new T[8];
+  T *dest = new T[10];
   T *d_dest = nullptr;
   hipErrchk(hipMalloc((void **)&d_dest, sizeof(T) * 10));
 


### PR DESCRIPTION
Support cuda atomicExchange in the same manner as other cuda atomics.
Add test for atomicExchange and atomicCAS.

# Summary

- This PR is a bugfix
- It does the following:
  - Fixes atomicExch\<cuda\>(double)
  - Fixes atomicExch\<hip\>(double)