### PR TITLE
Feature/kunen1/view refactor

### DIFF
--- a/include/RAJA/index/IndexValue.hpp
+++ b/include/RAJA/index/IndexValue.hpp
@@ -336,18 +336,14 @@ constexpr RAJA_HOST_DEVICE RAJA_INLINE
 
 namespace internal{
 template<typename FROM, typename Enable = void>
-struct StripIndexTypeT {};
+struct StripIndexTypeT {
+    using type = FROM;
+};
 
 template<typename FROM>
 struct StripIndexTypeT<FROM, typename std::enable_if<std::is_base_of<IndexValueBase, FROM>::value>::type>
 {
     using type = typename FROM::value_type;
-};
-
-template<typename FROM>
-struct StripIndexTypeT<FROM, typename std::enable_if<!std::is_base_of<IndexValueBase, FROM>::value>::type>
-{
-    using type = FROM;
 };
 } // namespace internal
 

--- a/include/RAJA/pattern/kernel/InitLocalMem.hpp
+++ b/include/RAJA/pattern/kernel/InitLocalMem.hpp
@@ -64,7 +64,7 @@ struct StatementExecutor<statement::InitLocalMem<RAJA::cpu_tile_mem,camp::idx_se
   
   //Execute statement list
   template<class Data>
-  static void RAJA_INLINE initMem(Data && data)
+  static void RAJA_INLINE exec_expanded(Data && data)
   {
     execute_statement_list<camp::list<EnclosedStmts...>, Types>(data);
   }
@@ -72,35 +72,37 @@ struct StatementExecutor<statement::InitLocalMem<RAJA::cpu_tile_mem,camp::idx_se
   //Intialize local array
   //Identifies type + number of elements needed
   template<camp::idx_t Pos, camp::idx_t... others, class Data>
-  static void RAJA_INLINE initMem(Data && data)
+  static void RAJA_INLINE exec_expanded(Data && data)
   {
-    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::element_t;
-    const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::NumElem;
-    
-    varType Array[NumElem];
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = Array;
-    initMem<others...>(data);
+    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::value_type;
+
+    // Initialize memory
+#ifdef RAJA_COMPILER_MSVC
+    // MSVC doesn't like taking a pointer to stack allocated data?!?!
+    varType *ptr = new varType[camp::get<Pos>(data.param_tuple).size()];
+    camp::get<Pos>(data.param_tuple).set_data(ptr);
+#else
+    varType Array[camp::get<Pos>(data.param_tuple).size()];
+    camp::get<Pos>(data.param_tuple).set_data(&Array[0]);
+#endif
+
+    // Initialize others and execute
+    exec_expanded<others...>(data);
+
+    // Cleanup and return
+    camp::get<Pos>(data.param_tuple).set_data(nullptr);
+#ifdef RAJA_COMPILER_MSVC
+    delete[] ptr;
+#endif
   }
   
-  //Set pointer to null
-  template<class Data>
-  static void RAJA_INLINE setPtrToNull(Data &&) {}
-  
-  template<camp::idx_t Pos, camp::idx_t... others, class Data>
-  static void RAJA_INLINE setPtrToNull(Data && data)
-  {
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = nullptr;
-    setPtrToNull<others...>(data);
-  }
+
   
   template<typename Data>
   static RAJA_INLINE void exec(Data &&data)
   {
-    //Initalize local arrays + execute statements
-    initMem<Indices...>(data);
-    
-    //set array pointers to null
-    setPtrToNull<Indices...>(data);
+    //Initalize local arrays + execute statements + cleanup
+    exec_expanded<Indices...>(data);
   }
   
 };

--- a/include/RAJA/policy/cuda/kernel/InitLocalMem.hpp
+++ b/include/RAJA/policy/cuda/kernel/InitLocalMem.hpp
@@ -58,11 +58,11 @@ struct CudaStatementExecutor<Data,
   RAJA_DEVICE
   void initMem(Data &data, bool thread_active)
   {
-    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::element_t;
-    const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::NumElem;
+    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::value_type;
+    const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::layout_type::s_size;
 
     __shared__ varType Array[NumElem];
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = Array;
+    camp::get<Pos>(data.param_tuple).set_data(&Array[0]);
 
     enclosed_stmts_t::exec(data, thread_active);
   }
@@ -75,11 +75,11 @@ struct CudaStatementExecutor<Data,
   RAJA_DEVICE
   void initMem(Data &data, bool thread_active)
   {
-    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::element_t;
-    const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::NumElem;
+    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::value_type;
+    const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::layout_type::s_size;
 
     __shared__ varType Array[NumElem];
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = Array;
+    camp::get<Pos>(data.param_tuple).set_data(&Array[0]);
     initMem<other0, others...>(data, thread_active);
   }
 
@@ -91,7 +91,7 @@ struct CudaStatementExecutor<Data,
   void setPtrToNull(Data &data)
   {
 
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = nullptr;
+    camp::get<Pos>(data.param_tuple).set_data(nullptr);
   }
 
 
@@ -103,7 +103,7 @@ struct CudaStatementExecutor<Data,
   void setPtrToNull(Data &data)
   {
 
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = nullptr;
+    camp::get<Pos>(data.param_tuple).set_data(nullptr);
     setPtrToNull<other0, others...>(data);
   }
 
@@ -147,11 +147,11 @@ struct CudaStatementExecutor<Data, statement::InitLocalMem<RAJA::cuda_thread_mem
   RAJA_DEVICE
   void initMem(Data &data, bool thread_active)
   {
-    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::element_t;
-    const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::NumElem;
+    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::value_type;
+    const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::layout_type::s_size;
 
     varType Array[NumElem];
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = Array;
+    camp::get<Pos>(data.param_tuple).set_data(&Array[0]);
 
     enclosed_stmts_t::exec(data, thread_active);
   }
@@ -164,11 +164,11 @@ struct CudaStatementExecutor<Data, statement::InitLocalMem<RAJA::cuda_thread_mem
   RAJA_DEVICE
   void initMem(Data &data, bool thread_active)
   {
-    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::element_t;
-    const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::NumElem;
+    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::value_type;
+    const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::layout_type::s_size;
 
     varType Array[NumElem];
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = Array;
+    camp::get<Pos>(data.param_tuple).set_data(&Array[0]);
     initMem<other0, others...>(data, thread_active);
   }
 
