### PR TITLE
Allow using imported camp cmake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,21 +233,23 @@ if (ENABLE_TBB)
     tbb)
 endif ()
 
-set(EXTERNAL_CAMP_SOURCE_DIR "" CACHE FILEPATH "build with a specific external
+if (NOT TARGET camp)
+  set(EXTERNAL_CAMP_SOURCE_DIR "" CACHE FILEPATH "build with a specific external
 camp source repository")
-if (EXTERNAL_CAMP_SOURCE_DIR)
-  message(STATUS "Using external source CAMP from: " ${EXTERNAL_CAMP_SOURCE_DIR})
-  add_subdirectory(${EXTERNAL_CAMP_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}/tpl/camp)
-else (EXTERNAL_CAMP_SOURCE_DIR)
-  find_package(camp QUIET)
-  if (NOT camp_FOUND)
-    message(STATUS "Using RAJA CAMP submodule.")
-    add_subdirectory(tpl/camp)
-  else (NOT camp_FOUND)
-    message(STATUS "Using installed CAMP from:  ${camp_INSTALL_PREFIX}")
-  endif(NOT camp_FOUND)
-endif (EXTERNAL_CAMP_SOURCE_DIR)
+  if (EXTERNAL_CAMP_SOURCE_DIR)
+    message(STATUS "Using external source CAMP from: " ${EXTERNAL_CAMP_SOURCE_DIR})
+    add_subdirectory(${EXTERNAL_CAMP_SOURCE_DIR}
+                     ${CMAKE_CURRENT_BINARY_DIR}/tpl/camp)
+  else (EXTERNAL_CAMP_SOURCE_DIR)
+    find_package(camp QUIET)
+    if (NOT camp_FOUND)
+      message(STATUS "Using RAJA CAMP submodule.")
+      add_subdirectory(tpl/camp)
+    else (NOT camp_FOUND)
+      message(STATUS "Using installed CAMP from:  ${camp_INSTALL_PREFIX}")
+    endif(NOT camp_FOUND)
+  endif (EXTERNAL_CAMP_SOURCE_DIR)
+endif (NOT TARGET camp)
 
 blt_add_library(
   NAME RAJA

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-add_custom_target(docs)
+add_custom_target(raja-docs)
 
 if (SPHINX_FOUND)
   add_subdirectory(sphinx/user_guide)

--- a/docs/doxygen/CMakeLists.txt
+++ b/docs/doxygen/CMakeLists.txt
@@ -21,5 +21,5 @@ add_custom_target(raja-doxygen
 install(DIRECTORY ${DOXYGEN_HTML_DIR}
   DESTINATION "docs/doxygen/" OPTIONAL)
 
-add_dependencies(docs
+add_dependencies(raja-docs
   raja-doxygen)

--- a/docs/sphinx/user_guide/CMakeLists.txt
+++ b/docs/sphinx/user_guide/CMakeLists.txt
@@ -23,5 +23,5 @@ add_custom_target(raja-userguide-sphinx
 install(DIRECTORY "${SPHINX_HTML_DIR}"
         DESTINATION "docs/user_guide/sphinx/" OPTIONAL)
 
-add_dependencies(docs
+add_dependencies(raja-docs
   raja-userguide-sphinx)


### PR DESCRIPTION
If camp is already imported as a cmake target, use that rather than an external camp or the camp submodule.

# Summary

- This PR is a bugfix
- It does the following:
  - Checks if camp is already a cmake target before trying to use an external camp or the camp submodule
  - Fixes issue #829 