### PR TITLE
Update wave-eqn.cpp

### DIFF
--- a/examples/wave-eqn.cpp
+++ b/examples/wave-eqn.cpp
@@ -129,8 +129,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   // OpenMP policy
   // using fdPolicy = RAJA::KernelPolicy<
-  // RAJA::statement::For<0, RAJA::omp_parallel_for_exec >,
-  // RAJA::statement::For<1, RAJA::seq_exec > >;
+  //   RAJA::statement::For<1, RAJA::omp_parallel_for_exec,
+  //   RAJA::statement::For<0, RAJA::loop_exec, RAJA::statement::Lambda<0> > > >;
 
   // CUDA policy
   // using fdPolicy = RAJA::KernelPolicy<


### PR DESCRIPTION
Corrections to the OpenMP example:
1. Do not close off the first For<... loop so that the second loop is nested properly.
2. Include the lambda so that actual work gets done.
3. Switch to loop_exec from seq_exec avoid discouraging the compiler from vectorizing.