### PR TITLE
Correct spelling of portable in README/User Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To cite RAJA, please use the following references:
 
 * RAJA Performance Portability Layer. https://github.com/LLNL/RAJA
 
-* D. A. Beckingsale, J. Burmark, R. Hornung, H. Jones, W. Killian, A. J. Kunen, O. Pearce, P. Robinson, B. S. Ryujin, T. R. W. Scogland, "RAJA: Porrtable Performance for Large-Scale Scientific Applications", 2019 IEEE/ACM International Workshop on Performance, Portability and Productivity in HPC (P3HPC). [Download here](https://conferences.computer.org/sc19w/2019/#!/toc/14)
+* D. A. Beckingsale, J. Burmark, R. Hornung, H. Jones, W. Killian, A. J. Kunen, O. Pearce, P. Robinson, B. S. Ryujin, T. R. W. Scogland, "RAJA: Portable Performance for Large-Scale Scientific Applications", 2019 IEEE/ACM International Workshop on Performance, Portability and Productivity in HPC (P3HPC). [Download here](https://conferences.computer.org/sc19w/2019/#!/toc/14)
 
 Related Software
 --------------------


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Fixes apparent spelling mistake on line 81 of the README