### PR TITLE
Task/forall view tests

### DIFF
--- a/test/functional/forall/CMakeLists.txt
+++ b/test/functional/forall/CMakeLists.txt
@@ -6,5 +6,7 @@
 ###############################################################################
 
 add_subdirectory(indexset)
+add_subdirectory(indexset-view)
 
 add_subdirectory(segment)
+add_subdirectory(segment-view)

--- a/test/functional/forall/indexset-view/CMakeLists.txt
+++ b/test/functional/forall/indexset-view/CMakeLists.txt
@@ -1,0 +1,40 @@
+###############################################################################
+# Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+raja_add_test(
+  NAME test-forall-indexset-view-seq
+  SOURCES test-forall-indexset-view-seq.cpp)
+
+if(RAJA_ENABLE_OPENMP)
+  raja_add_test(
+    NAME test-forall-indexset-view-openmp
+    SOURCES test-forall-indexset-view-openmp.cpp)
+endif()
+
+if(RAJA_ENABLE_TARGET_OPENMP)
+  raja_add_test(
+    NAME test-forall-indexset-view-openmp-target
+    SOURCES test-forall-indexset-view-openmp-target.cpp)
+endif()
+
+if(RAJA_ENABLE_TBB)
+  raja_add_test(
+    NAME test-forall-indexset-view-tbb
+    SOURCES test-forall-indexset-view-tbb.cpp)
+endif()
+
+if(RAJA_ENABLE_CUDA)
+  raja_add_test(
+    NAME test-forall-indexset-view-cuda
+    SOURCES test-forall-indexset-view-cuda.cpp)
+endif()
+
+if(RAJA_ENABLE_HIP)
+  raja_add_test(
+    NAME test-forall-indexset-view-hip
+    SOURCES test-forall-indexset-view-hip.cpp)
+endif()

--- a/test/functional/forall/indexset-view/test-forall-indexset-view-cuda.cpp
+++ b/test/functional/forall/indexset-view/test-forall-indexset-view-cuda.cpp
@@ -1,0 +1,23 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "tests/test-forall-indexset-view.hpp"
+
+// Cuda execution policy types
+using CudaForallIndexSetExecPols = 
+  camp::list< RAJA::ExecPolicy<RAJA::seq_segit, RAJA::cuda_exec<128>>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::cuda_exec<256>> >;
+
+// Cartesian product of types for Cuda tests
+using CudaForallIndexSetTypes =
+  Test< camp::cartesian_product<IdxTypeList, 
+                                CudaResourceList, 
+                                CudaForallIndexSetExecPols>>::Types;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(Cuda,
+                               ForallIndexSetViewTest,
+                               CudaForallIndexSetTypes);

--- a/test/functional/forall/indexset-view/test-forall-indexset-view-cuda.cpp
+++ b/test/functional/forall/indexset-view/test-forall-indexset-view-cuda.cpp
@@ -7,10 +7,9 @@
 
 #include "tests/test-forall-indexset-view.hpp"
 
-// Cuda execution policy types
-using CudaForallIndexSetExecPols = 
-  camp::list< RAJA::ExecPolicy<RAJA::seq_segit, RAJA::cuda_exec<128>>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::cuda_exec<256>> >;
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "../test-forall-indexset-execpol.hpp"
 
 // Cartesian product of types for Cuda tests
 using CudaForallIndexSetTypes =
@@ -21,3 +20,5 @@ using CudaForallIndexSetTypes =
 INSTANTIATE_TYPED_TEST_SUITE_P(Cuda,
                                ForallIndexSetViewTest,
                                CudaForallIndexSetTypes);
+
+#endif

--- a/test/functional/forall/indexset-view/test-forall-indexset-view-hip.cpp
+++ b/test/functional/forall/indexset-view/test-forall-indexset-view-hip.cpp
@@ -7,10 +7,9 @@
 
 #include "tests/test-forall-indexset-view.hpp"
 
-// Hip execution policy types
-using HipForallIndexSetExecPols = 
-  camp::list< RAJA::ExecPolicy<RAJA::seq_segit, RAJA::hip_exec<128>>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::hip_exec<256>> >;
+#if defined(RAJA_ENABLE_HIP)
+
+#include "../test-forall-indexset-execpol.hpp"
 
 // Cartesian product of types for Hip tests
 using HipForallIndexSetTypes =
@@ -21,3 +20,5 @@ using HipForallIndexSetTypes =
 INSTANTIATE_TYPED_TEST_SUITE_P(Hip,
                                ForallIndexSetViewTest,
                                HipForallIndexSetTypes);
+
+#endif

--- a/test/functional/forall/indexset-view/test-forall-indexset-view-hip.cpp
+++ b/test/functional/forall/indexset-view/test-forall-indexset-view-hip.cpp
@@ -1,0 +1,23 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "tests/test-forall-indexset-view.hpp"
+
+// Hip execution policy types
+using HipForallIndexSetExecPols = 
+  camp::list< RAJA::ExecPolicy<RAJA::seq_segit, RAJA::hip_exec<128>>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::hip_exec<256>> >;
+
+// Cartesian product of types for Hip tests
+using HipForallIndexSetTypes =
+  Test< camp::cartesian_product<IdxTypeList, 
+                                HipResourceList, 
+                                HipForallIndexSetExecPols>>::Types;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(Hip,
+                               ForallIndexSetViewTest,
+                               HipForallIndexSetTypes);

--- a/test/functional/forall/indexset-view/test-forall-indexset-view-openmp-target.cpp
+++ b/test/functional/forall/indexset-view/test-forall-indexset-view-openmp-target.cpp
@@ -7,12 +7,9 @@
 
 #include "tests/test-forall-indexset-view.hpp"
 
-// OpenMP target execution policy types
-using OpenMPTargetForallIndexSetExecPols = 
-  camp::list< RAJA::ExecPolicy<RAJA::seq_segit, 
-                               RAJA::omp_target_parallel_for_exec<8>>,
-              RAJA::ExecPolicy<RAJA::seq_segit, 
-                               RAJA::omp_target_parallel_for_exec_nt> >;
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "../test-forall-indexset-execpol.hpp"
 
 // Cartesian product of types for OpenMP target tests
 using OpenMPTargetForallIndexSetTypes =
@@ -23,3 +20,5 @@ using OpenMPTargetForallIndexSetTypes =
 INSTANTIATE_TYPED_TEST_SUITE_P(Cuda,
                                ForallIndexSetViewTest,
                                OpenMPTargetForallIndexSetTypes);
+
+#endif

--- a/test/functional/forall/indexset-view/test-forall-indexset-view-openmp-target.cpp
+++ b/test/functional/forall/indexset-view/test-forall-indexset-view-openmp-target.cpp
@@ -1,0 +1,25 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "tests/test-forall-indexset-view.hpp"
+
+// OpenMP target execution policy types
+using OpenMPTargetForallIndexSetExecPols = 
+  camp::list< RAJA::ExecPolicy<RAJA::seq_segit, 
+                               RAJA::omp_target_parallel_for_exec<8>>,
+              RAJA::ExecPolicy<RAJA::seq_segit, 
+                               RAJA::omp_target_parallel_for_exec_nt> >;
+
+// Cartesian product of types for OpenMP target tests
+using OpenMPTargetForallIndexSetTypes =
+  Test< camp::cartesian_product<IdxTypeList, 
+                                HostResourceList, 
+                                OpenMPTargetForallIndexSetExecPols>>::Types;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(Cuda,
+                               ForallIndexSetViewTest,
+                               OpenMPTargetForallIndexSetTypes);

--- a/test/functional/forall/indexset-view/test-forall-indexset-view-openmp.cpp
+++ b/test/functional/forall/indexset-view/test-forall-indexset-view-openmp.cpp
@@ -7,17 +7,9 @@
 
 #include "tests/test-forall-indexset-view.hpp"
 
-// OpenMP execution policy types
-using OpenMPForallIndexSetExecPols = 
-  camp::list< RAJA::ExecPolicy<RAJA::omp_parallel_for_segit, RAJA::seq_exec>,
-              RAJA::ExecPolicy<RAJA::omp_parallel_for_segit, RAJA::loop_exec>,
-              RAJA::ExecPolicy<RAJA::omp_parallel_for_segit, RAJA::simd_exec>,
-              RAJA::ExecPolicy<RAJA::omp_parallel_segit, RAJA::seq_exec>,
-              RAJA::ExecPolicy<RAJA::omp_parallel_segit, RAJA::loop_exec>,
-              RAJA::ExecPolicy<RAJA::omp_parallel_segit, RAJA::simd_exec>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::omp_for_exec>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::omp_parallel_for_exec>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::omp_for_nowait_exec> >;
+#if defined(RAJA_ENABLE_OPENMP)
+
+#include "../test-forall-indexset-execpol.hpp"
 
 // Cartesian product of types for OpenMP tests
 using OpenMPForallIndexSetTypes =
@@ -28,3 +20,5 @@ using OpenMPForallIndexSetTypes =
 INSTANTIATE_TYPED_TEST_SUITE_P(OpenMP,
                                ForallIndexSetViewTest,
                                OpenMPForallIndexSetTypes);
+
+#endif

--- a/test/functional/forall/indexset-view/test-forall-indexset-view-openmp.cpp
+++ b/test/functional/forall/indexset-view/test-forall-indexset-view-openmp.cpp
@@ -1,0 +1,30 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "tests/test-forall-indexset-view.hpp"
+
+// OpenMP execution policy types
+using OpenMPForallIndexSetExecPols = 
+  camp::list< RAJA::ExecPolicy<RAJA::omp_parallel_for_segit, RAJA::seq_exec>,
+              RAJA::ExecPolicy<RAJA::omp_parallel_for_segit, RAJA::loop_exec>,
+              RAJA::ExecPolicy<RAJA::omp_parallel_for_segit, RAJA::simd_exec>,
+              RAJA::ExecPolicy<RAJA::omp_parallel_segit, RAJA::seq_exec>,
+              RAJA::ExecPolicy<RAJA::omp_parallel_segit, RAJA::loop_exec>,
+              RAJA::ExecPolicy<RAJA::omp_parallel_segit, RAJA::simd_exec>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::omp_for_exec>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::omp_parallel_for_exec>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::omp_for_nowait_exec> >;
+
+// Cartesian product of types for OpenMP tests
+using OpenMPForallIndexSetTypes =
+  Test< camp::cartesian_product<IdxTypeList, 
+                                HostResourceList, 
+                                OpenMPForallIndexSetExecPols>>::Types;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(OpenMP,
+                               ForallIndexSetViewTest,
+                               OpenMPForallIndexSetTypes);

--- a/test/functional/forall/indexset-view/test-forall-indexset-view-seq.cpp
+++ b/test/functional/forall/indexset-view/test-forall-indexset-view-seq.cpp
@@ -7,11 +7,7 @@
 
 #include "tests/test-forall-indexset-view.hpp"
 
-// Sequential execution policy types
-using SequentialForallIndexSetExecPols = 
-  camp::list< RAJA::ExecPolicy<RAJA::seq_segit, RAJA::seq_exec>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::loop_exec>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::simd_exec> >;
+#include "../test-forall-indexset-execpol.hpp"
 
 // Cartesian product of types for Sequential tests
 using SequentialForallIndexSetTypes =

