### PR TITLE
Add reset to omp target reducer

### DIFF
--- a/include/RAJA/pattern/detail/reduce.hpp
+++ b/include/RAJA/pattern/detail/reduce.hpp
@@ -337,12 +337,14 @@ class BaseReduceMinLoc
 public:
   using Base = BaseReduce<ValueLoc<T, IndexType>, RAJA::reduce::min, Combiner>;
   using value_type = typename Base::value_type;
+  using reduce_type = typename Base::reduce_type;
   using Base::Base;
 
   constexpr BaseReduceMinLoc() : Base(value_type(T(), IndexType())) {}
 
-  constexpr BaseReduceMinLoc(T init_val, IndexType init_idx)
-      : Base(value_type(init_val, init_idx))
+  constexpr BaseReduceMinLoc(T init_val, IndexType init_idx,
+                             T identity_ = reduce_type::identity())
+    : Base(value_type(init_val, init_idx), identity_)
   {
   }
 
@@ -352,6 +354,12 @@ public:
   {
     this->combine(value_type(rhs, loc));
     return *this;
+  }
+
+  void reset(T init_val, IndexType init_idx=DefaultLoc<IndexType>().value(),
+             T identity_ = reduce_type::identity())
+  {
+    Base::reset(value_type(init_val, init_idx), identity_);
   }
 
   //! Get the calculated reduced value
@@ -422,12 +430,14 @@ class BaseReduceMaxLoc
 public:
   using Base = BaseReduce<ValueLoc<T, IndexType, false>, RAJA::reduce::max, Combiner>;
   using value_type = typename Base::value_type;
+  using reduce_type = typename Base::reduce_type;
   using Base::Base;
 
   constexpr BaseReduceMaxLoc() : Base(value_type(T(), IndexType())) {}
 
-  constexpr BaseReduceMaxLoc(T init_val, IndexType init_idx)
-      : Base(value_type(init_val, init_idx))
+  constexpr BaseReduceMaxLoc(T init_val, IndexType init_idx,
+                             T identity_ = reduce_type::identity())
+    : Base(value_type(init_val, init_idx), identity_)
   {
   }
 
@@ -437,6 +447,12 @@ public:
   {
     this->combine(value_type(rhs, loc));
     return *this;
+  }
+
+  void reset(T init_val, IndexType init_idx=DefaultLoc<IndexType>().value(),
+             T identity_ = reduce_type::identity())
+  {
+    Base::reset(value_type(init_val, init_idx), identity_);
   }
 
   //! Get the calculated reduced value

--- a/include/RAJA/policy/openmp_target/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/reduce.hpp
@@ -183,20 +183,20 @@ struct TargetReduce
   TargetReduce() = delete;
   TargetReduce(const TargetReduce &) = default;
 
-  explicit TargetReduce(T init_val, T identity_ = Reducer::identity())
+  explicit TargetReduce(T init_val_, T identity_ = Reducer::identity())
       : info(),
         val(identity_, identity_, info),
-        initVal(init_val),
+        initVal(init_val_),
         finalVal(identity_)
   {
   }
 
-  void reset(T in_val, T identity_ = Reducer::identity())
+  void reset(T init_val_, T identity_ = Reducer::identity())
   {
     operator T();
-    initVal = in_val;
-    finalVal = identity_;
     val.reset(identity_);
+    initVal = init_val_;
+    finalVal = identity_;
   }
 
 #ifdef __ibmxl__ // TODO: implicit declare target doesn't pick this up
