### PR TITLE
Segments for Atomic Functional Forall Tests

### DIFF
--- a/test/functional/forall/atomic-view/tests/test-forall-atomic-view.hpp
+++ b/test/functional/forall/atomic-view/tests/test-forall-atomic-view.hpp
@@ -32,12 +32,11 @@ void testAtomicViewBasic( RAJA::Index_type N )
   RAJA::TypedRangeSegment<RAJA::Index_type> seg(0, N);
   RAJA::TypedRangeSegment<RAJA::Index_type> seg_half(0, N / 2);
 
-  camp::resources::Resource src_res{WORKINGRES()};
-  camp::resources::Resource dest_res{WORKINGRES()};
+  camp::resources::Resource work_res{WORKINGRES()};
   camp::resources::Resource host_res{camp::resources::Host()};
 
-  T * source = src_res.allocate<T>(N);
-  T * dest = dest_res.allocate<T>(N/2);
+  T * source = work_res.allocate<T>(N);
+  T * dest = work_res.allocate<T>(N/2);
   T * check_array = host_res.allocate<T>(N/2);
 
 #if defined(RAJA_ENABLE_CUDA)
@@ -68,7 +67,7 @@ void testAtomicViewBasic( RAJA::Index_type N )
     sum_atomic_view(i / 2) += vec_view(i);
   });
 
-  dest_res.memcpy( check_array, dest, sizeof(T) * N/2 );
+  work_res.memcpy( check_array, dest, sizeof(T) * N/2 );
 
 #if defined(RAJA_ENABLE_CUDA)
   cudaErrchk(cudaDeviceSynchronize());
@@ -82,8 +81,8 @@ void testAtomicViewBasic( RAJA::Index_type N )
     EXPECT_EQ((T)2, check_array[i]);
   }
 
-  src_res.deallocate( source );
-  dest_res.deallocate( dest );
+  work_res.deallocate( source );
+  work_res.deallocate( dest );
   host_res.deallocate( check_array );
 }
 

--- a/test/functional/forall/atomic/test-forall-atomic-basic-cuda.cpp
+++ b/test/functional/forall/atomic/test-forall-atomic-basic-cuda.cpp
@@ -20,6 +20,7 @@ using CudaAtomicForallBasicTypes = Test< camp::cartesian_product<
                                                                   CudaForallExecPols,
                                                                   CudaAtomicPols,
                                                                   CudaResourceList,
+                                                                  AtomicSegmentList,
                                                                   AtomicDataTypeList >
                                        >::Types;
 

--- a/test/functional/forall/atomic/test-forall-atomic-basic-hip.cpp
+++ b/test/functional/forall/atomic/test-forall-atomic-basic-hip.cpp
@@ -20,6 +20,7 @@ using HipAtomicForallBasicTypes = Test< camp::cartesian_product<
                                                                  HipForallExecPols,
                                                                  HipAtomicPols,
                                                                  HipResourceList,
+                                                                 AtomicSegmentList,
                                                                  AtomicDataTypeList >
                                       >::Types;
 

--- a/test/functional/forall/atomic/test-forall-atomic-basic-openmp-target.cpp
+++ b/test/functional/forall/atomic/test-forall-atomic-basic-openmp-target.cpp
@@ -20,6 +20,7 @@ using OmpTargetAtomicForallBasicTypes = Test< camp::cartesian_product<
                                                                        OpenMPTargetForallExecPols,
                                                                        OpenMPAtomicPols,
                                                                        OpenMPTargetResourceList,
+                                                                       AtomicSegmentList,
                                                                        AtomicDataTypeList >
                                             >::Types;
 

--- a/test/functional/forall/atomic/test-forall-atomic-basic-openmp.cpp
+++ b/test/functional/forall/atomic/test-forall-atomic-basic-openmp.cpp
@@ -18,6 +18,7 @@ using OmpAtomicForallBasicTypes = Test< camp::cartesian_product<
                                                                  OpenMPForallAtomicExecPols,
                                                                  OpenMPAtomicPols,
                                                                  HostResourceList,