--- a/test/functional/forall/indexset-view/test-forall-indexset-view-seq.cpp
+++ b/test/functional/forall/indexset-view/test-forall-indexset-view-seq.cpp
@@ -1,0 +1,24 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "tests/test-forall-indexset-view.hpp"
+
+// Sequential execution policy types
+using SequentialForallIndexSetExecPols = 
+  camp::list< RAJA::ExecPolicy<RAJA::seq_segit, RAJA::seq_exec>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::loop_exec>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::simd_exec> >;
+
+// Cartesian product of types for Sequential tests
+using SequentialForallIndexSetTypes =
+  Test< camp::cartesian_product<IdxTypeList, 
+                                HostResourceList, 
+                                SequentialForallIndexSetExecPols>>::Types;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(Sequential,
+                               ForallIndexSetViewTest,
+                               SequentialForallIndexSetTypes);

--- a/test/functional/forall/indexset-view/test-forall-indexset-view-tbb.cpp
+++ b/test/functional/forall/indexset-view/test-forall-indexset-view-tbb.cpp
@@ -7,20 +7,9 @@
 
 #include "tests/test-forall-indexset-view.hpp"
 
-// TBB execution policy types
-using TBBForallIndexSetExecPols = 
-  camp::list< RAJA::ExecPolicy<RAJA::tbb_for_exec, RAJA::seq_exec>,
-              RAJA::ExecPolicy<RAJA::tbb_for_exec, RAJA::loop_exec>,
-              RAJA::ExecPolicy<RAJA::tbb_for_exec, RAJA::simd_exec>,
-              RAJA::ExecPolicy<RAJA::tbb_for_dynamic, RAJA::seq_exec>,
-              RAJA::ExecPolicy<RAJA::tbb_for_dynamic, RAJA::loop_exec>,
-              RAJA::ExecPolicy<RAJA::tbb_for_dynamic, RAJA::simd_exec>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_exec>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_static< >>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_static< 2 >>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_static< 4 >>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_static< 8 >>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_dynamic> >;
+#if defined(RAJA_ENABLE_TBB)
+
+#include "../test-forall-indexset-execpol.hpp"
 
 // Cartesian product of types for TBB tests
 using TBBForallIndexSetTypes =
@@ -31,3 +20,5 @@ using TBBForallIndexSetTypes =
 INSTANTIATE_TYPED_TEST_SUITE_P(TBB,
                                ForallIndexSetViewTest,
                                TBBForallIndexSetTypes);
+
+#endif

--- a/test/functional/forall/indexset-view/test-forall-indexset-view-tbb.cpp
+++ b/test/functional/forall/indexset-view/test-forall-indexset-view-tbb.cpp
@@ -1,0 +1,33 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "tests/test-forall-indexset-view.hpp"
+
+// TBB execution policy types
+using TBBForallIndexSetExecPols = 
+  camp::list< RAJA::ExecPolicy<RAJA::tbb_for_exec, RAJA::seq_exec>,
+              RAJA::ExecPolicy<RAJA::tbb_for_exec, RAJA::loop_exec>,
+              RAJA::ExecPolicy<RAJA::tbb_for_exec, RAJA::simd_exec>,
+              RAJA::ExecPolicy<RAJA::tbb_for_dynamic, RAJA::seq_exec>,
+              RAJA::ExecPolicy<RAJA::tbb_for_dynamic, RAJA::loop_exec>,
+              RAJA::ExecPolicy<RAJA::tbb_for_dynamic, RAJA::simd_exec>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_exec>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_static< >>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_static< 2 >>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_static< 4 >>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_static< 8 >>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_dynamic> >;
+
+// Cartesian product of types for TBB tests
+using TBBForallIndexSetTypes =
+  Test< camp::cartesian_product<IdxTypeList, 
+                                HostResourceList, 
+                                TBBForallIndexSetExecPols>>::Types;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(TBB,
+                               ForallIndexSetViewTest,
+                               TBBForallIndexSetTypes);

--- a/test/functional/forall/indexset-view/tests/test-forall-basic-indexset-view.hpp
+++ b/test/functional/forall/indexset-view/tests/test-forall-basic-indexset-view.hpp
@@ -63,11 +63,9 @@ void ForallISetViewTest()
 
   working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * N);
 
-  std::for_each( std::begin(is_indices), std::end(is_indices), 
-                 [=](INDEX_TYPE& idx) { 
-                   test_array[idx] = idx; 
-                 }
-               );
+  for (size_t i = 0; i < is_indices.size(); ++i) {
+    test_array[ is_indices[i] ] = is_indices[i];
+  }
 
   RAJA::Layout<1> layout(N);
   RAJA::View< INDEX_TYPE, RAJA::Layout<1, INDEX_TYPE, 0> >

--- a/test/functional/forall/indexset-view/tests/test-forall-basic-indexset-view.hpp
+++ b/test/functional/forall/indexset-view/tests/test-forall-basic-indexset-view.hpp
@@ -1,0 +1,103 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef __TEST_FORALL_BASIC_INDEXSET_VIEW__HPP__
+#define __TEST_FORALL_BASIC_INDEXSET_VIEW__HPP__
+
+#include "../../test-forall-indexset-utils.hpp"
+
+#include <cstdio>
+#include <algorithm>
+#include <vector>
+
+template <typename INDEX_TYPE, typename WORKING_RES, typename EXEC_POLICY>
+void ForallISetViewTest()
+{
+
+  using RangeSegType       = RAJA::TypedRangeSegment<INDEX_TYPE>;
+  using RangeStrideSegType = RAJA::TypedRangeStrideSegment<INDEX_TYPE>;
+  using ListSegType        = RAJA::TypedListSegment<INDEX_TYPE>;
+
+  using IndexSetType = 
+   RAJA::TypedIndexSet< RangeSegType, RangeStrideSegType, ListSegType >; 
+
+  camp::resources::Resource working_res{WORKING_RES()};
+
+  INDEX_TYPE last_idx = 0;
+
+  IndexSetType iset; 
+  buildIndexSet<INDEX_TYPE, RangeSegType, RangeStrideSegType, ListSegType>(
+    iset, last_idx, working_res);
+
+
+  //
+  // Collect actual indices in index set for testing.
+  //
+  std::vector<INDEX_TYPE> is_indices; 
+  getIndices(is_indices, iset);
+
+ 
+  //
+  // Working array length
+  //
+  const INDEX_TYPE N = last_idx + 1;
+
+  //
+  // Allocate and initialize arrays used in testing
+  //  
+  INDEX_TYPE* working_array;
+  INDEX_TYPE* check_array;
+  INDEX_TYPE* test_array;
+
+  allocateForallTestData<INDEX_TYPE>(N,
+                                     working_res,
+                                     &working_array,
+                                     &check_array,
+                                     &test_array);
+
+  memset( test_array, 0, sizeof(INDEX_TYPE) * N );  
+
+  working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * N);
+
+  std::for_each( std::begin(is_indices), std::end(is_indices), 
+                 [=](INDEX_TYPE& idx) { 
+                   test_array[idx] = idx; 
+                 }
+               );
+
+  RAJA::Layout<1> layout(N);
+  RAJA::View< INDEX_TYPE, RAJA::Layout<1, INDEX_TYPE, 0> >
+    work_view(working_array, layout);
+
+  RAJA::forall<EXEC_POLICY>(iset, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {
+    work_view( idx ) = idx;
+  });
+
+  working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * N);
+
+  // 
+  for (INDEX_TYPE i = 0; i < N; i++) {
+    ASSERT_EQ(test_array[i], check_array[i]);
+  }
+
+  deallocateForallTestData<INDEX_TYPE>(working_res,
+                                       working_array,
+                                       check_array,
+                                       test_array);
+}
+
+
+TYPED_TEST_P(ForallIndexSetViewTest, IndexSetForallView)
+{
+  using INDEX_TYPE       = typename camp::at<TypeParam, camp::num<0>>::type;
+  using WORKING_RESOURCE = typename camp::at<TypeParam, camp::num<1>>::type;
+  using EXEC_POLICY      = typename camp::at<TypeParam, camp::num<2>>::type;
+
+  ForallISetViewTest<INDEX_TYPE, WORKING_RESOURCE, EXEC_POLICY>();
+}
+
+#endif  // __TEST_FORALL_BASIC_INDEXSET_VIEW__HPP__

--- a/test/functional/forall/indexset-view/tests/test-forall-basic-indexset-view.hpp
+++ b/test/functional/forall/indexset-view/tests/test-forall-basic-indexset-view.hpp
@@ -10,6 +10,8 @@
 
 #include "../../test-forall-indexset-utils.hpp"
 
+#include "../../test-forall-functors.hpp"
+
 #include <cstdio>
 #include <algorithm>
 #include <vector>
@@ -67,13 +69,14 @@ void ForallISetViewTest()
     test_array[ is_indices[i] ] = is_indices[i];
   }
 
-  RAJA::Layout<1> layout(N);
-  RAJA::View< INDEX_TYPE, RAJA::Layout<1, INDEX_TYPE, 0> >
-    work_view(working_array, layout);
+  using view_type = RAJA::View< INDEX_TYPE, RAJA::Layout<1, INDEX_TYPE, 0> >;
 
-  RAJA::forall<EXEC_POLICY>(iset, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {
-    work_view( idx ) = idx;
-  });
+  RAJA::Layout<1> layout(N);
+  view_type work_view(working_array, layout);
+
+  IndexSetViewTestFunctor<INDEX_TYPE, view_type> tbody(work_view);
+
+  RAJA::forall<EXEC_POLICY>(iset, tbody);
 
   working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * N);
 

--- a/test/functional/forall/indexset-view/tests/test-forall-icount-indexset-view.hpp
+++ b/test/functional/forall/indexset-view/tests/test-forall-icount-indexset-view.hpp
@@ -65,11 +65,9 @@ void Forall_IcountISetViewTest()
   working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * N);
 
   INDEX_TYPE ticount = 0;
-  std::for_each( std::begin(is_indices), std::end(is_indices), 
-                 [&](INDEX_TYPE& idx) { 
-                   test_array[ticount++] = idx; 
-                 }
-               );
+  for (size_t i = 0; i < is_indices.size(); ++i) {
+    test_array[ ticount++ ] = is_indices[i];
+  }
 
   RAJA::Layout<1> layout(N);
   RAJA::View< INDEX_TYPE, RAJA::Layout<1, INDEX_TYPE, 0> >

