### PR TITLE
Allow using imported camp cmake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,21 +233,23 @@ if (ENABLE_TBB)
     tbb)
 endif ()
 
-set(EXTERNAL_CAMP_SOURCE_DIR "" CACHE FILEPATH "build with a specific external
+if (NOT TARGET camp)
+  set(EXTERNAL_CAMP_SOURCE_DIR "" CACHE FILEPATH "build with a specific external
 camp source repository")
-if (EXTERNAL_CAMP_SOURCE_DIR)
-  message(STATUS "Using external source CAMP from: " ${EXTERNAL_CAMP_SOURCE_DIR})
-  add_subdirectory(${EXTERNAL_CAMP_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}/tpl/camp)
-else (EXTERNAL_CAMP_SOURCE_DIR)
-  find_package(camp QUIET)
-  if (NOT camp_FOUND)
-    message(STATUS "Using RAJA CAMP submodule.")
-    add_subdirectory(tpl/camp)
-  else (NOT camp_FOUND)
-    message(STATUS "Using installed CAMP from:  ${camp_INSTALL_PREFIX}")
-  endif(NOT camp_FOUND)
-endif (EXTERNAL_CAMP_SOURCE_DIR)
+  if (EXTERNAL_CAMP_SOURCE_DIR)
+    message(STATUS "Using external source CAMP from: " ${EXTERNAL_CAMP_SOURCE_DIR})
+    add_subdirectory(${EXTERNAL_CAMP_SOURCE_DIR}
+                     ${CMAKE_CURRENT_BINARY_DIR}/tpl/camp)
+  else (EXTERNAL_CAMP_SOURCE_DIR)
+    find_package(camp QUIET)
+    if (NOT camp_FOUND)
+      message(STATUS "Using RAJA CAMP submodule.")
+      add_subdirectory(tpl/camp)
+    else (NOT camp_FOUND)
+      message(STATUS "Using installed CAMP from:  ${camp_INSTALL_PREFIX}")
+    endif(NOT camp_FOUND)
+  endif (EXTERNAL_CAMP_SOURCE_DIR)
+endif (NOT TARGET camp)
 
 blt_add_library(
   NAME RAJA


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Checks if camp is already a cmake target before trying to use an external camp or the camp submodule
  - Fixes issue #829 
