### PR TITLE
Bugfix/burmark1/loop divergence cuda

### DIFF
--- a/include/RAJA/policy/cuda/kernel/For.hpp
+++ b/include/RAJA/policy/cuda/kernel/For.hpp
@@ -54,8 +54,8 @@ struct CudaStatementExecutor<
   RAJA_DEVICE
   void exec(Data &data, bool thread_active)
   {
-    auto len = segment_length<ArgumentId>(data);
-    auto i = get_cuda_dim<ThreadDim>(threadIdx);
+    int len = segment_length<ArgumentId>(data);
+    int i = get_cuda_dim<ThreadDim>(threadIdx);
 
     // assign thread id directly to offset
     data.template assign_offset<ArgumentId>(i);
@@ -108,8 +108,8 @@ struct CudaStatementExecutor<
   RAJA_DEVICE
   void exec(Data &data, bool thread_active)
   {
-    auto len = segment_length<ArgumentId>(data);
-    auto i = threadIdx.x;
+    int len = segment_length<ArgumentId>(data);
+    int i = threadIdx.x;
 
     // assign thread id directly to offset
     data.template assign_offset<ArgumentId>(i);
@@ -304,9 +304,9 @@ struct CudaStatementExecutor<
   RAJA_DEVICE
   void exec(Data &data, bool thread_active)
   {
-    auto len = segment_length<ArgumentId>(data);
+    int len = segment_length<ArgumentId>(data);
 
-    auto i = mask_t::maskValue(threadIdx.x);
+    int i = mask_t::maskValue(threadIdx.x);
 
     // assign thread id directly to offset
     data.template assign_offset<ArgumentId>(i);
@@ -440,9 +440,9 @@ struct CudaStatementExecutor<
   RAJA_DEVICE
   void exec(Data &data, bool thread_active)
   {
-    auto len = segment_length<ArgumentId>(data);
+    int len = segment_length<ArgumentId>(data);
 
-    auto i = mask_t::maskValue(threadIdx.x);
+    int i = mask_t::maskValue(threadIdx.x);
 
     // assign thread id directly to offset
     data.template assign_offset<ArgumentId>(i);
@@ -573,8 +573,8 @@ struct CudaStatementExecutor<
   static
   inline RAJA_DEVICE void exec(Data &data, bool thread_active)
   {
-    auto len = segment_length<ArgumentId>(data);
-    auto i = get_cuda_dim<BlockDim>(blockIdx);
+    int len = segment_length<ArgumentId>(data);
+    int i = get_cuda_dim<BlockDim>(blockIdx);
 
     if (i < len) {
 
@@ -630,10 +630,14 @@ struct CudaStatementExecutor<
   inline RAJA_DEVICE void exec(Data &data, bool thread_active)
   {
     // grid stride loop
-    auto len = segment_length<ArgumentId>(data);
-    auto i0 = get_cuda_dim<BlockDim>(blockIdx);
-    auto i_stride = get_cuda_dim<BlockDim>(gridDim);
-    for(auto i = i0;i < len;i += i_stride){
+    int len = segment_length<ArgumentId>(data);
+    int i0 = get_cuda_dim<BlockDim>(blockIdx);
+
+    // Get our stride from the dimension
+    int i_stride = get_cuda_dim<BlockDim>(gridDim);
+
+    // Iterate through grid stride of chunks
+    for(int i = i0;i < len;i += i_stride){
 
       // Assign the x thread to the argument
       data.template assign_offset<ArgumentId>(i);
@@ -690,7 +694,8 @@ struct CudaStatementExecutor<
 
     idx_type len = segment_length<ArgumentId>(data);
 
-    for(idx_type i = 0;i < len;++ i){
+    for (idx_type i = 0;i < len;++ i) {
+
       // Assign i to the argument
       data.template assign_offset<ArgumentId>(i);
 

--- a/include/RAJA/policy/cuda/kernel/For.hpp
+++ b/include/RAJA/policy/cuda/kernel/For.hpp
@@ -165,31 +165,25 @@ struct CudaStatementExecutor<
   inline RAJA_DEVICE void exec(Data &data, bool thread_active)
   {
     // block stride loop
-    auto len = segment_length<ArgumentId>(data);
-    auto i0 = get_cuda_dim<ThreadDim>(threadIdx);
-    auto i_stride = get_cuda_dim<ThreadDim>(blockDim);
-    auto i = i0;
-    for(; i-i0+i_stride < len; i += i_stride) {
-      // execute enclosed statements if all thread will
+    int len = segment_length<ArgumentId>(data);
+    int i0 = get_cuda_dim<ThreadDim>(threadIdx);
+
+    // Get our stride from the dimension
+    int i_stride = get_cuda_dim<ThreadDim>(blockDim);
+
+    // Iterate through block stride of chunks
+    for (int ii = 0; ii < len; ii += i_stride) {
+      int i = ii + i0;
+
+      // execute enclosed statements if any thread will
+      // but mask off threads without work
+      bool have_work = i < len;
 
       // Assign the x thread to the argument
       data.template assign_offset<ArgumentId>(i);
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active);
-    }
-    // do we need one more masked iteration?
-    if(i - i0 < len)
-    {
-      // execute enclosed statements one more time, but masking them off
-      // this is because there's at least one thread that isn't masked off
-      // that is still executing the above loop
-
-      // Assign the x thread to the argument
-      data.template assign_offset<ArgumentId>(i);
-
-      // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active && (i < len));
+      enclosed_stmts_t::exec(data, thread_active && have_work);
     }
   }
 
@@ -237,31 +231,25 @@ struct CudaStatementExecutor<
   inline RAJA_DEVICE void exec(Data &data, bool thread_active)
   {
     // block stride loop
-    auto len = segment_length<ArgumentId>(data);
-    auto i0 = threadIdx.x;
-    auto i_stride = RAJA::policy::cuda::WARP_SIZE;
-    auto i = i0;
-    for(; i-i0+i_stride < len; i += i_stride) {
-      // execute enclosed statements if all thread will
+    int len = segment_length<ArgumentId>(data);
+    int i0 = threadIdx.x;
+
+    // Get our stride from the dimension
+    int i_stride = RAJA::policy::cuda::WARP_SIZE;
+
+    // Iterate through grid stride of chunks
+    for (int ii = 0; ii < len; ii += i_stride) {
+      int i = ii + i0;
+
+      // execute enclosed statements if any thread will
+      // but mask off threads without work
+      bool have_work = i < len;
 
       // Assign the x thread to the argument
       data.template assign_offset<ArgumentId>(i);
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active);
-    }
-    // do we need one more masked iteration?
-    if(i - i0 < len)
-    {
-      // execute enclosed statements one more time, but masking them off
-      // this is because there's at least one thread that isn't masked off
-      // that is still executing the above loop
-
-      // Assign the x thread to the argument
-      data.template assign_offset<ArgumentId>(i);
-
-      // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active && i < len);
+      enclosed_stmts_t::exec(data, thread_active && have_work);
     }
   }
 
@@ -383,29 +371,23 @@ struct CudaStatementExecutor<
     // masked size strided loop
     int len = segment_length<ArgumentId>(data);
     int i0 = mask_t::maskValue(threadIdx.x);
+
+    // Get our stride from the dimension
     int i_stride = (int) mask_t::max_masked_size;
-    int i = i0;
-    for(; i-i0+i_stride < len; i += i_stride) {
-      // execute enclosed statements if all thread will
+
+    // Iterate through grid stride of chunks
+    for (int ii = 0; ii < len; ii += i_stride) {
+      int i = ii + i0;
+
+      // execute enclosed statements if any thread will
+      // but mask off threads without work
+      bool have_work = i < len;
 
       // Assign the x thread to the argument
       data.template assign_offset<ArgumentId>(i);
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active);
-    }
-    // do we need one more masked iteration?
-    if(i - i0 < len)
-    {
-      // execute enclosed statements one more time, but masking them off
-      // this is because there's at least one thread that isn't masked off
-      // that is still executing the above loop
-
-      // Assign the x thread to the argument
-      data.template assign_offset<ArgumentId>(i);
-
-      // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active && (i < len));
+      enclosed_stmts_t::exec(data, thread_active && have_work);
     }
   }
 
@@ -525,31 +507,24 @@ struct CudaStatementExecutor<
     // masked size strided loop
     int len = segment_length<ArgumentId>(data);
     int i0 = mask_t::maskValue(threadIdx.x);
+
+    // Get our stride from the dimension
     int i_stride = (int) mask_t::max_masked_size;
-    int i = i0;
-    for(; i-i0+i_stride < len; i += i_stride) {
-      // execute enclosed statements if all thread will
+
+    // Iterate through grid stride of chunks
+    for (int ii = 0; ii < len; ii += i_stride) {
+      int i = ii + i0;
+
+      // execute enclosed statements if any thread will
+      // but mask off threads without work
+      bool have_work = i < len;
 
       // Assign the x thread to the argument
       data.template assign_offset<ArgumentId>(i);
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active);
+      enclosed_stmts_t::exec(data, thread_active && have_work);
     }
-    // do we need one more masked iteration?
-    if(i - i0 < len)
-    {
-      // execute enclosed statements one more time, but masking them off
-      // this is because there's at least one thread that isn't masked off
-      // that is still executing the above loop
-
-      // Assign the x thread to the argument
-      data.template assign_offset<ArgumentId>(i);
-
-      // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active && (i < len));
-    }
-
   }
 
 

--- a/include/RAJA/policy/cuda/kernel/ForICount.hpp
+++ b/include/RAJA/policy/cuda/kernel/ForICount.hpp
@@ -156,26 +156,32 @@ struct CudaStatementExecutor<
   {
     // block stride loop
     int len = segment_length<ArgumentId>(data);
-    //auto i0 = threadIdx.x;
-    //auto i_stride = RAJA::policy::cuda::WARP_SIZE;
-    //auto i = i0;
-    auto &i = camp::get<ArgumentId>(data.offset_tuple);
-    i = threadIdx.x;
-    for( ; i < len; i += RAJA::policy::cuda::WARP_SIZE){
+    auto i0 = threadIdx.x;
+    auto i_stride = RAJA::policy::cuda::WARP_SIZE;
+    auto i = i0;
+    for(; i-i0+i_stride < len; i += i_stride) {
+      // execute enclosed statements if all thread will
 
       // Assign the x thread to the argument
-      //  data.template assign_offset<ArgumentId>(i);
+      data.template assign_offset<ArgumentId>(i);
       data.template assign_param<ParamId>(i);
 
       // execute enclosed statements
       enclosed_stmts_t::exec(data, thread_active);
     }
     // do we need one more masked iteration?
-    if(i - threadIdx.x < len){
+    if(i - i0 < len)
+    {
       // execute enclosed statements one more time, but masking them off
       // this is because there's at least one thread that isn't masked off
       // that is still executing the above loop
-      enclosed_stmts_t::exec(data, false);
+
+      // Assign the x thread to the argument
+      data.template assign_offset<ArgumentId>(i);
+      data.template assign_param<ParamId>(i);
+
+      // execute enclosed statements
+      enclosed_stmts_t::exec(data, thread_active && (i < len));
     }
   }
 };
@@ -279,10 +285,13 @@ struct CudaStatementExecutor<
   {
     // masked size strided loop
     int len = segment_length<ArgumentId>(data);
-    auto i = mask_t::maskValue(threadIdx.x);
-    for( ; i < len; i += (int) mask_t::max_masked_size){
+    auto i0 = mask_t::maskValue(threadIdx.x);
+    auto i_stride = (int) mask_t::max_masked_size;
+    auto i = i0;
+    for(; i-i0+i_stride < len; i += i_stride) {
+      // execute enclosed statements if all thread will
 
-      // Assign the x thread to the argument and param
+      // Assign the x thread to the argument
       data.template assign_offset<ArgumentId>(i);
       data.template assign_param<ParamId>(i);
 
@@ -290,11 +299,18 @@ struct CudaStatementExecutor<
       enclosed_stmts_t::exec(data, thread_active);
     }
     // do we need one more masked iteration?
-    if(i - mask_t::maskValue(threadIdx.x) < len){
+    if(i - i0 < len)
+    {
       // execute enclosed statements one more time, but masking them off
       // this is because there's at least one thread that isn't masked off
       // that is still executing the above loop
-      enclosed_stmts_t::exec(data, false);
+
+      // Assign the x thread to the argument
+      data.template assign_offset<ArgumentId>(i);
+      data.template assign_param<ParamId>(i);
+
+      // execute enclosed statements
+      enclosed_stmts_t::exec(data, thread_active && (i < len));
     }
   }
 
@@ -397,8 +413,11 @@ struct CudaStatementExecutor<
   {
     // masked size strided loop
     int len = segment_length<ArgumentId>(data);
-    int i = mask_t::maskValue(threadIdx.x);
-    for( ; i < len; i += (int) mask_t::max_masked_size){
+    auto i0 = mask_t::maskValue(threadIdx.x);
+    auto i_stride = (int) mask_t::max_masked_size;
+    auto i = i0;
+    for(; i-i0+i_stride < len; i += i_stride) {
+      // execute enclosed statements if all thread will
 
       // Assign the x thread to the argument
       data.template assign_offset<ArgumentId>(i);
@@ -408,11 +427,18 @@ struct CudaStatementExecutor<
       enclosed_stmts_t::exec(data, thread_active);
     }
     // do we need one more masked iteration?
-    if(i - mask_t::maskValue(threadIdx.x) < len){
+    if(i - i0 < len)
+    {
       // execute enclosed statements one more time, but masking them off
       // this is because there's at least one thread that isn't masked off
       // that is still executing the above loop
-      enclosed_stmts_t::exec(data, false);
+
+      // Assign the x thread to the argument
+      data.template assign_offset<ArgumentId>(i);
+      data.template assign_param<ParamId>(i);
+
+      // execute enclosed statements
+      enclosed_stmts_t::exec(data, thread_active && (i < len));
     }
   }
 
@@ -456,7 +482,8 @@ struct CudaStatementExecutor<
     auto i0 = get_cuda_dim<ThreadDim>(threadIdx);
     auto i_stride = get_cuda_dim<ThreadDim>(blockDim);
     auto i = i0;
-    for(;i < len;i += i_stride){
+    for(; i-i0+i_stride < len; i += i_stride) {
+      // execute enclosed statements if all thread will
 
       // Assign the x thread to the argument
       data.template assign_offset<ArgumentId>(i);
@@ -471,7 +498,13 @@ struct CudaStatementExecutor<
       // execute enclosed statements one more time, but masking them off
       // this is because there's at least one thread that isn't masked off
       // that is still executing the above loop
-      enclosed_stmts_t::exec(data, false);
+
+      // Assign the x thread to the argument
+      data.template assign_offset<ArgumentId>(i);
+      data.template assign_param<ParamId>(i);
+
+      // execute enclosed statements
+      enclosed_stmts_t::exec(data, thread_active && (i < len));
     }
   }
 };

--- a/include/RAJA/policy/cuda/kernel/ForICount.hpp
+++ b/include/RAJA/policy/cuda/kernel/ForICount.hpp
@@ -61,8 +61,8 @@ struct CudaStatementExecutor<
   RAJA_DEVICE
   void exec(Data &data, bool thread_active)
   {
-    auto len = segment_length<ArgumentId>(data);
-    auto i = get_cuda_dim<ThreadDim>(threadIdx);
+    int len = segment_length<ArgumentId>(data);
+    int i = get_cuda_dim<ThreadDim>(threadIdx);
 
     // assign thread id directly to offset
     data.template assign_offset<ArgumentId>(i);
@@ -109,8 +109,8 @@ struct CudaStatementExecutor<
   RAJA_DEVICE
   void exec(Data &data, bool thread_active)
   {
-    auto len = segment_length<ArgumentId>(data);
-    auto i = get_cuda_dim<0>(threadIdx);
+    int len = segment_length<ArgumentId>(data);
+    int i = get_cuda_dim<0>(threadIdx);
 
     // assign thread id directly to offset
     data.template assign_offset<ArgumentId>(i);
@@ -220,9 +220,9 @@ struct CudaStatementExecutor<
   RAJA_DEVICE
   void exec(Data &data, bool thread_active)
   {
-    auto len = segment_length<ArgumentId>(data);
+    int len = segment_length<ArgumentId>(data);
 
-    auto i = mask_t::maskValue(threadIdx.x);
+    int i = mask_t::maskValue(threadIdx.x);
 
     // assign thread id directly to offset
     data.template assign_offset<ArgumentId>(i);
@@ -342,9 +342,9 @@ struct CudaStatementExecutor<
   RAJA_DEVICE
   void exec(Data &data, bool thread_active)
   {
-    auto len = segment_length<ArgumentId>(data);
+    int len = segment_length<ArgumentId>(data);
 
-    auto i = mask_t::maskValue(threadIdx.x);
+    int i = mask_t::maskValue(threadIdx.x);
 
     // assign thread id directly to offset
     data.template assign_offset<ArgumentId>(i);
@@ -511,8 +511,8 @@ struct CudaStatementExecutor<
   inline RAJA_DEVICE void exec(Data &data, bool thread_active)
   {
     // grid stride loop
-    auto len = segment_length<ArgumentId>(data);
-    auto i = get_cuda_dim<BlockDim>(blockIdx);
+    int len = segment_length<ArgumentId>(data);
+    int i = get_cuda_dim<BlockDim>(blockIdx);
 
     if (i < len) {
 
@@ -555,10 +555,14 @@ struct CudaStatementExecutor<
   inline RAJA_DEVICE void exec(Data &data, bool thread_active)
   {
     // grid stride loop
-    auto len = segment_length<ArgumentId>(data);
-    auto i0 = get_cuda_dim<BlockDim>(blockIdx);
-    auto i_stride = get_cuda_dim<BlockDim>(gridDim);
-    for(auto i = i0;i < len;i += i_stride){
+    int len = segment_length<ArgumentId>(data);
+    int i0 = get_cuda_dim<BlockDim>(blockIdx);
+
+    // Get our stride from the dimension
+    int i_stride = get_cuda_dim<BlockDim>(gridDim);
+
+    // Iterate through grid stride of chunks
+    for (int i = i0; i < len; i += i_stride) {
 
       // Assign the x thread to the argument
       data.template assign_offset<ArgumentId>(i);
@@ -604,7 +608,7 @@ struct CudaStatementExecutor<
 
     idx_type len = segment_length<ArgumentId>(data);
 
-    for(idx_type i = 0;i < len;++ i){
+    for (idx_type i = 0; i < len; ++i) {
       // Assign i to the argument
       data.template assign_offset<ArgumentId>(i);
       data.template assign_param<ParamId>(i);

--- a/include/RAJA/policy/cuda/kernel/ForICount.hpp
+++ b/include/RAJA/policy/cuda/kernel/ForICount.hpp
@@ -156,32 +156,25 @@ struct CudaStatementExecutor<
   {
     // block stride loop
     int len = segment_length<ArgumentId>(data);
-    auto i0 = threadIdx.x;
-    auto i_stride = RAJA::policy::cuda::WARP_SIZE;
-    auto i = i0;
-    for(; i-i0+i_stride < len; i += i_stride) {
-      // execute enclosed statements if all thread will
+    int i0 = threadIdx.x;
+
+    // Get our stride from the dimension
+    int i_stride = RAJA::policy::cuda::WARP_SIZE;
+
+    // Iterate through grid stride of chunks
+    for (int ii = 0; ii < len; ii += i_stride) {
+      int i = ii + i0;
+
+      // execute enclosed statements if any thread will
+      // but mask off threads without work
+      bool have_work = i < len;
 
       // Assign the x thread to the argument
       data.template assign_offset<ArgumentId>(i);
       data.template assign_param<ParamId>(i);
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active);
-    }
-    // do we need one more masked iteration?
-    if(i - i0 < len)
-    {
-      // execute enclosed statements one more time, but masking them off
-      // this is because there's at least one thread that isn't masked off
-      // that is still executing the above loop
-
-      // Assign the x thread to the argument
-      data.template assign_offset<ArgumentId>(i);
-      data.template assign_param<ParamId>(i);
-
-      // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active && (i < len));
+      enclosed_stmts_t::exec(data, thread_active && have_work);
     }
   }
 };
@@ -285,32 +278,25 @@ struct CudaStatementExecutor<
   {
     // masked size strided loop
     int len = segment_length<ArgumentId>(data);
-    auto i0 = mask_t::maskValue(threadIdx.x);
-    auto i_stride = (int) mask_t::max_masked_size;
-    auto i = i0;
-    for(; i-i0+i_stride < len; i += i_stride) {
-      // execute enclosed statements if all thread will
+    int i0 = mask_t::maskValue(threadIdx.x);
+
+    // Get our stride from the dimension
+    int i_stride = (int) mask_t::max_masked_size;
+
+    // Iterate through grid stride of chunks
+    for (int ii = 0; ii < len; ii += i_stride) {
+      int i = ii + i0;
+
+      // execute enclosed statements if any thread will
+      // but mask off threads without work
+      bool have_work = i < len;
 
       // Assign the x thread to the argument
       data.template assign_offset<ArgumentId>(i);
       data.template assign_param<ParamId>(i);
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active);
-    }
-    // do we need one more masked iteration?
-    if(i - i0 < len)
-    {
-      // execute enclosed statements one more time, but masking them off
-      // this is because there's at least one thread that isn't masked off
-      // that is still executing the above loop
-
-      // Assign the x thread to the argument
-      data.template assign_offset<ArgumentId>(i);
-      data.template assign_param<ParamId>(i);
-
-      // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active && (i < len));
+      enclosed_stmts_t::exec(data, thread_active && have_work);
     }
   }
 
@@ -413,32 +399,25 @@ struct CudaStatementExecutor<
   {
     // masked size strided loop
     int len = segment_length<ArgumentId>(data);
-    auto i0 = mask_t::maskValue(threadIdx.x);
-    auto i_stride = (int) mask_t::max_masked_size;
-    auto i = i0;
-    for(; i-i0+i_stride < len; i += i_stride) {
-      // execute enclosed statements if all thread will
+    int i0 = mask_t::maskValue(threadIdx.x);
+
+    // Get our stride from the dimension
+    int i_stride = (int) mask_t::max_masked_size;
+
+    // Iterate through grid stride of chunks
+    for (int ii = 0; ii < len; ii += i_stride) {
+      int i = ii + i0;
+
+      // execute enclosed statements if any thread will
+      // but mask off threads without work
+      bool have_work = i < len;
 
       // Assign the x thread to the argument
       data.template assign_offset<ArgumentId>(i);
       data.template assign_param<ParamId>(i);
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active);
-    }
-    // do we need one more masked iteration?
-    if(i - i0 < len)
-    {
-      // execute enclosed statements one more time, but masking them off
-      // this is because there's at least one thread that isn't masked off
-      // that is still executing the above loop
-
-      // Assign the x thread to the argument
-      data.template assign_offset<ArgumentId>(i);
-      data.template assign_param<ParamId>(i);
-
-      // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active && (i < len));
+      enclosed_stmts_t::exec(data, thread_active && have_work);
     }
   }
 
@@ -478,33 +457,26 @@ struct CudaStatementExecutor<
   inline RAJA_DEVICE void exec(Data &data, bool thread_active)
   {
     // block stride loop
-    auto len = segment_length<ArgumentId>(data);
-    auto i0 = get_cuda_dim<ThreadDim>(threadIdx);
-    auto i_stride = get_cuda_dim<ThreadDim>(blockDim);
-    auto i = i0;
-    for(; i-i0+i_stride < len; i += i_stride) {
-      // execute enclosed statements if all thread will
+    int len = segment_length<ArgumentId>(data);
+    int i0 = get_cuda_dim<ThreadDim>(threadIdx);
+
+    // Get our stride from the dimension
+    int i_stride = get_cuda_dim<ThreadDim>(blockDim);
+
+    // Iterate through grid stride of chunks
+    for (int ii = 0; ii < len; ii += i_stride) {
+      int i = ii + i0;
+
+      // execute enclosed statements if any thread will
+      // but mask off threads without work
+      bool have_work = i < len;
 
       // Assign the x thread to the argument
       data.template assign_offset<ArgumentId>(i);
       data.template assign_param<ParamId>(i);
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active);
-    }
-    // do we need one more masked iteration?
-    if(i - i0 < len)
-    {
-      // execute enclosed statements one more time, but masking them off
-      // this is because there's at least one thread that isn't masked off
-      // that is still executing the above loop
-
-      // Assign the x thread to the argument
-      data.template assign_offset<ArgumentId>(i);
-      data.template assign_param<ParamId>(i);
-
-      // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active && (i < len));
+      enclosed_stmts_t::exec(data, thread_active && have_work);
     }
   }
 };

--- a/include/RAJA/policy/cuda/kernel/Tile.hpp
+++ b/include/RAJA/policy/cuda/kernel/Tile.hpp
@@ -412,36 +412,26 @@ struct CudaStatementExecutor<
     segment_t orig_segment = segment;
 
     // compute trip count
-    auto i0 = get_cuda_dim<ThreadDim>(threadIdx) * chunk_size;
+    int len = segment_length<ArgumentId>(data);
+    int i0 = get_cuda_dim<ThreadDim>(threadIdx) * chunk_size;
 
     // Get our stride from the dimension
-    auto i_stride = get_cuda_dim<ThreadDim>(blockDim) * chunk_size;
+    int i_stride = get_cuda_dim<ThreadDim>(blockDim) * chunk_size;
 
     // Iterate through grid stride of chunks
-    int len = segment_length<ArgumentId>(data);
+    for (int ii = 0; ii < len; ii += i_stride) {
+      int i = ii + i0;
 
-    int i = i0;
-    for(; i-i0+i_stride < len; i += i_stride) {
-      // execute enclosed statements if all thread will
-
-      // Assign our new tiled segment
-      segment = orig_segment.slice(i, chunk_size);
-
-      // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active);
-    }
-    // do we need one more masked iteration?
-    if(i - i0 < len)
-    {
-      // execute enclosed statements one more time, but masking them off
-      // this is because there's at least one thread that isn't masked off
-      // that is still executing the above loop
+      // execute enclosed statements if any thread will
+      // but mask off threads without work
+      bool have_work = i < len;
 
       // Assign our new tiled segment
-      segment = orig_segment.slice(i, (i < len) ? chunk_size : 0);
+      int slice_size = have_work ? chunk_size : 0;
+      segment = orig_segment.slice(i, slice_size);
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active && (i < len));
+      enclosed_stmts_t::exec(data, thread_active && have_work);
     }
 
     // Set range back to original values

--- a/include/RAJA/policy/cuda/kernel/TileTCount.hpp
+++ b/include/RAJA/policy/cuda/kernel/TileTCount.hpp
@@ -343,40 +343,29 @@ struct CudaStatementExecutor<
     segment_t orig_segment = segment;
 
     // compute trip count
-    auto t0 = get_cuda_dim<ThreadDim>(threadIdx);
-    auto i0 = t0 * chunk_size;
+    int len = segment_length<ArgumentId>(data);
+    int t0 = get_cuda_dim<ThreadDim>(threadIdx);
+    int i0 = t0 * chunk_size;
 
     // Get our stride from the dimension
-    auto t_stride = get_cuda_dim<ThreadDim>(blockDim);
-    auto i_stride = t_stride * chunk_size;
+    int t_stride = get_cuda_dim<ThreadDim>(blockDim);
+    int i_stride = t_stride * chunk_size;
 
     // Iterate through grid stride of chunks
-    int len = segment_length<ArgumentId>(data);
+    for(int ii = 0, t = t0; ii < len; ii += i_stride, t += t_stride) {
+      int i = ii + i0;
 
-    int i = i0, t = t0;
-    for(; i-i0+i_stride < len; i += i_stride, t += t_stride) {
-      // execute enclosed statements if all thread will
+      // execute enclosed statements if any thread will
+      // but mask off threads without work
+      bool have_work = i < len;
 
       // Assign our new tiled segment
-      segment = orig_segment.slice(i, chunk_size);
+      int slice_size = have_work ? chunk_size : 0;
+      segment = orig_segment.slice(i, slice_size);
       data.template assign_param<ParamId>(t);
 
       // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active);
-    }
-    // do we need one more masked iteration?
-    if(i - i0 < len)
-    {
-      // execute enclosed statements one more time, but masking them off
-      // this is because there's at least one thread that isn't masked off
-      // that is still executing the above loop
-
-      // Assign our new tiled segment
-      segment = orig_segment.slice(i, (i < len) ? chunk_size : 0);
-      data.template assign_param<ParamId>(t);
-
-      // execute enclosed statements
-      enclosed_stmts_t::exec(data, thread_active && i < len);
+      enclosed_stmts_t::exec(data, thread_active && have_work);
     }
 
     // Set range back to original values

--- a/include/RAJA/policy/cuda/kernel/TileTCount.hpp
+++ b/include/RAJA/policy/cuda/kernel/TileTCount.hpp
@@ -141,8 +141,8 @@ struct CudaStatementExecutor<
 
     // compute trip count
     int len = segment.end() - segment.begin();
-    auto t = get_cuda_dim<BlockDim>(blockIdx);
-    auto i = t * chunk_size;
+    int t = get_cuda_dim<BlockDim>(blockIdx);
+    int i = t * chunk_size;
 
     // Iterate through grid stride of chunks
     if (i < len) {
@@ -210,10 +210,12 @@ struct CudaStatementExecutor<
 
     // compute trip count
     int len = segment.end() - segment.begin();
-    auto t0 = get_cuda_dim<BlockDim>(blockIdx);
-    auto t_stride = get_cuda_dim<BlockDim>(gridDim);
-    auto i0 = t0 * chunk_size;
-    auto i_stride = t_stride * chunk_size;
+    int t0 = get_cuda_dim<BlockDim>(blockIdx);
+    int i0 = t0 * chunk_size;
+
+    // Get our stride from the dimension
+    int t_stride = get_cuda_dim<BlockDim>(gridDim);
+    int i_stride = t_stride * chunk_size;
 
     // Iterate through grid stride of chunks
     for (int i = i0, t = t0; i < len; i += i_stride, t += t_stride) {
@@ -280,15 +282,20 @@ struct CudaStatementExecutor<
 
     // compute trip count
     int len = segment.end() - segment.begin();
-    auto t0 = get_cuda_dim<ThreadDim>(threadIdx);
-    auto i0 = t0 * chunk_size;
+    int t = get_cuda_dim<ThreadDim>(threadIdx);
+    int i = t * chunk_size;
+
+    // execute enclosed statements if any thread will
+    // but mask off threads without work
+    bool have_work = i < len;
 
     // Assign our new tiled segment
-    segment = orig_segment.slice(i0, (i0 < len) ? chunk_size : 0);
-    data.template assign_param<ParamId>(t0);
+    int slice_size = have_work ? chunk_size : 0;
+    segment = orig_segment.slice(i, slice_size);
+    data.template assign_param<ParamId>(t);
 
     // execute enclosed statements
-    enclosed_stmts_t::exec(data, thread_active && (i0 < len));
+    enclosed_stmts_t::exec(data, thread_active && have_work);
 
     // Set range back to original values
     segment = orig_segment;


### PR DESCRIPTION
# Summary

Avoid warp divergence in cuda kernel Tile and For statements.
Use int for indexing to avoid signed/unsigned issues (cuda clang uses unsigned int instead of int in dim3).

TODO
Fix hip kernel Tile and For statements
Use explicitly casts to int to avoid narrowing warnings

- This PR is a refactoring
- It does the following:
  - refactors cuda statement::Tile and statement::For implementations