--- a/test/functional/forall/indexset-view/tests/test-forall-icount-indexset-view.hpp
+++ b/test/functional/forall/indexset-view/tests/test-forall-icount-indexset-view.hpp
@@ -1,0 +1,106 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef __TEST_FORALL_ICOUNT_INDEXSET_VIEW__HPP__
+#define __TEST_FORALL_ICOUNT_INDEXSET_VIEW__HPP__
+
+#include "../../test-forall-indexset-utils.hpp"
+
+#include <cstdio>
+#include <algorithm>
+#include <vector>
+
+
+template <typename INDEX_TYPE, typename WORKING_RES, typename EXEC_POLICY>
+void Forall_IcountISetViewTest()
+{
+
+  using RangeSegType       = RAJA::TypedRangeSegment<INDEX_TYPE>;
+  using RangeStrideSegType = RAJA::TypedRangeStrideSegment<INDEX_TYPE>;
+  using ListSegType        = RAJA::TypedListSegment<INDEX_TYPE>;
+
+  using IndexSetType = 
+   RAJA::TypedIndexSet< RangeSegType, RangeStrideSegType, ListSegType >; 
+
+  camp::resources::Resource working_res{WORKING_RES()};
+
+  INDEX_TYPE last_idx = 0;
+
+  IndexSetType iset; 
+  buildIndexSet<INDEX_TYPE, RangeSegType, RangeStrideSegType, ListSegType>(
+    iset, last_idx, working_res);
+
+
+  //
+  // Collect actual indices in index set for testing.
+  //
+  std::vector<INDEX_TYPE> is_indices; 
+  getIndices(is_indices, iset);
+
+ 
+  //
+  // Working array length
+  //
+  const INDEX_TYPE N = last_idx + 1;
+
+  //
+  // Allocate and initialize arrays used in testing
+  //  
+  INDEX_TYPE* working_array;
+  INDEX_TYPE* check_array;
+  INDEX_TYPE* test_array;
+
+  allocateForallTestData<INDEX_TYPE>(N,
+                                     working_res,
+                                     &working_array,
+                                     &check_array,
+                                     &test_array);
+
+  memset( test_array, 0, sizeof(INDEX_TYPE) * N );  
+
+  working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * N);
+
+  INDEX_TYPE ticount = 0;
+  std::for_each( std::begin(is_indices), std::end(is_indices), 
+                 [&](INDEX_TYPE& idx) { 
+                   test_array[ticount++] = idx; 
+                 }
+               );
+
+  RAJA::Layout<1> layout(N);
+  RAJA::View< INDEX_TYPE, RAJA::Layout<1, INDEX_TYPE, 0> >
+    work_view(working_array, layout);
+
+  RAJA::forall_Icount<EXEC_POLICY>(iset, 
+    [=] RAJA_HOST_DEVICE(INDEX_TYPE icount, INDEX_TYPE idx) {
+    work_view( icount ) = idx;
+  });
+
+  working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * N);
+
+  // 
+  for (INDEX_TYPE i = 0; i < N; i++) {
+    ASSERT_EQ(test_array[i], check_array[i]);
+  }
+
+  deallocateForallTestData<INDEX_TYPE>(working_res,
+                                       working_array,
+                                       check_array,
+                                       test_array);
+}
+
+
+TYPED_TEST_P(ForallIndexSetViewTest, IndexSetForall_IcountView)
+{
+  using INDEX_TYPE       = typename camp::at<TypeParam, camp::num<0>>::type;
+  using WORKING_RESOURCE = typename camp::at<TypeParam, camp::num<1>>::type;
+  using EXEC_POLICY      = typename camp::at<TypeParam, camp::num<2>>::type;
+
+  Forall_IcountISetViewTest<INDEX_TYPE, WORKING_RESOURCE, EXEC_POLICY>();
+}
+
+#endif  // __TEST_FORALL_ICOUNT_INDEXSET_VIEW__HPP__

--- a/test/functional/forall/indexset-view/tests/test-forall-indexset-view.hpp
+++ b/test/functional/forall/indexset-view/tests/test-forall-indexset-view.hpp
@@ -1,0 +1,28 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef __TEST_FORALL_INDEXSET_VIEW__HPP__
+#define __TEST_FORALL_INDEXSET_VIEW__HPP__
+
+#include "RAJA/RAJA.hpp"
+
+#include "../../test-forall-utils.hpp"
+
+TYPED_TEST_SUITE_P(ForallIndexSetViewTest);
+template <typename T>
+class ForallIndexSetViewTest : public ::testing::Test
+{
+};
+
+#include "test-forall-basic-indexset-view.hpp"
+#include "test-forall-icount-indexset-view.hpp"
+
+REGISTER_TYPED_TEST_SUITE_P(ForallIndexSetViewTest,
+                            IndexSetForallView,
+                            IndexSetForall_IcountView);
+
+#endif  // __TEST_FORALL_INDEXSET_VIEW__HPP__

--- a/test/functional/forall/indexset/test-forall-indexset-cuda.cpp
+++ b/test/functional/forall/indexset/test-forall-indexset-cuda.cpp
@@ -7,10 +7,9 @@
 
 #include "tests/test-forall-indexset.hpp"
 
-// Cuda execution policy types
-using CudaForallIndexSetExecPols = 
-  camp::list< RAJA::ExecPolicy<RAJA::seq_segit, RAJA::cuda_exec<128>>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::cuda_exec<256>> >;
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "../test-forall-indexset-execpol.hpp"
 
 // Cartesian product of types for Cuda tests
 using CudaForallIndexSetTypes =
@@ -21,3 +20,5 @@ using CudaForallIndexSetTypes =
 INSTANTIATE_TYPED_TEST_SUITE_P(Cuda,
                                ForallIndexSetTest,
                                CudaForallIndexSetTypes);
+
+#endif

--- a/test/functional/forall/indexset/test-forall-indexset-hip.cpp
+++ b/test/functional/forall/indexset/test-forall-indexset-hip.cpp
@@ -7,10 +7,9 @@
 
 #include "tests/test-forall-indexset.hpp"
 
-// Hip execution policy types
-using HipForallIndexSetExecPols = 
-  camp::list< RAJA::ExecPolicy<RAJA::seq_segit, RAJA::hip_exec<128>>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::hip_exec<256>> >;
+#if defined(RAJA_ENABLE_HIP)
+
+#include "../test-forall-indexset-execpol.hpp"
 
 // Cartesian product of types for Hip tests
 using HipForallIndexSetTypes =
@@ -21,3 +20,5 @@ using HipForallIndexSetTypes =
 INSTANTIATE_TYPED_TEST_SUITE_P(Hip,
                                ForallIndexSetTest,
                                HipForallIndexSetTypes);
+
+#endif

--- a/test/functional/forall/indexset/test-forall-indexset-openmp-target.cpp
+++ b/test/functional/forall/indexset/test-forall-indexset-openmp-target.cpp
@@ -7,12 +7,9 @@
 
 #include "tests/test-forall-indexset.hpp"
 
-// OpenMP target execution policy types
-using OpenMPTargetForallIndexSetExecPols = 
-  camp::list< RAJA::ExecPolicy<RAJA::seq_segit, 
-                               RAJA::omp_target_parallel_for_exec<8>>,
-              RAJA::ExecPolicy<RAJA::seq_segit, 
-                               RAJA::omp_target_parallel_for_exec_nt> >;
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "../test-forall-indexset-execpol.hpp"
 
 // Cartesian product of types for OpenMP target tests
 using OpenMPTargetForallIndexSetTypes =
@@ -23,3 +20,5 @@ using OpenMPTargetForallIndexSetTypes =
 INSTANTIATE_TYPED_TEST_SUITE_P(Cuda,
                                ForallIndexSetTest,
                                OpenMPTargetForallIndexSetTypes);
+
+#endif

--- a/test/functional/forall/indexset/test-forall-indexset-openmp.cpp
+++ b/test/functional/forall/indexset/test-forall-indexset-openmp.cpp
@@ -7,17 +7,9 @@
 
 #include "tests/test-forall-indexset.hpp"
 
-// OpenMP execution policy types
-using OpenMPForallIndexSetExecPols = 
-  camp::list< RAJA::ExecPolicy<RAJA::omp_parallel_for_segit, RAJA::seq_exec>,
-              RAJA::ExecPolicy<RAJA::omp_parallel_for_segit, RAJA::loop_exec>,
-              RAJA::ExecPolicy<RAJA::omp_parallel_for_segit, RAJA::simd_exec>,
-              RAJA::ExecPolicy<RAJA::omp_parallel_segit, RAJA::seq_exec>,
-              RAJA::ExecPolicy<RAJA::omp_parallel_segit, RAJA::loop_exec>,
-              RAJA::ExecPolicy<RAJA::omp_parallel_segit, RAJA::simd_exec>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::omp_for_exec>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::omp_parallel_for_exec>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::omp_for_nowait_exec> >;
+#if defined(RAJA_ENABLE_OPENMP)
+
+#include "../test-forall-indexset-execpol.hpp"
 
 // Cartesian product of types for OpenMP tests
 using OpenMPForallIndexSetTypes =
@@ -28,3 +20,5 @@ using OpenMPForallIndexSetTypes =
 INSTANTIATE_TYPED_TEST_SUITE_P(OpenMP,
                                ForallIndexSetTest,
                                OpenMPForallIndexSetTypes);
+
+#endif

--- a/test/functional/forall/indexset/test-forall-indexset-seq.cpp
+++ b/test/functional/forall/indexset/test-forall-indexset-seq.cpp
@@ -7,11 +7,7 @@
 
 #include "tests/test-forall-indexset.hpp"
 
-// Sequential execution policy types
-using SequentialForallIndexSetExecPols = 
-  camp::list< RAJA::ExecPolicy<RAJA::seq_segit, RAJA::seq_exec>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::loop_exec>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::simd_exec> >;
+#include "../test-forall-indexset-execpol.hpp"
 
 // Cartesian product of types for Sequential tests
 using SequentialForallIndexSetTypes =

--- a/test/functional/forall/indexset/test-forall-indexset-tbb.cpp
+++ b/test/functional/forall/indexset/test-forall-indexset-tbb.cpp
@@ -7,20 +7,9 @@
 
 #include "tests/test-forall-indexset.hpp"
 
-// TBB execution policy types
-using TBBForallIndexSetExecPols = 
-  camp::list< RAJA::ExecPolicy<RAJA::tbb_for_exec, RAJA::seq_exec>,
-              RAJA::ExecPolicy<RAJA::tbb_for_exec, RAJA::loop_exec>,
-              RAJA::ExecPolicy<RAJA::tbb_for_exec, RAJA::simd_exec>,
-              RAJA::ExecPolicy<RAJA::tbb_for_dynamic, RAJA::seq_exec>,
-              RAJA::ExecPolicy<RAJA::tbb_for_dynamic, RAJA::loop_exec>,
-              RAJA::ExecPolicy<RAJA::tbb_for_dynamic, RAJA::simd_exec>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_exec>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_static< >>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_static< 2 >>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_static< 4 >>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_static< 8 >>,
-              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_dynamic> >;
+#if defined(RAJA_ENABLE_TBB)
+
+#include "../test-forall-indexset-execpol.hpp"
 
 // Cartesian product of types for TBB tests
 using TBBForallIndexSetTypes =
@@ -31,3 +20,5 @@ using TBBForallIndexSetTypes =
 INSTANTIATE_TYPED_TEST_SUITE_P(TBB,
                                ForallIndexSetTest,
                                TBBForallIndexSetTypes);
+
+#endif

--- a/test/functional/forall/indexset/tests/test-forall-basic-indexset.hpp
+++ b/test/functional/forall/indexset/tests/test-forall-basic-indexset.hpp
@@ -10,6 +10,8 @@
 
 #include "../../test-forall-indexset-utils.hpp"
 