+                                                                 AtomicSegmentList,
                                                                  AtomicDataTypeList >
                                       >::Types;
 

--- a/test/functional/forall/atomic/test-forall-atomic-basic-seq.cpp
+++ b/test/functional/forall/atomic/test-forall-atomic-basic-seq.cpp
@@ -19,6 +19,7 @@ using SeqAtomicForallBasicTypes = Test< camp::cartesian_product<
                                                                  SequentialForallAtomicExecPols,
                                                                  SequentialAtomicPols,
                                                                  HostResourceList,
+                                                                 AtomicSegmentList,
                                                                  AtomicDataTypeList >
                                       >::Types;
 

--- a/test/functional/forall/atomic/tests/test-forall-atomic-basic.hpp
+++ b/test/functional/forall/atomic/tests/test-forall-atomic-basic.hpp
@@ -14,8 +14,46 @@
 
 #include "RAJA/RAJA.hpp"
 #include "RAJA_gtest.hpp"
+#include "../../test-forall-utils.hpp"
+#include <numeric>
 
-#include "../../test-forall-atomic-utils.hpp"
+// range segment multiplexer
+template< typename Index, typename SegType >
+struct RSMultiplexer {};
+
+template< typename Index >
+struct RSMultiplexer < Index, RAJA::TypedRangeSegment<Index> >
+{
+  RAJA::TypedRangeSegment<Index>
+  makeseg( Index N, camp::resources::Resource work_res )
+  {
+    return RAJA::TypedRangeSegment<Index>( 0, N );
+  }
+};
+
+template< typename Index >
+struct RSMultiplexer < Index, RAJA::TypedRangeStrideSegment<Index> >
+{
+  RAJA::TypedRangeStrideSegment<Index>
+  makeseg( Index N, camp::resources::Resource work_res )
+  {
+    return RAJA::TypedRangeStrideSegment<Index>( 0, N, 1 );
+  }
+};
+
+template< typename Index >
+struct RSMultiplexer < Index, RAJA::TypedListSegment<Index> >
+{
+  RAJA::TypedListSegment<Index>
+  makeseg( Index N, camp::resources::Resource work_res )
+  {
+    std::vector<Index> temp(N);
+    std::iota( std::begin(temp), std::end(temp), 0 );
+    return RAJA::TypedListSegment<Index>( &temp[0], static_cast<size_t>(temp.size()), work_res );
+  }
+};
+// end range segment multiplexer
+
 
 TYPED_TEST_SUITE_P(ForallAtomicBasicFunctionalTest);
 