@@ -268,27 +268,27 @@ struct TargetReduceLoc
 {
   TargetReduceLoc() = delete;
   TargetReduceLoc(const TargetReduceLoc &) = default;
-  explicit TargetReduceLoc(T init_val, IndexType init_loc,
+  explicit TargetReduceLoc(T init_val_, IndexType init_loc,
                            T identity_ = Reducer::identity)
       : info(),
         val(identity_, identity_, info),
         loc(init_loc, IndexType(RAJA::reduce::detail::DefaultLoc<IndexType>().value()), info),
-        initVal(init_val),
+        initVal(init_val_),
         finalVal(identity_),
         initLoc(init_loc),
         finalLoc(IndexType(RAJA::reduce::detail::DefaultLoc<IndexType>().value()))
   {
   }
 
-  void reset(T in_val, T identity_ = Reducer::identity)
+  void reset(T init_val_, T identity_ = Reducer::identity)
   {
     operator T();
-    initVal = in_val;
-    initLoc = reduce::detail::DefaultLoc<IndexType>().value();
-    finalLoc = IndexType(RAJA::reduce::detail::DefaultLoc<IndexType>().value());
-    finalVal = identity_;
     val.reset(identity_);
     loc.reset(IndexType(RAJA::reduce::detail::DefaultLoc<IndexType>().value()));
+    initVal = init_val_;
+    finalVal = identity_;
+    initLoc = reduce::detail::DefaultLoc<IndexType>().value();
+    finalLoc = IndexType(RAJA::reduce::detail::DefaultLoc<IndexType>().value());
   }
 
   //! apply reduction on device upon destruction

--- a/include/RAJA/policy/openmp_target/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/reduce.hpp
@@ -280,11 +280,14 @@ struct TargetReduceLoc
   {
   }
 
-  void reset(T init_val_, T identity_ = Reducer::identity)
+  void reset(T init_val_,
+             IndexType init_local_ =
+             IndexType(RAJA::reduce::detail::DefaultLoc<IndexType>().value()),
+             T identity_ = Reducer::identity)
   {
     operator T();
     val.reset(identity_);
-    loc.reset(IndexType(RAJA::reduce::detail::DefaultLoc<IndexType>().value()));
+    loc.reset(init_local_);
     initVal = init_val_;
     finalVal = identity_;
     initLoc = reduce::detail::DefaultLoc<IndexType>().value();

--- a/include/RAJA/policy/openmp_target/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/reduce.hpp
@@ -196,6 +196,7 @@ struct TargetReduce
     operator T();
     initVal = in_val;
     finalVal = identity_;
+    val.reset(identity_);
   }
 
 #ifdef __ibmxl__ // TODO: implicit declare target doesn't pick this up
@@ -286,6 +287,8 @@ struct TargetReduceLoc
     initLoc = reduce::detail::DefaultLoc<IndexType>().value();
     finalLoc = IndexType(RAJA::reduce::detail::DefaultLoc<IndexType>().value());
     finalVal = identity_;
+    val.reset(identity_);
+    loc.reset(IndexType(RAJA::reduce::detail::DefaultLoc<IndexType>().value()));
   }
 
   //! apply reduction on device upon destruction

--- a/test/functional/forall/reduce-sanity/tests/test-forall-reduce-sanity-max.hpp
+++ b/test/functional/forall/reduce-sanity/tests/test-forall-reduce-sanity-max.hpp
@@ -58,13 +58,8 @@ void ForallReduceMaxSanityTest(RAJA::Index_type first, RAJA::Index_type last)
   ASSERT_EQ(static_cast<DATA_TYPE>(maxinit.get()), big_max);
   ASSERT_EQ(static_cast<DATA_TYPE>(max.get()), ref_max);
 
-#if !defined(RAJA_ENABLE_TARGET_OPENMP)
-  //
-  // Note: RAJA OpenMP target reductions do not currently support reset
-  //
   max.reset(max_init);
   ASSERT_EQ(static_cast<DATA_TYPE>(max.get()), max_init);
-#endif
 
   DATA_TYPE factor = 2;
   RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(RAJA::Index_type idx) {

--- a/test/functional/forall/reduce-sanity/tests/test-forall-reduce-sanity-maxloc.hpp
+++ b/test/functional/forall/reduce-sanity/tests/test-forall-reduce-sanity-maxloc.hpp
@@ -71,14 +71,9 @@ void ForallReduceMaxLocSanityTest(RAJA::Index_type first, RAJA::Index_type last)
   ASSERT_EQ(static_cast<DATA_TYPE>(max.get()), ref_max);
   ASSERT_EQ(static_cast<RAJA::Index_type>(max.getLoc()), ref_maxloc);
 
-#if !defined(RAJA_ENABLE_TARGET_OPENMP)
-  //
-  // Note: RAJA OpenMP target reductions do not currently support reset
-  //
   max.reset(max_init, maxloc_init);
   ASSERT_EQ(static_cast<DATA_TYPE>(max.get()), max_init);
   ASSERT_EQ(static_cast<RAJA::Index_type>(max.getLoc()), maxloc_init);
-#endif
 
   DATA_TYPE factor = 2;
   RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(RAJA::Index_type idx) {

--- a/test/functional/forall/reduce-sanity/tests/test-forall-reduce-sanity-min.hpp
+++ b/test/functional/forall/reduce-sanity/tests/test-forall-reduce-sanity-min.hpp
@@ -59,13 +59,8 @@ void ForallReduceMinSanityTest(RAJA::Index_type first, RAJA::Index_type last)
   ASSERT_EQ(static_cast<DATA_TYPE>(mininit.get()), small_min);
   ASSERT_EQ(static_cast<DATA_TYPE>(min.get()), ref_min);
 
-#if !defined(RAJA_ENABLE_TARGET_OPENMP)
-  //
-  // Note: RAJA OpenMP target reductions do not currently support reset
-  //
   min.reset(min_init);
   ASSERT_EQ(static_cast<DATA_TYPE>(min.get()), min_init);
-#endif
 
   DATA_TYPE factor = 3; 
   RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(RAJA::Index_type idx) {

--- a/test/functional/forall/reduce-sanity/tests/test-forall-reduce-sanity-minloc.hpp
+++ b/test/functional/forall/reduce-sanity/tests/test-forall-reduce-sanity-minloc.hpp
@@ -71,14 +71,9 @@ void ForallReduceMinLocSanityTest(RAJA::Index_type first, RAJA::Index_type last)
   ASSERT_EQ(static_cast<DATA_TYPE>(min.get()), ref_min);
   ASSERT_EQ(static_cast<RAJA::Index_type>(min.getLoc()), ref_minloc);
 
-#if !defined(RAJA_ENABLE_TARGET_OPENMP)
-  //
-  // Note: RAJA OpenMP target reductions do not currently support reset
-  //
   min.reset(min_init, minloc_init);
   ASSERT_EQ(static_cast<DATA_TYPE>(min.get()), min_init);
   ASSERT_EQ(static_cast<RAJA::Index_type>(min.getLoc()), minloc_init);
-#endif
 
   DATA_TYPE factor = 2;
   RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(RAJA::Index_type idx) {

--- a/test/functional/forall/reduce-sanity/tests/test-forall-reduce-sanity-sum.hpp
+++ b/test/functional/forall/reduce-sanity/tests/test-forall-reduce-sanity-sum.hpp
@@ -57,9 +57,7 @@ void ForallReduceSumSanityTest(RAJA::Index_type first, RAJA::Index_type last)
   ASSERT_EQ(static_cast<DATA_TYPE>(sum.get()), ref_sum);
   ASSERT_EQ(static_cast<DATA_TYPE>(sum2.get()), ref_sum + 2);
 
-#if !defined(RAJA_ENABLE_TARGET_OPENMP)
   sum.reset(0);
-#endif
 
   const int nloops = 2;
 
@@ -69,11 +67,7 @@ void ForallReduceSumSanityTest(RAJA::Index_type first, RAJA::Index_type last)
     });
   }
 
-#if defined(RAJA_ENABLE_TARGET_OPENMP)
-  ASSERT_EQ(static_cast<DATA_TYPE>(sum.get()), nloops * ref_sum + ref_sum);
-#else
   ASSERT_EQ(static_cast<DATA_TYPE>(sum.get()), nloops * ref_sum);
-#endif
    
 
   deallocateForallTestData<DATA_TYPE>(working_res,

--- a/test/old-tests/unit/cpu/test-reductions.cpp
+++ b/test/old-tests/unit/cpu/test-reductions.cpp
@@ -495,7 +495,7 @@ TYPED_TEST_P(ReductionCorrectnessTest, ReduceMinLocGenericIndex2)
 
   RAJA::ReduceMinLoc<ReducePolicy, double, Index> minloc_reducer;
 
-  minloc_reducer.reset({1024.0, Index(0)});
+  minloc_reducer.reset(1024.0, Index(0));
 
   RAJA::forall<ExecPolicy>(RAJA::RangeSegment(0, this->array_length),
                            [=](int i) {
@@ -549,7 +549,7 @@ TYPED_TEST_P(ReductionCorrectnessTest, ReduceMaxLocGenericIndex2)
 
   RAJA::ReduceMaxLoc<ReducePolicy, double, Index> maxloc_reducer;
 
-  maxloc_reducer.reset({0.0, Index()});
+  maxloc_reducer.reset(0.0, Index());
 
   RAJA::forall<ExecPolicy>(RAJA::RangeSegment(0, this->array_length),
                            [=](int i) {

--- a/test/unit/reducer/CMakeLists.txt
+++ b/test/unit/reducer/CMakeLists.txt
@@ -37,6 +37,10 @@ if(RAJA_ENABLE_TARGET_OPENMP)
 raja_add_test(
   NAME test-reducer-constructors-openmp-target
   SOURCES test-reducer-constructors-openmp-target.cpp)
+
+raja_add_test(
+  NAME test-reducer-reset-openmp-target
+  SOURCES test-reducer-reset-openmp-target.cpp)
 endif()
 
 if(RAJA_ENABLE_CUDA)

--- a/test/unit/reducer/test-reducer-reset-openmp-target.cpp
+++ b/test/unit/reducer/test-reducer-reset-openmp-target.cpp
@@ -1,0 +1,27 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Source file containing tests for RAJA reducer reset.
+///
+
+#include "tests/test-reducer-reset.hpp"
+
+#include "test-reducer-utils.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+using OpenMPTargetReducerResetTypes = 
+  Test< camp::cartesian_product< OpenMPTargetReducerPolicyList,
+                                 DataTypeList,
+                                 OpenMPTargetResourceList,
+                                 SequentialForoneList > >::Types;
+
+
+INSTANTIATE_TYPED_TEST_SUITE_P(OpenMPTargetResetTest,
+                               ReducerResetUnitTest,
+                               OpenMPTargetReducerResetTypes);
+#endif


### PR DESCRIPTION
# Summary

- This PR adds the reset method to the omp target reduce class. 

Folks, in general I had hard time building all of RAJA with omp target. I had to choose which files to build to manage build times. 

Additionally, using OpenMPTargetResourceList led to segfaults, I had to use HostResourceList to test this code. 
