### PR TITLE
Fix Gtest warning and XL span test compilation error.

### DIFF
--- a/test/functional/atomic/test-atomic-forall-basic.cpp
+++ b/test/functional/atomic/test-atomic-forall-basic.cpp
@@ -134,7 +134,7 @@ TYPED_TEST_P(AtomicFuncBasicFunctionalTest, builtin_basic_AtomicFuncFunctionalTe
   testAtomicFunctionBasicV2<RAJA::seq_exec, RAJA::builtin_atomic, TypeParam>( tenk );
 }
 
-REGISTER_TYPED_TEST_CASE_P( AtomicFuncBasicFunctionalTest,
+REGISTER_TYPED_TEST_SUITE_P( AtomicFuncBasicFunctionalTest,
                             auto_basic_AtomicFuncFunctionalTest,
                             seq_basic_AtomicFuncFunctionalTest,
                             builtin_basic_AtomicFuncFunctionalTest
@@ -149,5 +149,5 @@ using seqtypes = ::testing::Types<
                           double
                  >;
 
-INSTANTIATE_TYPED_TEST_CASE_P( AtomicBasicFunctionalTest, AtomicFuncBasicFunctionalTest, seqtypes );
+INSTANTIATE_TYPED_TEST_SUITE_P( AtomicBasicFunctionalTest, AtomicFuncBasicFunctionalTest, seqtypes );
 // END Type parameterized test for experimentation/discussion.

--- a/test/functional/atomic/test-atomic-forall-basic.hpp
+++ b/test/functional/atomic/test-atomic-forall-basic.hpp
@@ -93,7 +93,7 @@ struct AtomicFuncBasicFunctionalTest : public ::testing::Test
 {
 };
 
-TYPED_TEST_CASE_P(AtomicFuncBasicFunctionalTest);
+TYPED_TEST_SUITE_P(AtomicFuncBasicFunctionalTest);
 
 template <typename ExecPolicy,
           typename AtomicPolicy,

--- a/test/unit/util/test-span.hpp
+++ b/test/unit/util/test-span.hpp
@@ -25,7 +25,7 @@
 template <typename ValueType, typename IndexType>
 void testSpanConstructTypes()
 {
-  IndexType len = 4;
+  constexpr IndexType len = 4;
   ValueType* ptr = new ValueType[len];
 
   {
@@ -48,7 +48,7 @@ void testSpanConstructTypes()
 template <typename ValueType, typename IndexType>
 void testSpanAssignTypes()
 {
-  IndexType len = 4;
+  constexpr IndexType len = 4;
   ValueType* ptr = new ValueType[len];
 
   {
@@ -62,7 +62,7 @@ void testSpanAssignTypes()
 
   {
     ValueType* ptr2 = ptr + 1;
-    IndexType len2 = 1;
+    constexpr IndexType len2 = 1;
     RAJA::Span<ValueType*, IndexType> span(ptr, len);
     const RAJA::Span<ValueType*, IndexType> span2(ptr2, len2);
     span = span2;
@@ -80,14 +80,14 @@ void testSpanIteratorTypes()
   using span_type = RAJA::Span<ValueType*, IndexType>;
   using iterator = typename span_type::iterator;
   using const_iterator = typename span_type::const_iterator;
-  IndexType len = 4;
+  constexpr IndexType len = 4;
   ValueType* ptr = new ValueType[len];
 
   // XL cannot handle initialization list with new
   // e.g. new ValueType[len]{0,1,2,3} produces error
-  for ( int ii = 0; ii < static_cast<int>(len); ++ii )
+  for ( IndexType ii = 0; ii < len; ++ii )
   {
-    ptr[ii] = ii;
+    ptr[ii] = static_cast<ValueType>(ii);
   }
 
   {
@@ -124,14 +124,14 @@ void testSpanIteratorTypes()
 template <typename ValueType, typename IndexType>
 void testSpanElementAccessTypes()
 {
-  IndexType len = 4;
+  constexpr IndexType len = 4;
   ValueType* ptr = new ValueType[len];
 
   // XL cannot handle initialization list with new
   // e.g. new ValueType[len]{0,1,2,3} produces error
-  for ( int ii = 0; ii < static_cast<int>(len); ++ii )
+  for ( IndexType ii = 0; ii < len; ++ii )
   {
-    ptr[ii] = ii;
+    ptr[ii] = static_cast<ValueType>(ii);
   }
 
   {
@@ -152,14 +152,14 @@ void testSpanElementAccessTypes()
 template <typename ValueType, typename IndexType>
 void testSpanObserveTypes()
 {
-  IndexType len = 4;
+  constexpr IndexType len = 4;
   ValueType* ptr = new ValueType[len];
 
   // XL cannot handle initialization list with new
   // e.g. new ValueType[len]{0,1,2,3} produces error
-  for ( int ii = 0; ii < static_cast<int>(len); ++ii )
+  for ( IndexType ii = 0; ii < len; ++ii )
   {
-    ptr[ii] = ii;
+    ptr[ii] = static_cast<ValueType>(ii);
   }
 
   {
@@ -182,18 +182,18 @@ void testSpanObserveTypes()
 template <typename ValueType, typename IndexType>
 void testSpanSubViewTypes()
 {
-  IndexType len = 4;
+  constexpr IndexType len = 4;
   ValueType* ptr = new ValueType[len];
 
   // XL cannot handle initialization list with new
   // e.g. new ValueType[len]{0,1,2,3} produces error
-  for ( int ii = 0; ii < static_cast<int>(len); ++ii )
+  for ( IndexType ii = 0; ii < len; ++ii )
   {
-    ptr[ii] = ii;
+    ptr[ii] = static_cast<ValueType>(ii);
   }
 
   {
-    IndexType count = 3;
+    constexpr IndexType count = 3;
     const RAJA::Span<ValueType*, IndexType> span(ptr, len);
     const RAJA::Span<ValueType*, IndexType> subspan = span.first(count);
 
@@ -202,7 +202,7 @@ void testSpanSubViewTypes()
   }
 
   {
-    IndexType count = 3;
+    constexpr IndexType count = 3;
     const RAJA::Span<ValueType*, IndexType> span(ptr, len);
     const RAJA::Span<ValueType*, IndexType> subspan = span.last(count);
 
@@ -211,8 +211,8 @@ void testSpanSubViewTypes()
   }
 
   {
-    IndexType begin = 1;
-    IndexType count = 2;
+    constexpr IndexType begin = 1;
+    constexpr IndexType count = 2;
     const RAJA::Span<ValueType*, IndexType> span(ptr, len);
     const RAJA::Span<ValueType*, IndexType> subspan = span.subspan(begin, count);
 
@@ -221,8 +221,8 @@ void testSpanSubViewTypes()
   }
 
   {
-    IndexType begin = 1;
-    IndexType count = 2;
+    constexpr IndexType begin = 1;
+    constexpr IndexType count = 2;
     const RAJA::Span<ValueType*, IndexType> span(ptr, len);
     const RAJA::Span<ValueType*, IndexType> subspan = span.slice(begin, count);
 
@@ -236,7 +236,7 @@ void testSpanSubViewTypes()
 template <typename ValueType, typename IndexType>
 void testSpanMakeSpanTypes()
 {
-  IndexType len = 4;
+  constexpr IndexType len = 4;
   ValueType* ptr = new ValueType[len];
 
   {

--- a/test/unit/util/test-span.hpp
+++ b/test/unit/util/test-span.hpp
@@ -81,7 +81,14 @@ void testSpanIteratorTypes()
   using iterator = typename span_type::iterator;
   using const_iterator = typename span_type::const_iterator;
   IndexType len = 4;
-  ValueType* ptr = new ValueType[len]{0,1,2,3};
+  ValueType* ptr = new ValueType[len];
+
+  // XL cannot handle initialization list with new
+  // e.g. new ValueType[len]{0,1,2,3} produces error
+  for ( int ii = 0; ii < len; ++ii )
+  {
+    ptr[ii] = ii;
+  }
 
   {
     const span_type span(ptr, len);
@@ -118,7 +125,14 @@ template <typename ValueType, typename IndexType>
 void testSpanElementAccessTypes()
 {
   IndexType len = 4;
-  ValueType* ptr = new ValueType[len]{0,1,2,3};
+  ValueType* ptr = new ValueType[len];
+
+  // XL cannot handle initialization list with new
+  // e.g. new ValueType[len]{0,1,2,3} produces error
+  for ( int ii = 0; ii < len; ++ii )
+  {
+    ptr[ii] = ii;
+  }
 
   {
     const RAJA::Span<ValueType*, IndexType> span(ptr, len);
@@ -139,7 +153,14 @@ template <typename ValueType, typename IndexType>
 void testSpanObserveTypes()
 {
   IndexType len = 4;
-  ValueType* ptr = new ValueType[len]{0,1,2,3};
+  ValueType* ptr = new ValueType[len];
+
+  // XL cannot handle initialization list with new
+  // e.g. new ValueType[len]{0,1,2,3} produces error
+  for ( int ii = 0; ii < len; ++ii )
+  {
+    ptr[ii] = ii;
+  }
 
   {
     const RAJA::Span<ValueType*, IndexType> span(ptr, len);
@@ -162,7 +183,14 @@ template <typename ValueType, typename IndexType>
 void testSpanSubViewTypes()
 {
   IndexType len = 4;
-  ValueType* ptr = new ValueType[len]{0,1,2,3};
+  ValueType* ptr = new ValueType[len];
+
+  // XL cannot handle initialization list with new
+  // e.g. new ValueType[len]{0,1,2,3} produces error
+  for ( int ii = 0; ii < len; ++ii )
+  {
+    ptr[ii] = ii;
+  }
 
   {
     IndexType count = 3;

--- a/test/unit/util/test-span.hpp
+++ b/test/unit/util/test-span.hpp
@@ -85,7 +85,7 @@ void testSpanIteratorTypes()
 
   // XL cannot handle initialization list with new
   // e.g. new ValueType[len]{0,1,2,3} produces error
-  for ( int ii = 0; ii < len; ++ii )
+  for ( int ii = 0; ii < static_cast<int>(len); ++ii )
   {
     ptr[ii] = ii;
   }
@@ -129,7 +129,7 @@ void testSpanElementAccessTypes()
 
   // XL cannot handle initialization list with new
   // e.g. new ValueType[len]{0,1,2,3} produces error
-  for ( int ii = 0; ii < len; ++ii )
+  for ( int ii = 0; ii < static_cast<int>(len); ++ii )
   {
     ptr[ii] = ii;
   }
@@ -157,7 +157,7 @@ void testSpanObserveTypes()
 
   // XL cannot handle initialization list with new
   // e.g. new ValueType[len]{0,1,2,3} produces error
-  for ( int ii = 0; ii < len; ++ii )
+  for ( int ii = 0; ii < static_cast<int>(len); ++ii )
   {
     ptr[ii] = ii;
   }
@@ -187,7 +187,7 @@ void testSpanSubViewTypes()
 
   // XL cannot handle initialization list with new
   // e.g. new ValueType[len]{0,1,2,3} produces error
-  for ( int ii = 0; ii < len; ++ii )
+  for ( int ii = 0; ii < static_cast<int>(len); ++ii )
   {
     ptr[ii] = ii;
   }


### PR DESCRIPTION
# Summary

- This PR is a bug fix
- It does the following:
  - Fixes atomic/functional Gtest CASE warning (converted to SUITE).
  - Fixes XL span test compilation error. XL cannot compile a new'ed array with initializer list.