### PR TITLE
Squash compiler warnings for CPU builds

### DIFF
--- a/examples/raja-teams.cpp
+++ b/examples/raja-teams.cpp
@@ -119,13 +119,15 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     // Allocate memory for either host or device
     int N_tri = 5;
 
-    int *Ddat;
-    if (select_cpu_or_gpu == RAJA::expt::HOST)
+    int* Ddat = nullptr;
+    if (select_cpu_or_gpu == RAJA::expt::HOST) {
       Ddat = host_res.allocate<int>(N_tri * N_tri);
+    }
 
 #if defined(RAJA_DEVICE_ACTIVE)
-    if (select_cpu_or_gpu == RAJA::expt::DEVICE)
+    if (select_cpu_or_gpu == RAJA::expt::DEVICE) {
       Ddat = device_res.allocate<int>(N_tri * N_tri);
+    }
 #endif
 
     /*

--- a/include/RAJA/pattern/teams/teams_sequential.hpp
+++ b/include/RAJA/pattern/teams/teams_sequential.hpp
@@ -35,7 +35,8 @@ struct seq_launch_t {
 template <>
 struct LaunchExecute<RAJA::expt::null_launch_t> {
   template <typename BODY>
-  static void exec(LaunchContext const &ctx, BODY const &body)
+  static void exec(LaunchContext const& RAJA_UNUSED_ARG(ctx), 
+                   BODY const& RAJA_UNUSED_ARG(body))
   {
     RAJA_ABORT_OR_THROW("NULL Launch");
   }


### PR DESCRIPTION
# Summary

- This PR squashes warnings in the raja teams implementation code and example for CPU builds.