@@ -31,14 +69,24 @@ template <typename ExecPolicy,
           typename T>
 void testAtomicFunctionBasic( RAJA::Index_type seglimit )
 {
-  SegmentType seg = RSMultiplexer<RAJA::Index_type, SegmentType>().makeseg(seglimit);
-
   // initialize an array
   const int len = 10;
 
   camp::resources::Resource work_res{WORKINGRES()};
 
-  T * dest = work_res.allocate<T>(len);
+  SegmentType seg = RSMultiplexer<RAJA::Index_type, SegmentType>().makeseg(seglimit, work_res);
+
+  T * work_array;
+  T * test_array;
+  T * check_array;
+
+  allocateForallTestData<T>(  len,
+                              work_res,
+                              &work_array,
+                              &check_array,
+                              &test_array );
+
+  work_res.memcpy( work_array, test_array, sizeof(T) * len );
 
 #if defined(RAJA_ENABLE_CUDA)
   cudaErrchk(cudaDeviceSynchronize());
@@ -49,30 +97,33 @@ void testAtomicFunctionBasic( RAJA::Index_type seglimit )
 #endif
 
   // use atomic add to reduce the array
-  dest[0] = (T)0;
-  dest[1] = (T)seglimit;
-  dest[2] = (T)seglimit;
-  dest[3] = (T)0;
-  dest[4] = (T)0;
-  dest[5] = (T)0;
-  dest[6] = (T)seglimit + 1;
-  dest[7] = (T)0;
-  dest[8] = (T)seglimit;
-  dest[9] = (T)0;
+  test_array[0] = (T)0;
+  test_array[1] = (T)seglimit;
+  test_array[2] = (T)seglimit;
+  test_array[3] = (T)0;
+  test_array[4] = (T)0;
+  test_array[5] = (T)0;
+  test_array[6] = (T)seglimit + 1;
+  test_array[7] = (T)0;
+  test_array[8] = (T)seglimit;
+  test_array[9] = (T)0;
 
+  work_res.memcpy( work_array, test_array, sizeof(T) * len );
 
   RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(RAJA::Index_type i) {
-    RAJA::atomicAdd<AtomicPolicy>(dest + 0, (T)1);
-    RAJA::atomicSub<AtomicPolicy>(dest + 1, (T)1);
-    RAJA::atomicMin<AtomicPolicy>(dest + 2, (T)i);
-    RAJA::atomicMax<AtomicPolicy>(dest + 3, (T)i);
-    RAJA::atomicInc<AtomicPolicy>(dest + 4);
-    RAJA::atomicInc<AtomicPolicy>(dest + 5, (T)16);
-    RAJA::atomicDec<AtomicPolicy>(dest + 6);
-    RAJA::atomicDec<AtomicPolicy>(dest + 7, (T)16);
-    RAJA::atomicExchange<AtomicPolicy>(dest + 8, (T)i);
-    RAJA::atomicCAS<AtomicPolicy>(dest + 9, (T)i, (T)(i+1));
+    RAJA::atomicAdd<AtomicPolicy>(work_array + 0, (T)1);
+    RAJA::atomicSub<AtomicPolicy>(work_array + 1, (T)1);
+    RAJA::atomicMin<AtomicPolicy>(work_array + 2, (T)i);
+    RAJA::atomicMax<AtomicPolicy>(work_array + 3, (T)i);
+    RAJA::atomicInc<AtomicPolicy>(work_array + 4);
+    RAJA::atomicInc<AtomicPolicy>(work_array + 5, (T)16);
+    RAJA::atomicDec<AtomicPolicy>(work_array + 6);
+    RAJA::atomicDec<AtomicPolicy>(work_array + 7, (T)16);
+    RAJA::atomicExchange<AtomicPolicy>(work_array + 8, (T)i);
+    RAJA::atomicCAS<AtomicPolicy>(work_array + 9, (T)i, (T)(i+1));
   });
+
+  work_res.memcpy( check_array, work_array, sizeof(T) * len );
 
 #if defined(RAJA_ENABLE_CUDA)
   cudaErrchk(cudaDeviceSynchronize());
@@ -82,20 +133,23 @@ void testAtomicFunctionBasic( RAJA::Index_type seglimit )
   hipErrchk(hipDeviceSynchronize());
 #endif
 
-  EXPECT_EQ((T)seglimit, dest[0]);
-  EXPECT_EQ((T)0, dest[1]);
-  EXPECT_EQ((T)0, dest[2]);
-  EXPECT_EQ((T)seglimit - 1, dest[3]);
-  EXPECT_EQ((T)seglimit, dest[4]);
-  EXPECT_EQ((T)4, dest[5]);
-  EXPECT_EQ((T)1, dest[6]);
-  EXPECT_EQ((T)13, dest[7]);
-  EXPECT_LE((T)0, dest[8]);
-  EXPECT_GT((T)seglimit, dest[8]);
-  EXPECT_LT((T)0, dest[9]);
-  EXPECT_GE((T)seglimit, dest[9]);
+  EXPECT_EQ((T)seglimit, check_array[0]);
+  EXPECT_EQ((T)0, check_array[1]);
+  EXPECT_EQ((T)0, check_array[2]);
+  EXPECT_EQ((T)seglimit - 1, check_array[3]);
+  EXPECT_EQ((T)seglimit, check_array[4]);
+  EXPECT_EQ((T)4, check_array[5]);
+  EXPECT_EQ((T)1, check_array[6]);
+  EXPECT_EQ((T)13, check_array[7]);
+  EXPECT_LE((T)0, check_array[8]);
+  EXPECT_GT((T)seglimit, check_array[8]);
+  EXPECT_LT((T)0, check_array[9]);
+  EXPECT_GE((T)seglimit, check_array[9]);
 
