### PR TITLE
MultiView CHAI Integration

### DIFF
--- a/include/RAJA/util/View.hpp
+++ b/include/RAJA/util/View.hpp
@@ -198,22 +198,24 @@ RAJA_HOST_DEVICE RAJA_INLINE auto removenth( Lay lyout, Tup&& tup ) ->
 template <typename ValueType,
           typename LayoutType,
           RAJA::Index_type P2Pidx = 0,
-          typename PointerType = ValueType **>
+          typename PointerType = ValueType **,
+          typename NonConstPointerType =
+              camp::type::ptr::add< // adds *
+                camp::type::ptr::add<
+                  camp::type::cv::rem<  // removes cv
+                    camp::type::ptr::rem<
+                      camp::type::ptr::rem<PointerType>  // removes *
+                    >
+                  >
+                >
+              >
+          >
 struct MultiView {
   using value_type = ValueType;
   using pointer_type = PointerType;
   using layout_type = LayoutType;
   using nc_value_type = camp::decay<value_type>;
-  using nc_pointer_type =  
-    camp::type::ptr::add< // adds *
-      camp::type::ptr::add<
-        camp::type::cv::rem<  // removes cv
-          camp::type::ptr::rem<
-            camp::type::ptr::rem<pointer_type>  // removes *
-          >
-        >
-      >
-    >;
+  using nc_pointer_type = NonConstPointerType;
   using NonConstView = MultiView<nc_value_type, layout_type, P2Pidx, nc_pointer_type>;
 
   layout_type const layout;

--- a/test/unit/view-layout/test-multiview.cpp
+++ b/test/unit/view-layout/test-multiview.cpp
@@ -65,6 +65,20 @@ TYPED_TEST(MultiViewUnitTest, Constructors)
 
   // construct a const MultiView from a const MultiView
   RAJA::MultiView<TypeParam const, layout, 1> const_view1p2(const_view1p);
+
+
+  // non-default construction of MultiView with array-of-pointers index moved to 1st position
+  // and non-const pointer type specification (used in CHAI)
+  RAJA::MultiView<TypeParam, layout, 1, TypeParam **> view1pnc(data, layout(10));
+
+  // construct a non-const MultiView from a non-const MultiView
+  RAJA::MultiView<TypeParam, layout, 1, TypeParam **> view1pnc2(view1pnc);
+
+  // construct a const MultiView from a non-const MultiView
+  RAJA::MultiView<TypeParam const, layout, 1, TypeParam **> const_view1pnc(view1pnc);
+
+  // construct a const MultiView from a const MultiView
+  RAJA::MultiView<TypeParam const, layout, 1, TypeParam **> const_view1pnc2(const_view1pnc);
 }
 
 TYPED_TEST(MultiViewUnitTest, Accessor)


### PR DESCRIPTION
# Summary

- This PR is an update:
  - Modifies MultiView to allow better CHAI integration. The compiler has difficulty deducing the non-const version of the array-of-pointers in MultiView when a CHAI::ManagedArray is the set of pointers. Allowing a custom non-const type to be passed in as a template parameter resolves this, while the default remains the same cv-removed type as before. Following this PR, there will be a corresponding CHAI PR uses this ability.