### PR TITLE
make common iterable and view types trivially copyable

### DIFF
--- a/include/RAJA/index/IndexValue.hpp
+++ b/include/RAJA/index/IndexValue.hpp
@@ -49,7 +49,11 @@ struct IndexValue : public IndexValueBase {
   using value_type = VALUE;
 
   //! Default constructor initializes value to 0.
-  RAJA_HOST_DEVICE RAJA_INLINE constexpr IndexValue() : value(0) {}
+  RAJA_INLINE constexpr IndexValue() = default;
+  constexpr RAJA_INLINE IndexValue(IndexValue const &) = default;
+  constexpr RAJA_INLINE IndexValue(IndexValue &&) = default;
+  RAJA_INLINE IndexValue &operator=(IndexValue const &) = default;
+  RAJA_INLINE IndexValue &operator=(IndexValue &&) = default;
 
   /*!
    * \brief Explicit constructor.
@@ -272,7 +276,7 @@ struct IndexValue : public IndexValueBase {
   static std::string getName();
 
 protected:
-  value_type value;
+  value_type value = 0;
 };
 
 namespace internal

--- a/include/RAJA/index/RangeSegment.hpp
+++ b/include/RAJA/index/RangeSegment.hpp
@@ -102,28 +102,16 @@ struct TypedRangeSegment {
   RAJA_HOST_DEVICE TypedRangeSegment() = delete;
 
   //! move constructor
-  RAJA_HOST_DEVICE constexpr TypedRangeSegment(TypedRangeSegment&& o)
-      : m_begin(std::move(o.m_begin)), m_end(std::move(o.m_end))
-  {
-  }
+  constexpr TypedRangeSegment(TypedRangeSegment&& o) = default;
 
   //! copy constructor
-  RAJA_HOST_DEVICE constexpr TypedRangeSegment(TypedRangeSegment const& o)
-      : m_begin(o.m_begin), m_end(o.m_end)
-  {
-  }
+  constexpr TypedRangeSegment(TypedRangeSegment const& o) = default;
 
   //! copy assignment
-  RAJA_HOST_DEVICE RAJA_INLINE TypedRangeSegment& operator=(
-      TypedRangeSegment const& o)
-  {
-    m_begin = o.m_begin;
-    m_end = o.m_end;
-    return *this;
-  }
+  RAJA_INLINE TypedRangeSegment& operator=(TypedRangeSegment const& o) = default;
 
   //! destructor
-  RAJA_HOST_DEVICE RAJA_INLINE ~TypedRangeSegment() {}
+  RAJA_INLINE ~TypedRangeSegment() = default;
 
   //! swap one TypedRangeSegment with another
   /*!
@@ -301,34 +289,19 @@ struct TypedRangeStrideSegment {
   }
 
   //! disable compiler generated constructor
-  RAJA_HOST_DEVICE TypedRangeStrideSegment() = delete;
+  TypedRangeStrideSegment() = delete;
 
   //! move constructor
-  RAJA_HOST_DEVICE TypedRangeStrideSegment(TypedRangeStrideSegment&& o)
-      : m_begin(std::move(o.m_begin)),
-        m_end(std::move(o.m_end)),
-        m_size(std::move(o.m_size))
-  {
-  }
+  TypedRangeStrideSegment(TypedRangeStrideSegment&& o) = default;
 
   //! copy constructor
-  RAJA_HOST_DEVICE TypedRangeStrideSegment(TypedRangeStrideSegment const& o)
-      : m_begin(o.m_begin), m_end(o.m_end), m_size(o.m_size)
-  {
-  }
+  TypedRangeStrideSegment(TypedRangeStrideSegment const& o) = default;
 
   //! copy assignment
-  RAJA_HOST_DEVICE TypedRangeStrideSegment& operator=(
-      TypedRangeStrideSegment const& o)
-  {
-    m_begin = o.m_begin;
-    m_end = o.m_end;
-    m_size = o.m_size;
-    return *this;
-  }
+  TypedRangeStrideSegment& operator=(TypedRangeStrideSegment const& o) = default;
 
   //! destructor
-  RAJA_HOST_DEVICE ~TypedRangeStrideSegment() {}
+  ~TypedRangeStrideSegment() = default;
 
   //! swap one TypedRangeStrideSegment with another
   /*!

--- a/include/RAJA/index/RangeSegment.hpp
+++ b/include/RAJA/index/RangeSegment.hpp
@@ -102,13 +102,13 @@ struct TypedRangeSegment {
   RAJA_HOST_DEVICE TypedRangeSegment() = delete;
 
   //! move constructor
-  constexpr TypedRangeSegment(TypedRangeSegment&& o) = default;
+  constexpr TypedRangeSegment(TypedRangeSegment&&) = default;
 
   //! copy constructor
-  constexpr TypedRangeSegment(TypedRangeSegment const& o) = default;
+  constexpr TypedRangeSegment(TypedRangeSegment const&) = default;
 
   //! copy assignment
-  RAJA_INLINE TypedRangeSegment& operator=(TypedRangeSegment const& o) = default;
+  RAJA_INLINE TypedRangeSegment& operator=(TypedRangeSegment const&) = default;
 
   //! destructor
   RAJA_INLINE ~TypedRangeSegment() = default;
@@ -292,13 +292,13 @@ struct TypedRangeStrideSegment {
   TypedRangeStrideSegment() = delete;
 
   //! move constructor
-  TypedRangeStrideSegment(TypedRangeStrideSegment&& o) = default;
+  TypedRangeStrideSegment(TypedRangeStrideSegment&&) = default;
 
   //! copy constructor
-  TypedRangeStrideSegment(TypedRangeStrideSegment const& o) = default;
+  TypedRangeStrideSegment(TypedRangeStrideSegment const&) = default;
 
   //! copy assignment
-  TypedRangeStrideSegment& operator=(TypedRangeStrideSegment const& o) = default;
+  TypedRangeStrideSegment& operator=(TypedRangeStrideSegment const&) = default;
 
   //! destructor
   ~TypedRangeStrideSegment() = default;

--- a/include/RAJA/internal/Iterators.hpp
+++ b/include/RAJA/internal/Iterators.hpp
@@ -113,25 +113,12 @@ public:
   using reference = value_type&;
   using iterator_category = std::random_access_iterator_tag;
 
-  RAJA_HOST_DEVICE constexpr numeric_iterator() {}
-  RAJA_HOST_DEVICE constexpr numeric_iterator(const numeric_iterator& rhs)
-      : val(rhs.val)
-  {
-  }
-  RAJA_HOST_DEVICE constexpr numeric_iterator(numeric_iterator&& rhs)
-      : val(rhs.val)
-  {
-  }
-  RAJA_HOST_DEVICE numeric_iterator& operator=(const numeric_iterator& rhs)
-  {
-    val = rhs.val;
-    return *this;
-  }
-  RAJA_HOST_DEVICE numeric_iterator& operator=(numeric_iterator&& rhs)
-  {
-    val = rhs.val;
-    return *this;
-  }
+  constexpr numeric_iterator() noexcept = default;
+  constexpr numeric_iterator(const numeric_iterator& rhs) noexcept = default;
+  constexpr numeric_iterator(numeric_iterator&& rhs) noexcept = default;
+  numeric_iterator& operator=(const numeric_iterator& rhs) noexcept = default;
+  numeric_iterator& operator=(numeric_iterator&& rhs) noexcept = default;
+
   RAJA_HOST_DEVICE constexpr numeric_iterator(const stripped_value_type& rhs)
       : val(rhs)
   {
@@ -299,30 +286,11 @@ public:
   using reference = DifferenceType&;
   using iterator_category = std::random_access_iterator_tag;
 
-  RAJA_HOST_DEVICE constexpr strided_numeric_iterator() {}
-  RAJA_HOST_DEVICE constexpr strided_numeric_iterator(
-      const strided_numeric_iterator& rhs)
-      : val(rhs.val), stride(rhs.stride)
-  {
-  }
-  RAJA_HOST_DEVICE constexpr strided_numeric_iterator(strided_numeric_iterator&& rhs)
-      : val(rhs.val), stride(rhs.stride)
-  {
-  }
-  RAJA_HOST_DEVICE strided_numeric_iterator& operator=(
-      const strided_numeric_iterator& rhs)
-  {
-    val = rhs.val;
-    stride = rhs.stride;
-    return *this;
-  }
-  RAJA_HOST_DEVICE strided_numeric_iterator& operator=(
-      strided_numeric_iterator&& rhs)
-  {
-    val = rhs.val;
-    stride = rhs.stride;
-    return *this;
-  }
+  constexpr strided_numeric_iterator() noexcept = default;
+  constexpr strided_numeric_iterator(const strided_numeric_iterator& rhs) noexcept = default;
+  constexpr strided_numeric_iterator(strided_numeric_iterator&& rhs) noexcept = default;
+  strided_numeric_iterator& operator=(const strided_numeric_iterator& rhs) noexcept = default;
+  strided_numeric_iterator& operator=(strided_numeric_iterator&& rhs) noexcept = default;
 
   RAJA_HOST_DEVICE constexpr strided_numeric_iterator(
       stripped_value_type rhs,

--- a/include/RAJA/internal/Iterators.hpp
+++ b/include/RAJA/internal/Iterators.hpp
@@ -114,10 +114,10 @@ public:
   using iterator_category = std::random_access_iterator_tag;
 
   constexpr numeric_iterator() noexcept = default;
-  constexpr numeric_iterator(const numeric_iterator& rhs) noexcept = default;
-  constexpr numeric_iterator(numeric_iterator&& rhs) noexcept = default;
-  numeric_iterator& operator=(const numeric_iterator& rhs) noexcept = default;
-  numeric_iterator& operator=(numeric_iterator&& rhs) noexcept = default;
+  constexpr numeric_iterator(const numeric_iterator&) noexcept = default;
+  constexpr numeric_iterator(numeric_iterator&&) noexcept = default;
+  numeric_iterator& operator=(const numeric_iterator&) noexcept = default;
+  numeric_iterator& operator=(numeric_iterator&&) noexcept = default;
 
   RAJA_HOST_DEVICE constexpr numeric_iterator(const stripped_value_type& rhs)
       : val(rhs)
@@ -287,10 +287,10 @@ public:
   using iterator_category = std::random_access_iterator_tag;
 
   constexpr strided_numeric_iterator() noexcept = default;
-  constexpr strided_numeric_iterator(const strided_numeric_iterator& rhs) noexcept = default;
-  constexpr strided_numeric_iterator(strided_numeric_iterator&& rhs) noexcept = default;
-  strided_numeric_iterator& operator=(const strided_numeric_iterator& rhs) noexcept = default;
-  strided_numeric_iterator& operator=(strided_numeric_iterator&& rhs) noexcept = default;
+  constexpr strided_numeric_iterator(const strided_numeric_iterator&) noexcept = default;
+  constexpr strided_numeric_iterator(strided_numeric_iterator&&) noexcept = default;
+  strided_numeric_iterator& operator=(const strided_numeric_iterator&) noexcept = default;
+  strided_numeric_iterator& operator=(strided_numeric_iterator&&) noexcept = default;
 
   RAJA_HOST_DEVICE constexpr strided_numeric_iterator(
       stripped_value_type rhs,

--- a/include/RAJA/pattern/detail/reduce.hpp
+++ b/include/RAJA/pattern/detail/reduce.hpp
@@ -135,8 +135,8 @@ public:
   ValueLoc &operator=(ValueLoc const &other) { val = other.val; loc = other.loc; return *this;}
 #else
   constexpr ValueLoc() = default;
-  constexpr ValueLoc(ValueLoc const &other) = default;
-  ValueLoc &operator=(ValueLoc const &other) = default;
+  constexpr ValueLoc(ValueLoc const &) = default;
+  ValueLoc &operator=(ValueLoc const &) = default;
 #endif
 
   RAJA_HOST_DEVICE constexpr ValueLoc(T const &val_) : val{val_}, loc{DefaultLoc<IndexType>().value()} {}

--- a/include/RAJA/util/Layout.hpp
+++ b/include/RAJA/util/Layout.hpp
@@ -106,21 +106,22 @@ public:
   static constexpr IdxLin limit = RAJA::operators::limits<IdxLin>::max();
   static constexpr ptrdiff_t stride1_dim = StrideOneDim;
 
-  // const char *index_types[sizeof...(RangeInts)];
-
-  IdxLin sizes[n_dims];
-  IdxLin strides[n_dims];
-  IdxLin inv_strides[n_dims];
-  IdxLin inv_mods[n_dims];
+  IdxLin sizes[n_dims] = {0};
+  IdxLin strides[n_dims] = {0};
+  IdxLin inv_strides[n_dims] = {0};
+  IdxLin inv_mods[n_dims] = {0};
 
 
   /*!
    * Default constructor with zero sizes and strides.
    */
-  RAJA_INLINE RAJA_HOST_DEVICE constexpr LayoutBase_impl()
-      : sizes{0}, strides{0}, inv_strides{0}, inv_mods{0}
-  {
-  }
+  constexpr RAJA_INLINE LayoutBase_impl() = default;
+  constexpr RAJA_INLINE LayoutBase_impl(LayoutBase_impl const &) = default;
+  constexpr RAJA_INLINE LayoutBase_impl(LayoutBase_impl &&) = default;
+  RAJA_INLINE LayoutBase_impl &operator=(LayoutBase_impl const &) =
+      default;
+  RAJA_INLINE LayoutBase_impl &operator=(LayoutBase_impl &&) =
+      default;
 
   /*!
    * Construct a layout given the size of each dimension.
@@ -139,7 +140,7 @@ public:
   }
 
   /*!
-   *  Copy ctor.
+   *  Templated copy ctor from simillar layout.
    */
   template <typename CIdxLin, ptrdiff_t CStrideOneDim>
   constexpr RAJA_INLINE RAJA_HOST_DEVICE LayoutBase_impl(

--- a/include/RAJA/util/View.hpp
+++ b/include/RAJA/util/View.hpp
@@ -76,10 +76,10 @@ struct View {
   }
 
   constexpr View() = delete;
-  RAJA_INLINE constexpr View(View const &V) = default;
-  RAJA_INLINE constexpr View(View &&V) = default;
-  RAJA_INLINE View& operator=(View const &V) = default;
-  RAJA_INLINE View& operator=(View &&V) = default;
+  RAJA_INLINE constexpr View(View const &) = default;
+  RAJA_INLINE constexpr View(View &&) = default;
+  RAJA_INLINE View& operator=(View const &) = default;
+  RAJA_INLINE View& operator=(View &&) = default;
 
   template <bool IsConstView = std::is_const<value_type>::value>
   RAJA_INLINE constexpr View(
@@ -222,10 +222,10 @@ struct MultiView {
   {
   }
 
-  RAJA_INLINE constexpr MultiView(MultiView const &V) = default;
-  RAJA_INLINE constexpr MultiView(MultiView &&V) = default;
-  RAJA_INLINE MultiView& operator=(MultiView const &V) = default;
-  RAJA_INLINE MultiView& operator=(MultiView &&V) = default;
+  RAJA_INLINE constexpr MultiView(MultiView const &) = default;
+  RAJA_INLINE constexpr MultiView(MultiView &&) = default;
+  RAJA_INLINE MultiView& operator=(MultiView const &) = default;
+  RAJA_INLINE MultiView& operator=(MultiView &&) = default;
 
   template <bool IsConstView = std::is_const<value_type>::value>
   RAJA_INLINE constexpr MultiView(

--- a/include/RAJA/util/View.hpp
+++ b/include/RAJA/util/View.hpp
@@ -75,14 +75,11 @@ struct View {
   {
   }
 
-  // We found the compiler-generated copy constructor does not actually
-  // copy-construct the object on the device in certain nvcc versions. By
-  // explicitly defining the copy constructor we are able ensure proper
-  // behavior. Git-hub pull request link https://github.com/LLNL/RAJA/pull/477
-  RAJA_INLINE RAJA_HOST_DEVICE constexpr View(View const &V)
-      : layout(V.layout), data(V.data)
-  {
-  }
+  constexpr View() = delete;
+  RAJA_INLINE constexpr View(View const &V) = default;
+  RAJA_INLINE constexpr View(View &&V) = default;
+  RAJA_INLINE View& operator=(View const &V) = default;
+  RAJA_INLINE View& operator=(View &&V) = default;
 
   template <bool IsConstView = std::is_const<value_type>::value>
   RAJA_INLINE constexpr View(
@@ -225,14 +222,10 @@ struct MultiView {
   {
   }
 
-  // We found the compiler-generated copy constructor does not actually
-  // copy-construct the object on the device in certain nvcc versions. By
-  // explicitly defining the copy constructor we are able ensure proper
-  // behavior. Git-hub pull request link https://github.com/LLNL/RAJA/pull/477
-  RAJA_INLINE RAJA_HOST_DEVICE constexpr MultiView(MultiView const &V)
-      : layout(V.layout), data(V.data)
-  {
-  }
+  RAJA_INLINE constexpr MultiView(MultiView const &V) = default;
+  RAJA_INLINE constexpr MultiView(MultiView &&V) = default;
+  RAJA_INLINE MultiView& operator=(MultiView const &V) = default;
+  RAJA_INLINE MultiView& operator=(MultiView &&V) = default;
 
   template <bool IsConstView = std::is_const<value_type>::value>
   RAJA_INLINE constexpr MultiView(

--- a/scripts/lc-builds/blueos_clang-ibm-2019.10.03_omptarget.sh
+++ b/scripts/lc-builds/blueos_clang-ibm-2019.10.03_omptarget.sh
@@ -25,10 +25,6 @@ cmake \
   -DENABLE_TARGET_OPENMP=On \
   -DOpenMP_CXX_FLAGS="-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda" \
   -DENABLE_ALL_WARNINGS=Off \
-  -DENABLE_TESTS=Off \
-  -DENABLE_EXAMPLES=Off \
-  -DENABLE_EXERCISES=Off \
-  -DENABLE_REPRODUCERS=On \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
   "$@" \
   ..

--- a/scripts/lc-builds/blueos_xl-2020.06.25.sh
+++ b/scripts/lc-builds/blueos_xl-2020.06.25.sh
@@ -19,10 +19,6 @@ cmake \
   -DCMAKE_CXX_COMPILER=/usr/tce/packages/xl/xl-2020.06.25/bin/xlc++_r \
   -C ../host-configs/lc-builds/blueos/xl_X.cmake \
   -DENABLE_OPENMP=On \
-  -DENABLE_TESTS=Off \
-  -DENABLE_EXAMPLES=Off \
-  -DENABLE_EXERCISES=Off \
-  -DENABLE_REPRODUCERS=On \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
   "$@" \
   ..

--- a/scripts/lc-builds/blueos_xl-2020.06.25_omptarget.sh
+++ b/scripts/lc-builds/blueos_xl-2020.06.25_omptarget.sh
@@ -20,10 +20,6 @@ cmake \
   -C ../host-configs/lc-builds/blueos/xl_X.cmake \
   -DENABLE_OPENMP=On \
   -DENABLE_TARGET_OPENMP=On \
-  -DENABLE_TESTS=Off \
-  -DENABLE_EXAMPLES=Off \
-  -DENABLE_EXERCISES=Off \
-  -DENABLE_REPRODUCERS=On \
   -DOpenMP_CXX_FLAGS="-qoffload;-qsmp=omp;-qnoeh;-qalias=noansi" \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
   "$@" \

--- a/scripts/lc-builds/toss3_clang9.0.0.sh
+++ b/scripts/lc-builds/toss3_clang9.0.0.sh
@@ -19,10 +19,6 @@ cmake \
   -DCMAKE_CXX_COMPILER=/usr/tce/packages/clang/clang-9.0.0/bin/clang++ \
   -C ../host-configs/lc-builds/toss3/clang_X.cmake \
   -DENABLE_OPENMP=On \
-  -DENABLE_TESTS=Off \
-  -DENABLE_EXAMPLES=Off \
-  -DENABLE_EXERCISES=Off \
-  -DENABLE_REPRODUCERS=On \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
   "$@" \
   .. 

--- a/test/functional/forall/segment-view/tests/test-forall-ListSegmentView.hpp
+++ b/test/functional/forall/segment-view/tests/test-forall-ListSegmentView.hpp
@@ -57,7 +57,20 @@ void ForallListSegmentViewTestImpl(INDEX_TYPE N)
     test_array[ idx_array[i] ] = idx_array[i];
   }
 
-  using view_type = RAJA::View< INDEX_TYPE, RAJA::Layout<1, INDEX_TYPE, 0> >;
+  using layout_type = RAJA::Layout<1, INDEX_TYPE, 0>;
+  using view_type = RAJA::View< INDEX_TYPE, layout_type >;
+#if (!(defined(_GLIBCXX_RELEASE) || defined(RAJA_COMPILER_INTEL) || defined(RAJA_COMPILER_MSVC)))\
+    || _GLIBCXX_RELEASE >= 20150716
+  #if (__GNUG__ && __GNUC__ < 5)
+  #define IS_TRIVIALLY_COPYABLE(T) __has_trivial_copy(T)
+  #else
+  #define IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value
+  #endif
+  static_assert(IS_TRIVIALLY_COPYABLE(layout_type),
+                "These layouts should always be triviallly copyable");
+  static_assert(IS_TRIVIALLY_COPYABLE(view_type),
+                "These views should always be triviallly copyable");
+#endif
   
   RAJA::Layout<1> layout(N);
   view_type work_view(working_array, layout);
@@ -121,17 +134,6 @@ void ForallListSegmentOffsetViewTestImpl(INDEX_TYPE N, INDEX_TYPE offset)
 
   using layout_type = RAJA::OffsetLayout<1, INDEX_TYPE>;
   using view_type = RAJA::View< INDEX_TYPE, layout_type >;
-#if (!defined(_GLIBCXX_RELEASE)) || _GLIBCXX_RELEASE >= 20150716
-  #if (__GNUG__ && __GNUC__ < 5) ||
-  #define IS_TRIVIALLY_COPYABLE(T) __has_trivial_copy(T)
-  #else
-  #define IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value
-  #endif
-  static_assert(IS_TRIVIALLY_COPYABLE(layout_type),
-                "These layouts should always be triviallly copyable");
-  static_assert(IS_TRIVIALLY_COPYABLE(view_type),
-                "These views should always be triviallly copyable");
-#endif
 
   INDEX_TYPE N_offset = N + offset;
   view_type work_view(working_array, 

--- a/test/functional/forall/segment-view/tests/test-forall-ListSegmentView.hpp
+++ b/test/functional/forall/segment-view/tests/test-forall-ListSegmentView.hpp
@@ -14,6 +14,7 @@
 #include <ctime>
 #include <algorithm>
 #include <numeric>
+#include <type_traits>
 
 template <typename INDEX_TYPE, typename WORKING_RES, typename EXEC_POLICY>
 void ForallListSegmentViewTestImpl(INDEX_TYPE N)
@@ -118,7 +119,19 @@ void ForallListSegmentOffsetViewTestImpl(INDEX_TYPE N, INDEX_TYPE offset)
     test_array[ idx_array[i]-offset ] = idx_array[i];
   }
 
-  using view_type = RAJA::View< INDEX_TYPE, RAJA::OffsetLayout<1, INDEX_TYPE> >;
+  using layout_type = RAJA::OffsetLayout<1, INDEX_TYPE>;
+  using view_type = RAJA::View< INDEX_TYPE, layout_type >;
+#if (!defined(_GLIBCXX_RELEASE)) || _GLIBCXX_RELEASE >= 20150716
+  #if (__GNUG__ && __GNUC__ < 5) ||
+  #define IS_TRIVIALLY_COPYABLE(T) __has_trivial_copy(T)
+  #else
+  #define IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value
+  #endif
+  static_assert(IS_TRIVIALLY_COPYABLE(layout_type),
+                "These layouts should always be triviallly copyable");
+  static_assert(IS_TRIVIALLY_COPYABLE(view_type),
+                "These views should always be triviallly copyable");
+#endif
 
   INDEX_TYPE N_offset = N + offset;
   view_type work_view(working_array, 


### PR DESCRIPTION
This PR makes View, TypedRange[Stride]Segment, and [strided_]numeric_iterator trivially copyable.  It may be worth adding a check into a test file somewhere to check the type trait to make sure this is true all the time, but for now this should solve many of the warnings @rhornung67 was getting with target offload.
