### PR TITLE
add kernel statement sanity test

### DIFF
--- a/include/RAJA/pattern/kernel/internal/Statement.hpp
+++ b/include/RAJA/pattern/kernel/internal/Statement.hpp
@@ -19,6 +19,8 @@
 #define RAJA_pattern_kernel_internal_Statement_HPP
 
 #include "RAJA/pattern/kernel/internal/StatementList.hpp"
+#include <type_traits>
+#include <camp/camp.hpp>
 
 namespace RAJA
 {
@@ -29,6 +31,8 @@ namespace internal
 
 template <typename ExecPolicy, typename... EnclosedStmts>
 struct Statement {
+  static_assert(std::is_same<ExecPolicy, camp::nil>::value || sizeof...(EnclosedStmts) > 0,
+      "Executable statement with no enclosed statements, this is almost certainly a bug");
   Statement() = delete;
 
   using enclosed_statements_t = StatementList<EnclosedStmts...>;


### PR DESCRIPTION
All of our kernel statements that take enclosing statements, except
reduction, really need those enclosing statements.  After helping Will
debug some kernel shared memory code this morning, we worked out what
seems like a surprisingly nice way to catch most of this class of
errors. Everywhere we have a statement that either doesn't need or can't
take nested statements, it uses camp::nil as the policy, so this checks
for either camp::nil as the policy or at least one nested statement.
All of our tests in raja compile and run correctly with this in there,
but if I add say `statement::For<0, seq_exec>,` to a kernel policy it
errors out with this.  Same for if I put in an `InitSharedMem` and
forget to nest the rest of the policy (or at least something) under
it.

We might be able to go farther, and have a check that ensures that the
bottom thing is a camp::nil policy item, or that there's a lambda
underneath something somewhere unless the thing is a camp::nil policy,
but this seemed like a good quick compromise thing to get us better
errors.

