### PR TITLE
Range(Strided)Segment Unit Test Warnings on Intel

### DIFF
--- a/test/unit/index/test-rangesegment.cpp
+++ b/test/unit/index/test-rangesegment.cpp
@@ -43,7 +43,9 @@ void NegativeRangeSegConstructorsTest()
   RAJA::TypedRangeSegment<T> r3(-13, -1);
   ASSERT_EQ(17, r1.size());
   ASSERT_EQ(12, r3.size());
+#if !defined(RAJA_ENABLE_CUDA) && !defined(RAJA_ENABLE_HIP)
   ASSERT_ANY_THROW(RAJA::TypedRangeSegment<T> r2(0, -50));
+#endif
 }
 
 TYPED_TEST(RangeSegmentUnitTest, Constructors)
@@ -62,9 +64,7 @@ TYPED_TEST(RangeSegmentUnitTest, Constructors)
   ASSERT_ANY_THROW(RAJA::TypedRangeSegment<TypeParam> neg(20, 19));
 #endif
 
-#if !defined(RAJA_ENABLE_CUDA) && !defined(RAJA_ENABLE_HIP)
   NegativeRangeSegConstructorsTest<TypeParam>();
-#endif
 }
 
 TYPED_TEST(RangeSegmentUnitTest, Assignments)
@@ -108,9 +108,7 @@ TYPED_TEST(RangeSegmentUnitTest, Iterators)
   ASSERT_EQ(100, std::distance(r1.begin(), r1.end()));
   ASSERT_EQ(100, r1.size());
 
-#if !defined(__CUDA_ARCH__)
   NegativeRangeSegIteratorsTest<TypeParam>();
-#endif
 }
 
 TYPED_TEST(RangeSegmentUnitTest, Slices)

--- a/test/unit/index/test-rangesegment.cpp
+++ b/test/unit/index/test-rangesegment.cpp
@@ -31,6 +31,21 @@ using MyTypes = ::testing::Types<RAJA::Index_type,
 
 TYPED_TEST_SUITE(RangeSegmentUnitTest, MyTypes);
 
+template< typename T, typename std::enable_if<std::is_unsigned<T>::value>::type* = nullptr>
+void NegativeRangeSegConstructorsTest()
+{
+}
+
+template< typename T, typename std::enable_if<std::is_signed<T>::value>::type* = nullptr>
+void NegativeRangeSegConstructorsTest()
+{
+  RAJA::TypedRangeSegment<T> r1(-10, 7);
+  RAJA::TypedRangeSegment<T> r3(-13, -1);
+  ASSERT_EQ(17, r1.size());
+  ASSERT_EQ(12, r3.size());
+  ASSERT_ANY_THROW(RAJA::TypedRangeSegment<T> r2(0, -50));
+}
+
 TYPED_TEST(RangeSegmentUnitTest, Constructors)
 {
   RAJA::TypedRangeSegment<TypeParam> first(0, 10);
@@ -47,18 +62,9 @@ TYPED_TEST(RangeSegmentUnitTest, Constructors)
   ASSERT_ANY_THROW(RAJA::TypedRangeSegment<TypeParam> neg(20, 19));
 #endif
 
-  if(std::is_signed<TypeParam>::value){
-#if !defined(__CUDA_ARCH__)
-    RAJA::TypedRangeSegment<TypeParam> r1(-10, 7);
-    RAJA::TypedRangeSegment<TypeParam> r3(-13, -1);
-    ASSERT_EQ(17, r1.size());
-    ASSERT_EQ(12, r3.size());
-#endif
-
 #if !defined(RAJA_ENABLE_CUDA) && !defined(RAJA_ENABLE_HIP)
-    ASSERT_ANY_THROW(RAJA::TypedRangeSegment<TypeParam> r2(0, -50));
+  NegativeRangeSegConstructorsTest<TypeParam>();
 #endif
-  }
 }
 
 TYPED_TEST(RangeSegmentUnitTest, Assignments)
@@ -81,6 +87,18 @@ TYPED_TEST(RangeSegmentUnitTest, Swaps)
   ASSERT_EQ(r2, r3);
 }
 
