### PR TITLE
change Register::get() to return raw pointer

### DIFF
--- a/include/RAJA/util/Registry.hpp
+++ b/include/RAJA/util/Registry.hpp
@@ -25,7 +25,7 @@ namespace util {
 
     const std::string& getName() const { return Name; }
     const std::string& getDesc() const { return Desc; }
-    std::shared_ptr<T> & get() const { return object; }
+    std::shared_ptr<T> const & get() const { return object; }
   };
 
   /// A global registry used in conjunction with static constructors to make

--- a/include/RAJA/util/Registry.hpp
+++ b/include/RAJA/util/Registry.hpp
@@ -25,7 +25,7 @@ namespace util {
 
     const std::string& getName() const { return Name; }
     const std::string& getDesc() const { return Desc; }
-    std::shared_ptr<T> get() const { return object; }
+    T * const get() const { return object.get(); }
   };
 
   /// A global registry used in conjunction with static constructors to make

--- a/include/RAJA/util/Registry.hpp
+++ b/include/RAJA/util/Registry.hpp
@@ -25,7 +25,7 @@ namespace util {
 
     const std::string& getName() const { return Name; }
     const std::string& getDesc() const { return Desc; }
-    T * const get() const { return object.get(); }
+    T * get() const { return object.get(); }
   };
 
   /// A global registry used in conjunction with static constructors to make

--- a/include/RAJA/util/Registry.hpp
+++ b/include/RAJA/util/Registry.hpp
@@ -25,7 +25,7 @@ namespace util {
 
     const std::string& getName() const { return Name; }
     const std::string& getDesc() const { return Desc; }
-    T * get() const { return object.get(); }
+    std::shared_ptr<T> & get() const { return object; }
   };
 
   /// A global registry used in conjunction with static constructors to make


### PR DESCRIPTION

# Summary

- This PR is a performance improvement
- It does the following (modify list as needed):
  - changes Register::get() to return a raw pointer instead of a shared_ptr to reduce overhead of plugin lookups

