### PR TITLE
Adjust forall execpols to exercise openmp stuff properly.

### DIFF
--- a/test/include/RAJA_test-forall-execpol.hpp
+++ b/test/include/RAJA_test-forall-execpol.hpp
@@ -34,26 +34,21 @@ using SequentialForallAtomicExecPols = camp::list< RAJA::seq_exec,
 
 #if defined(RAJA_ENABLE_OPENMP)
 using OpenMPForallExecPols = 
-  camp::list< // This policy works for the tests, but commenting it out
-              // since its usage is questionable
-              // RAJA::omp_parallel_exec<RAJA::seq_exec>,
-              RAJA::omp_parallel_for_exec, 
-              RAJA::omp_for_nowait_exec,
-              RAJA::omp_for_exec >;
+  camp::list< RAJA::omp_parallel_for_exec, 
+              RAJA::omp_parallel_exec<RAJA::omp_for_nowait_exec>,
+              RAJA::omp_parallel_exec<RAJA::omp_for_exec> >;
 
 using OpenMPForallReduceExecPols = OpenMPForallExecPols;
 
 using OpenMPForallAtomicExecPols =
-  camp::list< // This policy works for the tests, but commenting it out
-              // since its usage is questionable
-              // RAJA::omp_parallel_exec<RAJA::seq_exec>,
+  camp::list< RAJA::omp_parallel_for_exec
 #if defined(RAJA_TEST_EXHAUSTIVE)
-              RAJA::omp_parallel_for_exec, 
-              RAJA::omp_for_nowait_exec,
+              , RAJA::omp_parallel_exec<RAJA::omp_for_nowait_exec>
+              , RAJA::omp_parallel_exec<RAJA::omp_for_exec>
 #endif
-              RAJA::omp_for_exec >;
+            >; 
 
-#endif
+#endif  // RAJA_ENABLE_OPENMP
 
 #if defined(RAJA_ENABLE_TBB)
 using TBBForallExecPols = camp::list< RAJA::tbb_for_exec,


### PR DESCRIPTION

# Summary

- This PR adjusts the OpenMP exec policies in our forall tests. 
- Previous use of 'omp_for_*' policies was running all iterations on thread zero since no openmp parallel region was created. Probably not what we want to test.