+template< typename T, typename std::enable_if<std::is_unsigned<T>::value>::type* = nullptr>
+void NegativeRangeSegIteratorsTest()
+{
+}
+
+template< typename T, typename std::enable_if<std::is_signed<T>::value>::type* = nullptr>
+void NegativeRangeSegIteratorsTest()
+{
+  RAJA::TypedRangeSegment<T> r3(-2, 100);
+  ASSERT_EQ(-2, *r3.begin());
+}
+
 TYPED_TEST(RangeSegmentUnitTest, Iterators)
 {
   RAJA::TypedRangeSegment<TypeParam> r1(0, 100);
@@ -91,10 +109,7 @@ TYPED_TEST(RangeSegmentUnitTest, Iterators)
   ASSERT_EQ(100, r1.size());
 
 #if !defined(__CUDA_ARCH__)
-  if(std::is_signed<TypeParam>::value){
-    RAJA::TypedRangeSegment<TypeParam> r3(-2, 100);
-    ASSERT_EQ(-2, *r3.begin());
-  }
+  NegativeRangeSegIteratorsTest<TypeParam>();
 #endif
 }
 

--- a/test/unit/index/test-rangestridesegment.cpp
+++ b/test/unit/index/test-rangestridesegment.cpp
@@ -141,9 +141,7 @@ TYPED_TEST(RangeStrideSegmentUnitTest, Sizes)
   ASSERT_EQ(segment15.size(), 0);
 
   // NEGATIVE INDICES
-#if !defined(__CUDA_ARCH__)
   NegativeRangeStrideTestSizes<TypeParam>();
-#endif
 }
 
 TYPED_TEST(RangeStrideSegmentUnitTest, Slices)

--- a/test/unit/index/test-rangestridesegment.cpp
+++ b/test/unit/index/test-rangestridesegment.cpp
@@ -72,6 +72,24 @@ TYPED_TEST(RangeStrideSegmentUnitTest, Iterators)
     ASSERT_EQ(25, r1.size());
 }
 
+template< typename T, typename std::enable_if<std::is_unsigned<T>::value>::type* = nullptr>
+void NegativeRangeStrideTestSizes()
+{
+}
+
+template< typename T, typename std::enable_if<std::is_signed<T>::value>::type* = nullptr>
+void NegativeRangeStrideTestSizes()
+{
+  RAJA::TypedRangeStrideSegment<T> segment16(-10, -2, 2);
+  ASSERT_EQ(segment16.size(), 4);
+
+  RAJA::TypedRangeStrideSegment<T> segment17(-5, 5, 2);
+  ASSERT_EQ(segment17.size(), 5);
+
+  RAJA::TypedRangeStrideSegment<T> segment18(0, -5, 1);
+  ASSERT_EQ(segment18.size(), 0);
+}
+
 TYPED_TEST(RangeStrideSegmentUnitTest, Sizes)
 {
   RAJA::TypedRangeStrideSegment<TypeParam> segment1(0, 20, 1);
@@ -124,16 +142,7 @@ TYPED_TEST(RangeStrideSegmentUnitTest, Sizes)
 
   // NEGATIVE INDICES
 #if !defined(__CUDA_ARCH__)
-  if (std::is_signed<TypeParam>::value) {
-    RAJA::TypedRangeStrideSegment<TypeParam> segment16(-10, -2, 2);
-    ASSERT_EQ(segment16.size(), 4);
-
-    RAJA::TypedRangeStrideSegment<TypeParam> segment17(-5, 5, 2);
-    ASSERT_EQ(segment17.size(), 5);
-
-    RAJA::TypedRangeStrideSegment<TypeParam> segment18(0, -5, 1);
-    ASSERT_EQ(segment18.size(), 0);
-  }
+  NegativeRangeStrideTestSizes<TypeParam>();
 #endif
 }
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Modifies RangeSegment and RangeStrideSegment Unit tests to call negative tests through SFINAE functions.
  - Cleans up ifdef calls within RSeg and RStridedSeg Unit tests.
  - Fixes warnings that are generated by sign changes when unsigned types are tested, warnings were generating when compiling on travis with intel compilers.

