### PR TITLE
Add missing header for max_align_t

### DIFF
--- a/include/RAJA/pattern/WorkGroup/WorkStruct.hpp
+++ b/include/RAJA/pattern/WorkGroup/WorkStruct.hpp
@@ -21,6 +21,7 @@
 #include "RAJA/config.hpp"
 
 #include <utility>
+#include <cstddef>
 
 #include "RAJA/pattern/WorkGroup/Vtable.hpp"
 


### PR DESCRIPTION
# Add missing include

- This PR is a bugfix
- It does the following:
  - Fixes compile issue where std::max_align_t is not defined.