+#include "../../test-forall-functors.hpp"
+
 #include <cstdio>
 #include <algorithm>
 #include <vector>
@@ -67,9 +69,9 @@ void ForallISetTest()
     test_array[ is_indices[i] ] = is_indices[i];
   }
 
-  RAJA::forall<EXEC_POLICY>(iset, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {
-    working_array[idx] = idx;
-  });
+  IndexSetTestFunctor<INDEX_TYPE> tbody(working_array);
+
+  RAJA::forall<EXEC_POLICY>(iset, tbody);
 
   working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * N);
 

--- a/test/functional/forall/indexset/tests/test-forall-basic-indexset.hpp
+++ b/test/functional/forall/indexset/tests/test-forall-basic-indexset.hpp
@@ -8,7 +8,7 @@
 #ifndef __TEST_FORALL_BASIC_INDEXSET_HPP__
 #define __TEST_FORALL_BASIC_INDEXSET_HPP__
 
-#include "test-forall-indexset-utils.hpp"
+#include "../../test-forall-indexset-utils.hpp"
 
 #include <cstdio>
 #include <algorithm>

--- a/test/functional/forall/indexset/tests/test-forall-basic-indexset.hpp
+++ b/test/functional/forall/indexset/tests/test-forall-basic-indexset.hpp
@@ -63,11 +63,9 @@ void ForallISetTest()
 
   working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * N);
 
-  std::for_each( std::begin(is_indices), std::end(is_indices), 
-                 [=](INDEX_TYPE& idx) { 
-                   test_array[idx] = idx; 
-                 }
-               );
+  for (size_t i = 0; i < is_indices.size(); ++i) {
+    test_array[ is_indices[i] ] = is_indices[i];
+  }
 
   RAJA::forall<EXEC_POLICY>(iset, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {
     working_array[idx] = idx;

--- a/test/functional/forall/indexset/tests/test-forall-icount-indexset.hpp
+++ b/test/functional/forall/indexset/tests/test-forall-icount-indexset.hpp
@@ -8,7 +8,7 @@
 #ifndef __TEST_FORALL_ICOUNT_INDEXSET_HPP__
 #define __TEST_FORALL_ICOUNT_INDEXSET_HPP__
 
-#include "test-forall-indexset-utils.hpp"
+#include "../../test-forall-indexset-utils.hpp"
 
 #include <cstdio>
 #include <algorithm>

--- a/test/functional/forall/indexset/tests/test-forall-icount-indexset.hpp
+++ b/test/functional/forall/indexset/tests/test-forall-icount-indexset.hpp
@@ -65,11 +65,9 @@ void Forall_IcountISetTest()
   working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * N);
 
   INDEX_TYPE ticount = 0;
-  std::for_each( std::begin(is_indices), std::end(is_indices), 
-                 [&](INDEX_TYPE& idx) { 
-                   test_array[ticount++] = idx; 
-                 }
-               );
+  for (size_t i = 0; i < is_indices.size(); ++i) {
+    test_array[ ticount++ ] = is_indices[i];
+  }
 
   RAJA::forall_Icount<EXEC_POLICY>(iset, 
     [=] RAJA_HOST_DEVICE(INDEX_TYPE icount, INDEX_TYPE idx) {

--- a/test/functional/forall/segment-view/CMakeLists.txt
+++ b/test/functional/forall/segment-view/CMakeLists.txt
@@ -1,0 +1,40 @@
+###############################################################################
+# Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+raja_add_test(
+  NAME test-forall-segment-view-seq
+  SOURCES test-forall-segment-view-seq.cpp)
+
+if(RAJA_ENABLE_OPENMP)
+  raja_add_test(
+    NAME test-forall-segment-view-openmp
+    SOURCES test-forall-segment-view-openmp.cpp)
+endif()
+
+if(RAJA_ENABLE_TARGET_OPENMP)
+  raja_add_test(
+    NAME test-forall-segment-view-openmp-target
+    SOURCES test-forall-segment-view-openmp-target.cpp)
+endif()
+
+if(RAJA_ENABLE_TBB)
+  raja_add_test(
+    NAME test-forall-segment-view-tbb
+    SOURCES test-forall-segment-view-tbb.cpp)
+endif()
+
+if(RAJA_ENABLE_CUDA)
+  raja_add_test(
+    NAME test-forall-segment-view-cuda
+    SOURCES test-forall-segment-view-cuda.cpp)
+endif()
+
+if(RAJA_ENABLE_HIP)
+  raja_add_test(
+    NAME test-forall-segment-view-hip
+    SOURCES test-forall-segment-view-hip.cpp)
+endif()

--- a/test/functional/forall/segment-view/test-forall-segment-view-cuda.cpp
+++ b/test/functional/forall/segment-view/test-forall-segment-view-cuda.cpp
@@ -1,0 +1,26 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "tests/test-forall-segment-view.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+// Cuda execution policy types
+using CudaForallExecPols = camp::list< RAJA::cuda_exec<128>,
+                                       RAJA::cuda_exec<256> >;
+
+// Cartesian product of types for Cuda tests
+using CudaForallSegmentTypes = 
+  Test< camp::cartesian_product<IdxTypeList, 
+                                CudaResourceList, 
+                                CudaForallExecPols> >::Types;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(Cuda,
+                               ForallSegmentViewTest,
+                               CudaForallSegmentTypes);
+
+#endif

--- a/test/functional/forall/segment-view/test-forall-segment-view-cuda.cpp
+++ b/test/functional/forall/segment-view/test-forall-segment-view-cuda.cpp
@@ -9,9 +9,7 @@
 
 #if defined(RAJA_ENABLE_CUDA)
 
-// Cuda execution policy types
-using CudaForallExecPols = camp::list< RAJA::cuda_exec<128>,
-                                       RAJA::cuda_exec<256> >;
+#include "../test-forall-execpol.hpp"
 
 // Cartesian product of types for Cuda tests
 using CudaForallSegmentTypes = 

--- a/test/functional/forall/segment-view/test-forall-segment-view-hip.cpp
+++ b/test/functional/forall/segment-view/test-forall-segment-view-hip.cpp
@@ -1,0 +1,26 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "tests/test-forall-segment-view.hpp"
+
+#if defined(RAJA_ENABLE_HIP)
+
+// Hip execution policy types
+using HipForallExecPols = camp::list< RAJA::hip_exec<128>,
+                                      RAJA::hip_exec<256>  >;
+
+// Cartesian product of types for Hip tests
+using HipForallSegmentTypes = 
+  Test< camp::cartesian_product<IdxTypeList, 
+                                HipResourceList, 
+                                HipForallExecPols> >::Types;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(Hip,
+                               ForallSegmentViewTest,
+                               HipForallSegmentTypes);
+
+#endif

--- a/test/functional/forall/segment-view/test-forall-segment-view-hip.cpp
+++ b/test/functional/forall/segment-view/test-forall-segment-view-hip.cpp
@@ -9,9 +9,7 @@
 
 #if defined(RAJA_ENABLE_HIP)
 
-// Hip execution policy types
-using HipForallExecPols = camp::list< RAJA::hip_exec<128>,
-                                      RAJA::hip_exec<256>  >;
+#include "../test-forall-execpol.hpp"
 
 // Cartesian product of types for Hip tests
 using HipForallSegmentTypes = 

--- a/test/functional/forall/segment-view/test-forall-segment-view-openmp-target.cpp
+++ b/test/functional/forall/segment-view/test-forall-segment-view-openmp-target.cpp
@@ -9,10 +9,7 @@
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
 
-// OpenMP target execution policy types
-using OpenMPTargetForallExecPols = 
-  camp::list< RAJA::omp_target_parallel_for_exec<8>,
-              RAJA::omp_target_parallel_for_exec_nt >;
+#include "../test-forall-execpol.hpp"
 
 // Cartesian product of types for OpenMP target tests
 using OpenMPTargetForallSegmentTypes =

--- a/test/functional/forall/segment-view/test-forall-segment-view-openmp-target.cpp
+++ b/test/functional/forall/segment-view/test-forall-segment-view-openmp-target.cpp
@@ -1,0 +1,26 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "tests/test-forall-segment-view.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+// OpenMP target execution policy types
+using OpenMPTargetForallExecPols = 
+  camp::list< RAJA::omp_target_parallel_for_exec<8>,
+              RAJA::omp_target_parallel_for_exec_nt >;
+
+// Cartesian product of types for OpenMP target tests
+using OpenMPTargetForallSegmentTypes =
+  Test< camp::cartesian_product<IdxTypeList, 
+                                OpenMPTargetResourceList, 
+                                OpenMPTargetForallExecPols> >::Types;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(OpenMPTarget,
+                               ForallSegmentViewTest,
+                               OpenMPTargetForallSegmentTypes);
+#endif

--- a/test/functional/forall/segment-view/test-forall-segment-view-openmp.cpp
+++ b/test/functional/forall/segment-view/test-forall-segment-view-openmp.cpp
@@ -9,12 +9,7 @@
 
 #if defined(RAJA_ENABLE_OPENMP)
 
-// OpenMP execution policy types
-using OpenMPForallExecPols = 
-  camp::list< RAJA::omp_parallel_exec<RAJA::seq_exec>,
-              RAJA::omp_for_nowait_exec,
-              RAJA::omp_for_exec,
-              RAJA::omp_parallel_for_exec >;
+#include "../test-forall-execpol.hpp"
 
 // Cartesian product of types for OpenMP tests
 using OpenMPForallSegmentTypes =

--- a/test/functional/forall/segment-view/test-forall-segment-view-openmp.cpp
+++ b/test/functional/forall/segment-view/test-forall-segment-view-openmp.cpp
@@ -1,0 +1,29 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "tests/test-forall-segment-view.hpp"
+
+#if defined(RAJA_ENABLE_OPENMP)
+
+// OpenMP execution policy types
+using OpenMPForallExecPols = 
+  camp::list< RAJA::omp_parallel_exec<RAJA::seq_exec>,
+              RAJA::omp_for_nowait_exec,
+              RAJA::omp_for_exec,
+              RAJA::omp_parallel_for_exec >;
+
+// Cartesian product of types for OpenMP tests
+using OpenMPForallSegmentTypes =
+  Test< camp::cartesian_product<IdxTypeList, 
+                                HostResourceList,
+                                OpenMPForallExecPols> >::Types;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(OpenMP,
+                               ForallSegmentViewTest,
+                               OpenMPForallSegmentTypes);
+
+#endif

--- a/test/functional/forall/segment-view/test-forall-segment-view-seq.cpp
+++ b/test/functional/forall/segment-view/test-forall-segment-view-seq.cpp
@@ -1,0 +1,23 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "tests/test-forall-segment-view.hpp"
+
+// Sequential execution policy types
+using SequentialForallExecPols = camp::list< RAJA::seq_exec,
+                                             RAJA::loop_exec,
+                                             RAJA::simd_exec >;
+
+// Cartesian product of types for Sequential tests
+using SequentialForallSegmentTypes =
+  Test< camp::cartesian_product<IdxTypeList, 
+                                HostResourceList, 
+                                SequentialForallExecPols>>::Types;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(Sequential,
+                               ForallSegmentViewTest,
+                               SequentialForallSegmentTypes);

--- a/test/functional/forall/segment-view/test-forall-segment-view-seq.cpp
+++ b/test/functional/forall/segment-view/test-forall-segment-view-seq.cpp
@@ -7,10 +7,7 @@
 
 #include "tests/test-forall-segment-view.hpp"
 
-// Sequential execution policy types
-using SequentialForallExecPols = camp::list< RAJA::seq_exec,
-                                             RAJA::loop_exec,
-                                             RAJA::simd_exec >;
+#include "../test-forall-execpol.hpp"
 
 // Cartesian product of types for Sequential tests
 using SequentialForallSegmentTypes =

--- a/test/functional/forall/segment-view/test-forall-segment-view-tbb.cpp
+++ b/test/functional/forall/segment-view/test-forall-segment-view-tbb.cpp
@@ -1,0 +1,29 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "tests/test-forall-segment-view.hpp"
+
+#if defined(RAJA_ENABLE_TBB)
+
+// TBB execution policy types
+using TBBForallExecPols = camp::list< RAJA::tbb_for_exec,
+                                      RAJA::tbb_for_static< >,
+                                      RAJA::tbb_for_static< 2 >,
+                                      RAJA::tbb_for_static< 4 >,
+                                      RAJA::tbb_for_static< 8 >,
+                                      RAJA::tbb_for_dynamic >;
+
+// Cartesian product of types for TBB tests
+using TBBForallSegmentTypes =
+  Test< camp::cartesian_product<IdxTypeList, 
+                                HostResourceList, 
+                                TBBForallExecPols> >::Types;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(TBB,
+                               ForallSegmentViewTest,
+                               TBBForallSegmentTypes);
+#endif

--- a/test/functional/forall/segment-view/test-forall-segment-view-tbb.cpp
+++ b/test/functional/forall/segment-view/test-forall-segment-view-tbb.cpp
@@ -9,13 +9,7 @@
 
 #if defined(RAJA_ENABLE_TBB)
 
-// TBB execution policy types
-using TBBForallExecPols = camp::list< RAJA::tbb_for_exec,
-                                      RAJA::tbb_for_static< >,
-                                      RAJA::tbb_for_static< 2 >,
-                                      RAJA::tbb_for_static< 4 >,
-                                      RAJA::tbb_for_static< 8 >,
-                                      RAJA::tbb_for_dynamic >;
+#include "../test-forall-execpol.hpp"
 
 // Cartesian product of types for TBB tests
 using TBBForallSegmentTypes =

--- a/test/functional/forall/segment-view/tests/test-forall-listsegment-view.hpp
+++ b/test/functional/forall/segment-view/tests/test-forall-listsegment-view.hpp
@@ -37,7 +37,6 @@ void ForallListSegmentViewTest(INDEX_TYPE N)
 
   camp::resources::Resource working_res{WORKING_RES()};
 
-  // Create list segment for tests
   RAJA::TypedListSegment<INDEX_TYPE> lseg(&idx_array[0], idxlen, 
                                           working_res);
 
@@ -69,7 +68,6 @@ void ForallListSegmentViewTest(INDEX_TYPE N)
 
   working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * N);
 
-  // 
   for (INDEX_TYPE i = 0; i < N; i++) {
     ASSERT_EQ(test_array[i], check_array[i]);
   }
@@ -80,6 +78,66 @@ void ForallListSegmentViewTest(INDEX_TYPE N)
                                        test_array);
 }
 
