### PR TITLE
CAMP update to register-singleton branch for omptarget correctness

### DIFF
--- a/host-configs/lc-builds/blueos/xl_2020_X.cmake
+++ b/host-configs/lc-builds/blueos/xl_2020_X.cmake
@@ -1,0 +1,25 @@
+###############################################################################
+# Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+set(RAJA_COMPILER "RAJA_COMPILER_XLC" CACHE STRING "")
+
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qsmp=omp -qhot -qnoeh -qsuppress=1500-029 -qsuppress=1500-036" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qsmp=omp -qhot -qnoeh -qsuppress=1500-029 -qsuppress=1500-036" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -qsmp=omp:noopt " CACHE STRING "")
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,-z,muldefs" CACHE STRING "")
+
+# Suppressed XLC warnings:
+# - 1500-029 cannot inline
+# - 1500-036 nostrict optimizations may alter code semantics
+#   (can be countered with -qstrict, with less optimization)
+
+set(RAJA_RANGE_ALIGN 4 CACHE STRING "")
+set(RAJA_RANGE_MIN_LENGTH 32 CACHE STRING "")
+set(RAJA_DATA_ALIGN 64 CACHE STRING "")
+
+set(RAJA_HOST_CONFIG_LOADED On CACHE BOOL "")
+

--- a/scripts/lc-builds/blueos_xl-2020.03.18.sh
+++ b/scripts/lc-builds/blueos_xl-2020.03.18.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+BUILD_SUFFIX=lc_blueos-xl_2020.03.18
+
+rm -rf build_${BUILD_SUFFIX} 2>/dev/null
+mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
+
+module load cmake/3.14.5
+
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_COMPILER=/usr/tce/packages/xl/xl-2020.03.18/bin/xlc++_r \
+  -C ../host-configs/lc-builds/blueos/xl_2020_X.cmake \
+  -DENABLE_OPENMP=On \
+  -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
+  "$@" \
+  ..

--- a/scripts/lc-builds/blueos_xl-2020.03.18_omptarget.sh
+++ b/scripts/lc-builds/blueos_xl-2020.03.18_omptarget.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+BUILD_SUFFIX=lc_blueos-xl_2020.03.18_omptarget
+
+rm -rf build_${BUILD_SUFFIX} 2>/dev/null
+mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
+
+module load cmake/3.14.5
+
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_COMPILER=/usr/tce/packages/xl/xl-2020.03.18/bin/xlc++_r \
+  -C ../host-configs/lc-builds/blueos/xl_2020_X.cmake \
+  -DENABLE_OPENMP=On \
+  -DENABLE_TARGET_OPENMP=On \
+  -DOpenMP_CXX_FLAGS="-qoffload;-qsmp=omp;-qnoeh;-qalias=noansi" \
+  -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
+  "$@" \
+  ..

--- a/test/functional/forall/indexset-view/test-forall-indexset-view-openmp-target.cpp
+++ b/test/functional/forall/indexset-view/test-forall-indexset-view-openmp-target.cpp
@@ -14,7 +14,7 @@
 // Cartesian product of types for OpenMP target tests
 using OpenMPTargetForallIndexSetTypes =
   Test< camp::cartesian_product<IdxTypeList, 
-                                HostResourceList, 
+                                OpenMPTargetResourceList, 
                                 OpenMPTargetForallIndexSetExecPols>>::Types;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Cuda,

--- a/test/functional/forall/indexset/test-forall-indexset-openmp-target.cpp
+++ b/test/functional/forall/indexset/test-forall-indexset-openmp-target.cpp
@@ -14,7 +14,7 @@
 // Cartesian product of types for OpenMP target tests
 using OpenMPTargetForallIndexSetTypes =
   Test< camp::cartesian_product<IdxTypeList, 
-                                HostResourceList, 
+                                OpenMPTargetResourceList, 
                                 OpenMPTargetForallIndexSetExecPols>>::Types;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Cuda,

--- a/test/unit/reducer/tests/test-reducer-constructors.hpp
+++ b/test/unit/reducer/tests/test-reducer-constructors.hpp
@@ -179,9 +179,9 @@ TYPED_TEST_P(ReducerInitConstructorUnitTest, InitReducerConstructor)
 }
 
 
-REGISTER_TYPED_TEST_CASE_P(ReducerBasicConstructorUnitTest,
+REGISTER_TYPED_TEST_SUITE_P(ReducerBasicConstructorUnitTest,
                            BasicReducerConstructor);
 
-REGISTER_TYPED_TEST_CASE_P(ReducerInitConstructorUnitTest,
+REGISTER_TYPED_TEST_SUITE_P(ReducerInitConstructorUnitTest,
                            InitReducerConstructor);
 #endif  //__TEST_REDUCER_CONSTRUCTOR__

--- a/test/unit/reducer/tests/test-reducer-reset.hpp
+++ b/test/unit/reducer/tests/test-reducer-reset.hpp
@@ -187,7 +187,7 @@ TYPED_TEST_P(ReducerResetUnitTest, BasicReset)
   testReducerReset< ReduceType, NumericType, ResourceType, ForOneType >();
 }
 
-REGISTER_TYPED_TEST_CASE_P(ReducerResetUnitTest,
+REGISTER_TYPED_TEST_SUITE_P(ReducerResetUnitTest,
                            BasicReset);
 
 #endif  //__TEST_REDUCER_RESET__


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Updates CAMP version to register-singleton branch to fix OpenMP target compilation. New OpenMP target tests will still segfault due to camp::resources:omp not mapping correctly.
  - Various other fixes:
    - Use correct OpenMPTargetResource for indexset tests.
    - Use updated REGISTER_TEST_SUITE in reducer unit tests.
    - Add xl/2020.03.18 build scripts for omp-target testing.
