### PR TITLE
work around nvcc tuple copy constructor generation bug

### DIFF
--- a/include/RAJA/pattern/kernel/internal/LoopData.hpp
+++ b/include/RAJA/pattern/kernel/internal/LoopData.hpp
@@ -119,24 +119,14 @@ struct LoopData {
   const BodiesTuple bodies;
   offset_tuple_t offset_tuple;
 
-  RAJA_INLINE RAJA_HOST_DEVICE
+  RAJA_INLINE RAJA_HOST_DEVICE constexpr
   LoopData(SegmentTuple const &s, ParamTuple const &p, Bodies const &... b)
       : segment_tuple(s), param_tuple(p), bodies(b...)
   {
     //assign_begin_all();
   }
-
-  template <typename SegmentTuple0,
-            typename ParamTuple0,
-            typename... Bodies0>
-  RAJA_INLINE RAJA_HOST_DEVICE constexpr LoopData(
-      LoopData<SegmentTuple0, ParamTuple0, Bodies0...> &c)
-      : segment_tuple(c.segment_tuple),
-        param_tuple(c.param_tuple),
-        bodies(c.bodies),
-        offset_tuple(c.offset_tuple)
-  {
-  }
+  constexpr LoopData(LoopData const &) = default;
+  constexpr LoopData(LoopData &&) = default;
 
   template <camp::idx_t Idx, typename IndexT>
   RAJA_HOST_DEVICE RAJA_INLINE void assign_offset(IndexT const &i)

--- a/include/RAJA/pattern/kernel/internal/LoopData.hpp
+++ b/include/RAJA/pattern/kernel/internal/LoopData.hpp
@@ -119,7 +119,7 @@ struct LoopData {
   const BodiesTuple bodies;
   offset_tuple_t offset_tuple;
 
-  RAJA_INLINE
+  RAJA_INLINE RAJA_HOST_DEVICE
   LoopData(SegmentTuple const &s, ParamTuple const &p, Bodies const &... b)
       : segment_tuple(s), param_tuple(p), bodies(b...)
   {


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following (modify list as needed):
  - Modifies/refactors LoopData to be able to be constructed from parts on the device
  - Fixes the tuple copy constructor warning issue for the segment tuple of the LoopData object by making the initial constructor host/device, which causes the copy constructor to generate appropriately
  - Removes slightly odd, possibly dangerous, "similar" LoopData copy construction, since we have no cases of assigning different but similar LoopData objects this way.


I should note, it seems as though this is an entirely RAJA-side fix.  There's an alternate method we could use to address this, but it would increase compile time for all usages of the tuple, where this should be a smaller increase only for the LoopData class.