+template <typename INDEX_TYPE, typename WORKING_RES, typename EXEC_POLICY>
+void ForallListSegmentOffsetViewTest(INDEX_TYPE N, INDEX_TYPE offset)
+{
+
+  // Create and initialize indices in idx_array used to create list segment
+  std::vector<INDEX_TYPE> idx_array;
+
+  srand ( time(NULL) );
+
+  for (INDEX_TYPE i = 0; i < N; ++i) {
+    INDEX_TYPE randval = rand() % N;
+    if ( i < randval ) {
+      idx_array.push_back(i+offset);
+    }     
+  }
+
+  size_t idxlen = idx_array.size();
+
+  camp::resources::Resource working_res{WORKING_RES()};
+
+  RAJA::TypedListSegment<INDEX_TYPE> lseg(&idx_array[0], idxlen, 
+                                          working_res);
+
+  INDEX_TYPE* working_array;
+  INDEX_TYPE* check_array;
+  INDEX_TYPE* test_array;
+
+  allocateForallTestData<INDEX_TYPE>(N,
+                                     working_res,
+                                     &working_array,
+                                     &check_array,
+                                     &test_array);
+
+  memset( test_array, 0, sizeof(INDEX_TYPE) * N );  
+
+  working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * N);
+
+  std::for_each( std::begin(idx_array), std::end(idx_array), 
+                 [=](INDEX_TYPE& idx ) { test_array[idx-offset] = idx; }
+               );
+
+  RAJA::View< INDEX_TYPE, RAJA::OffsetLayout<1, INDEX_TYPE> > 
+    work_view(working_array, 
+              RAJA::make_offset_layout<1, INDEX_TYPE>({{offset}}, {{N+offset}}));
+
+  RAJA::forall<EXEC_POLICY>(lseg, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {
+    work_view( idx ) = idx;
+  });
+
+  working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * N);
+
+  for (INDEX_TYPE i = 0; i < N; i++) {
+    ASSERT_EQ(test_array[i], check_array[i]);
+  }
+
+  deallocateForallTestData<INDEX_TYPE>(working_res,
+                                       working_array,
+                                       check_array,
+                                       test_array);
+}
 
 TYPED_TEST_P(ForallSegmentViewTest, ListSegmentForallView)
 {
@@ -88,11 +146,12 @@ TYPED_TEST_P(ForallSegmentViewTest, ListSegmentForallView)
   using EXEC_POLICY      = typename camp::at<TypeParam, camp::num<2>>::type;
 
   ForallListSegmentViewTest<INDEX_TYPE, WORKING_RESOURCE, EXEC_POLICY>(13);
-
   ForallListSegmentViewTest<INDEX_TYPE, WORKING_RESOURCE, EXEC_POLICY>(2047);
-
   ForallListSegmentViewTest<INDEX_TYPE, WORKING_RESOURCE, EXEC_POLICY>(32000);
 
+  ForallListSegmentOffsetViewTest<INDEX_TYPE, WORKING_RESOURCE, EXEC_POLICY>(13, 1);
+  ForallListSegmentOffsetViewTest<INDEX_TYPE, WORKING_RESOURCE, EXEC_POLICY>(2047, 2);
+  ForallListSegmentOffsetViewTest<INDEX_TYPE, WORKING_RESOURCE, EXEC_POLICY>(32000, 3);
 }
 
 #endif  // __TEST_FORALL_LISTSEGMENT_VIEW_HPP__

--- a/test/functional/forall/segment-view/tests/test-forall-listsegment-view.hpp
+++ b/test/functional/forall/segment-view/tests/test-forall-listsegment-view.hpp
@@ -54,9 +54,9 @@ void ForallListSegmentViewTest(INDEX_TYPE N)
 
   working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * N);
 
-  std::for_each( std::begin(idx_array), std::end(idx_array), 
-                 [=](INDEX_TYPE& idx ) { test_array[idx] = idx; }
-               );
+  for (size_t i = 0; i < idxlen; ++i) {
+    test_array[ idx_array[i] ] = idx_array[i];
+  }
 
   RAJA::Layout<1> layout(N);
   RAJA::View< INDEX_TYPE, RAJA::Layout<1, INDEX_TYPE, 0> > 

--- a/test/functional/forall/segment-view/tests/test-forall-listsegment-view.hpp
+++ b/test/functional/forall/segment-view/tests/test-forall-listsegment-view.hpp
@@ -1,0 +1,98 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef __TEST_FORALL_LISTSEGMENT_VIEW_HPP__
+#define __TEST_FORALL_LISTSEGMENT_VIEW_HPP__
+
+#include "test-forall-segment-view.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <algorithm>
+#include <numeric>
+
+template <typename INDEX_TYPE, typename WORKING_RES, typename EXEC_POLICY>
+void ForallListSegmentViewTest(INDEX_TYPE N)
+{
+
+  // Create and initialize indices in idx_array used to create list segment
+  std::vector<INDEX_TYPE> idx_array;
+
+  srand ( time(NULL) );
+
+  for (INDEX_TYPE i = 0; i < N; ++i) {
+    INDEX_TYPE randval = rand() % N;
+    if ( i < randval ) {
+      idx_array.push_back(i);
+    }     
+  }
+
+  size_t idxlen = idx_array.size();
+
+  camp::resources::Resource working_res{WORKING_RES()};
+
+  // Create list segment for tests
+  RAJA::TypedListSegment<INDEX_TYPE> lseg(&idx_array[0], idxlen, 
+                                          working_res);
+
+  INDEX_TYPE* working_array;
+  INDEX_TYPE* check_array;
+  INDEX_TYPE* test_array;
+
+  allocateForallTestData<INDEX_TYPE>(N,
+                                     working_res,
+                                     &working_array,
+                                     &check_array,
+                                     &test_array);
+
+  memset( test_array, 0, sizeof(INDEX_TYPE) * N );  
+
+  working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * N);
+
+  std::for_each( std::begin(idx_array), std::end(idx_array), 
+                 [=](INDEX_TYPE& idx ) { test_array[idx] = idx; }
+               );
+
+  RAJA::Layout<1> layout(N);
+  RAJA::View< INDEX_TYPE, RAJA::Layout<1, INDEX_TYPE, 0> > 
+    work_view(working_array, layout);
+
+  RAJA::forall<EXEC_POLICY>(lseg, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {
+    work_view( idx ) = idx;
+  });
+
+  working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * N);
+
+  // 
+  for (INDEX_TYPE i = 0; i < N; i++) {
+    ASSERT_EQ(test_array[i], check_array[i]);
+  }
+
+  deallocateForallTestData<INDEX_TYPE>(working_res,
+                                       working_array,
+                                       check_array,
+                                       test_array);
+}
+
+
+TYPED_TEST_P(ForallSegmentViewTest, ListSegmentForallView)
+{
+  using INDEX_TYPE       = typename camp::at<TypeParam, camp::num<0>>::type;
+  using WORKING_RESOURCE = typename camp::at<TypeParam, camp::num<1>>::type;
+  using EXEC_POLICY      = typename camp::at<TypeParam, camp::num<2>>::type;
+
+  ForallListSegmentViewTest<INDEX_TYPE, WORKING_RESOURCE, EXEC_POLICY>(13);
+
+  ForallListSegmentViewTest<INDEX_TYPE, WORKING_RESOURCE, EXEC_POLICY>(2047);
+
+  ForallListSegmentViewTest<INDEX_TYPE, WORKING_RESOURCE, EXEC_POLICY>(32000);
+
+}
+
+#endif  // __TEST_FORALL_LISTSEGMENT_VIEW_HPP__

