### PR TITLE
Rename docs target

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-add_custom_target(docs)
+add_custom_target(raja-docs)
 
 if (SPHINX_FOUND)
   add_subdirectory(sphinx/user_guide)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-add_custom_target(raja-docs)
+add_custom_target(docs)
 
 if (SPHINX_FOUND)
   add_subdirectory(sphinx/user_guide)

--- a/docs/doxygen/CMakeLists.txt
+++ b/docs/doxygen/CMakeLists.txt
@@ -21,5 +21,5 @@ add_custom_target(raja-doxygen
 install(DIRECTORY ${DOXYGEN_HTML_DIR}
   DESTINATION "docs/doxygen/" OPTIONAL)
 
-add_dependencies(docs
+add_dependencies(raja-docs
   raja-doxygen)

--- a/docs/doxygen/CMakeLists.txt
+++ b/docs/doxygen/CMakeLists.txt
@@ -21,5 +21,5 @@ add_custom_target(raja-doxygen
 install(DIRECTORY ${DOXYGEN_HTML_DIR}
   DESTINATION "docs/doxygen/" OPTIONAL)
 
-add_dependencies(raja-docs
+add_dependencies(docs
   raja-doxygen)

--- a/docs/sphinx/user_guide/CMakeLists.txt
+++ b/docs/sphinx/user_guide/CMakeLists.txt
@@ -23,5 +23,5 @@ add_custom_target(raja-userguide-sphinx
 install(DIRECTORY "${SPHINX_HTML_DIR}"
         DESTINATION "docs/user_guide/sphinx/" OPTIONAL)
 
-add_dependencies(docs
+add_dependencies(raja-docs
   raja-userguide-sphinx)

--- a/docs/sphinx/user_guide/CMakeLists.txt
+++ b/docs/sphinx/user_guide/CMakeLists.txt
@@ -23,5 +23,5 @@ add_custom_target(raja-userguide-sphinx
 install(DIRECTORY "${SPHINX_HTML_DIR}"
         DESTINATION "docs/user_guide/sphinx/" OPTIONAL)
 
-add_dependencies(raja-docs
+add_dependencies(docs
   raja-userguide-sphinx)


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Renames the "docs" cmake target to "raja-docs" to avoid target conflicts