### PR TITLE
Bugfix/burmark1/warn sign compare

### DIFF
--- a/include/RAJA/pattern/kernel/internal/LoopData.hpp
+++ b/include/RAJA/pattern/kernel/internal/LoopData.hpp
@@ -166,10 +166,17 @@ struct LoopData {
 
 
 template <camp::idx_t ArgumentId, typename Data>
-RAJA_INLINE RAJA_HOST_DEVICE auto segment_length(Data const &data) ->
+using segment_diff_type =
     typename std::iterator_traits<
         typename camp::at_v<typename Data::segment_tuple_t::TList,
-                            ArgumentId>::iterator>::difference_type
+                            ArgumentId>::iterator>::difference_type;
+
+
+
+
+template <camp::idx_t ArgumentId, typename Data>
+RAJA_INLINE RAJA_HOST_DEVICE auto segment_length(Data const &data) ->
+  segment_diff_type<ArgumentId, Data>
 {
   return camp::get<ArgumentId>(data.segment_tuple).end() -
          camp::get<ArgumentId>(data.segment_tuple).begin();

--- a/include/RAJA/policy/cuda/kernel/For.hpp
+++ b/include/RAJA/policy/cuda/kernel/For.hpp
@@ -52,14 +52,15 @@ struct CudaStatementExecutor<
   using enclosed_stmts_t =
       CudaStatementListExecutor<Data, stmt_list_t, NewTypes>;
 
+  using diff_t = segment_diff_type<ArgumentId, Data>;
 
   static
   inline
   RAJA_DEVICE
   void exec(Data &data, bool thread_active)
   {
-    auto len = segment_length<ArgumentId>(data);
-    auto i = get_cuda_dim<ThreadDim>(threadIdx);
+    diff_t len = segment_length<ArgumentId>(data);
+    diff_t i = get_cuda_dim<ThreadDim>(threadIdx);
 
     // assign thread id directly to offset
     data.template assign_offset<ArgumentId>(i);
@@ -73,7 +74,7 @@ struct CudaStatementExecutor<
   inline
   LaunchDims calculateDimensions(Data const &data)
   {
-    auto len = segment_length<ArgumentId>(data);
+    diff_t len = segment_length<ArgumentId>(data);
 
     // request one thread per element in the segment
     LaunchDims dims;
@@ -111,14 +112,16 @@ struct CudaStatementExecutor<
   using enclosed_stmts_t =
       CudaStatementListExecutor<Data, stmt_list_t, NewTypes>;
 
+  using diff_t = segment_diff_type<ArgumentId, Data>;
+
 
   static
   inline
   RAJA_DEVICE
   void exec(Data &data, bool thread_active)
   {
-    auto len = segment_length<ArgumentId>(data);
-    auto i = threadIdx.x;
+    diff_t len = segment_length<ArgumentId>(data);
+    diff_t i = threadIdx.x;
 
     // assign thread id directly to offset
     data.template assign_offset<ArgumentId>(i);
@@ -136,7 +139,7 @@ struct CudaStatementExecutor<
     LaunchDims dims = enclosed_stmts_t::calculateDimensions(data);
 
     // we always get EXACTLY one warp by allocating one warp in the X dimension
-    int len = RAJA::policy::cuda::WARP_SIZE;
+    diff_t len = RAJA::policy::cuda::WARP_SIZE;
 
     // request one thread per element in the segment
     set_cuda_dim<0>(dims.threads, len);
@@ -174,15 +177,17 @@ struct CudaStatementExecutor<
   using enclosed_stmts_t =
       CudaStatementListExecutor<Data, stmt_list_t, NewTypes>;
 
+  using diff_t = segment_diff_type<ArgumentId, Data>;
+
 
   static
   inline RAJA_DEVICE void exec(Data &data, bool thread_active)
   {
     // block stride loop
-    auto len = segment_length<ArgumentId>(data);
-    auto i0 = get_cuda_dim<ThreadDim>(threadIdx);
-    auto i_stride = get_cuda_dim<ThreadDim>(blockDim);
-    auto i = i0;
+    diff_t len = segment_length<ArgumentId>(data);
+    diff_t i0 = get_cuda_dim<ThreadDim>(threadIdx);
+    diff_t i_stride = get_cuda_dim<ThreadDim>(blockDim);
+    diff_t i = i0;
     for(;i < len;i += i_stride){
 
       // Assign the x thread to the argument
@@ -206,7 +211,7 @@ struct CudaStatementExecutor<
   inline
   LaunchDims calculateDimensions(Data const &data)
   {
-    auto len = segment_length<ArgumentId>(data);
+    diff_t len = segment_length<ArgumentId>(data);
 
     // request one thread per element in the segment
     LaunchDims dims;
@@ -245,15 +250,17 @@ struct CudaStatementExecutor<
   using enclosed_stmts_t =
       CudaStatementListExecutor<Data, stmt_list_t, NewTypes>;
 
+  using diff_t = segment_diff_type<ArgumentId, Data>;
+
 
   static
   inline RAJA_DEVICE void exec(Data &data, bool thread_active)
   {
     // block stride loop
-    auto len = segment_length<ArgumentId>(data);
-    auto i0 = threadIdx.x;
-    auto i_stride = RAJA::policy::cuda::WARP_SIZE;
-    auto i = i0;
+    diff_t len = segment_length<ArgumentId>(data);
+    diff_t i0 = threadIdx.x;
+    diff_t i_stride = RAJA::policy::cuda::WARP_SIZE;
+    diff_t i = i0;
     for(;i < len;i += i_stride){
 
       // Assign the x thread to the argument
@@ -281,7 +288,7 @@ struct CudaStatementExecutor<
     LaunchDims dims = enclosed_stmts_t::calculateDimensions(data);
 
     // we always get EXACTLY one warp by allocating one warp in the X dimension
-    int len = RAJA::policy::cuda::WARP_SIZE;
+    diff_t len = RAJA::policy::cuda::WARP_SIZE;
 
     // request one thread per element in the segment
     set_cuda_dim<0>(dims.threads, len);
@@ -320,6 +327,8 @@ struct CudaStatementExecutor<
 
   using mask_t = Mask;
 
+  using diff_t = segment_diff_type<ArgumentId, Data>;
+
   static_assert(mask_t::max_masked_size <= RAJA::policy::cuda::WARP_SIZE,
                 "BitMask is too large for CUDA warp size");
 
@@ -328,9 +337,9 @@ struct CudaStatementExecutor<
   RAJA_DEVICE
   void exec(Data &data, bool thread_active)
   {
-    auto len = segment_length<ArgumentId>(data);
+    diff_t len = segment_length<ArgumentId>(data);
 
-    auto i = mask_t::maskValue(threadIdx.x);
+    diff_t i = mask_t::maskValue(threadIdx.x);
 
     // assign thread id directly to offset
     data.template assign_offset<ArgumentId>(i);
@@ -349,7 +358,7 @@ struct CudaStatementExecutor<
 
     // we always get EXACTLY one warp by allocating one warp in the X
     // dimension
-    int len = RAJA::policy::cuda::WARP_SIZE;
+    diff_t len = RAJA::policy::cuda::WARP_SIZE;
 
     // request one thread per element in the segment
     set_cuda_dim<0>(dims.threads, len);
@@ -389,6 +398,8 @@ struct CudaStatementExecutor<
 
   using mask_t = Mask;
 
+  using diff_t = segment_diff_type<ArgumentId, Data>;
+
   static_assert(mask_t::max_masked_size <= RAJA::policy::cuda::WARP_SIZE,
                 "BitMask is too large for CUDA warp size");
 
@@ -398,9 +409,9 @@ struct CudaStatementExecutor<
   void exec(Data &data, bool thread_active)
   {
     // masked size strided loop
-    int len = segment_length<ArgumentId>(data);
-    int i = mask_t::maskValue(threadIdx.x);
-    for( ; i < len; i += (int) mask_t::max_masked_size){
+    diff_t len = segment_length<ArgumentId>(data);
+    diff_t i = mask_t::maskValue(threadIdx.x);
+    for( ; i < len; i += (diff_t) mask_t::max_masked_size){
 
       // Assign the x thread to the argument
       data.template assign_offset<ArgumentId>(i);
@@ -428,7 +439,7 @@ struct CudaStatementExecutor<
 
     // we always get EXACTLY one warp by allocating one warp in the X
     // dimension
-    int len = RAJA::policy::cuda::WARP_SIZE;
+    diff_t len = RAJA::policy::cuda::WARP_SIZE;
 
     // request one thread per element in the segment
     set_cuda_dim<0>(dims.threads, len);
@@ -467,14 +478,16 @@ struct CudaStatementExecutor<
 
   using mask_t = Mask;
 
+  using diff_t = segment_diff_type<ArgumentId, Data>;
+
   static
   inline
   RAJA_DEVICE
   void exec(Data &data, bool thread_active)
   {
-    auto len = segment_length<ArgumentId>(data);
+    diff_t len = segment_length<ArgumentId>(data);
 
-    auto i = mask_t::maskValue(threadIdx.x);
+    diff_t i = mask_t::maskValue(threadIdx.x);
 
     // assign thread id directly to offset
     data.template assign_offset<ArgumentId>(i);
@@ -493,7 +506,7 @@ struct CudaStatementExecutor<
 
     // we need to allocate enough threads for the segment size, and the
     // shifted off bits
-    int len = mask_t::max_input_size;
+    diff_t len = mask_t::max_input_size;
 
     // request one thread per element in the segment
     set_cuda_dim<0>(dims.threads, len);
@@ -535,6 +548,8 @@ struct CudaStatementExecutor<
 
   using mask_t = Mask;
 
+  using diff_t = segment_diff_type<ArgumentId, Data>;
+
 
   static
   inline
@@ -542,9 +557,9 @@ struct CudaStatementExecutor<
   void exec(Data &data, bool thread_active)
   {
     // masked size strided loop
-    int len = segment_length<ArgumentId>(data);
-    int i = mask_t::maskValue(threadIdx.x);
-    for( ; i < len; i += (int) mask_t::max_masked_size){
+    diff_t len = segment_length<ArgumentId>(data);
+    diff_t i = mask_t::maskValue(threadIdx.x);
+    for( ; i < len; i += (diff_t) mask_t::max_masked_size){
 
       // Assign the x thread to the argument
       data.template assign_offset<ArgumentId>(i);
@@ -572,7 +587,7 @@ struct CudaStatementExecutor<
 
     // we need to allocate enough threads for the segment size, and the
     // shifted off bits
-    int len = mask_t::max_input_size;
+    diff_t len = mask_t::max_input_size;
 
     // request one thread per element in the segment
     set_cuda_dim<0>(dims.threads, len);
@@ -609,12 +624,14 @@ struct CudaStatementExecutor<
   using enclosed_stmts_t =
       CudaStatementListExecutor<Data, stmt_list_t, NewTypes>;
 
+  using diff_t = segment_diff_type<ArgumentId, Data>;
+
 
   static
   inline RAJA_DEVICE void exec(Data &data, bool thread_active)
   {
-    auto len = segment_length<ArgumentId>(data);
-    auto i = get_cuda_dim<BlockDim>(blockIdx);
+    diff_t len = segment_length<ArgumentId>(data);
+    diff_t i = get_cuda_dim<BlockDim>(blockIdx);
 
     if (i < len) {
 
@@ -631,7 +648,7 @@ struct CudaStatementExecutor<
   inline
   LaunchDims calculateDimensions(Data const &data)
   {
-    auto len = segment_length<ArgumentId>(data);
+    diff_t len = segment_length<ArgumentId>(data);
 
     // request one block per element in the segment
     LaunchDims dims;
@@ -670,15 +687,17 @@ struct CudaStatementExecutor<
   using enclosed_stmts_t =
       CudaStatementListExecutor<Data, stmt_list_t, NewTypes>;
 
+  using diff_t = segment_diff_type<ArgumentId, Data>;
+
 
   static
   inline RAJA_DEVICE void exec(Data &data, bool thread_active)
   {
     // grid stride loop
-    auto len = segment_length<ArgumentId>(data);
-    auto i0 = get_cuda_dim<BlockDim>(blockIdx);
-    auto i_stride = get_cuda_dim<BlockDim>(gridDim);
-    for(auto i = i0;i < len;i += i_stride){
+    diff_t len = segment_length<ArgumentId>(data);
+    diff_t i0 = get_cuda_dim<BlockDim>(blockIdx);
+    diff_t i_stride = get_cuda_dim<BlockDim>(gridDim);
+    for(diff_t i = i0;i < len;i += i_stride){
 
       // Assign the x thread to the argument
       data.template assign_offset<ArgumentId>(i);
@@ -693,7 +712,7 @@ struct CudaStatementExecutor<
   inline
   LaunchDims calculateDimensions(Data const &data)
   {
-    auto len = segment_length<ArgumentId>(data);
+    diff_t len = segment_length<ArgumentId>(data);
 
     // request one block per element in the segment
     LaunchDims dims;
@@ -730,17 +749,16 @@ struct CudaStatementExecutor<
   using enclosed_stmts_t =
       CudaStatementListExecutor<Data, stmt_list_t, NewTypes>;
 
+  using diff_t = segment_diff_type<ArgumentId, Data>;
+
   static
   inline
   RAJA_DEVICE
   void exec(Data &data, bool thread_active)
   {
+    diff_t len = segment_length<ArgumentId>(data);
 
-    using idx_type = camp::decay<decltype(camp::get<ArgumentId>(data.offset_tuple))>;
-
-    idx_type len = segment_length<ArgumentId>(data);
-
-    for(idx_type i = 0;i < len;++ i){
+    for(diff_t i = 0;i < len;++ i){
       // Assign i to the argument
       data.template assign_offset<ArgumentId>(i);
 

--- a/include/RAJA/policy/cuda/kernel/Tile.hpp
+++ b/include/RAJA/policy/cuda/kernel/Tile.hpp
@@ -57,6 +57,7 @@ struct CudaStatementExecutor<
 
   using stmt_list_t = StatementList<EnclosedStmts...>;
   using enclosed_stmts_t = CudaStatementListExecutor<Data, stmt_list_t, Types>;
+  using diff_t = segment_diff_type<ArgumentId, Data>;
 
   static
   inline
@@ -69,13 +70,13 @@ struct CudaStatementExecutor<
     using segment_t = camp::decay<decltype(segment)>;
     segment_t orig_segment = segment;
 
-    int chunk_size = TPol::chunk_size;
+    diff_t chunk_size = TPol::chunk_size;
 
     // compute trip count
-    int len = segment.end() - segment.begin();
+    diff_t len = segment.end() - segment.begin();
 
     // Iterate through tiles
-    for (int i = 0; i < len; i += chunk_size) {
+    for (diff_t i = 0; i < len; i += chunk_size) {
 
       // Assign our new tiled segment
       segment = orig_segment.slice(i, chunk_size);
@@ -137,6 +138,8 @@ struct CudaStatementExecutor<
 
   using enclosed_stmts_t = CudaStatementListExecutor<Data, stmt_list_t, Types>;
 
+  using diff_t = segment_diff_type<ArgumentId, Data>;
+
   static
   inline
   RAJA_DEVICE
@@ -148,8 +151,8 @@ struct CudaStatementExecutor<
     using segment_t = camp::decay<decltype(segment)>;
 
     // compute trip count
-    auto len = segment.end() - segment.begin();
-    auto i = get_cuda_dim<BlockDim>(blockIdx) * chunk_size;
+    diff_t len = segment.end() - segment.begin();
+    diff_t i = get_cuda_dim<BlockDim>(blockIdx) * chunk_size;
 
     // check have chunk
     if (i < len) {
@@ -175,8 +178,8 @@ struct CudaStatementExecutor<
   {
 
     // Compute how many blocks
-    int len = segment_length<ArgumentId>(data);
-    int num_blocks = len / chunk_size;
+    diff_t len = segment_length<ArgumentId>(data);
+    diff_t num_blocks = len / chunk_size;
     if (num_blocks * chunk_size < len) {
       num_blocks++;
     }
@@ -229,6 +232,8 @@ struct CudaStatementExecutor<
 
   using enclosed_stmts_t = CudaStatementListExecutor<Data, stmt_list_t, Types>;
 
+  using diff_t = segment_diff_type<ArgumentId, Data>;
+
   static
   inline
   RAJA_DEVICE
@@ -242,12 +247,12 @@ struct CudaStatementExecutor<
     segment_t orig_segment = segment;
 
     // compute trip count
-    auto len = segment.end() - segment.begin();
-    auto i0 = get_cuda_dim<BlockDim>(blockIdx) * chunk_size;
-    auto i_stride = get_cuda_dim<BlockDim>(gridDim) * chunk_size;
+    diff_t len = segment.end() - segment.begin();
+    diff_t i0 = get_cuda_dim<BlockDim>(blockIdx) * chunk_size;
+    diff_t i_stride = get_cuda_dim<BlockDim>(gridDim) * chunk_size;
 
     // Iterate through grid stride of chunks
-    for (int i = i0; i < len; i += i_stride) {
+    for (diff_t i = i0; i < len; i += i_stride) {
 
       // Assign our new tiled segment
       segment = orig_segment.slice(i, chunk_size);
@@ -267,8 +272,8 @@ struct CudaStatementExecutor<
   {
 
     // Compute how many blocks
-    int len = segment_length<ArgumentId>(data);
-    int num_blocks = len / chunk_size;
+    diff_t len = segment_length<ArgumentId>(data);
+    diff_t num_blocks = len / chunk_size;
     if (num_blocks * chunk_size < len) {
       num_blocks++;
     }
@@ -320,6 +325,8 @@ struct CudaStatementExecutor<
 
   using enclosed_stmts_t = CudaStatementListExecutor<Data, stmt_list_t, Types>;
 
+  using diff_t = segment_diff_type<ArgumentId, Data>;
+
   static
   inline
   RAJA_DEVICE
@@ -333,7 +340,7 @@ struct CudaStatementExecutor<
     segment_t orig_segment = segment;
 
     // compute trip count
-    auto i0 = get_cuda_dim<ThreadDim>(threadIdx) * chunk_size;
+    diff_t i0 = get_cuda_dim<ThreadDim>(threadIdx) * chunk_size;
 
     // Assign our new tiled segment
     segment = orig_segment.slice(i0, chunk_size);
@@ -352,8 +359,8 @@ struct CudaStatementExecutor<
   {
 
     // Compute how many blocks
-    int len = segment_length<ArgumentId>(data);
-    int num_threads = len / chunk_size;
+    diff_t len = segment_length<ArgumentId>(data);
+    diff_t num_threads = len / chunk_size;
     if(num_threads * chunk_size < len){
       num_threads++;
     }
@@ -404,6 +411,8 @@ struct CudaStatementExecutor<
 
   using enclosed_stmts_t = CudaStatementListExecutor<Data, stmt_list_t, Types>;
 
+  using diff_t = segment_diff_type<ArgumentId, Data>;
+
   static
   inline
   RAJA_DEVICE
@@ -417,14 +426,14 @@ struct CudaStatementExecutor<
     segment_t orig_segment = segment;
 
     // compute trip count
-    auto i0 = get_cuda_dim<ThreadDim>(threadIdx) * chunk_size;
+    diff_t i0 = get_cuda_dim<ThreadDim>(threadIdx) * chunk_size;
 
     // Get our stride from the dimension
-    auto i_stride = get_cuda_dim<ThreadDim>(blockDim) * chunk_size;
+    diff_t i_stride = get_cuda_dim<ThreadDim>(blockDim) * chunk_size;
 
     // Iterate through grid stride of chunks
-    int len = segment_length<ArgumentId>(data);
-    for (int i = i0; i < len; i += i_stride) {
+    diff_t len = segment_length<ArgumentId>(data);
+    for (diff_t i = i0; i < len; i += i_stride) {
 
       // Assign our new tiled segment
       segment = orig_segment.slice(i, chunk_size);
@@ -444,12 +453,12 @@ struct CudaStatementExecutor<
   {
 
     // Compute how many blocks
-    int len = segment_length<ArgumentId>(data);
-    int num_threads = len / chunk_size;
+    diff_t len = segment_length<ArgumentId>(data);
+    diff_t num_threads = len / chunk_size;
     if(num_threads * chunk_size < len){
       num_threads++;
     }
-    num_threads = std::max(num_threads, MinThreads);
+    num_threads = std::max(num_threads, (diff_t)MinThreads);
 
     LaunchDims dims;
     set_cuda_dim<ThreadDim>(dims.threads, num_threads);

--- a/include/RAJA/policy/cuda/kernel/TileTCount.hpp
+++ b/include/RAJA/policy/cuda/kernel/TileTCount.hpp
@@ -63,6 +63,7 @@ struct CudaStatementExecutor<
       statement::Tile<ArgumentId, TPol, seq_exec, EnclosedStmts...>, Types>;
 
   using typename Base::enclosed_stmts_t;
+  using typename Base::diff_t;
 
   static
   inline
@@ -75,13 +76,13 @@ struct CudaStatementExecutor<
     using segment_t = camp::decay<decltype(segment)>;
     segment_t orig_segment = segment;
 
-    int chunk_size = TPol::chunk_size;
+    diff_t chunk_size = TPol::chunk_size;
 
     // compute trip count
-    int len = segment.end() - segment.begin();
+    diff_t len = segment.end() - segment.begin();
 
     // Iterate through tiles
-    for (int i = 0, t = 0; i < len; i += chunk_size, ++t) {
+    for (diff_t i = 0, t = 0; i < len; i += chunk_size, ++t) {
 
       // Assign our new tiled segment
       segment = orig_segment.slice(i, chunk_size);
@@ -133,6 +134,7 @@ struct CudaStatementExecutor<
                       Types>;
 
   using typename Base::enclosed_stmts_t;
+  using typename Base::diff_t;
 
   static
   inline
@@ -145,9 +147,9 @@ struct CudaStatementExecutor<
     using segment_t = camp::decay<decltype(segment)>;
 
     // compute trip count
-    int len = segment.end() - segment.begin();
-    auto t = get_cuda_dim<BlockDim>(blockIdx);
-    auto i = t * chunk_size;
+    diff_t len = segment.end() - segment.begin();
+    diff_t t = get_cuda_dim<BlockDim>(blockIdx);
+    diff_t i = t * chunk_size;
 
     // Iterate through grid stride of chunks
     if (i < len) {
@@ -204,6 +206,7 @@ struct CudaStatementExecutor<
                       Types>;
 
   using typename Base::enclosed_stmts_t;
+  using typename Base::diff_t;
 
   static
   inline
@@ -218,14 +221,14 @@ struct CudaStatementExecutor<
     segment_t orig_segment = segment;
 
     // compute trip count
-    int len = segment.end() - segment.begin();
-    auto t0 = get_cuda_dim<BlockDim>(blockIdx);
-    auto t_stride = get_cuda_dim<BlockDim>(gridDim);
-    auto i0 = t0 * chunk_size;
-    auto i_stride = t_stride * chunk_size;
+    diff_t len = segment.end() - segment.begin();
+    diff_t t0 = get_cuda_dim<BlockDim>(blockIdx);
+    diff_t t_stride = get_cuda_dim<BlockDim>(gridDim);
+    diff_t i0 = t0 * chunk_size;
+    diff_t i_stride = t_stride * chunk_size;
 
     // Iterate through grid stride of chunks
-    for (int i = i0, t = t0; i < len; i += i_stride, t += t_stride) {
+    for (diff_t i = i0, t = t0; i < len; i += i_stride, t += t_stride) {
 
       // Assign our new tiled segment
       segment = orig_segment.slice(i, chunk_size);
@@ -278,6 +281,7 @@ struct CudaStatementExecutor<
                           Types>;
 
   using typename Base::enclosed_stmts_t;
+  using typename Base::diff_t;
 
   static
   inline
@@ -292,10 +296,10 @@ struct CudaStatementExecutor<
     segment_t orig_segment = segment;
 
     // compute trip count
-    int len = segment.end() - segment.begin();
-    auto t0 = get_cuda_dim<ThreadDim>(threadIdx);
-    auto t_stride = get_cuda_dim<ThreadDim>(blockDim);
-    auto i0 = t0 * chunk_size;
+    diff_t len = segment.end() - segment.begin();
+    diff_t t0 = get_cuda_dim<ThreadDim>(threadIdx);
+    diff_t t_stride = get_cuda_dim<ThreadDim>(blockDim);
+    diff_t i0 = t0 * chunk_size;
 
     // Assign our new tiled segment
     segment = orig_segment.slice(i0, chunk_size);


### PR DESCRIPTION
# Use difference type in cuda kernel statements for consistency and to fix warnings

- This PR is a refactoring/bugfix
- It does the following:
  - refactors the types used in cuda kernel statements to use the difference type of the segment
  - Fixes different sign compilation warnings