--- a/test/functional/forall/segment-view/tests/test-forall-rangesegment-view.hpp
+++ b/test/functional/forall/segment-view/tests/test-forall-rangesegment-view.hpp
@@ -1,0 +1,82 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef __TEST_FORALL_RANGESEGMENT_VIEW_HPP__
+#define __TEST_FORALL_RANGESEGMENT_VIEW_HPP__
+
+#include "test-forall-segment-view.hpp"
+
+#include <numeric>
+
+template <typename INDEX_TYPE, typename WORKING_RES, typename EXEC_POLICY>
+void ForallRangeSegmentViewTest(INDEX_TYPE first, INDEX_TYPE last)
+{
+  RAJA::TypedRangeSegment<INDEX_TYPE> r1(first, last);
+  INDEX_TYPE N = r1.end() - r1.begin();
+
+  camp::resources::Resource working_res{WORKING_RES()};
+  INDEX_TYPE* working_array;
+  INDEX_TYPE* check_array;
+  INDEX_TYPE* test_array;
+
+  allocateForallTestData<INDEX_TYPE>(N,
+                                     working_res,
+                                     &working_array,
+                                     &check_array,
+                                     &test_array);
+
+  std::iota(test_array, test_array + N, *r1.begin());
+
+  RAJA::Layout<1> layout(N);
+  RAJA::View< INDEX_TYPE, RAJA::Layout<1, INDEX_TYPE, 0> > 
+    work_view(working_array, layout);
+
+  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {
+    work_view( idx - *r1.begin() ) = idx;
+  });
+
+  working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * N);
+
+  for (INDEX_TYPE i = 0; i < N; i++) {
+    ASSERT_EQ(test_array[i], check_array[i]);
+  }
+
+  deallocateForallTestData<INDEX_TYPE>(working_res,
+                                       working_array,
+                                       check_array,
+                                       test_array);
+}
+
+template <typename INDEX_TYPE, typename WORKING_RES, typename EXEC_POLICY,
+  typename std::enable_if<std::is_unsigned<INDEX_TYPE>::value>::type* = nullptr>
+void runNegativeViewTests()
+{
+}
+
+template <typename INDEX_TYPE, typename WORKING_RES, typename EXEC_POLICY,
+  typename std::enable_if<std::is_signed<INDEX_TYPE>::value>::type* = nullptr>
+void runNegativeViewTests()
+{
+  ForallRangeSegmentViewTest<INDEX_TYPE, WORKING_RES, EXEC_POLICY>(-5, 0);
+  ForallRangeSegmentViewTest<INDEX_TYPE, WORKING_RES, EXEC_POLICY>(-5, 5);
+}
+
+
+TYPED_TEST_P(ForallSegmentViewTest, RangeSegmentForallView)
+{
+  using INDEX_TYPE  = typename camp::at<TypeParam, camp::num<0>>::type;
+  using WORKING_RES = typename camp::at<TypeParam, camp::num<1>>::type;
+  using EXEC_POLICY = typename camp::at<TypeParam, camp::num<2>>::type;
+
+  ForallRangeSegmentViewTest<INDEX_TYPE, WORKING_RES, EXEC_POLICY>(0, 5);
+  ForallRangeSegmentViewTest<INDEX_TYPE, WORKING_RES, EXEC_POLICY>(1, 5);
+  ForallRangeSegmentViewTest<INDEX_TYPE, WORKING_RES, EXEC_POLICY>(1, 255);
+
+  runNegativeViewTests<INDEX_TYPE, WORKING_RES, EXEC_POLICY>();
+}
+
+#endif  // __TEST_FORALL_RANGESEGMENT_VIEW_HPP__

--- a/test/functional/forall/segment-view/tests/test-forall-rangesegment-view.hpp
+++ b/test/functional/forall/segment-view/tests/test-forall-rangesegment-view.hpp
@@ -29,14 +29,16 @@ void ForallRangeSegmentViewTest(INDEX_TYPE first, INDEX_TYPE last)
                                      &check_array,
                                      &test_array);
 
-  std::iota(test_array, test_array + N, *r1.begin());
+  INDEX_TYPE rbegin = *r1.begin();
+
+  std::iota(test_array, test_array + N, rbegin);
 
   RAJA::Layout<1> layout(N);
   RAJA::View< INDEX_TYPE, RAJA::Layout<1, INDEX_TYPE, 0> > 
     work_view(working_array, layout);
 
   RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {
-    work_view( idx - *r1.begin() ) = idx;
+    work_view( idx - rbegin ) = idx;
   });
 
   working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * N);
@@ -69,7 +71,9 @@ void ForallRangeSegmentOffsetViewTest(INDEX_TYPE first, INDEX_TYPE last,
                                      &check_array,
                                      &test_array);
 
-  std::iota(test_array, test_array + N, *r1.begin());
+  INDEX_TYPE rbegin = *r1.begin();
+
+  std::iota(test_array, test_array + N, rbegin);
 
   RAJA::View< INDEX_TYPE, RAJA::OffsetLayout<1, INDEX_TYPE> > 
     work_view(working_array, 

--- a/test/functional/forall/segment-view/tests/test-forall-rangesegment-view.hpp
+++ b/test/functional/forall/segment-view/tests/test-forall-rangesegment-view.hpp
@@ -10,6 +10,8 @@
 
 #include "test-forall-segment-view.hpp"
 
+#include "../../test-forall-functors.hpp"
+
 #include <numeric>
 
 template <typename INDEX_TYPE, typename WORKING_RES, typename EXEC_POLICY>
@@ -33,13 +35,14 @@ void ForallRangeSegmentViewTest(INDEX_TYPE first, INDEX_TYPE last)
 
   std::iota(test_array, test_array + N, rbegin);
 
+  using view_type = RAJA::View< INDEX_TYPE, RAJA::Layout<1, INDEX_TYPE, 0> >;
+ 
   RAJA::Layout<1> layout(N);
-  RAJA::View< INDEX_TYPE, RAJA::Layout<1, INDEX_TYPE, 0> > 
-    work_view(working_array, layout);
+  view_type work_view(working_array, layout);
 
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {
-    work_view( idx - rbegin ) = idx;
-  });
+  RangeSegmentViewTestFunctor<INDEX_TYPE, view_type> tbody(work_view, rbegin);
+
+  RAJA::forall<EXEC_POLICY>(r1, tbody);
 
   working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * N);
 
@@ -75,14 +78,15 @@ void ForallRangeSegmentOffsetViewTest(INDEX_TYPE first, INDEX_TYPE last,
 
   std::iota(test_array, test_array + N, rbegin);
 
-  RAJA::View< INDEX_TYPE, RAJA::OffsetLayout<1, INDEX_TYPE> > 
-    work_view(working_array, 
-              RAJA::make_offset_layout<1, INDEX_TYPE>({{first+offset}}, 
-                                                      {{last+offset}}));
+  using view_type = RAJA::View< INDEX_TYPE, RAJA::OffsetLayout<1, INDEX_TYPE> >;
 
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {
-    work_view( idx ) = idx;
-  });
+  view_type work_view(working_array, 
+                      RAJA::make_offset_layout<1, INDEX_TYPE>({{first+offset}},
+                                                              {{last+offset}}));
+
+  RangeSegmentOffsetViewTestFunctor<INDEX_TYPE, view_type> tbody(work_view);
+
+  RAJA::forall<EXEC_POLICY>(r1, tbody);
 
   working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * N);
 

--- a/test/functional/forall/segment-view/tests/test-forall-rangestridesegment-view.hpp
+++ b/test/functional/forall/segment-view/tests/test-forall-rangestridesegment-view.hpp
@@ -1,0 +1,95 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef __TEST_FORALL_RANGESTRIDESEGMENT_VIEW_HPP__
+#define __TEST_FORALL_RANGESTRIDESEGMENT_VIEW_HPP__
+
+#include "test-forall-segment-view.hpp"
+
+template <typename INDEX_TYPE, typename DIFF_TYPE, 
+          typename WORKING_RES, typename EXEC_POLICY>
+void ForallRangeStrideSegmentViewTest(INDEX_TYPE first, INDEX_TYPE last, 
+                                      DIFF_TYPE stride)
+{
+  RAJA::TypedRangeStrideSegment<INDEX_TYPE> r1(first, last, stride);
+  INDEX_TYPE N = r1.size();
+
+  camp::resources::Resource working_res{WORKING_RES()};
+  INDEX_TYPE* working_array;
+  INDEX_TYPE* check_array;
+  INDEX_TYPE* test_array;
+
+  allocateForallTestData<INDEX_TYPE>(N,
+                                     working_res,
+                                     &working_array,
+                                     &check_array,
+                                     &test_array);
+
+  INDEX_TYPE val = first;
+  for (INDEX_TYPE i = 0; i < N; i++) {
+    test_array[ (val-first)/stride ] = val;
+    val += stride;
+  }
+
+  RAJA::Layout<1> layout(N);
+  RAJA::View< INDEX_TYPE, RAJA::Layout<1, INDEX_TYPE, 0> > 
+    work_view(working_array, layout);
+
+  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(INDEX_TYPE val) {
+    work_view( (val-first)/stride ) = val;
+  });
+
+  working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * N);
+
+  for (INDEX_TYPE i = 0; i < N; i++) {
+    ASSERT_EQ(test_array[i], check_array[i]);
+  }
+
+  deallocateForallTestData<INDEX_TYPE>(working_res,
+                                       working_array,
+                                       check_array,
+                                       test_array);
+}
+
+template <typename INDEX_TYPE, typename DIFF_TYPE, typename WORKING_RES, typename EXEC_POLICY,
+  typename std::enable_if<std::is_unsigned<INDEX_TYPE>::value>::type* = nullptr>
+void runNegativeStrideViewTests()
+{
+}
+
+template <typename INDEX_TYPE, typename DIFF_TYPE, typename WORKING_RES, typename EXEC_POLICY,
+  typename std::enable_if<std::is_signed<INDEX_TYPE>::value>::type* = nullptr>
+void runNegativeStrideViewTests()
+{
+  ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(-10, -1, 2);
+  ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(-5, 0, 2);
+  ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(-5, 5, 3);
+}
+
+
+TYPED_TEST_P(ForallSegmentViewTest, RangeStrideSegmentForallView)
+{
+  using INDEX_TYPE  = typename camp::at<TypeParam, camp::num<0>>::type;
+  using WORKING_RES = typename camp::at<TypeParam, camp::num<1>>::type;
+  using EXEC_POLICY = typename camp::at<TypeParam, camp::num<2>>::type;
+  using DIFF_TYPE   = typename std::make_signed<INDEX_TYPE>::type;
+
+  ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(0, 20, 1);
+  ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(1, 20, 1);
+  ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(0, 20, 2);
+  ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(1, 20, 2);
+  ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(0, 21, 2);
+  ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(1, 21, 2);
+  ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(1, 255, 2);
+
+  ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(0, 20, -2);
+  ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(1, 20, -2);
+
+  runNegativeStrideViewTests<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>();
+}
+
+#endif  // __TEST_FORALL_RANGESTRIDESEGMENT_VIEW_HPP__

