### PR TITLE
Add namespace to pluginLinker

### DIFF
--- a/include/RAJA/util/PluginLinker.hpp
+++ b/include/RAJA/util/PluginLinker.hpp
@@ -12,7 +12,7 @@
 #include "RAJA/util/KokkosPluginLoader.hpp"
 
 namespace {
-  namespace RAJA {
+  namespace anonymous_RAJA {
     struct pluginLinker {
       inline pluginLinker() {
         (void)RAJA::util::linkRuntimePluginLoader();

--- a/include/RAJA/util/PluginLinker.hpp
+++ b/include/RAJA/util/PluginLinker.hpp
@@ -12,11 +12,13 @@
 #include "RAJA/util/KokkosPluginLoader.hpp"
 
 namespace {
-  struct pluginLinker {
-    inline pluginLinker() {
-      (void)RAJA::util::linkRuntimePluginLoader();
-      (void)RAJA::util::linkKokkosPluginLoader();
-    }
-  } pluginLinker;
+  namespace RAJA {
+    struct pluginLinker {
+      inline pluginLinker() {
+        (void)RAJA::util::linkRuntimePluginLoader();
+        (void)RAJA::util::linkKokkosPluginLoader();
+      }
+    } pluginLinker;
+  }
 }
 #endif


### PR DESCRIPTION
# Summary
Add RAJA namespace to pluginLinker to avoid collision with CHAI.
This is needed because anonymous namespaces in headers are all the same for the same source file.
Not that I am using anonymous_RAJA to avoid potential conflicts between ::RAJA and ::\<anonymous\>::RAJA, and am open to other suggestions.