@@ -180,7 +180,7 @@ struct CudaStatementExecutor<Data, statement::InitLocalMem<RAJA::cuda_thread_mem
   void setPtrToNull(Data &data)
   {
 
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = nullptr;
+    camp::get<Pos>(data.param_tuple).set_data(nullptr);
   }
 
 
@@ -192,7 +192,7 @@ struct CudaStatementExecutor<Data, statement::InitLocalMem<RAJA::cuda_thread_mem
   void setPtrToNull(Data &data)
   {
 
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = nullptr;
+    camp::get<Pos>(data.param_tuple).set_data(nullptr);
     setPtrToNull<other0, others...>(data);
   }
 

--- a/include/RAJA/policy/hip/kernel/InitLocalMem.hpp
+++ b/include/RAJA/policy/hip/kernel/InitLocalMem.hpp
@@ -55,11 +55,11 @@ struct HipStatementExecutor<Data, statement::InitLocalMem<RAJA::hip_shared_mem, 
   RAJA_DEVICE
   void initMem(Data &data, bool thread_active)
   {
-    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::element_t;
-    const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::NumElem;
+    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::value_type;
+    const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::layout_type::s_size;
 
     __shared__ varType Array[NumElem];
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = Array;
+    camp::get<Pos>(data.param_tuple).set_data(&Array[0]);
 
     enclosed_stmts_t::exec(data, thread_active);
   }
@@ -72,11 +72,11 @@ struct HipStatementExecutor<Data, statement::InitLocalMem<RAJA::hip_shared_mem, 
   RAJA_DEVICE
   void initMem(Data &data, bool thread_active)
   {
-    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::element_t;
-    const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::NumElem;
+    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::value_type;
+    const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::layout_type::s_size;
 
     __shared__ varType Array[NumElem];
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = Array;
+    camp::get<Pos>(data.param_tuple).set_data(&Array[0]);
     initMem<other0, others...>(data, thread_active);
   }
 
@@ -88,7 +88,7 @@ struct HipStatementExecutor<Data, statement::InitLocalMem<RAJA::hip_shared_mem, 
   void setPtrToNull(Data &data)
   {
 
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = nullptr;
+    camp::get<Pos>(data.param_tuple).set_data(nullptr);
   }
 
 
@@ -100,7 +100,7 @@ struct HipStatementExecutor<Data, statement::InitLocalMem<RAJA::hip_shared_mem, 
   void setPtrToNull(Data &data)
   {
 
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = nullptr;
+    camp::get<Pos>(data.param_tuple).set_data(nullptr);
     setPtrToNull<other0, others...>(data);
   }
 
@@ -144,11 +144,11 @@ struct HipStatementExecutor<Data, statement::InitLocalMem<RAJA::hip_thread_mem, 
   RAJA_DEVICE
   void initMem(Data &data, bool thread_active)
   {
-    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::element_t;
-    const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::NumElem;
+    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::value_type;
+    const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::layout_type::s_size;
 
     varType Array[NumElem];
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = Array;
+    camp::get<Pos>(data.param_tuple).set_data(&Array[0]);
 
     enclosed_stmts_t::exec(data, thread_active);
   }
@@ -161,11 +161,11 @@ struct HipStatementExecutor<Data, statement::InitLocalMem<RAJA::hip_thread_mem, 
   RAJA_DEVICE
   void initMem(Data &data, bool thread_active)
   {
-    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::element_t;
-    const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::NumElem;
+    using varType = typename camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::value_type;
+    const camp::idx_t NumElem = camp::tuple_element_t<Pos, typename camp::decay<Data>::param_tuple_t>::layout_type::s_size;
 
     varType Array[NumElem];
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = Array;
+    camp::get<Pos>(data.param_tuple).set_data(&Array[0]);
     initMem<other0, others...>(data, thread_active);
   }
 
@@ -177,7 +177,7 @@ struct HipStatementExecutor<Data, statement::InitLocalMem<RAJA::hip_thread_mem, 
   void setPtrToNull(Data &data)
   {
 
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = nullptr;
+    camp::get<Pos>(data.param_tuple).set_data(nullptr);
   }
 
 
@@ -189,7 +189,7 @@ struct HipStatementExecutor<Data, statement::InitLocalMem<RAJA::hip_thread_mem, 
   void setPtrToNull(Data &data)
   {
 
-    camp::get<Pos>(data.param_tuple).m_arrayPtr = nullptr;
+    camp::get<Pos>(data.param_tuple).set_data(nullptr);
     setPtrToNull<other0, others...>(data);
   }
 

--- a/include/RAJA/util/Layout.hpp
+++ b/include/RAJA/util/Layout.hpp
@@ -37,34 +37,6 @@ namespace RAJA
 namespace detail
 {
 
-/*!
- * Functor that returns a*b[i] for all i!=exlcude_i,
- * and returns a for i==exclude_i.
- *
- * This allows Layout to more efficiently compute layouts where a single
- * dimension is stride-1.  Also, it allows compilers to better reason about
- * loop optimizations.
- */
-template <ptrdiff_t i, ptrdiff_t exclude_i>
-struct ConditionalMultiply {
-
-  template <typename A, typename B>
-  static RAJA_INLINE RAJA_HOST_DEVICE constexpr A multiply(A a, B b)
-  {
-    // regular product term
-    return a * b;
-  }
-};
-
-template <ptrdiff_t i>
-struct ConditionalMultiply<i, i> {
-  template <typename A, typename B>
-  static RAJA_INLINE RAJA_HOST_DEVICE constexpr A multiply(A a, B)
-  {
-    // assume b[i]==1
-    return a;
-  }
-};
 
 
 template <typename Range,
@@ -104,7 +76,7 @@ public:
 
   static constexpr size_t n_dims = sizeof...(RangeInts);
   static constexpr IdxLin limit = RAJA::operators::limits<IdxLin>::max();
-  static constexpr ptrdiff_t stride1_dim = StrideOneDim;
+  static constexpr ptrdiff_t stride_one_dim = StrideOneDim;
 
   IdxLin sizes[n_dims] = {0};
   IdxLin strides[n_dims] = {0};
@@ -211,13 +183,12 @@ public:
     BoundsCheck<0>(indices...);
 #endif
     // dot product of strides and indices
-#ifdef RAJA_COMPILER_INTEL
-    // Intel compiler has issues with Condition
-    return sum<IdxLin>((indices * strides[RangeInts])...);
-#else
-    return sum<IdxLin>
-      (((IdxLin) detail::ConditionalMultiply<RangeInts, stride1_dim>::multiply(IdxLin(indices), strides[RangeInts]) )...);
-#endif
+    return sum<IdxLin>(
+      (RangeInts==stride_one_dim ?   // Is this dimension stride-one?
+         indices :  // it's stride one, so dont bother with multiple
+         strides[RangeInts]*indices // it's not stride one
+			)...
+    );
   }
 
 