--- a/test/functional/forall/segment-view/tests/test-forall-rangestridesegment-view.hpp
+++ b/test/functional/forall/segment-view/tests/test-forall-rangestridesegment-view.hpp
@@ -29,8 +29,12 @@ void ForallRangeStrideSegmentViewTest(INDEX_TYPE first, INDEX_TYPE last,
                                      &check_array,
                                      &test_array);
 
+  memset( test_array, 0, sizeof(INDEX_TYPE) * N );
+
+  working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * N);
+
   INDEX_TYPE val = first;
-  for (INDEX_TYPE i = 0; i < N; i++) {
+  for (INDEX_TYPE i = 0; i < N; ++i) {
     test_array[ (val-first)/stride ] = val;
     val += stride;
   }
@@ -68,6 +72,10 @@ void runNegativeStrideViewTests()
   ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(-10, -1, 2);
   ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(-5, 0, 2);
   ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(-5, 5, 3);
+
+// Test negative strides
+  ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(10, -1, -1);
+  ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(10, 0, -2);
 }
 
 
@@ -86,6 +94,7 @@ TYPED_TEST_P(ForallSegmentViewTest, RangeStrideSegmentForallView)
   ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(1, 21, 2);
   ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(1, 255, 2);
 
+// Test size zero segments
   ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(0, 20, -2);
   ForallRangeStrideSegmentViewTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(1, 20, -2);
 

--- a/test/functional/forall/segment-view/tests/test-forall-segment-view.hpp
+++ b/test/functional/forall/segment-view/tests/test-forall-segment-view.hpp
@@ -1,0 +1,30 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef __TEST_FORALL_SEGMENT_VIEW_HPP__
+#define __TEST_FORALL_SEGMENT_VIEW_HPP__
+
+#include "RAJA/RAJA.hpp"
+
+#include "../../test-forall-utils.hpp"
+
+TYPED_TEST_SUITE_P(ForallSegmentViewTest);
+template <typename T>
+class ForallSegmentViewTest : public ::testing::Test
+{
+};
+
+#include "test-forall-rangesegment-view.hpp"
+#include "test-forall-rangestridesegment-view.hpp"
+#include "test-forall-listsegment-view.hpp"
+
+REGISTER_TYPED_TEST_SUITE_P(ForallSegmentViewTest,
+                            RangeSegmentForallView,
+                            RangeStrideSegmentForallView,
+                            ListSegmentForallView);
+
+#endif  // __TEST_FORALL_SEGMENT_VIEW_HPP__

--- a/test/functional/forall/segment/test-forall-segment-cuda.cpp
+++ b/test/functional/forall/segment/test-forall-segment-cuda.cpp
@@ -9,9 +9,7 @@
 
 #if defined(RAJA_ENABLE_CUDA)
 
-// Cuda execution policy types
-using CudaForallExecPols = camp::list< RAJA::cuda_exec<128>,
-                                       RAJA::cuda_exec<256> >;
+#include "../test-forall-execpol.hpp"
 
 // Cartesian product of types for Cuda tests
 using CudaForallSegmentTypes = 

--- a/test/functional/forall/segment/test-forall-segment-hip.cpp
+++ b/test/functional/forall/segment/test-forall-segment-hip.cpp
@@ -9,9 +9,7 @@
 
 #if defined(RAJA_ENABLE_HIP)
 
-// Hip execution policy types
-using HipForallExecPols = camp::list< RAJA::hip_exec<128>,
-                                      RAJA::hip_exec<256>  >;
+#include "../test-forall-execpol.hpp"
 
 // Cartesian product of types for Hip tests
 using HipForallSegmentTypes = 

--- a/test/functional/forall/segment/test-forall-segment-openmp-target.cpp
+++ b/test/functional/forall/segment/test-forall-segment-openmp-target.cpp
@@ -9,10 +9,7 @@
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
 
-// OpenMP target execution policy types
-using OpenMPTargetForallExecPols = 
-  camp::list< RAJA::omp_target_parallel_for_exec<8>,
-              RAJA::omp_target_parallel_for_exec_nt >;
+#include "../test-forall-execpol.hpp"
 
 // Cartesian product of types for OpenMP target tests
 using OpenMPTargetForallSegmentTypes =

--- a/test/functional/forall/segment/test-forall-segment-openmp.cpp
+++ b/test/functional/forall/segment/test-forall-segment-openmp.cpp
@@ -9,12 +9,7 @@
 
 #if defined(RAJA_ENABLE_OPENMP)
 
-// OpenMP execution policy types
-using OpenMPForallExecPols = 
-  camp::list< RAJA::omp_parallel_exec<RAJA::seq_exec>,
-              RAJA::omp_for_nowait_exec,
-              RAJA::omp_for_exec,
-              RAJA::omp_parallel_for_exec >;
+#include "../test-forall-execpol.hpp"
 
 // Cartesian product of types for OpenMP tests
 using OpenMPForallSegmentTypes =

--- a/test/functional/forall/segment/test-forall-segment-seq.cpp
+++ b/test/functional/forall/segment/test-forall-segment-seq.cpp
@@ -7,10 +7,7 @@
 
 #include "tests/test-forall-segment.hpp"
 
-// Sequential execution policy types
-using SequentialForallExecPols = camp::list< RAJA::seq_exec,
-                                             RAJA::loop_exec,
-                                             RAJA::simd_exec >;
+#include "../test-forall-execpol.hpp"
 
 // Cartesian product of types for Sequential tests
 using SequentialForallSegmentTypes =

--- a/test/functional/forall/segment/test-forall-segment-tbb.cpp
+++ b/test/functional/forall/segment/test-forall-segment-tbb.cpp
@@ -9,13 +9,7 @@
 
 #if defined(RAJA_ENABLE_TBB)
 
-// TBB execution policy types
-using TBBForallExecPols = camp::list< RAJA::tbb_for_exec,
-                                      RAJA::tbb_for_static< >,
-                                      RAJA::tbb_for_static< 2 >,
-                                      RAJA::tbb_for_static< 4 >,
-                                      RAJA::tbb_for_static< 8 >,
-                                      RAJA::tbb_for_dynamic >;
+#include "../test-forall-execpol.hpp"
 
 // Cartesian product of types for TBB tests
 using TBBForallSegmentTypes =

--- a/test/functional/forall/segment/tests/test-forall-listsegment.hpp
+++ b/test/functional/forall/segment/tests/test-forall-listsegment.hpp
@@ -55,9 +55,9 @@ void ForallListSegmentTest(INDEX_TYPE N)
 
   working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * N);
 
-  std::for_each( std::begin(idx_array), std::end(idx_array), 
-                 [=](INDEX_TYPE& idx ) { test_array[idx] = idx; }
-               );
+  for (size_t i = 0; i < idxlen; ++i) {
+    test_array[ idx_array[i] ] = idx_array[i];
+  }
 
   RAJA::forall<EXEC_POLICY>(lseg, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {
     working_array[idx] = idx;

--- a/test/functional/forall/segment/tests/test-forall-listsegment.hpp
+++ b/test/functional/forall/segment/tests/test-forall-listsegment.hpp
@@ -10,6 +10,8 @@
 
 #include "test-forall-segment.hpp"
 
+#include "../../test-forall-functors.hpp"
+
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -59,9 +61,9 @@ void ForallListSegmentTest(INDEX_TYPE N)
     test_array[ idx_array[i] ] = idx_array[i];
   }
 
-  RAJA::forall<EXEC_POLICY>(lseg, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {
-    working_array[idx] = idx;
-  });
+  ListSegmentTestFunctor<INDEX_TYPE> tbody(working_array);
+
+  RAJA::forall<EXEC_POLICY>(lseg, tbody);
 
   working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * N);
 

--- a/test/functional/forall/segment/tests/test-forall-rangesegment.hpp
+++ b/test/functional/forall/segment/tests/test-forall-rangesegment.hpp
@@ -29,10 +29,12 @@ void ForallRangeSegmentTest(INDEX_TYPE first, INDEX_TYPE last)
                                      &check_array,
                                      &test_array);
 
-  std::iota(test_array, test_array + N, *r1.begin());
+  INDEX_TYPE rbegin = *r1.begin();
+
+  std::iota(test_array, test_array + N, rbegin);
 
   RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {
-    working_array[idx - *r1.begin()] = idx;
+    working_array[idx - rbegin] = idx;
   });
 
   working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * N);

--- a/test/functional/forall/segment/tests/test-forall-rangesegment.hpp
+++ b/test/functional/forall/segment/tests/test-forall-rangesegment.hpp
@@ -10,6 +10,8 @@
 
 #include "test-forall-segment.hpp"
 
+#include "../../test-forall-functors.hpp"
+
 #include <numeric>
 
 template <typename INDEX_TYPE, typename WORKING_RES, typename EXEC_POLICY>
@@ -33,9 +35,9 @@ void ForallRangeSegmentTest(INDEX_TYPE first, INDEX_TYPE last)
 
   std::iota(test_array, test_array + N, rbegin);
 
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {
-    working_array[idx - rbegin] = idx;
-  });
+  RangeSegmentTestFunctor<INDEX_TYPE> tbody(working_array, rbegin);
+  
+  RAJA::forall<EXEC_POLICY>(r1, tbody);
 
   working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * N);
 

--- a/test/functional/forall/segment/tests/test-forall-rangestridesegment.hpp
+++ b/test/functional/forall/segment/tests/test-forall-rangestridesegment.hpp
@@ -10,6 +10,8 @@
 
 #include "test-forall-segment.hpp"
 
+#include "../../test-forall-functors.hpp"
+
 template <typename INDEX_TYPE, typename DIFF_TYPE, 
           typename WORKING_RES, typename EXEC_POLICY>
 void ForallRangeStrideSegmentTest(INDEX_TYPE first, INDEX_TYPE last, 
@@ -33,15 +35,15 @@ void ForallRangeStrideSegmentTest(INDEX_TYPE first, INDEX_TYPE last,
 
   working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * N); 
 
-  INDEX_TYPE val = first;
+  INDEX_TYPE idx = first;
   for (INDEX_TYPE i = 0; i < N; ++i) {
-    test_array[ (val-first)/stride ] = val;
-    val += stride; 
+    test_array[ (idx-first)/stride ] = idx;
+    idx += stride; 
   }
 
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(INDEX_TYPE val) {
-    working_array[ (val-first)/stride ] = val;
-  });
+  RangeStrideSegmentTestFunctor<INDEX_TYPE> tbody(working_array, first, stride);
+
+  RAJA::forall<EXEC_POLICY>(r1, tbody);
 
   working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * N);
 

--- a/test/functional/forall/segment/tests/test-forall-rangestridesegment.hpp
+++ b/test/functional/forall/segment/tests/test-forall-rangestridesegment.hpp
@@ -29,14 +29,18 @@ void ForallRangeStrideSegmentTest(INDEX_TYPE first, INDEX_TYPE last,
                                      &check_array,
                                      &test_array);
 
+  memset( test_array, 0, sizeof(INDEX_TYPE) * N );
+
+  working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * N); 
+
   INDEX_TYPE val = first;
