### PR TITLE
Bugfix/listsegment test memory

### DIFF
--- a/include/RAJA/index/ListSegment.hpp
+++ b/include/RAJA/index/ListSegment.hpp
@@ -299,8 +299,9 @@ public:
     : m_resource(other.m_resource), m_use_resource(other.m_use_resource),
       m_owned(Unowned), m_data(nullptr), m_size(0)
   {
+    bool from_copy_ctor = true;
     initIndexData(other.m_use_resource,
-                  other.m_data, other.m_size, other.m_owned);
+                  other.m_data, other.m_size, other.m_owned, from_copy_ctor);
   }
 
   ///
@@ -392,7 +393,8 @@ private:
   void initIndexData(bool use_resource,
                      const value_type* container,
                      Index_type len,
-                     IndexOwnership container_own)
+                     IndexOwnership container_own,
+                     bool from_copy_ctor = false)
   {
     using namespace camp::resources;
 
@@ -411,18 +413,27 @@ private:
 
       if (use_resource) {
 
-        Resource host_res{Host()};
+        if ( from_copy_ctor ) {
 
-        value_type* tmp = host_res.allocate<value_type>(m_size);
+          m_data = m_resource.allocate<value_type>(m_size);
+          m_resource.memcpy(m_data, container, sizeof(value_type) * m_size); 
 
-        for (Index_type i = 0; i < m_size; ++i) {
-          tmp[i] = container[i];
+        } else {
+
+          Resource host_res{Host()};
+
+          value_type* tmp = host_res.allocate<value_type>(m_size);
+
+          for (Index_type i = 0; i < m_size; ++i) {
+            tmp[i] = container[i];
+          }
+
+          m_data = m_resource.allocate<value_type>(m_size);
+          m_resource.memcpy(m_data, tmp, sizeof(value_type) * m_size);
+
+          host_res.deallocate(tmp);
+
         }
-
-        m_data = m_resource.allocate<value_type>(m_size);
-        m_resource.memcpy(m_data, tmp, sizeof(value_type) * m_size);
-
-        host_res.deallocate(tmp);
 
       } else {
         allocate_and_copy<Has_GPU>(RAJA::make_span(container, len));

--- a/test/functional/forall/indexset-view/tests/test-ForallIcountIndexSetView.hpp
+++ b/test/functional/forall/indexset-view/tests/test-ForallIcountIndexSetView.hpp
@@ -28,24 +28,15 @@ void ForallIcountIndexSetViewTestImpl()
 
   camp::resources::Resource working_res{WORKING_RES()};
 
-  INDEX_TYPE last_idx = 0;
-
-  IndexSetType iset; 
-  buildIndexSet<INDEX_TYPE, RangeSegType, RangeStrideSegType, ListSegType>(
-    iset, last_idx, working_res);
-
-
-  //
-  // Collect actual indices in index set for testing.
-  //
+  IndexSetType iset;
   std::vector<INDEX_TYPE> is_indices; 
-  getIndices(is_indices, iset);
+  buildIndexSet<INDEX_TYPE, RangeSegType, RangeStrideSegType, ListSegType>(
+    iset, is_indices, working_res);
 
- 
   //
   // Working array length
   //
-  const INDEX_TYPE N = last_idx + 1;
+  const INDEX_TYPE N = is_indices[ is_indices.size() - 1 ] + 1;
 
   //
   // Allocate and initialize arrays used in testing

--- a/test/functional/forall/indexset-view/tests/test-ForallIndexSetView.hpp
+++ b/test/functional/forall/indexset-view/tests/test-ForallIndexSetView.hpp
@@ -27,24 +27,15 @@ void ForallIndexSetViewTestImpl()
 
   camp::resources::Resource working_res{WORKING_RES()};
 
-  INDEX_TYPE last_idx = 0;
-
   IndexSetType iset; 
+  std::vector<INDEX_TYPE> is_indices;
   buildIndexSet<INDEX_TYPE, RangeSegType, RangeStrideSegType, ListSegType>(
-    iset, last_idx, working_res);
+    iset, is_indices, working_res);
 
-
-  //
-  // Collect actual indices in index set for testing.
-  //
-  std::vector<INDEX_TYPE> is_indices; 
-  getIndices(is_indices, iset);
-
- 
   //
   // Working array length
   //
-  const INDEX_TYPE N = last_idx + 1;
+  const INDEX_TYPE N = is_indices[ is_indices.size() - 1 ] + 1;
 
   //
   // Allocate and initialize arrays used in testing

--- a/test/functional/forall/indexset/tests/test-ForallIcountIndexSet.hpp
+++ b/test/functional/forall/indexset/tests/test-ForallIcountIndexSet.hpp
@@ -26,24 +26,15 @@ void ForallIcountIndexSetTestImpl()
 
   camp::resources::Resource working_res{WORKING_RES()};
 
-  INDEX_TYPE last_idx = 0;
-
   IndexSetType iset; 
-  buildIndexSet<INDEX_TYPE, RangeSegType, RangeStrideSegType, ListSegType>(
-    iset, last_idx, working_res);
-
-
-  //
-  // Collect actual indices in index set for testing.
-  //
   std::vector<INDEX_TYPE> is_indices; 
-  getIndices(is_indices, iset);
+  buildIndexSet<INDEX_TYPE, RangeSegType, RangeStrideSegType, ListSegType>(
+    iset, is_indices, working_res);
 
- 
   //
   // Working array length
   //
-  const INDEX_TYPE N = last_idx + 1;
+  const INDEX_TYPE N = is_indices[ is_indices.size() - 1 ] + 1;
 
   //
   // Allocate and initialize arrays used in testing

--- a/test/functional/forall/indexset/tests/test-ForallIndexSet.hpp
+++ b/test/functional/forall/indexset/tests/test-ForallIndexSet.hpp
@@ -25,24 +25,15 @@ void ForallIndexSetTestImpl()
 
   camp::resources::Resource working_res{WORKING_RES()};
 
-  INDEX_TYPE last_idx = 0;
-
   IndexSetType iset; 
-  buildIndexSet<INDEX_TYPE, RangeSegType, RangeStrideSegType, ListSegType>(
-    iset, last_idx, working_res);
-
-
-  //
-  // Collect actual indices in index set for testing.
-  //
   std::vector<INDEX_TYPE> is_indices; 
-  getIndices(is_indices, iset);
+  buildIndexSet<INDEX_TYPE, RangeSegType, RangeStrideSegType, ListSegType>(
+    iset, is_indices, working_res);
 
- 
   //
   // Working array length
   //
-  const INDEX_TYPE N = last_idx + 1;
+  const INDEX_TYPE N = is_indices[ is_indices.size() - 1 ] + 1;
 
   //
   // Allocate and initialize arrays used in testing

--- a/test/include/RAJA_test-indexset-build.hpp
+++ b/test/include/RAJA_test-indexset-build.hpp
@@ -17,6 +17,7 @@
 #include "camp/resource.hpp"
 
 #include <random>
+#include <random>
 
 //
 // Utility routine to construct index set with mix of Range, RangeStride, 
@@ -28,7 +29,7 @@ template <typename INDEX_TYPE,
           typename LIST_TYPE>
 void buildIndexSet( 
   RAJA::TypedIndexSet< RANGE_TYPE, RANGESTRIDE_TYPE, LIST_TYPE >& iset, 
-  INDEX_TYPE& last_idx,
+  std::vector<INDEX_TYPE>& indices_out,
   camp::resources::Resource& working_res )
 {
   //
@@ -51,12 +52,15 @@ void buildIndexSet(
   // Construct a mix of Range, RangeStride, and List segments 
   // and add them to index set
   //
-  INDEX_TYPE rbeg;
-  INDEX_TYPE rend;
-  INDEX_TYPE stride;
+  INDEX_TYPE rbeg = 0;
+  INDEX_TYPE rend = 0;
+  INDEX_TYPE stride = 0;
+  INDEX_TYPE last_idx = 0;
   INDEX_TYPE lseg_len = static_cast<INDEX_TYPE>( lindices.size() );
   std::vector<INDEX_TYPE> lseg(lseg_len);
   std::vector<INDEX_TYPE> lseg_vec(lseg_len);
+
+  indices_out.clear(); 
 
   // Create empty Range segment
   rbeg = 1;
@@ -68,11 +72,15 @@ void buildIndexSet(
   rbeg = 1;
   rend = 1578;
   iset.push_back(RANGE_TYPE(rbeg, rend));
+  for (INDEX_TYPE i = rbeg; i < rend; ++i) { 
+    indices_out.push_back( i ); 
+  }
   last_idx = rend;
 
   // Create List segment
   for (INDEX_TYPE i = 0; i < lseg_len; ++i) {
     lseg[i] = lindices[i] + last_idx + 3;
+    indices_out.push_back( lseg[i] );
   }
   iset.push_back(LIST_TYPE(&lseg[0], lseg_len, working_res));
   last_idx = lseg[lseg_len - 1];
@@ -80,6 +88,7 @@ void buildIndexSet(
   // Create List segment using alternate ctor
   for (INDEX_TYPE i = 0; i < lseg_len; ++i) {
     lseg_vec[i] = lindices[i] + last_idx + 3;
+    indices_out.push_back( lseg_vec[i] );
   }
   iset.push_back(LIST_TYPE(lseg_vec, working_res));
   last_idx = lseg_vec[lseg_len - 1];
@@ -89,17 +98,24 @@ void buildIndexSet(
   rend = rbeg + 2040;
   stride = 3;
   iset.push_back(RANGESTRIDE_TYPE(rbeg, rend, stride));
+  for (INDEX_TYPE i = rbeg; i < rend; i += stride) { 
+    indices_out.push_back( i ); 
+  }
   last_idx = rend;
 
   // Create Range segment
   rbeg = last_idx + 4;
   rend = rbeg + 2759;
   iset.push_back(RANGE_TYPE(rbeg, rend));
+  for (INDEX_TYPE i = rbeg; i < rend; ++i) { 
+    indices_out.push_back( i ); 
+  }
   last_idx = rend;
 
   // Create List segment
   for (INDEX_TYPE i = 0; i < lseg_len; ++i) {
     lseg[i] = lindices[i] + last_idx + 5;
+    indices_out.push_back( lseg[i] );
   }
   iset.push_back(LIST_TYPE(&lseg[0], lseg_len, working_res));
   last_idx = lseg[lseg_len - 1];
@@ -108,11 +124,15 @@ void buildIndexSet(
   rbeg = last_idx + 1;
   rend = rbeg + 320;
   iset.push_back(RANGE_TYPE(rbeg, rend));
+  for (INDEX_TYPE i = rbeg; i < rend; ++i) { 
+    indices_out.push_back( i ); 
+  }
   last_idx = rend;
 
   // Create List segment using alternate ctor
   for (INDEX_TYPE i = 0; i < lseg_len; ++i) {
     lseg_vec[i] = lindices[i] + last_idx + 7;
+    indices_out.push_back( lseg_vec[i] );
   }
   iset.push_back(LIST_TYPE(lseg_vec, working_res));
   last_idx = lseg_vec[lseg_len - 1];


### PR DESCRIPTION
# Summary

- This PR addresses two issues, one involving memory usage in indexset tests, and one involving memory management in the list segment copy ctor.
- The indexset tests now pass with all back-ends, in particular with openmp target.