@@ -261,6 +232,14 @@ public:
     // replacing 1 for any zero-sized dimensions
     return foldl(RAJA::operators::multiplies<IdxLin>(),
                          (sizes[RangeInts] == IdxLin(0) ? IdxLin(1) : sizes[RangeInts])...);
+  }
+
+  template<camp::idx_t DIM>
+  RAJA_INLINE
+  RAJA_HOST_DEVICE
+  constexpr
+  IndexLinear get_dim_stride() const {
+    return strides[DIM];
   }
 };
 
@@ -420,6 +399,8 @@ RAJA_INLINE TypedLayout<IdxLin, IdxTuple, s1_dim> make_stride_one(
   // Use non-typed layout to initialize new typed layout
   return TypedLayout<IdxLin, IdxTuple, s1_dim>(b);
 }
+
+
 
 
 }  // namespace RAJA

--- a/include/RAJA/util/LocalArray.hpp
+++ b/include/RAJA/util/LocalArray.hpp
@@ -25,6 +25,7 @@
 #include <type_traits>
 
 #include "RAJA/util/StaticLayout.hpp"
+#include "RAJA/util/TypedViewBase.hpp"
 
 namespace RAJA
 {
@@ -48,25 +49,38 @@ using ParamList = camp::idx_seq<Sizes...>;
  * Two versions are created below, a strongly typed version and
  * a non-strongly typed version.
  */
-template<typename DataType, typename Perm, typename Sizes, typename... IndexTypes>
-struct TypedLocalArray
-{
-};
 
-template<typename DataType, camp::idx_t ... Perm, camp::idx_t ...Sizes, typename... IndexTypes>
-struct TypedLocalArray<DataType, camp::idx_seq<Perm...>, RAJA::SizeList<Sizes...>, IndexTypes...>
-{
-  DataType *m_arrayPtr = nullptr;
-  using element_t = DataType;
-  using layout_t = StaticLayout<camp::idx_seq<Perm...>, Sizes...>;
-  static const camp::idx_t NumElem = layout_t::size();
 
-  RAJA_HOST_DEVICE
-  element_t &operator()(IndexTypes ...indices) const
-  {
-    return  m_arrayPtr[layout_t::s_oper(stripIndexType(indices)...)];
-  }
-};
+namespace internal {
+
+
+
+  template<typename Perm, typename Sizes>
+  struct StaticLayoutHelper;
+
+  template<camp::idx_t ... Perm, camp::idx_t ...Sizes>
+  struct StaticLayoutHelper<camp::idx_seq<Perm...>, camp::idx_seq<Sizes...>>{
+      using type =  StaticLayout<camp::idx_seq<Perm...>, Sizes...>;
+  };
+
+  template<typename Perm, typename Sizes>
+  using getStaticLayoutType = typename StaticLayoutHelper<Perm, Sizes>::type;
+
+
+
+}
+
+
+template<typename ValueType, typename Perm, typename Sizes, typename... IndexTypes>
+using TypedLocalArray =
+    internal::TypedViewBase<ValueType, ValueType *, internal::getStaticLayoutType<Perm, Sizes>, camp::list<IndexTypes...> >;
+
+
+template<typename ValueType, typename Perm, typename Sizes>
+using LocalArray =
+    internal::TypedViewBase<ValueType, ValueType *, internal::getStaticLayoutType<Perm, Sizes>, internal::getDefaultIndexTypes<Perm> >;
+
+
 
 
 
@@ -80,42 +94,34 @@ template<typename AtomicPolicy, typename DataType, camp::idx_t ... Perm,
 struct AtomicTypedLocalArray<AtomicPolicy, DataType, camp::idx_seq<Perm ...>,
                              RAJA::SizeList<Sizes ...>, IndexTypes ...>{
   DataType *m_arrayPtr = nullptr;
-  using element_t = DataType;
-  using atomic_ref_t = RAJA::AtomicRef<element_t, AtomicPolicy>;
-  using layout_t = RAJA::StaticLayout<camp::idx_seq<Perm ...>, Sizes ...>;
-  static const camp::idx_t NumElem = layout_t::size();
+  using value_type = DataType;
+  using atomic_ref_t = RAJA::AtomicRef<value_type, AtomicPolicy>;
+  using layout_type = RAJA::StaticLayout<camp::idx_seq<Perm ...>, Sizes ...>;
+  static const camp::idx_t NumElem = layout_type::s_size;
 
   RAJA_HOST_DEVICE
   atomic_ref_t operator()(IndexTypes ... indices) const
   {
-    return(atomic_ref_t(&m_arrayPtr[layout_t::s_oper(stripIndexType(indices)
+    return(atomic_ref_t(&m_arrayPtr[layout_type::s_oper(stripIndexType(indices)
                                                      ...)]));
   }
-};
 
-
-
-template<typename DataType, typename Perm, typename Sizes>
-struct LocalArray
-{
-};
-
-template<typename DataType, camp::idx_t ... Perm, camp::idx_t ...Sizes>
-struct LocalArray<DataType, camp::idx_seq<Perm...>, RAJA::SizeList<Sizes...> >
-{
-  DataType *m_arrayPtr = nullptr;
-  using element_t = DataType;
-  using layout_t = StaticLayout<camp::idx_seq<Perm...>, Sizes...>;
-  static const camp::idx_t NumElem = layout_t::size();
-
-  template<typename ...Indices>
   RAJA_HOST_DEVICE
-  element_t &operator()(Indices ...indices) const
+  RAJA_INLINE
+  constexpr
+  camp::idx_t size() const
   {
-    return m_arrayPtr[layout_t::s_oper(indices...)];
+    return layout_type::s_size;
   }
 
+  RAJA_HOST_DEVICE
+  RAJA_INLINE void set_data(DataType * data_ptr){
+    m_arrayPtr = data_ptr;
+  }
 };
+
+
+
 
 
 }  // end namespace RAJA

--- a/include/RAJA/util/LocalArray.hpp
+++ b/include/RAJA/util/LocalArray.hpp
@@ -58,8 +58,8 @@ namespace internal {
   template<typename Perm, typename Sizes>
   struct StaticLayoutHelper;
 
-  template<camp::idx_t ... Perm, camp::idx_t ...Sizes>
-  struct StaticLayoutHelper<camp::idx_seq<Perm...>, camp::idx_seq<Sizes...>>{
+  template<camp::idx_t ... Perm, Index_type ...Sizes>
+  struct StaticLayoutHelper<camp::idx_seq<Perm...>, SizeList<Sizes...>>{
       using type =  StaticLayout<camp::idx_seq<Perm...>, Sizes...>;
   };
 
@@ -90,7 +90,7 @@ struct AtomicTypedLocalArray {
 };
 
 template<typename AtomicPolicy, typename DataType, camp::idx_t ... Perm,
-         camp::idx_t ... Sizes, typename ... IndexTypes>
+          Index_type ... Sizes, typename ... IndexTypes>
 struct AtomicTypedLocalArray<AtomicPolicy, DataType, camp::idx_seq<Perm ...>,
                              RAJA::SizeList<Sizes ...>, IndexTypes ...>{
   DataType *m_arrayPtr = nullptr;

--- a/include/RAJA/util/OffsetLayout.hpp
+++ b/include/RAJA/util/OffsetLayout.hpp
@@ -44,8 +44,11 @@ template <camp::idx_t... RangeInts, typename IdxLin>
 struct OffsetLayout_impl<camp::idx_seq<RangeInts...>, IdxLin> {
   using Self = OffsetLayout_impl<camp::idx_seq<RangeInts...>, IdxLin>;
   using IndexRange = camp::idx_seq<RangeInts...>;
+  using IndexLinear = IdxLin;
   using Base = RAJA::detail::LayoutBase_impl<IndexRange, IdxLin>;
   Base base_;
+
+  static constexpr camp::idx_t stride_one_dim = Base::stride_one_dim;
 
   static constexpr size_t n_dims = sizeof...(RangeInts);
   IdxLin offsets[n_dims]={0}; //If not specified set to zero
@@ -118,6 +121,14 @@ struct OffsetLayout_impl<camp::idx_seq<RangeInts...>, IdxLin> {
       : base_{rhs}
   {
   }
+
+  template<camp::idx_t DIM>
+  RAJA_INLINE
+  RAJA_HOST_DEVICE
+  constexpr
+  IndexLinear get_dim_stride() const {
+    return base_.get_dim_stride();
+  }
 };
 
 }  // namespace internal
@@ -150,6 +161,7 @@ struct TypedOffsetLayout<IdxLin, camp::tuple<DimTypes...>>
    using Self = TypedOffsetLayout<IdxLin, camp::tuple<DimTypes...>>;
    using Base = OffsetLayout<sizeof...(DimTypes), Index_type>;
    using DimArr = std::array<Index_type, sizeof...(DimTypes)>;
+   using IndexLinear = IdxLin;
 
    // Pull in base coonstructors
  #if 0

--- a/include/RAJA/util/Operators.hpp
+++ b/include/RAJA/util/Operators.hpp
@@ -614,6 +614,7 @@ DefineTypeTraitFromConcept(is_binary_function, RAJA::concepts::BinaryFunction);
 DefineTypeTraitFromConcept(is_unary_function, RAJA::concepts::UnaryFunction);
 }  // namespace type_traits
 
+
 }  // namespace RAJA
 
 #endif  // closing endif for header file include guard

--- a/include/RAJA/util/StaticLayout.hpp
+++ b/include/RAJA/util/StaticLayout.hpp
@@ -32,6 +32,7 @@
 #include "RAJA/util/Permutations.hpp"
 
 
+
 namespace RAJA
 {
 
@@ -55,6 +56,12 @@ struct StaticLayoutBase_impl<IdxLin,
   using IndexLinear = IdxLin;
   using sizes = camp::int_seq<IdxLin, Sizes...>;
   using strides = camp::int_seq<IdxLin, Strides...>;
+
+  static constexpr camp::idx_t stride_one_dim =
+      RAJA::max<camp::idx_t>(
+          (camp::seq_at<RangeInts, strides>::value == 1 ? RangeInts : -1)...);
+
+  static constexpr size_t n_dims = sizeof...(Sizes);
 
   /*!
    * Default constructor.
@@ -82,7 +89,7 @@ struct StaticLayoutBase_impl<IdxLin,
       Indices... indices) const
   {
     // dot product of strides and indices
-    return sum<IdxLin>((IdxLin(indices * Strides))...);
+    return RAJA::sum<IdxLin>((IdxLin(indices * Strides))...);
   }
 
 
@@ -90,10 +97,12 @@ struct StaticLayoutBase_impl<IdxLin,
   static RAJA_INLINE RAJA_HOST_DEVICE constexpr IdxLin s_oper(Indices... indices)
   {
     // dot product of strides and indices
-    return sum<IdxLin>((IdxLin(indices * Strides))...);
+    return RAJA::sum<IdxLin>((IdxLin(indices * Strides))...);
   }
 
 
+  // Multiply together all of the sizes,
+  // replacing 1 for any zero-sized dimensions
   static constexpr IdxLin s_size =
       RAJA::product<IdxLin>((Sizes == IdxLin(0) ? IdxLin(1) : Sizes)...);
 
@@ -112,6 +121,14 @@ struct StaticLayoutBase_impl<IdxLin,
     return s_size;
   }
 
+
+  template<camp::idx_t DIM>
+  RAJA_INLINE
+  RAJA_HOST_DEVICE
+  constexpr
+  IndexLinear get_dim_stride() const {
+    return camp::seq_at<DIM, strides>::value;
+  }
 
 
 };
@@ -168,6 +185,12 @@ template <typename Layout, typename... DimTypes>
 struct TypedStaticLayoutImpl<Layout, camp::list<DimTypes...>> {
 
   using IndexLinear = typename Layout::IndexLinear;
+
+  static
+  constexpr
+  camp::idx_t stride_one_dim = Layout::stride_one_dim;
+
+  static constexpr IndexLinear n_dims = sizeof...(DimTypes);
   /*!
    * Computes a linear space index from specified indices.
    * This is formed by the dot product of the indices and the layout strides.
@@ -187,6 +210,14 @@ struct TypedStaticLayoutImpl<Layout, camp::list<DimTypes...>> {
   RAJA_INLINE RAJA_HOST_DEVICE constexpr static IndexLinear size()
   {
     return s_size;
+  }
+
+  template<camp::idx_t DIM>
+  RAJA_INLINE
+  RAJA_HOST_DEVICE
+  constexpr
+  IndexLinear get_dim_stride() const {
+    return Layout{}.get_dim_stride();
   }
 
   RAJA_INLINE

--- a/include/RAJA/util/TypedViewBase.hpp
+++ b/include/RAJA/util/TypedViewBase.hpp
@@ -1,0 +1,553 @@
+/*!
+ ******************************************************************************
+ *
+ * \file
+ *
+ * \brief   RAJA header file defining a multi-dimensional view class.
+ *
+ ******************************************************************************
+ */
+
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-19, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef RAJA_util_TypedViewBase_HPP
+#define RAJA_util_TypedViewBase_HPP
+
+#include <type_traits>
+
+#include "RAJA/config.hpp"
+
+#include "RAJA/pattern/atomic.hpp"
+
+#include "RAJA/util/Layout.hpp"
+#include "RAJA/util/OffsetLayout.hpp"
+
+namespace RAJA
+{
+
+namespace internal
+{
+
+  template<camp::idx_t, typename T>
+  struct IndexToType{
+      using type = T;
+  };
+
+  template<typename IdxSeq, typename T>
+  struct SequenceToType;
+
+  template<camp::idx_t ... Perm, typename T>
+  struct SequenceToType<camp::idx_seq<Perm...>, T>{
+      using type =  camp::list<typename IndexToType<Perm, T>::type...>;
+  };
+
+  template<typename Perm>
+  using getDefaultIndexTypes = typename SequenceToType<Perm, RAJA::Index_type>::type;
+
+
+
+
+  //Helpers to convert
+  //layouts -> OffsetLayouts
+  //Typedlayouts -> TypedOffsetLayouts
+  template<typename layout>
+  struct add_offset
+  {
+    using type = RAJA::OffsetLayout<layout::n_dims>;
+  };
+
+  template<typename IdxLin, typename...DimTypes>
+  struct add_offset<RAJA::TypedLayout<IdxLin,camp::tuple<DimTypes...>>>
+  {
+    using type = RAJA::TypedOffsetLayout<IdxLin,camp::tuple<DimTypes...>>;
+  };
+
+
+
+#if 0
+  namespace detail
+  {
+    /*
+     * Returns the argument number which contains a VectorIndex
+     *
+     * returns -1 if none of the arguments are VectorIndexs
+     */
+    template<camp::idx_t DIM, typename ... ARGS, camp::idx_t ... IDX>
+    RAJA_INLINE
+    RAJA_HOST_DEVICE
+    static constexpr camp::idx_t get_tensor_arg_idx_expanded(camp::list<ARGS...> const &, camp::idx_seq<IDX...> const &){
+      return RAJA::foldl_max<camp::idx_t>(
+          (isTensorIndex<ARGS>()&&getTensorDim<ARGS>()==DIM ? IDX : -1) ...);
+    }
+
+
+
+  } // namespace detail
+#endif
+
+  /*
+   * Returns the number of arguments which are VectorIndexs
+   */
+  template<typename ... ARGS>
+  RAJA_INLINE
+  RAJA_HOST_DEVICE
+  static constexpr camp::idx_t count_num_tensor_args(){
+		return 0;
+//    return RAJA::foldl_sum<camp::idx_t>(
+//        (isTensorIndex<ARGS>() ? 1 : 0) ...);
+  }
+
+#if 0
+  /*
+   * Returns which argument has a vector index
+   */
+  template<camp::idx_t DIM, typename ... ARGS>
+  RAJA_INLINE
+  RAJA_HOST_DEVICE
+  static constexpr camp::idx_t get_tensor_arg_idx(){
+    return detail::get_tensor_arg_idx_expanded<DIM>(
+        camp::list<ARGS...>{},
+        camp::make_idx_seq_t<sizeof...(ARGS)>{});
+  }
+
+  /*
+   * Returns the number of elements in the vector argument
+   */
+  template<camp::idx_t DIM, typename ... ARGS>
+  RAJA_INLINE
+  RAJA_HOST_DEVICE
+  static constexpr camp::idx_t get_tensor_args_size(ARGS ... args){
+    return RAJA::foldl_max<camp::idx_t>(
+        getTensorDim<ARGS>()==DIM
+        ? getTensorSize<ARGS>(args)
+        : 0 ...);
+  }
+
+#endif
+
+  namespace detail {
+
+  template<camp::idx_t NumVectors, typename Args, typename ElementType, typename PointerType, typename LinIdx, camp::idx_t StrideOneDim>
+  struct ViewReturnHelper
+  {
+      static_assert(NumVectors < 3, "Not supported: too many tensor indices");
+  };
+
+
+  /*
+   * Specialization for Scalar return types
+   */
+  template<typename ... Args, typename ElementType, typename PointerType, typename LinIdx, camp::idx_t StrideOneDim>
+  struct ViewReturnHelper<0, camp::list<Args...>, ElementType, PointerType, LinIdx, StrideOneDim>
+  {
+      using return_type = ElementType &;
+
+      template<typename LayoutType>
+      RAJA_INLINE
+      RAJA_HOST_DEVICE
+      static
+      constexpr
+      return_type make_return(LayoutType const &layout, PointerType const &data, Args const &... args){
+        return data[stripIndexType(layout(args...))];
+      }
+  };
+
+#if 0
+  /*
+   * Specialization for Vector return types
+   */
+  template<typename ... Args, typename ElementType, typename PointerType, typename LinIdx, camp::idx_t StrideOneDim>
+  struct ViewReturnHelper<1, camp::list<Args...>, ElementType, PointerType, LinIdx, StrideOneDim>
+  {
+      using vector_type = typename camp::at_v<camp::list<Args...>, get_tensor_arg_idx<0, Args...>()>::tensor_type;
+      using return_type = VectorRef<vector_type, LinIdx, PointerType, StrideOneDim == get_tensor_arg_idx<0, Args...>()>;
+
+      template<typename LayoutType>
+      RAJA_INLINE
+      RAJA_HOST_DEVICE
+      static
+      constexpr
+      return_type make_return(LayoutType const &layout, PointerType const &data, Args const &... args){
+        return return_type(stripIndexType(layout(stripTensorIndex(args)...)),
+                           get_tensor_args_size<0>(args...),
+                           data,
+                           layout.template get_dim_stride<get_tensor_arg_idx<0, Args...>()>());
+      }
+  };
+
+  /*
+   * Specialization for Matrix return types
+   */
+  template<typename ... Args, typename ElementType, typename PointerType, typename LinIdx, camp::idx_t StrideOneDim>
+  struct ViewReturnHelper<2, camp::list<Args...>, ElementType, PointerType, LinIdx, StrideOneDim>
+  {
+      using row_matrix_type = typename camp::at_v<camp::list<Args...>, get_tensor_arg_idx<0, Args...>()>::tensor_type;
+      using col_matrix_type = typename camp::at_v<camp::list<Args...>, get_tensor_arg_idx<1, Args...>()>::tensor_type;
+
+      // compute a matrix type using features from the row and col
+      using matrix_type = MatrixViewCombiner<row_matrix_type, col_matrix_type>;
+
+      using return_type = internal::MatrixRef<matrix_type,
+                                              LinIdx,
+                                              PointerType,
+                                              StrideOneDim == get_tensor_arg_idx<0, Args...>(),
+                                              StrideOneDim == get_tensor_arg_idx<1, Args...>()>;
+
+
+      template<typename LayoutType>
+      RAJA_INLINE
+      RAJA_HOST_DEVICE
+      static
+      constexpr
+      return_type make_return(LayoutType const &layout, PointerType const &data, Args const &... args){
+        return return_type(stripIndexType(layout(stripTensorIndex(args)...)),
+                           get_tensor_args_size<0>(args...),
+                           get_tensor_args_size<1>(args...),
+                           data,
+                           layout.template get_dim_stride<get_tensor_arg_idx<0, Args...>()>(),
+                           layout.template get_dim_stride<get_tensor_arg_idx<1, Args...>()>());
+      }
+  };
+
+#endif
+
+
+  } // namespace detail
+
+
+  /*
+   * Computes the return type of a view.
+   *
+   * If any of the arguments are a VectorIndex, it creates a VectorRef
+   * return type.
+   *
+   * Otherwise it produces the usual scalar reference return type
+   */
+  template<typename ElementType, typename PointerType, typename LinIdx, typename LayoutType, typename ... Args>
+  using view_return_type_t =
+      typename detail::ViewReturnHelper<
+        count_num_tensor_args<Args...>(),
+        camp::list<Args...>,
+        ElementType,
+        PointerType,
+        LinIdx,
+        LayoutType::stride_one_dim>::return_type;
+
+  /*
+   * Creates the return value for a View
+   *
+   * If any of the arguments are a VectorIndex, it creates a VectorRef
+   * return value.
+   *
+   * Otherwise it produces the usual scalar reference return value
+   */
+  template<typename ElementType, typename LinIdx, typename LayoutType, typename PointerType, typename ... Args>
+  RAJA_INLINE
+  RAJA_HOST_DEVICE
+  constexpr
+  view_return_type_t<ElementType, PointerType, LinIdx, LayoutType, Args...>
+  view_make_return_value(LayoutType const &layout, PointerType const &data, Args const &... args){
+    return detail::ViewReturnHelper<
+        count_num_tensor_args<Args...>(),
+        camp::list<Args...>,
+        ElementType,
+        PointerType,
+        LinIdx,
+        LayoutType::stride_one_dim>::make_return(layout, data, args...);
+  }
+
+
+
+  namespace detail
+  {
+
+  /**
+   * This class will help strip strongly typed
+   *
+   * This default implementation static_asserts that Expected==Arg, otherwise
+   * it's an error.  This enforces types for the TypedView.
+   *
+   * Specialization where expected type is same as argument type.
+   * In this case, there is no VectorIndex to unpack, just strip any strongly
+   * typed indices.
+   */
+  template<typename Expected, typename Arg>
+  struct MatchTypedViewArgHelper{
+    static_assert(std::is_convertible<Arg, Expected>::value,
+        "Argument isn't compatible");
+
+    using type = strip_index_type_t<Arg>;
+
+    static RAJA_HOST_DEVICE RAJA_INLINE
+    constexpr
+    type extract(Arg arg){
+      return stripIndexType(arg);
+    }
+  };
+
+#if 0
+  /**
+   * Specialization where expected type is wrapped in a VectorIndex type
+   *
+   * In this case, there is no VectorIndex to unpack, just strip any strongly
+   * typed indices.
+   */
+  template<typename Expected, typename Arg, typename VectorType, camp::idx_t DIM>
+  struct MatchTypedViewArgHelper<Expected, RAJA::TensorIndex<Arg, VectorType, DIM> >{
+
+    static_assert(std::is_convertible<Arg, Expected>::value,
+        "Argument isn't compatible");
+
+    using arg_type = strip_index_type_t<Arg>;
+
+    using type = RAJA::TensorIndex<arg_type, VectorType, DIM>;
+
+    static constexpr RAJA_HOST_DEVICE RAJA_INLINE
+    type extract(RAJA::TensorIndex<Arg, VectorType, DIM> vec_arg){
+      return type(stripIndexType(*vec_arg), vec_arg.size());
+    }
+  };
+#endif	
+
+  } //namespace detail
+
+
+  template<typename Expected, typename Arg>
+  RAJA_HOST_DEVICE
+  RAJA_INLINE
+  constexpr
+  typename detail::MatchTypedViewArgHelper<Expected, Arg>::type
+  match_typed_view_arg(Arg const &arg)
+  {
+    return detail::MatchTypedViewArgHelper<Expected, Arg>::extract(arg);
+  }
+
+
+
+template <typename ValueType,
+          typename PointerType,
+          typename LayoutType>
+class ViewBase {
+
+  public:
+    using value_type = ValueType;
+    using pointer_type = PointerType;
+    using layout_type = LayoutType;
+    using linear_index_type = typename layout_type::IndexLinear;
+    using nc_value_type = typename std::remove_const<value_type>::type;
+    using nc_pointer_type = typename std::add_pointer<typename std::remove_const<
+        typename std::remove_pointer<pointer_type>::type>::type>::type;
+
+    using Self = ViewBase<value_type, pointer_type, layout_type>;
+    using NonConstView = ViewBase<nc_value_type, nc_pointer_type, layout_type>;
+
+    using shifted_layout_type = typename add_offset<layout_type>::type;
+    using ShiftedView = ViewBase<value_type, pointer_type, shifted_layout_type>;
+
+  protected:
+    pointer_type m_data;
+    layout_type const m_layout;
+
+  public:
+
+    constexpr ViewBase() = default;
+    RAJA_INLINE constexpr ViewBase(ViewBase const &) = default;
+    RAJA_INLINE constexpr ViewBase(ViewBase &&) = default;
+    RAJA_INLINE ViewBase& operator=(ViewBase const &) = default;
+    RAJA_INLINE ViewBase& operator=(ViewBase &&) = default;
+
+
+
+    RAJA_HOST_DEVICE
+    RAJA_INLINE
+    constexpr
+    ViewBase(pointer_type data, layout_type &&layout) :
+    m_data(data), m_layout(layout)
+    {
+    }
+
+    template <typename... Args>
+    RAJA_HOST_DEVICE
+    RAJA_INLINE
+    constexpr
+    ViewBase(pointer_type data, Args... dim_sizes) :
+    m_data(data), m_layout(dim_sizes...)
+    {
+    }
+
+
+    template <bool IsConstView = std::is_const<value_type>::value>
+    RAJA_HOST_DEVICE
+    RAJA_INLINE
+    constexpr
+    ViewBase(typename std::enable_if<IsConstView, NonConstView>::type const &rhs) :
+    m_data(rhs.get_data()), m_layout(rhs.get_layout())
+    {
+    }
+
+
+    RAJA_HOST_DEVICE
+    RAJA_INLINE void set_data(PointerType data_ptr){
+      m_data = data_ptr;
+    }
+
+    RAJA_HOST_DEVICE
+    RAJA_INLINE
+    constexpr
+    pointer_type const &get_data() const
+    {
+      return m_data;
+    }
+
+    RAJA_HOST_DEVICE
+    RAJA_INLINE
+    constexpr
+    layout_type const &get_layout() const
+    {
+      return m_layout;
+    }
+
+    RAJA_HOST_DEVICE
+    RAJA_INLINE
+    constexpr
+    camp::idx_t size() const
+    {
+      return m_layout.size();
+    }
+
+
+    template <typename... Args>
+    RAJA_HOST_DEVICE
+    RAJA_INLINE
+    constexpr
+    view_return_type_t<value_type, pointer_type, linear_index_type, layout_type, Args...>
+    operator()(Args... args) const
+    {
+      return view_make_return_value<value_type, linear_index_type>(m_layout, m_data, args...);
+    }
+
+
+
+    /*
+     * Compatibility note (AJK):
+     * We are using variadic arguments even though operator[] takes exactly 1 argument
+     * This gets around a template instantiation bug in CUDA/nvcc 9.1, which seems to have
+     * been fixed in CUDA 9.2+
+     */
+    template <typename ... Args>
+    RAJA_HOST_DEVICE
+    RAJA_INLINE
+    constexpr
+    view_return_type_t<value_type, pointer_type, linear_index_type, layout_type, Args...>
+    operator[](Args ... args) const
+    {
+      return view_make_return_value<value_type, linear_index_type>(m_layout, m_data, args...);
+    }
+
+
+
+    template <size_t n_dims = layout_type::n_dims, typename IdxLin = linear_index_type>
+    RAJA_INLINE
+    ShiftedView shift(const std::array<IdxLin, n_dims>& shift)
+    {
+      static_assert(n_dims==layout_type::n_dims, "Dimension mismatch in view shift");
+
+      shifted_layout_type shift_layout(m_layout);
+      shift_layout.shift(shift);
+
+      return ShiftedView(m_data, shift_layout);
+    }
+
+};
+
+
+template <typename ValueType,
+        typename PointerType,
+        typename LayoutType,
+        typename IndexTypes>
+class TypedViewBase;
+
+template <typename ValueType,
+          typename PointerType,
+          typename LayoutType,
+          typename... IndexTypes>
+class TypedViewBase<ValueType, PointerType, LayoutType, camp::list<IndexTypes...>> :
+  public ViewBase<ValueType, PointerType, LayoutType>
+{
+
+  public:
+    using value_type = ValueType;
+    using pointer_type = PointerType;
+    using layout_type = LayoutType;
+    using linear_index_type = typename layout_type::IndexLinear;
+    using nc_value_type = typename std::remove_const<value_type>::type;
+    using nc_pointer_type = typename std::add_pointer<typename std::remove_const<
+        typename std::remove_pointer<pointer_type>::type>::type>::type;
+
+    using Base = ViewBase<ValueType, PointerType, LayoutType>;
+    using Self = TypedViewBase<value_type, pointer_type, layout_type, camp::list<IndexTypes...> >;
+    using NonConstView = TypedViewBase<nc_value_type, nc_pointer_type, layout_type, camp::list<IndexTypes...> >;
+
+    using shifted_layout_type = typename add_offset<layout_type>::type;
+    using ShiftedView = TypedViewBase<value_type, pointer_type, shifted_layout_type, camp::list<IndexTypes...> >;
+
+    static constexpr size_t n_dims = sizeof...(IndexTypes);
+
+    using Base::Base;
+
+    template <typename... Args>
+    RAJA_HOST_DEVICE
+    RAJA_INLINE
+    constexpr
+    view_return_type_t<value_type, pointer_type, linear_index_type, layout_type, Args...>
+    operator()(Args... args) const
+    {
+      return view_make_return_value<value_type, linear_index_type>(Base::m_layout, Base::m_data, match_typed_view_arg<IndexTypes>(args)...);
+    }
+
+
+
+    /*
+     * Compatibility note (AJK):
+     * We are using variadic arguments even though operator[] takes exactly 1 argument
+     * This gets around a template instantiation bug in CUDA/nvcc 9.1, which seems to have
+     * been fixed in CUDA 9.2+
+     */
+    template <typename ... Args>
+    RAJA_HOST_DEVICE
+    RAJA_INLINE
+    constexpr
+    view_return_type_t<value_type, pointer_type, linear_index_type, layout_type, Args...>
+    operator[](Args ... args) const
+    {
+      return view_make_return_value<value_type, linear_index_type>(Base::m_layout, Base::m_data, match_typed_view_arg<IndexTypes>(args)...);
+    }
+
+
+
+    template <size_t n_dims = sizeof...(IndexTypes), typename IdxLin = linear_index_type>
+    RAJA_INLINE
+    ShiftedView shift(const std::array<IdxLin, n_dims>& shift)
+    {
+      static_assert(n_dims==layout_type::n_dims, "Dimension mismatch in view shift");
+
+      shifted_layout_type shift_layout(Base::get_layout());
+      shift_layout.shift(shift);
+
+      return ShiftedView(Base::get_data(), shift_layout);
+    }
+
+};
+
+
+
+} // namespace internal
+
+}  // namespace RAJA
+
+#endif

--- a/include/RAJA/util/View.hpp
+++ b/include/RAJA/util/View.hpp
@@ -26,6 +26,7 @@
 
 #include "RAJA/util/Layout.hpp"
 #include "RAJA/util/OffsetLayout.hpp"
+#include "RAJA/util/TypedViewBase.hpp"
 
 namespace RAJA
 {
@@ -48,69 +49,25 @@ struct add_offset<RAJA::TypedLayout<IdxLin,camp::tuple<DimTypes...>>>
 template <typename ValueType,
           typename LayoutType,
           typename PointerType = ValueType *>
-struct View {
-  using value_type = ValueType;
-  using pointer_type = PointerType;
-  using layout_type = LayoutType;
-  using nc_value_type = camp::decay<value_type>;
-  using nc_pointer_type = 
-    camp::type::ptr::add< // adds *
-      camp::type::cv::rem<
-        camp::type::ptr::rem<pointer_type>  // removes *
-      >
-    >;
-  using NonConstView = View<nc_value_type, layout_type, nc_pointer_type>;
+using View =
+    internal::ViewBase<ValueType, ValueType *, LayoutType>;
 
-  layout_type const layout;
-  pointer_type data;
 
-  template <typename... Args>
-  RAJA_INLINE constexpr View(pointer_type data_ptr, Args... dim_sizes)
-      : layout(dim_sizes...), data(data_ptr)
-  {
-  }
 
-  RAJA_INLINE constexpr View(pointer_type data_ptr, layout_type &&layout)
-      : layout(layout), data(data_ptr)
-  {
-  }
+template <typename ValueType, typename LayoutType, typename... IndexTypes>
+using TypedView =
+    internal::TypedViewBase<ValueType, ValueType *, LayoutType, camp::list<IndexTypes...> >;
 
-  constexpr View() = delete;
-  RAJA_INLINE constexpr View(View const &) = default;
-  RAJA_INLINE constexpr View(View &&) = default;
-  RAJA_INLINE View& operator=(View const &) = default;
-  RAJA_INLINE View& operator=(View &&) = default;
 
-  template <bool IsConstView = std::is_const<value_type>::value>
-  RAJA_INLINE constexpr View(
-      typename std::enable_if<IsConstView, NonConstView>::type const &rhs)
-      : layout(rhs.layout), data(rhs.data)
-  {
-  }
 
-  RAJA_INLINE void set_data(pointer_type data_ptr) { data = data_ptr; }
 
-  template <size_t n_dims=layout_type::n_dims, typename IdxLin = Index_type>
-  RAJA_INLINE RAJA::View<ValueType, typename add_offset<layout_type>::type>
-  shift(const std::array<IdxLin, n_dims>& shift)
-  {
-    static_assert(n_dims==layout_type::n_dims, "Dimension mismatch in view shift");
 
-    typename add_offset<layout_type>::type shift_layout(layout);
-    shift_layout.shift(shift);
-
-    return RAJA::View<ValueType, typename add_offset<layout_type>::type>(data, shift_layout);
-  }
-
-  // making this specifically typed would require unpacking the layout,
-  // this is easier to maintain
-  template <typename... Args>
-  RAJA_HOST_DEVICE RAJA_INLINE value_type &operator()(Args... args) const
-  {
-    auto idx = stripIndexType(layout(args...));
-    return data[idx];
-  }
-};
+template <typename IndexType, typename ValueType>
+RAJA_INLINE View<ValueType, Layout<1, IndexType, 0> > make_view(
+    ValueType *ptr)
+{
+  return View<ValueType, Layout<1, IndexType, 0> >(ptr, 1);
+}
 
 
 // select certain indices from a tuple, given a curated index sequence
@@ -274,52 +231,6 @@ struct MultiView {
     return data[pidx][idx];
   }
 };
-
-template <typename ValueType,
-          typename PointerType,
-          typename LayoutType,
-          typename... IndexTypes>
-struct TypedViewBase {
-  using Base = View<ValueType, LayoutType, PointerType>;
-
-  Base base_;
-
-  template <typename... Args>
-  RAJA_INLINE constexpr TypedViewBase(PointerType data_ptr, Args... dim_sizes)
-      : base_(data_ptr, dim_sizes...)
-  {
-  }
-
-  template <typename CLayoutType>
-  RAJA_INLINE constexpr TypedViewBase(PointerType data_ptr,
-                                      CLayoutType &&layout)
-      : base_(data_ptr, std::forward<CLayoutType>(layout))
-  {
-  }
-
-  RAJA_INLINE void set_data(PointerType data_ptr) { base_.set_data(data_ptr); }
-
-  template <size_t n_dims=Base::layout_type::n_dims, typename IdxLin = Index_type>
-  RAJA_INLINE RAJA::TypedViewBase<ValueType, ValueType *, typename add_offset<LayoutType>::type, IndexTypes...>
-  shift(const std::array<IdxLin, n_dims>& shift)
-  {
-    static_assert(n_dims==Base::layout_type::n_dims, "Dimension mismatch in view shift");
-
-    typename add_offset<LayoutType>::type shift_layout(base_.layout);
-    shift_layout.shift(shift);
-
-    return RAJA::TypedViewBase<ValueType, ValueType *, typename add_offset<LayoutType>::type, IndexTypes...>(base_.data, shift_layout);
-  }
-
-  RAJA_HOST_DEVICE RAJA_INLINE ValueType &operator()(IndexTypes... args) const
-  {
-    return base_.operator()(stripIndexType(args)...);
-  }
-};
-
-template <typename ValueType, typename LayoutType, typename... IndexTypes>
-using TypedView =
-    TypedViewBase<ValueType, ValueType *, LayoutType, IndexTypes...>;
 
 template <typename ViewType, typename AtomicPolicy = RAJA::auto_atomic>
 struct AtomicViewWrapper {


### PR DESCRIPTION
# Summary

- This PR is a refactoring of the View and View-like things to be more consistent and extensible
- It does the following (modify list as needed):
  - All view like things now implemented with TypedViewBase
  - View like things include all of the View types, and LocalArray types
  - Refactored for future vector/matrix work where the return type may be some complex thing that depends on the view operator() argument type

This work is mainly motivated by the vectorization branch... but with all of the recent churn to the views, it seems better to merge this in now and make sure things stay consistent.
That being said:  there are a number of places that seem unnecessary now (without the vector branch) because they are placeholders/stubs for that work.
