### PR TITLE
fix pointer translation issue in openmp_target policy

### DIFF
--- a/include/RAJA/policy/openmp_target/forall.hpp
+++ b/include/RAJA/policy/openmp_target/forall.hpp
@@ -81,7 +81,7 @@ RAJA_INLINE void forall_impl(const omp_target_parallel_for_exec_nt&,
   RAJA_EXTRACT_BED_IT(iter);
 
 #pragma omp target teams distribute parallel for schedule(static, 1) \
-    map(to : body)
+    firstprivate(body,begin_it)
   for (decltype(distance_it) i = 0; i < distance_it; ++i) {
     Body ib = body;
     ib(begin_it[i]);


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following (modify list as needed):
  - makes the two openmp-target policies consistent, along with a camp patch fixing the new forall tests for openmp target
