### PR TITLE
Remove Reduce min and max CUDA host device warnings

### DIFF
--- a/include/RAJA/pattern/detail/reduce.hpp
+++ b/include/RAJA/pattern/detail/reduce.hpp
@@ -347,6 +347,7 @@ public:
   }
 
   /// \brief reducer function; updates the current instance's state
+  RAJA_HOST_DEVICE
   const BaseReduceMinLoc &minloc(T rhs, IndexType loc) const
   {
     this->combine(value_type(rhs, loc));
@@ -431,6 +432,7 @@ public:
   }
 
   //! reducer function; updates the current instance's state
+  RAJA_HOST_DEVICE
   const BaseReduceMaxLoc &maxloc(T rhs, IndexType loc) const
   {
     this->combine(value_type(rhs, loc));

--- a/include/RAJA/pattern/detail/reduce.hpp
+++ b/include/RAJA/pattern/detail/reduce.hpp
@@ -315,6 +315,7 @@ public:
   using Base::Base;
 
   //! reducer function; updates the current instance's state
+  RAJA_HOST_DEVICE 
   const BaseReduceMin &min(T rhs) const
   {
     this->combine(rhs);
@@ -374,6 +375,7 @@ public:
   using Base::Base;
 
   //! reducer function; updates the current instance's state
+  RAJA_HOST_DEVICE 
   const BaseReduceMax &max(T rhs) const
   {
     this->combine(rhs);


### PR DESCRIPTION
This PR gets rid of host device warnings when using `RAJA::ReduceMin::min()` and `RAJA::ReduceMax::max()` in a kernel.

Relevant to LLNL/Axom#174.

[Link to warning messages](https://github.com/LLNL/axom/pull/156#issuecomment-589899148)
