### PR TITLE
bugfix/taller1/coronarajafixup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,22 +204,22 @@ if (ENABLE_HIP)
     hip_runtime)
 endif ()
 
-#if (ENABLE_HIP)
-#  if(ENABLE_EXTERNAL_ROCPRIM)
-#    find_package(ROCPRIM)
-#    if (ROCPRIM_FOUND)
-#      blt_register_library(
-#        NAME rocPRIM
-#        INCLUDES ${ROCPRIM_INCLUDE_DIRS})
-#      set(raja_depends
-#          ${raja_depends}
-#          rocPRIM)
-#    else()
-#      message(WARNING "External rocPRIM not found.")
-#      set(ENABLE_EXTERNAL_ROCPRIM Off)
-#     endif()
-#  endif ()
-#endif ()
+if (ENABLE_HIP)
+  if(ENABLE_EXTERNAL_ROCPRIM)
+    find_package(ROCPRIM)
+    if (ROCPRIM_FOUND)
+      blt_register_library(
+        NAME rocPRIM
+        INCLUDES ${ROCPRIM_INCLUDE_DIRS})
+      set(raja_depends
+          ${raja_depends}
+          rocPRIM)
+    else()
+      message(WARNING "External rocPRIM not found.")
+      set(ENABLE_EXTERNAL_ROCPRIM Off)
+     endif()
+  endif ()
+endif ()
 
 if (ENABLE_CHAI)
   set (raja_depends

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,12 @@ if (ENABLE_HIP)
   endif ()
 endif ()
 
+if (ENABLE_HIP)
+   set(HIP_ROOT_DIR "/opt/rocm-3.5.0/hip" CACHE PATH "")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --hip-device-lib-path=/opt/rocm-3.5.0/lib  -I/opt/rocm-3.5.0/llvm/lib/clang/11.0.0 -x hip")
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --hip-device-lib-path=/opt/rocm-3.5.0/lib -I/opt/rocm-3.5.0/llvm/lib/clang/11.0.0 -x hip")
+endif()
+
 if (ENABLE_CHAI)
   set (raja_depends
     ${raja_depends}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,25 +201,25 @@ endif ()
 if (ENABLE_HIP)
   set (raja_depends
     ${raja_depends}
-    hip)
+    hip_runtime)
 endif ()
 
-if (ENABLE_HIP)
-  if(ENABLE_EXTERNAL_ROCPRIM)
-    find_package(ROCPRIM)
-    if (ROCPRIM_FOUND)
-      blt_register_library(
-        NAME rocPRIM
-        INCLUDES ${ROCPRIM_INCLUDE_DIRS})
-      set(raja_depends
-          ${raja_depends}
-          rocPRIM)
-    else()
-      message(WARNING "External rocPRIM not found.")
-      set(ENABLE_EXTERNAL_ROCPRIM Off)
-     endif()
-  endif ()
-endif ()
+#if (ENABLE_HIP)
+#  if(ENABLE_EXTERNAL_ROCPRIM)
+#    find_package(ROCPRIM)
+#    if (ROCPRIM_FOUND)
+#      blt_register_library(
+#        NAME rocPRIM
+#        INCLUDES ${ROCPRIM_INCLUDE_DIRS})
+#      set(raja_depends
+#          ${raja_depends}
+#          rocPRIM)
+#    else()
+#      message(WARNING "External rocPRIM not found.")
+#      set(ENABLE_EXTERNAL_ROCPRIM Off)
+#     endif()
+#  endif ()
+#endif ()
 
 if (ENABLE_CHAI)
   set (raja_depends

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,8 +223,8 @@ endif ()
 
 if (ENABLE_HIP)
    set(HIP_ROOT_DIR "/opt/rocm-3.5.0/hip" CACHE PATH "")
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --hip-device-lib-path=/opt/rocm-3.5.0/lib  -I/opt/rocm-3.5.0/llvm/lib/clang/11.0.0 -x hip")
-   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --hip-device-lib-path=/opt/rocm-3.5.0/lib -I/opt/rocm-3.5.0/llvm/lib/clang/11.0.0 -x hip")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I/opt/rocm-3.5.0/lib  -I/opt/rocm-3.5.0/llvm/lib/clang/11.0.0 -x hip")
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I/opt/rocm-3.5.0/lib -I/opt/rocm-3.5.0/llvm/lib/clang/11.0.0 -x hip")
 endif()
 
 if (ENABLE_CHAI)

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -24,6 +24,7 @@
 
 #include <stdexcept>
 #include <type_traits>
+#include "hip/hip_runtime_api.h"
 
 #include "RAJA/util/Operators.hpp"
 #include "RAJA/util/TypeConvert.hpp"

--- a/include/RAJA/policy/hip/forall.hpp
+++ b/include/RAJA/policy/hip/forall.hpp
@@ -26,6 +26,7 @@
 
 #if defined(RAJA_ENABLE_HIP)
 
+#include "hip/hip_runtime_api.h"
 #include <algorithm>
 
 #include "RAJA/pattern/forall.hpp"

--- a/include/RAJA/policy/hip/policy.hpp
+++ b/include/RAJA/policy/hip/policy.hpp
@@ -155,11 +155,13 @@ struct hip_thread_masked_loop {};
 
 //
 // Operations in the included files are parametrized using the following
-// values for HIP warp size and max block size.
+// values for HIP warp size and max block size. Note that we cannot use __HIPCC__
+// or __CUDACC__ here, because these values need to be defined when the compiler makes
+// passes targeting both the cpu and gpu
 //
-#if defined(__HIPCC__)
+#if defined(RAJA_ENABLE_HIP)
 constexpr const RAJA::Index_type WARP_SIZE = 64;
-#elif defined(__CUDACC__)
+#elif defined(RAJA_ENABLE_CUDA)
 constexpr const RAJA::Index_type WARP_SIZE = 32;
 #endif
 

--- a/include/RAJA/policy/hip/policy.hpp
+++ b/include/RAJA/policy/hip/policy.hpp
@@ -159,9 +159,9 @@ struct hip_thread_masked_loop {};
 // or __CUDACC__ here, because these values need to be defined when the compiler makes
 // passes targeting both the cpu and gpu
 //
-#if defined(RAJA_ENABLE_HIP)
+#if defined(__HIP_PLATFORM_HCC__)
 constexpr const RAJA::Index_type WARP_SIZE = 64;
-#elif defined(RAJA_ENABLE_CUDA)
+#elif defined(__HIP_PLATFORM_NVCC__)
 constexpr const RAJA::Index_type WARP_SIZE = 32;
 #endif
 


### PR DESCRIPTION
# Summary

This PR is a bugfix
- It does the following:
  - Allows RAJA to build on cz corona with ENABLE_HIP On, using clang compiler
      i. Changed a dependency from hip to hip_runtime, which is consistent with chai and umpire
  - Did not check tests and examples