-  for (INDEX_TYPE i = 0; i < N; i++) {
-    test_array[i] = val;
-    val += stride;
+  for (INDEX_TYPE i = 0; i < N; ++i) {
+    test_array[ (val-first)/stride ] = val;
+    val += stride; 
   }
 
   RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(INDEX_TYPE val) {
-    working_array[(val-first)/stride] = val;
+    working_array[ (val-first)/stride ] = val;
   });
 
   working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * N);
@@ -64,6 +68,10 @@ void runNegativeStrideTests()
   ForallRangeStrideSegmentTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(-10, -1, 2);
   ForallRangeStrideSegmentTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(-5, 0, 2);
   ForallRangeStrideSegmentTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(-5, 5, 3);
+
+// Test negative strides
+  ForallRangeStrideSegmentTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(10, -1, -1);
+  ForallRangeStrideSegmentTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(10, 0, -2);
 }
 
 
@@ -82,6 +90,7 @@ TYPED_TEST_P(ForallSegmentTest, RangeStrideSegmentForall)
   ForallRangeStrideSegmentTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(1, 21, 2);
   ForallRangeStrideSegmentTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(1, 255, 2);
 
+// Test size zero segments
   ForallRangeStrideSegmentTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(0, 20, -2);
   ForallRangeStrideSegmentTest<INDEX_TYPE, DIFF_TYPE, WORKING_RES, EXEC_POLICY>(1, 20, -2);
 

--- a/test/functional/forall/test-forall-execpol.hpp
+++ b/test/functional/forall/test-forall-execpol.hpp
@@ -1,0 +1,51 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef __TEST_FORALL_EXECPOL_HPP__
+#define __TEST_FORALL_EXECPOL_HPP__
+
+#include "RAJA/RAJA.hpp"
+
+// Sequential execution policy types
+using SequentialForallExecPols = camp::list< RAJA::seq_exec,
+                                             RAJA::loop_exec,
+                                             RAJA::simd_exec >;
+
+#if defined(RAJA_ENABLE_OPENMP)
+using OpenMPForallExecPols = 
+  camp::list< RAJA::omp_parallel_exec<RAJA::seq_exec>,
+              RAJA::omp_for_nowait_exec,
+              RAJA::omp_for_exec,
+              RAJA::omp_parallel_for_exec >;
+#endif
+
+#if defined(RAJA_ENABLE_TBB)
+using TBBForallExecPols = camp::list< RAJA::tbb_for_exec,
+                                      RAJA::tbb_for_static< >,
+                                      RAJA::tbb_for_static< 2 >,
+                                      RAJA::tbb_for_static< 4 >,
+                                      RAJA::tbb_for_static< 8 >,
+                                      RAJA::tbb_for_dynamic >;
+#endif
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+using OpenMPTargetForallExecPols =
+  camp::list< RAJA::omp_target_parallel_for_exec<8>,
+              RAJA::omp_target_parallel_for_exec_nt >;
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
+using CudaForallExecPols = camp::list< RAJA::cuda_exec<128>,
+                                       RAJA::cuda_exec<256> >;
+#endif
+
+#if defined(RAJA_ENABLE_HIP)
+using HipForallExecPols = camp::list< RAJA::hip_exec<128>,
+                                      RAJA::hip_exec<256>  >;
+#endif
+
+#endif  // __TEST_FORALL_EXECPOL_HPP__

--- a/test/functional/forall/test-forall-functors.hpp
+++ b/test/functional/forall/test-forall-functors.hpp
@@ -1,0 +1,152 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef __TEST_FORALL_FUNCTORS_HPP__
+#define __TEST_FORALL_FUNCTORS_HPP__
+
+////////////////////////////////////////////////////////////
+// Functors that provide loop bodies for range segment tests
+////////////////////////////////////////////////////////////
+template <typename T>
+class RangeSegmentTestFunctor
+{
+public:
+   RangeSegmentTestFunctor(T* wa, T beg)
+   : working_array(wa), rbegin(beg) { ; }
+
+   RAJA_HOST_DEVICE
+   void operator() (T idx)
+   {
+     working_array[idx - rbegin] = idx; 
+   }
+
+   T* working_array;
+   T rbegin;
+};
+
+template <typename T, typename VT>
+class RangeSegmentViewTestFunctor
+{
+public:
+   RangeSegmentViewTestFunctor(VT& v, T beg)
+   : work_view(v), rbegin(beg) { ; }
+
+   RAJA_HOST_DEVICE
+   void operator() (T idx)
+   {
+     work_view( idx - rbegin ) = idx;
+   }
+
+   VT work_view;
+   T rbegin;
+};
+
+template <typename T, typename VT>
+class RangeSegmentOffsetViewTestFunctor
+{
+public:
+   RangeSegmentOffsetViewTestFunctor(VT& v)
+   : work_view(v) { ; }
+
+   RAJA_HOST_DEVICE
+   void operator() (T idx)
+   {
+     work_view( idx ) = idx;
+   }
+
+   VT work_view;
+};
+
+
+////////////////////////////////////////////////////////////////////
+// Functors that provide loop bodies for range-stride segment tests
+////////////////////////////////////////////////////////////////////
+template <typename T>
+class RangeStrideSegmentTestFunctor
+{
+public:
+   RangeStrideSegmentTestFunctor(T* wa, T fir, T str)
+   : working_array(wa), first(fir), stride(str) { ; }
+
+   RAJA_HOST_DEVICE
+   void operator() (T idx)
+   {
+     working_array[ (idx-first)/stride ] = idx;
+   }
+
+   T* working_array;
+   T first;
+   T stride;
+};
+
+template <typename T, typename VT>
+class RangeStrideSegmentViewTestFunctor
+{
+public:
+   RangeStrideSegmentViewTestFunctor(VT& v, T fir, T str)
+   : work_view(v), first(fir), stride(str) { ; }
+
+   RAJA_HOST_DEVICE
+   void operator() (T idx)
+   {
+     work_view( (idx-first)/stride ) = idx;
+   }
+
+   VT work_view;
+   T first;
+   T stride;
+};
+
+ 
+////////////////////////////////////////////////////////////
+// Functors that provide loop bodies for list segment tests
+////////////////////////////////////////////////////////////
+template <typename T>
+class ListSegmentTestFunctor
+{
+public:
+   ListSegmentTestFunctor(T* wa)
+   : working_array(wa) { ; }
+
+   RAJA_HOST_DEVICE
+   void operator() (T idx)
+   {
+     working_array[idx] = idx;
+   }
+
+   T* working_array;
+};
+
+template <typename T, typename VT>
+class ListSegmentViewTestFunctor
+{
+public:
+   ListSegmentViewTestFunctor(VT& v)
+   : work_view(v) { ; }
+
+   RAJA_HOST_DEVICE
+   void operator() (T idx)
+   {
+     work_view( idx ) = idx;
+   }
+
+   VT work_view;
+};
+
+
+////////////////////////////////////////////////////////////
+// Functors that provide loop bodies for indexset tests
+////////////////////////////////////////////////////////////
+
+template <typename T>
+using IndexSetTestFunctor = ListSegmentTestFunctor<T>;
+
+template <typename T, typename VT>
+using IndexSetViewTestFunctor = ListSegmentViewTestFunctor<T, VT>;
+
+
+#endif  // __TEST_FORALL_UTILS_HPP__

--- a/test/functional/forall/test-forall-indexset-execpol.hpp
+++ b/test/functional/forall/test-forall-indexset-execpol.hpp
@@ -1,0 +1,68 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef __TEST_FORALL_INDEXSET_EXECPOL_HPP__
+#define __TEST_FORALL_INDEXSET_EXECPOL_HPP__
+
+#include "RAJA/RAJA.hpp"
+
+// Sequential execution policy types
+using SequentialForallIndexSetExecPols =
+  camp::list< RAJA::ExecPolicy<RAJA::seq_segit, RAJA::seq_exec>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::loop_exec>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::simd_exec> >;
+
+#if defined(RAJA_ENABLE_OPENMP)
+using OpenMPForallIndexSetExecPols =  
+  camp::list< RAJA::ExecPolicy<RAJA::omp_parallel_for_segit, RAJA::seq_exec>,
+              RAJA::ExecPolicy<RAJA::omp_parallel_for_segit, RAJA::loop_exec>,
+              RAJA::ExecPolicy<RAJA::omp_parallel_for_segit, RAJA::simd_exec>,
+              RAJA::ExecPolicy<RAJA::omp_parallel_segit, RAJA::seq_exec>,
+              RAJA::ExecPolicy<RAJA::omp_parallel_segit, RAJA::loop_exec>,
+              RAJA::ExecPolicy<RAJA::omp_parallel_segit, RAJA::simd_exec>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::omp_for_exec>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::omp_parallel_for_exec>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::omp_for_nowait_exec> >;
+#endif
+
+#if defined(RAJA_ENABLE_TBB)
+using TBBForallIndexSetExecPols = 
+  camp::list< RAJA::ExecPolicy<RAJA::tbb_for_exec, RAJA::seq_exec>,
+              RAJA::ExecPolicy<RAJA::tbb_for_exec, RAJA::loop_exec>,
+              RAJA::ExecPolicy<RAJA::tbb_for_exec, RAJA::simd_exec>,
+              RAJA::ExecPolicy<RAJA::tbb_for_dynamic, RAJA::seq_exec>,
+              RAJA::ExecPolicy<RAJA::tbb_for_dynamic, RAJA::loop_exec>,
+              RAJA::ExecPolicy<RAJA::tbb_for_dynamic, RAJA::simd_exec>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_exec>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_static< >>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_static< 2 >>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_static< 4 >>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_static< 8 >>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::tbb_for_dynamic> >;
+#endif
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+using OpenMPTargetForallIndexSetExecPols =
+  camp::list< RAJA::ExecPolicy<RAJA::seq_segit,
+                               RAJA::omp_target_parallel_for_exec<8>>,
+              RAJA::ExecPolicy<RAJA::seq_segit, 
+                               RAJA::omp_target_parallel_for_exec_nt> >;
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
+using CudaForallIndexSetExecPols =
+  camp::list< RAJA::ExecPolicy<RAJA::seq_segit, RAJA::cuda_exec<128>>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::cuda_exec<256>> >;
+#endif
+
+#if defined(RAJA_ENABLE_HIP)
+using HipForallIndexSetExecPols =
+  camp::list< RAJA::ExecPolicy<RAJA::seq_segit, RAJA::hip_exec<128>>,
+              RAJA::ExecPolicy<RAJA::seq_segit, RAJA::hip_exec<256>> >;
+#endif
+
+#endif  // __TEST_FORALL_INDEXSET_EXECPOL_HPP__

--- a/test/functional/forall/test-forall-indexset-utils.hpp
+++ b/test/functional/forall/test-forall-indexset-utils.hpp
@@ -12,7 +12,7 @@
 
 #include <random>
 
-#include "../../test-forall-utils.hpp"
+#include "test-forall-utils.hpp"
 
 //
 // Utility routine to construct index set with mix of Range, RangeStride, 


### PR DESCRIPTION
# Summary

- This PR adds segment and indexset tests using 1D Views. The segment tests also include offset view tests.
- Some test header files are moved up in the directory structure to make it easier to use exec policies, etc. in multipletest subdirectories.