### PR TITLE
Use explicit CAMP namespace names 

### DIFF
--- a/include/RAJA/index/ListSegment.hpp
+++ b/include/RAJA/index/ListSegment.hpp
@@ -217,11 +217,10 @@ public:
     : m_resource(resource), m_use_resource(true),
       m_owned(Unowned), m_data(nullptr), m_size(container.size())
   {
-    using namespace camp::resources;
 
     if (m_size > 0) {
 
-      Resource host_res{Host()};
+      camp::resources::Resource host_res{camp::resources::Host()};
 
       value_type* tmp = host_res.allocate<value_type>(m_size);
 
@@ -398,7 +397,6 @@ private:
                      IndexOwnership container_own,
                      bool from_copy_ctor = false)
   {
-    using namespace camp::resources;
 
     // empty list segment
     if (len <= 0 || container == nullptr) {
@@ -422,7 +420,7 @@ private:
 
         } else {
 
-          Resource host_res{Host()};
+          camp::resources::Resource host_res{camp::resources::Host()};
 
           value_type* tmp = host_res.allocate<value_type>(m_size);
 

--- a/include/RAJA/util/concepts.hpp
+++ b/include/RAJA/util/concepts.hpp
@@ -34,7 +34,7 @@ using namespace camp::concepts;
 
 template <typename From, typename To>
 struct ConvertibleTo
-  : DefineConcept(convertible_to<To>(camp::val<From>())) {
+  : DefineConcept(::RAJA::concepts::convertible_to<To>(camp::val<From>())) {
 };
 
 }


### PR DESCRIPTION
# Summary

- This PR is a refactoring
- It does the following:
    -Uses explicit namespaces as it simplifies integrating RAJA in build systems. 

Note this is unexpected as  using namespace ``camp::resources;`` was defined within scope. 
