### PR TITLE
Task/scan test reorg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
     env:
     - COMPILER=/opt/intel/bin/icpc
     - IMG=icc18
-    - CMAKE_EXTRA_FLAGS="-DENABLE_TBB=On"
+    - CMAKE_EXTRA_FLAGS="-DENABLE_FORCEINLINE_RECURSIVE=Off -DENABLE_TBB=On"
   - compiler: nvcc9
     env:
     - COMPILER=g++

--- a/test/functional/CMakeLists.txt
+++ b/test/functional/CMakeLists.txt
@@ -8,3 +8,5 @@
 add_subdirectory(atomic)
 
 add_subdirectory(forall)
+
+add_subdirectory(scan)

--- a/test/functional/scan/test-scan-exclusive-cuda.cpp
+++ b/test/functional/scan/test-scan-exclusive-cuda.cpp
@@ -5,18 +5,17 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "test-scan-exclusive.hpp"
+#include "tests/test-scan-exclusive.hpp"
 
 #if defined(RAJA_ENABLE_CUDA)
 
-// CUDA policy types to test
-using CudaExecTypes = camp::list< RAJA::cuda_exec<128>,
-                                  RAJA::cuda_exec<256> >;
-
-using ListCudaRes = camp::list<camp::resources::Cuda>;
+#include "../forall/test-forall-utils.hpp"
+#include "../forall/test-forall-execpol.hpp"
 
 using CudaExclusiveScanTypes = 
-  Test<cartesian_product< CudaExecTypes, ListCudaRes, OpTypes >>::Types;
+  Test<camp::cartesian_product< CudaForallExecPols, 
+                                CudaResourceList, 
+                                ScanOpTypes >>::Types;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Cuda, 
                                ScanFunctionalTest, 

--- a/test/functional/scan/test-scan-exclusive-hip.cpp
+++ b/test/functional/scan/test-scan-exclusive-hip.cpp
@@ -5,18 +5,17 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "test-scan-exclusive.hpp"
+#include "tests/test-scan-exclusive.hpp"
 
 #if defined(RAJA_ENABLE_HIP)
 
-// CUDA policy types to test
-using HipExecTypes = camp::list< RAJA::hip_exec<128>,
-                                 RAJA::hip_exec<256> >;
-
-using ListHipRes = camp::list<camp::resources::Hip>;
+#include "../forall/test-forall-utils.hpp"
+#include "../forall/test-forall-execpol.hpp"
 
 using HipExclusiveScanTypes = 
-  Test<cartesian_product< HipExecTypes, ListHipRes, OpTypes >>::Types;
+  Test< camp::cartesian_product< HipForallExecPols,
+                                 HipResourceList, 
+                                 ScanOpTypes >>::Types;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Hip, 
                                ScanFunctionalTest, 

--- a/test/functional/scan/test-scan-exclusive-openmp.cpp
+++ b/test/functional/scan/test-scan-exclusive-openmp.cpp
@@ -5,17 +5,17 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "test-scan-exclusive.hpp"
+#include "tests/test-scan-exclusive.hpp"
 
 #if defined(RAJA_ENABLE_OPENMP)
 
-// OpenMP policy types to test
-using OpenMPExecTypes = camp::list< RAJA::omp_parallel_for_exec,
-                                    RAJA::omp_for_exec,
-                                    RAJA::omp_for_nowait_exec >;
+#include "../forall/test-forall-utils.hpp"
+#include "../forall/test-forall-execpol.hpp"
 
 using OpenMPExclusiveScanTypes = 
