### PR TITLE
Update local spack package

### DIFF
--- a/scripts/uberenv/packages/raja/package.py
+++ b/scripts/uberenv/packages/raja/package.py
@@ -56,7 +56,9 @@ class Raja(CMakePackage, CudaPackage):
     git      = "https://github.com/LLNL/RAJA.git"
 
     version('develop', branch='develop', submodules='True')
-    version('master',  branch='main',  submodules='True')
+    version('main',  branch='main',  submodules='True')
+    version('0.12.1', tag='v0.12.1', submodules="True")
+    version('0.12.0', tag='v0.12.0', submodules="True")
     version('0.11.0', tag='v0.11.0', submodules="True")
     version('0.10.1', tag='v0.10.1', submodules="True")
     version('0.10.0', tag='v0.10.0', submodules="True")
@@ -235,8 +237,7 @@ class Raja(CMakePackage, CudaPackage):
 
             if not spec.satisfies('cuda_arch=none'):
                 cuda_arch = spec.variants['cuda_arch'].value
-                flag = '-arch sm_{0}'.format(cuda_arch[0])
-                cfg.write(cmake_cache_string("CMAKE_CUDA_FLAGS", flag))
+                options.append('-DCUDA_ARCH=sm_{0}'.format(cuda_arch[0]))
 
         else:
             cfg.write(cmake_cache_option("ENABLE_CUDA", False))
@@ -264,7 +265,7 @@ class Raja(CMakePackage, CudaPackage):
                 print("MSG: no testing supported on %clang target=ppc64le:")
         else:
             cfg.write(cmake_cache_option("ENABLE_BENCHMARKS", 'tests=benchmarks' in spec))
-            cfg.write(cmake_cache_option("ENABLE_TESTS", not 'tests=none' in spec))
+            cfg.write(cmake_cache_option("ENABLE_TESTS", not 'tests=none' in spec or self.run_tests))
 
         #######################
         # Close and save

--- a/scripts/uberenv/packages/raja/package.py
+++ b/scripts/uberenv/packages/raja/package.py
@@ -256,9 +256,10 @@ class Raja(CMakePackage, CudaPackage):
         cfg.write(cmake_cache_option("BUILD_SHARED_LIBS","+shared" in spec))
         cfg.write(cmake_cache_option("ENABLE_OPENMP","+openmp" in spec))
 
-        # Work around spack adding -march=ppc64le to SPACK_TARGET_ARGS which
+        # Note 1: Work around spack adding -march=ppc64le to SPACK_TARGET_ARGS which
         # is used by the spack compiler wrapper.  This can go away when BLT
         # removes -Werror from GTest flags
+        # Note 2: Test are either built if variant is set, or if run-tests option is on
         if self.spec.satisfies('%clang target=ppc64le:'):
             cfg.write(cmake_cache_option("ENABLE_TESTS",False))
             if 'tests=benchmarks' in spec or not 'tests=none' in spec:

--- a/scripts/uberenv/packages/raja/package.py
+++ b/scripts/uberenv/packages/raja/package.py
@@ -256,10 +256,11 @@ class Raja(CMakePackage, CudaPackage):
         cfg.write(cmake_cache_option("BUILD_SHARED_LIBS","+shared" in spec))
         cfg.write(cmake_cache_option("ENABLE_OPENMP","+openmp" in spec))
 
-        # Note 1: Work around spack adding -march=ppc64le to SPACK_TARGET_ARGS which
-        # is used by the spack compiler wrapper.  This can go away when BLT
-        # removes -Werror from GTest flags
-        # Note 2: Test are either built if variant is set, or if run-tests option is on
+        # Note 1: Work around spack adding -march=ppc64le to SPACK_TARGET_ARGS
+        # which is used by the spack compiler wrapper.  This can go away when
+        # BLT removes -Werror from GTest flags
+        # Note 2: Tests are either built if variant is set, or if run-tests
+        # option is passed.
         if self.spec.satisfies('%clang target=ppc64le:'):
             cfg.write(cmake_cache_option("ENABLE_TESTS",False))
             if 'tests=benchmarks' in spec or not 'tests=none' in spec:


### PR DESCRIPTION
### Summary

- Update the local "copy" of RAJA Spack package to reflect changes in Spack.

### Details

The local copy of RAJA Spack package is used to experiment with future changes in the official RAJA Spack package.
That means that it is totally optional to have a local copy, and should only happen when needed. The changes should be updated to Spack asap.

There are currently new changes in the local copy, due to the recent introduction of Uberenv in the CI on Gitlab.
These changes will be submitted to Spack soon. They should first be reviewed here, and are tested as part of RAJA CI on Gitlab.