-  work_res.deallocate(dest);
+  deallocateForallTestData<T>(  work_res,
+                                work_array,
+                                check_array,
+                                test_array );
 }
 
 TYPED_TEST_P(ForallAtomicBasicFunctionalTest, AtomicBasicFunctionalForall)

--- a/test/functional/forall/atomic/tests/test-forall-atomic-basic.hpp
+++ b/test/functional/forall/atomic/tests/test-forall-atomic-basic.hpp
@@ -15,6 +15,8 @@
 #include "RAJA/RAJA.hpp"
 #include "RAJA_gtest.hpp"
 
+#include "../../test-forall-atomic-utils.hpp"
+
 TYPED_TEST_SUITE_P(ForallAtomicBasicFunctionalTest);
 
 template <typename T>
@@ -25,10 +27,11 @@ class ForallAtomicBasicFunctionalTest : public ::testing::Test
 template <typename ExecPolicy,
           typename AtomicPolicy,
           typename WORKINGRES,
+          typename SegmentType,
           typename T>
 void testAtomicFunctionBasic( RAJA::Index_type seglimit )
 {
-  RAJA::TypedRangeSegment<RAJA::Index_type> seg(0, seglimit);
+  SegmentType seg = RSMultiplexer<RAJA::Index_type, SegmentType>().makeseg(seglimit);
 
   // initialize an array
   const int len = 10;
@@ -100,8 +103,9 @@ TYPED_TEST_P(ForallAtomicBasicFunctionalTest, AtomicBasicFunctionalForall)
   using AExec   = typename camp::at<TypeParam, camp::num<0>>::type;
   using APol    = typename camp::at<TypeParam, camp::num<1>>::type;
   using ResType = typename camp::at<TypeParam, camp::num<2>>::type;
-  using DType   = typename camp::at<TypeParam, camp::num<3>>::type;
-  testAtomicFunctionBasic<AExec, APol, ResType, DType>( 10000 );
+  using SType   = typename camp::at<TypeParam, camp::num<3>>::type;
+  using DType   = typename camp::at<TypeParam, camp::num<4>>::type;
+  testAtomicFunctionBasic<AExec, APol, ResType, SType, DType>( 10000 );
 }
 
 REGISTER_TYPED_TEST_SUITE_P( ForallAtomicBasicFunctionalTest,

--- a/test/functional/forall/atomic/tests/test-forall-atomic-basic.hpp
+++ b/test/functional/forall/atomic/tests/test-forall-atomic-basic.hpp
@@ -25,7 +25,7 @@ template< typename Index >
 struct RSMultiplexer < Index, RAJA::TypedRangeSegment<Index> >
 {
   RAJA::TypedRangeSegment<Index>
-  makeseg( Index N, camp::resources::Resource work_res )
+  makeseg( Index N, camp::resources::Resource RAJA_UNUSED_ARG(work_res) )
   {
     return RAJA::TypedRangeSegment<Index>( 0, N );
   }
@@ -35,7 +35,7 @@ template< typename Index >
 struct RSMultiplexer < Index, RAJA::TypedRangeStrideSegment<Index> >
 {
   RAJA::TypedRangeStrideSegment<Index>
-  makeseg( Index N, camp::resources::Resource work_res )
+  makeseg( Index N, camp::resources::Resource RAJA_UNUSED_ARG(work_res) )
   {
     return RAJA::TypedRangeStrideSegment<Index>( 0, N, 1 );
   }

--- a/test/functional/forall/test-forall-atomic-utils.hpp
+++ b/test/functional/forall/test-forall-atomic-utils.hpp
@@ -12,8 +12,6 @@
 
 #include "test-forall-utils.hpp"
 
-#include <numeric>
-
 using SequentialForallAtomicExecPols =
   camp::list<
               RAJA::seq_exec,
@@ -89,72 +87,11 @@ using AtomicDataTypeList =
            >;
 
 
-// range segment multiplexer
-template< typename Index, typename SegType >
-struct RSMultiplexer {};
-
-template< typename Index >
-struct RSMultiplexer < Index, RAJA::TypedRangeSegment<Index> >
-{
-  RAJA::TypedRangeSegment<Index>
-  makeseg( Index N )
-  {
-    return RAJA::TypedRangeSegment<Index>( 0, N );
-  }
-};
-
-template< typename Index >
-struct RSMultiplexer < Index, RAJA::TypedRangeStrideSegment<Index> >
-{
-  RAJA::TypedRangeStrideSegment<Index>
-  makeseg( Index N )
-  {
-    return RAJA::TypedRangeStrideSegment<Index>( 0, N, 1 );
-  }
-};
-
-template< typename Index >
-struct RSMultiplexer < Index, RAJA::TypedListSegment<Index> >
-{
-  RAJA::TypedListSegment<Index>
-  makeseg( Index N )
-  {
-    std::vector<Index> temp(N);
-    std::iota( std::begin(temp), std::end(temp), 0 );
-    return RAJA::TypedListSegment<Index>( &temp[0], static_cast<size_t>(temp.size()) );
-  }
-};
-
-template< typename Index >
-struct RSMultiplexer < Index, RAJA::TypedIndexSet<RAJA::TypedListSegment<Index>, RAJA::TypedRangeSegment<Index>, RAJA::TypedRangeStrideSegment<Index>> >
-{
-  RAJA::TypedIndexSet<RAJA::TypedListSegment<Index>, RAJA::TypedRangeSegment<Index>, RAJA::TypedRangeStrideSegment<Index>>
-  makeseg( Index N )
-  {
-    RAJA::Index_type chunk = N/3;
-    RAJA::TypedIndexSet<RAJA::TypedListSegment<Index>, RAJA::TypedRangeSegment<Index>, RAJA::TypedRangeStrideSegment<Index>> Iset;
-
-    // create ListSegment for first 1/3rd
-    std::vector<Index> temp(chunk);
-    std::iota( std::begin(temp), std::begin(temp) + chunk, 0 );
-    Iset.push_back( RAJA::TypedListSegment<Index>( &temp[0], static_cast<size_t>(temp.size()) ) );
-
-    // create RangeSegment for second 1/3rd
-    Iset.push_back( RAJA::TypedRangeSegment<Index>( chunk, 2*chunk ) );
-
-    // create RangeStrideSegment for last 1/3rd
-    Iset.push_back( RAJA::TypedRangeStrideSegment<Index>( 2*chunk, N, 1 ) );
-
-    return Iset;
-  }
-};
-
 using AtomicSegmentList = 
   camp::list<
               RAJA::TypedRangeSegment<RAJA::Index_type>,
               RAJA::TypedRangeStrideSegment<RAJA::Index_type>,
               RAJA::TypedListSegment<RAJA::Index_type>
-              //RAJA::TypedIndexSet<RAJA::TypedListSegment<RAJA::Index_type>, RAJA::TypedRangeSegment<RAJA::Index_type>, RAJA::TypedRangeStrideSegment<RAJA::Index_type>>
             >;
 
 #endif  // __TEST_FORALL_ATOMIC_UTILS_HPP__


### PR DESCRIPTION
# Summary

- This PR is a refactoring of the atomic forall test
- It does the following:
  - Adds simple TypedRangeStrideSegment and TypedListSegment to forall-atomic-basic tests.
  - Adds framework for TypedIndexSet, but not activated due to incompatible execution policies. This can be removed from the PR if so desired.