-  Test<cartesian_product< OpenMPExecTypes, ListHostRes, OpTypes >>::Types;
+  Test< camp::cartesian_product< OpenMPForallExecPols,
+                                 HostResourceList, 
+                                 ScanOpTypes >>::Types;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(OpenMP, 
                                ScanFunctionalTest, 

--- a/test/functional/scan/test-scan-exclusive-seq.cpp
+++ b/test/functional/scan/test-scan-exclusive-seq.cpp
@@ -5,14 +5,15 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "test-scan-exclusive.hpp"
+#include "tests/test-scan-exclusive.hpp"
 
-// Sequential policy types to test
-using SequentialExecTypes = camp::list< RAJA::seq_exec, 
-                                        RAJA::loop_exec >;
+#include "../forall/test-forall-utils.hpp"
+#include "../forall/test-forall-execpol.hpp"
 
 using SequentialExclusiveScanTypes = 
-  Test<cartesian_product< SequentialExecTypes, ListHostRes, OpTypes >>::Types;
+  Test<camp::cartesian_product< SequentialForallExecPols, 
+                                HostResourceList, 
+                                ScanOpTypes >>::Types;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Sequential, 
                                ScanFunctionalTest, 

--- a/test/functional/scan/test-scan-exclusive-tbb.cpp
+++ b/test/functional/scan/test-scan-exclusive-tbb.cpp
@@ -6,20 +6,17 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "test-scan-exclusive.hpp"
+#include "tests/test-scan-exclusive.hpp"
 
 #if defined(RAJA_ENABLE_TBB)
 
-// TBB policy types to test
-using TBBExecTypes = camp::list< RAJA::tbb_for_exec,
-                                 RAJA::tbb_for_static< >,
-                                 RAJA::tbb_for_static< 2 >,
-                                 RAJA::tbb_for_static< 4 >,
-                                 RAJA::tbb_for_static< 8 >,
-                                 RAJA::tbb_for_dynamic >;
+#include "../forall/test-forall-utils.hpp"
+#include "../forall/test-forall-execpol.hpp"
 
 using TBBExclusiveScanTypes = 
-  Test<cartesian_product< TBBExecTypes, ListHostRes, OpTypes >>::Types;
+  Test<camp::cartesian_product< TBBForallExecPols, 
+                                HostResourceList, 
+                                ScanOpTypes >>::Types;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(TBB, 
                                ScanFunctionalTest, 

--- a/test/functional/scan/test-scan-inclusive-cuda.cpp
+++ b/test/functional/scan/test-scan-inclusive-cuda.cpp
@@ -5,18 +5,17 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "test-scan-inclusive.hpp"
+#include "tests/test-scan-inclusive.hpp"
 
 #if defined(RAJA_ENABLE_CUDA)
 
-// CUDA policy types to test
-using CudaExecTypes = camp::list< RAJA::cuda_exec<128>,
-                                  RAJA::cuda_exec<256> >;
-
-using ListCudaRes = camp::list<camp::resources::Cuda>;
+#include "../forall/test-forall-utils.hpp"
+#include "../forall/test-forall-execpol.hpp"
 
 using CudaInclusiveScanTypes =
-  Test<cartesian_product< CudaExecTypes, ListCudaRes, OpTypes >>::Types;
+  Test<camp::cartesian_product< CudaForallExecPols, 
+                                CudaResourceList, 
+                                ScanOpTypes >>::Types;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Cuda, 
                                ScanFunctionalTest, 

--- a/test/functional/scan/test-scan-inclusive-hip.cpp
+++ b/test/functional/scan/test-scan-inclusive-hip.cpp
@@ -5,18 +5,17 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "test-scan-exclusive.hpp"
+#include "tests/test-scan-exclusive.hpp"
 
 #if defined(RAJA_ENABLE_HIP)
 
-// CUDA policy types to test
-using HipExecTypes = camp::list< RAJA::hip_exec<128>,
-                                 RAJA::hip_exec<256> >;
-
-using ListHipRes = camp::list<camp::resources::Hip>;
+#include "../forall/test-forall-utils.hpp"
+#include "../forall/test-forall-execpol.hpp"
 
 using HipInclusiveScanTypes = 
-  Test<cartesian_product< HipExecTypes, ListHipRes, OpTypes >>::Types;
+  Test< camp::cartesian_product< HipForallExecPols,
+                                 HipResourceList, 
+                                 ScanOpTypes >>::Types;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Hip, 
                                ScanFunctionalTest, 

--- a/test/functional/scan/test-scan-inclusive-openmp.cpp
+++ b/test/functional/scan/test-scan-inclusive-openmp.cpp
@@ -5,17 +5,17 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "test-scan-inclusive.hpp"
+#include "tests/test-scan-inclusive.hpp"
 
 #if defined(RAJA_ENABLE_OPENMP)
 
-// OpenMP policy types to test
-using OpenMPExecTypes = camp::list< RAJA::omp_parallel_for_exec, 
-                                    RAJA::omp_for_exec,
-                                    RAJA::omp_for_nowait_exec >;
+#include "../forall/test-forall-utils.hpp"
+#include "../forall/test-forall-execpol.hpp"
 
 using OpenMPInclusiveScanTypes = 
-  Test<cartesian_product< OpenMPExecTypes, ListHostRes, OpTypes >>::Types;
+  Test< camp::cartesian_product< OpenMPForallExecPols,
+                                 HostResourceList,
+                                 ScanOpTypes >>::Types;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(OpenMP, 
                                ScanFunctionalTest, 

--- a/test/functional/scan/test-scan-inclusive-seq.cpp
+++ b/test/functional/scan/test-scan-inclusive-seq.cpp
@@ -5,14 +5,15 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "test-scan-inclusive.hpp"
+#include "tests/test-scan-inclusive.hpp"
 
-// Sequential policy types to test
-using SequentialExecTypes = camp::list< RAJA::seq_exec, 
-                                        RAJA::loop_exec >;
+#include "../forall/test-forall-utils.hpp"
+#include "../forall/test-forall-execpol.hpp"
 
 using SequentialInclusiveScanTypes = 
-  Test<cartesian_product< SequentialExecTypes, ListHostRes, OpTypes >>::Types;
+  Test<camp::cartesian_product< SequentialForallExecPols,
+                                HostResourceList,
+                                ScanOpTypes >>::Types;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Sequential, 
                                ScanFunctionalTest, 

--- a/test/functional/scan/test-scan-inclusive-tbb.cpp
+++ b/test/functional/scan/test-scan-inclusive-tbb.cpp
@@ -5,20 +5,17 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "test-scan-inclusive.hpp"
+#include "tests/test-scan-inclusive.hpp"
 
 #if defined(RAJA_ENABLE_TBB)
 
-// TBB policy types to test
-using TBBExecTypes = camp::list< RAJA::tbb_for_exec,
-                                 RAJA::tbb_for_static< >,
-                                 RAJA::tbb_for_static< 2 >,
-                                  RAJA::tbb_for_static< 4 >,
-                                  RAJA::tbb_for_static< 8 >,
-                                  RAJA::tbb_for_dynamic >;
+#include "../forall/test-forall-utils.hpp"
+#include "../forall/test-forall-execpol.hpp"
 
 using TBBInclusiveScanTypes = 
-  Test<cartesian_product< TBBExecTypes, ListHostRes, OpTypes >>::Types;
+  Test<camp::cartesian_product< TBBForallExecPols, 
+                                HostResourceList, 
+                                ScanOpTypes >>::Types;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(TBB, 
                                ScanFunctionalTest, 

--- a/test/functional/scan/tests/test-scan-exclusive.hpp
+++ b/test/functional/scan/tests/test-scan-exclusive.hpp
@@ -10,21 +10,20 @@
 
 #include <numeric>
 
-#include "test-scan.hpp"
+#include "test-scan-utils.hpp"
 
-template <typename OP>
-::testing::AssertionResult check_inclusive(
-  const typename OP::result_type* actual,
-  const typename OP::result_type* original,
-  int N)
+template <typename OP, typename T>
+::testing::AssertionResult check_exclusive(const T* actual,
+                                           const T* original,
+                                           int N,
+                                           T init = OP::identity())
 {
-  typename OP::result_type init = OP::identity();
   for (int i = 0; i < N; ++i) {
-    init = OP()(init, *original);
     if (*actual != init) {
       return ::testing::AssertionFailure()
              << *actual << " != " << init << " (at index " << i << ")";
     }
+    init = OP()(init, *original);
     ++actual;
     ++original;
   }
@@ -32,7 +31,9 @@ template <typename OP>
 }
 
 template <typename EXEC_POLICY, typename WORKING_RES, typename OP_TYPE>
-void ScanInclusiveFunctionalTest(int N)
+void ScanExclusiveFunctionalTest(int N,
+                                 typename OP_TYPE::result_type offset = 
+                                 OP_TYPE::identity())
 {
   using T = typename OP_TYPE::result_type;
 
@@ -52,14 +53,15 @@ void ScanInclusiveFunctionalTest(int N)
 
   working_res.memcpy(work_in, host_in, sizeof(T) * N);
 
-  RAJA::inclusive_scan<EXEC_POLICY>(work_in,
+  RAJA::exclusive_scan<EXEC_POLICY>(work_in,
                                     work_in + N,
                                     work_out,
-                                    OP_TYPE{});
+                                    OP_TYPE{},
+                                    offset);
 
   working_res.memcpy(host_out, work_out, sizeof(T) * N);
 
-  ASSERT_TRUE(check_inclusive<OP_TYPE>(host_out, host_in, N));
+  ASSERT_TRUE(check_exclusive<OP_TYPE>(host_out, host_in, N, offset));
 
   deallocScanTestData(working_res,
                       work_in, work_out,             
@@ -67,7 +69,9 @@ void ScanInclusiveFunctionalTest(int N)
 }
 
 template <typename EXEC_POLICY, typename WORKING_RES, typename OP_TYPE>
-void ScanInclusiveInplaceFunctionalTest(int N)
+void ScanExclusiveInplaceFunctionalTest(int N,
+                                        typename OP_TYPE::result_type offset =
+                                        OP_TYPE::identity())
 {
   using T = typename OP_TYPE::result_type;
 
@@ -87,49 +91,74 @@ void ScanInclusiveInplaceFunctionalTest(int N)
 
   working_res.memcpy(work_in, host_in, sizeof(T) * N);
 
-  RAJA::inclusive_scan_inplace<EXEC_POLICY>(work_in,
+  RAJA::exclusive_scan_inplace<EXEC_POLICY>(work_in,
                                             work_in + N,
-                                            OP_TYPE{});
+                                            OP_TYPE{},
+                                            offset);
 
   working_res.memcpy(host_out, work_in, sizeof(T) * N);
 
-  ASSERT_TRUE(check_inclusive<OP_TYPE>(host_out, host_in, N));
+  ASSERT_TRUE(check_exclusive<OP_TYPE>(host_out, host_in, N, offset));
 
   deallocScanTestData(working_res,
                       work_in, work_out,
                       host_in, host_out);
 }
 
-TYPED_TEST_P(ScanFunctionalTest, ScanInclusive)
+TYPED_TEST_P(ScanFunctionalTest, ScanExclusive)
 {
-  using EXEC_POLICY      = typename at<TypeParam, num<0>>::type;
-  using WORKING_RESOURCE = typename at<TypeParam, num<1>>::type;
-  using OP_TYPE          = typename at<TypeParam, num<2>>::type;
+  using EXEC_POLICY      = typename camp::at<TypeParam, camp::num<0>>::type;
+  using WORKING_RESOURCE = typename camp::at<TypeParam, camp::num<1>>::type;
+  using OP_TYPE          = typename camp::at<TypeParam, camp::num<2>>::type;
 
-  ScanInclusiveFunctionalTest<EXEC_POLICY, 
+  ScanExclusiveFunctionalTest<EXEC_POLICY, 
                               WORKING_RESOURCE, 
                               OP_TYPE>(357);
-  ScanInclusiveFunctionalTest<EXEC_POLICY, 
+  ScanExclusiveFunctionalTest<EXEC_POLICY, 
                               WORKING_RESOURCE, 
                               OP_TYPE>(32000);
+
+  //
+  // Perform some non-identity offset tests
+  // 
+  using T = typename OP_TYPE::result_type;
+
+  ScanExclusiveFunctionalTest<EXEC_POLICY, 
+                              WORKING_RESOURCE, 
+                              OP_TYPE>(357, T(15));
+  ScanExclusiveFunctionalTest<EXEC_POLICY, 
+                              WORKING_RESOURCE, 
+                              OP_TYPE>(32000, T(2));
 }
 
 TYPED_TEST_P(ScanFunctionalTest, ScanInclusiveInplace)
 {
-  using EXEC_POLICY      = typename at<TypeParam, num<0>>::type;
-  using WORKING_RESOURCE = typename at<TypeParam, num<1>>::type;
-  using OP_TYPE          = typename at<TypeParam, num<2>>::type;
+  using EXEC_POLICY      = typename camp::at<TypeParam, camp::num<0>>::type;
+  using WORKING_RESOURCE = typename camp::at<TypeParam, camp::num<1>>::type;
+  using OP_TYPE          = typename camp::at<TypeParam, camp::num<2>>::type;
 
-  ScanInclusiveInplaceFunctionalTest<EXEC_POLICY, 
+  ScanExclusiveInplaceFunctionalTest<EXEC_POLICY, 
                                      WORKING_RESOURCE,
                                      OP_TYPE>(357);
-  ScanInclusiveInplaceFunctionalTest<EXEC_POLICY,
+  ScanExclusiveInplaceFunctionalTest<EXEC_POLICY,
                                      WORKING_RESOURCE,
                                      OP_TYPE>(32000);
+
+  //
+  // Perform some non-identity offset tests
+  //
+  using T = typename OP_TYPE::result_type;
+
+  ScanExclusiveInplaceFunctionalTest<EXEC_POLICY,
+                                     WORKING_RESOURCE,
+                                     OP_TYPE>(357, T(15));
+  ScanExclusiveInplaceFunctionalTest<EXEC_POLICY,
+                                     WORKING_RESOURCE,
+                                     OP_TYPE>(32000, T(2));
 }
 
 REGISTER_TYPED_TEST_SUITE_P(ScanFunctionalTest, 
-                            ScanInclusive,
+                            ScanExclusive,
                             ScanInclusiveInplace);
 
 #endif // __TEST_SCAN_INCLUSIVE_HPP__

--- a/test/functional/scan/tests/test-scan-exclusive.hpp
+++ b/test/functional/scan/tests/test-scan-exclusive.hpp
@@ -113,6 +113,9 @@ TYPED_TEST_P(ScanFunctionalTest, ScanExclusive)
 
   ScanExclusiveFunctionalTest<EXEC_POLICY, 
                               WORKING_RESOURCE, 
+                              OP_TYPE>(0);
+  ScanExclusiveFunctionalTest<EXEC_POLICY, 
+                              WORKING_RESOURCE, 
                               OP_TYPE>(357);
   ScanExclusiveFunctionalTest<EXEC_POLICY, 
                               WORKING_RESOURCE, 
@@ -123,6 +126,9 @@ TYPED_TEST_P(ScanFunctionalTest, ScanExclusive)
   // 
   using T = typename OP_TYPE::result_type;
 
+  ScanExclusiveFunctionalTest<EXEC_POLICY, 
+                              WORKING_RESOURCE, 
+                              OP_TYPE>(0, T(13));
   ScanExclusiveFunctionalTest<EXEC_POLICY, 
                               WORKING_RESOURCE, 
                               OP_TYPE>(357, T(15));
@@ -139,6 +145,9 @@ TYPED_TEST_P(ScanFunctionalTest, ScanInclusiveInplace)
 
   ScanExclusiveInplaceFunctionalTest<EXEC_POLICY, 
                                      WORKING_RESOURCE,
+                                     OP_TYPE>(0);
+  ScanExclusiveInplaceFunctionalTest<EXEC_POLICY, 
+                                     WORKING_RESOURCE,
                                      OP_TYPE>(357);
   ScanExclusiveInplaceFunctionalTest<EXEC_POLICY,
                                      WORKING_RESOURCE,
@@ -149,6 +158,9 @@ TYPED_TEST_P(ScanFunctionalTest, ScanInclusiveInplace)
   //
   using T = typename OP_TYPE::result_type;
 
+  ScanExclusiveInplaceFunctionalTest<EXEC_POLICY,
+                                     WORKING_RESOURCE,
+                                     OP_TYPE>(0, T(13));
   ScanExclusiveInplaceFunctionalTest<EXEC_POLICY,
                                      WORKING_RESOURCE,
                                      OP_TYPE>(357, T(15));

--- a/test/functional/scan/tests/test-scan-inclusive.hpp
+++ b/test/functional/scan/tests/test-scan-inclusive.hpp
@@ -108,6 +108,9 @@ TYPED_TEST_P(ScanFunctionalTest, ScanInclusive)
 
   ScanInclusiveFunctionalTest<EXEC_POLICY, 
                               WORKING_RESOURCE, 
+                              OP_TYPE>(0);
+  ScanInclusiveFunctionalTest<EXEC_POLICY, 
+                              WORKING_RESOURCE, 
                               OP_TYPE>(357);
   ScanInclusiveFunctionalTest<EXEC_POLICY, 
                               WORKING_RESOURCE, 
@@ -120,6 +123,9 @@ TYPED_TEST_P(ScanFunctionalTest, ScanInclusiveInplace)
   using WORKING_RESOURCE = typename camp::at<TypeParam, camp::num<1>>::type;
   using OP_TYPE          = typename camp::at<TypeParam, camp::num<2>>::type;
 
+  ScanInclusiveInplaceFunctionalTest<EXEC_POLICY, 
+                                     WORKING_RESOURCE,
+                                     OP_TYPE>(0);
   ScanInclusiveInplaceFunctionalTest<EXEC_POLICY, 
                                      WORKING_RESOURCE,
                                      OP_TYPE>(357);

--- a/test/functional/scan/tests/test-scan-utils.hpp
+++ b/test/functional/scan/tests/test-scan-utils.hpp
@@ -13,15 +13,6 @@
 
 #include "camp/list.hpp"
 
-// Unroll types for gtest testing::Types
-template<class T>
-struct Test;
-
-template<class ...T>
-struct Test<camp::list<T...>>{
-  using Types = ::testing::Types<T...>;
-};
-
 
 // Scan functional test class
 template<typename T>
@@ -29,18 +20,18 @@ class ScanFunctionalTest: public ::testing::Test {};
 
 
 // Define scan operation types
-using OpTypes = camp::list< RAJA::operators::plus<int>,
+using ScanOpTypes = camp::list< RAJA::operators::plus<int>,
 #if 0  // Parallel tests with plus operator and float data do not work
        // likely due to precision being too low and plus not associative
-                            RAJA::operators::plus<float>,
+                                RAJA::operators::plus<float>,
 #endif
-                            RAJA::operators::plus<double>,
-                            RAJA::operators::minimum<int>,
-                            RAJA::operators::minimum<float>,
-                            RAJA::operators::minimum<double>,
-                            RAJA::operators::maximum<int>,
-                            RAJA::operators::maximum<float>,
-                            RAJA::operators::maximum<double> >;
+                                RAJA::operators::plus<double>,
+                                RAJA::operators::minimum<int>,
+                                RAJA::operators::minimum<float>,
+                                RAJA::operators::minimum<double>,
+                                RAJA::operators::maximum<int>,
+                                RAJA::operators::maximum<float>,
+                                RAJA::operators::maximum<double> >;
 
 using ListHostRes = camp::list< camp::resources::Host >;
 


### PR DESCRIPTION
# Summary

- This PR reorganizes the scan functional test files to match the organization of other functional tests.
- Also, using execution policies and camp resources from forall functional tests