### PR TITLE
Add host implemention of hip atomics

### DIFF
--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -471,28 +471,49 @@ type. Atomic policy types are distinct from loop execution policy types.
            policy for the kernel in which the atomic operation is used. The
            following table summarizes RAJA atomic policies and usage.
 
-===================== ============= ===========================================
-Atomic Policy         Loop Policies Brief description
-                      to Use With
-===================== ============= ===========================================
-seq_atomic            seq_exec,     Atomic operation performed in a non-parallel
-                      loop_exec     (sequential) kernel.
-omp_atomic            any OpenMP    Atomic operation performed in an OpenMP.
-                      policy        multithreading or target kernel; i.e.,
-                                    apply ``omp atomic`` pragma.
-cuda/hip_atomic       any CUDA/HIP  Atomic operation performed in a CUDA/HIP 
-                                    kernel.
-builtin_atomic        seq_exec,     Compiler *builtin* atomic operation.
-                      loop_exec,
-                      any OpenMP
-                      policy
-auto_atomic           seq_exec,     Atomic operation *compatible* with loop
-                      loop_exec,    execution policy. See example below.
-                      any OpenMP
-                      policy,
-                      any CUDA/HIP
-                      policy
-===================== ============= ===========================================
+========================= ============= ===========================================
+Atomic Policy             Loop Policies Brief description
+                          to Use With
+========================= ============= ===========================================
+seq_atomic                seq_exec,     Atomic operation performed in a
+                          loop_exec     non-parallel (sequential) kernel.
+omp_atomic                any OpenMP    Atomic operation performed in an OpenMP.
+                          policy        multithreading or target kernel; i.e.,
+                                        apply ``omp atomic`` pragma.
+cuda/hip_atomic           any CUDA/HIP  Atomic operation performed in a CUDA/HIP
+                                        kernel.
+cuda/hip_atomic_explicit  any CUDA/HIP  Atomic operation performed in a CUDA/HIP
+< host_atomic_policy >    any policy    kernel when compiling for the device.
+                          matching the  See description of host_atomic_policy
+                          host atomic   when compiling for the host.
+                          policy
+builtin_atomic            seq_exec,     Compiler *builtin* atomic operation.
+                          loop_exec,
+                          any OpenMP
+                          policy
+auto_atomic               seq_exec,     Atomic operation *compatible* with loop
+                          loop_exec,    execution policy. See example below.
+                          any OpenMP    Can not be used inside cuda/hip
+                          policy,       explicit atomic policies.
+                          any CUDA/HIP
+                          policy
+========================= ============= ===========================================
+
+Here is an example illustrating use of the ``cuda_atomic_explicit`` policy::
+
+  auto kernel = [=] RAJA_HOST_DEVICE (RAJA::Index_type i) {
+
+    RAJA::atomicAdd< RAJA::cuda_atomic_explicit<omp_atomic> >(&sum, 1);
+
+  };
+  RAJA::forall< RAJA::cuda_exec >(RAJA::RangeSegment seg(0, N), kernel);
+  RAJA::forall< RAJA::omp_parallel_for_exec >(RAJA::RangeSegment seg(0, N),
+      kernel);
+
+In this case, the atomic operation knows when it is compiled for the device
+in a CUDA kernel context and the CUDA atomic operation is applied. Similarly
+when it is compiled for the host in an OpenMP kernel the omp_atomic policy is
+used and the OpenMP version of the atomic operation is applied.
 
 Here is an example illustrating use of the ``auto_atomic`` policy::
 

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -25,6 +25,8 @@
 #include <stdexcept>
 #include <type_traits>
 
+#include "RAJA/policy/loop/atomic.hpp"
+
 #include "RAJA/util/Operators.hpp"
 #include "RAJA/util/TypeConvert.hpp"
 #include "RAJA/util/macros.hpp"
@@ -577,8 +579,18 @@ RAJA_INLINE __device__ unsigned long long cuda_atomicCAS<unsigned long long>(
 }  // namespace detail
 
 
-struct cuda_atomic {
-};
+/*!
+ * Cuda atomic policy for using cuda atomics on the device and
+ * the provided host_policy on the host
+ */
+template<typename host_policy>
+struct cuda_atomic_explicit{};
+
+/*!
+ * Default cuda atomic policy uses cuda atomics on the device and non-atomics
+ * on the host
+ */
+using cuda_atomic = cuda_atomic_explicit<loop_atomic>;
 
 
 /*!
@@ -590,177 +602,162 @@ struct cuda_atomic {
  * These are atomic in cuda device code and non-atomic otherwise
  */
 RAJA_SUPPRESS_HD_WARN
-template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicAdd(cuda_atomic, T volatile *acc, T value)
+template <typename T, typename host_policy>
+RAJA_INLINE RAJA_HOST_DEVICE T
+atomicAdd(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicAdd(acc, value);
 #else
-  T old = *acc;
-  *acc = old + value;
-  return old;
+  return atomicAdd(host_policy{}, acc, value);
 #endif
 }
 
 RAJA_SUPPRESS_HD_WARN
-template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicSub(cuda_atomic, T volatile *acc, T value)
+template <typename T, typename host_policy>
+RAJA_INLINE RAJA_HOST_DEVICE T
+atomicSub(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicSub(acc, value);
 #else
-  T old = *acc;
-  *acc = old - value;
-  return old;
+  return atomicSub(host_policy{}, acc, value);
 #endif
 }
 
 RAJA_SUPPRESS_HD_WARN
-template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicMin(cuda_atomic, T volatile *acc, T value)
+template <typename T, typename host_policy>
+RAJA_INLINE RAJA_HOST_DEVICE T
+atomicMin(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicMin(acc, value);
 #else
-  T old = *acc;
-  if (value < old) *acc = value;
-  return old;
+  return atomicMin(host_policy{}, acc, value);
 #endif
 }
 
 RAJA_SUPPRESS_HD_WARN
-template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicMax(cuda_atomic, T volatile *acc, T value)
+template <typename T, typename host_policy>
+RAJA_INLINE RAJA_HOST_DEVICE T
+atomicMax(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicMax(acc, value);
 #else
-  T old = *acc;
-  if (value > old) *acc = value;
-  return old;
+  return atomicMax(host_policy{}, acc, value);
 #endif
 }
 
 RAJA_SUPPRESS_HD_WARN
-template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicInc(cuda_atomic, T volatile *acc, T val)
+template <typename T, typename host_policy>
+RAJA_INLINE RAJA_HOST_DEVICE T
+atomicInc(cuda_atomic_explicit<host_policy>, T volatile *acc, T val)
 {
 #ifdef __CUDA_ARCH__
   // See:
   // http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomicinc
   return detail::cuda_atomicInc(acc, val);
 #else
-  T old = *acc;
-  *acc = ((old >= val) ? 0 : (old + 1));
-  return old;
+  return atomicInc(host_policy{}, acc, val);
 #endif
 }
 
 RAJA_SUPPRESS_HD_WARN
-template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicInc(cuda_atomic, T volatile *acc)
+template <typename T, typename host_policy>
+RAJA_INLINE RAJA_HOST_DEVICE T
+atomicInc(cuda_atomic_explicit<host_policy>, T volatile *acc)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicInc(acc);
 #else
-  T old = *acc;
-  *acc = old + 1;
-  return old;
+  return atomicInc(host_policy{}, acc);
 #endif
 }
 
 RAJA_SUPPRESS_HD_WARN
-template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicDec(cuda_atomic, T volatile *acc, T val)
+template <typename T, typename host_policy>
+RAJA_INLINE RAJA_HOST_DEVICE T
+atomicDec(cuda_atomic_explicit<host_policy>, T volatile *acc, T val)
 {
 #ifdef __CUDA_ARCH__
   // See:
   // http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomicdec
   return detail::cuda_atomicDec(acc, val);
 #else
-  T old = *acc;
-  *acc = (((old == 0) | (old > val)) ? val : (old - 1));
-  return old;
+  return atomicDec(host_policy{}, acc, val);
 #endif
 }
 
 RAJA_SUPPRESS_HD_WARN
-template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicDec(cuda_atomic, T volatile *acc)
+template <typename T, typename host_policy>
+RAJA_INLINE RAJA_HOST_DEVICE T
+atomicDec(cuda_atomic_explicit<host_policy>, T volatile *acc)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicDec(acc);
 #else
-  T old = *acc;
-  *acc = old - 1;
-  return old;
+  return atomicDec(host_policy{}, acc);
 #endif
 }
 
 RAJA_SUPPRESS_HD_WARN
-template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicAnd(cuda_atomic, T volatile *acc, T value)
+template <typename T, typename host_policy>
+RAJA_INLINE RAJA_HOST_DEVICE T
+atomicAnd(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicAnd(acc, value);
 #else
-  T old = *acc;
-  *acc = old & value;
-  return old;
+  return atomicAnd(host_policy{}, acc, value);
 #endif
 }
 
 RAJA_SUPPRESS_HD_WARN
-template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicOr(cuda_atomic, T volatile *acc, T value)
+template <typename T, typename host_policy>
+RAJA_INLINE RAJA_HOST_DEVICE T
+atomicOr(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicOr(acc, value);
 #else
-  T old = *acc;
-  *acc = old | value;
-  return old;
+  return atomicOr(host_policy{}, acc, value);
 #endif
 }
 
 RAJA_SUPPRESS_HD_WARN
-template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicXor(cuda_atomic, T volatile *acc, T value)
+template <typename T, typename host_policy>
+RAJA_INLINE RAJA_HOST_DEVICE T
+atomicXor(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicXor(acc, value);
 #else
-  T old = *acc;
-  *acc = old ^ value;
-  return old;
+  return atomicXor(host_policy{}, acc, value);
 #endif
 }
 
 RAJA_SUPPRESS_HD_WARN
-template <typename T>
+template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicExchange(cuda_atomic, T volatile *acc, T value)
+atomicExchange(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicExchange(acc, value);
 #else
-  T old = *acc;
-  *acc = value;
-  return old;
+  return atomicExchange(host_policy{}, acc, value);
 #endif
 }
 
 RAJA_SUPPRESS_HD_WARN
-template <typename T>
+template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicCAS(cuda_atomic, T volatile *acc, T compare, T value)
+atomicCAS(cuda_atomic_explicit<host_policy>, T volatile *acc, T compare, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicCAS(acc, compare, value);
 #else
-  T old = *acc;
-  if (old == compare) *acc = value;
-  return old;
+  return atomicCAS(host_policy{}, acc, compare, value);
 #endif
 }
 

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -609,7 +609,7 @@ atomicAdd(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicAdd(acc, value);
 #else
-  return atomicAdd(host_policy{}, acc, value);
+  return RAJA::atomicAdd(host_policy{}, acc, value);
 #endif
 }
 
@@ -621,7 +621,7 @@ atomicSub(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicSub(acc, value);
 #else
-  return atomicSub(host_policy{}, acc, value);
+  return RAJA::atomicSub(host_policy{}, acc, value);
 #endif
 }
 
@@ -633,7 +633,7 @@ atomicMin(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicMin(acc, value);
 #else
-  return atomicMin(host_policy{}, acc, value);
+  return RAJA::atomicMin(host_policy{}, acc, value);
 #endif
 }
 
@@ -645,7 +645,7 @@ atomicMax(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicMax(acc, value);
 #else
-  return atomicMax(host_policy{}, acc, value);
+  return RAJA::atomicMax(host_policy{}, acc, value);
 #endif
 }
 
@@ -659,7 +659,7 @@ atomicInc(cuda_atomic_explicit<host_policy>, T volatile *acc, T val)
   // http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomicinc
   return detail::cuda_atomicInc(acc, val);
 #else
-  return atomicInc(host_policy{}, acc, val);
+  return RAJA::atomicInc(host_policy{}, acc, val);
 #endif
 }
 
@@ -671,7 +671,7 @@ atomicInc(cuda_atomic_explicit<host_policy>, T volatile *acc)
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicInc(acc);
 #else
-  return atomicInc(host_policy{}, acc);
+  return RAJA::atomicInc(host_policy{}, acc);
 #endif
 }
 
@@ -685,7 +685,7 @@ atomicDec(cuda_atomic_explicit<host_policy>, T volatile *acc, T val)
   // http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomicdec
   return detail::cuda_atomicDec(acc, val);
 #else
-  return atomicDec(host_policy{}, acc, val);
+  return RAJA::atomicDec(host_policy{}, acc, val);
 #endif
 }
 
@@ -697,7 +697,7 @@ atomicDec(cuda_atomic_explicit<host_policy>, T volatile *acc)
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicDec(acc);
 #else
-  return atomicDec(host_policy{}, acc);
+  return RAJA::atomicDec(host_policy{}, acc);
 #endif
 }
 
@@ -709,7 +709,7 @@ atomicAnd(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicAnd(acc, value);
 #else
-  return atomicAnd(host_policy{}, acc, value);
+  return RAJA::atomicAnd(host_policy{}, acc, value);
 #endif
 }
 
@@ -721,7 +721,7 @@ atomicOr(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicOr(acc, value);
 #else
-  return atomicOr(host_policy{}, acc, value);
+  return RAJA::atomicOr(host_policy{}, acc, value);
 #endif
 }
 
@@ -733,7 +733,7 @@ atomicXor(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicXor(acc, value);
 #else
-  return atomicXor(host_policy{}, acc, value);
+  return RAJA::atomicXor(host_policy{}, acc, value);
 #endif
 }
 
@@ -745,7 +745,7 @@ atomicExchange(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicExchange(acc, value);
 #else
-  return atomicExchange(host_policy{}, acc, value);
+  return RAJA::atomicExchange(host_policy{}, acc, value);
 #endif
 }
 
@@ -757,7 +757,7 @@ atomicCAS(cuda_atomic_explicit<host_policy>, T volatile *acc, T compare, T value
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicCAS(acc, compare, value);
 #else
-  return atomicCAS(host_policy{}, acc, compare, value);
+  return RAJA::atomicCAS(host_policy{}, acc, compare, value);
 #endif
 }
 

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -31,9 +31,6 @@
 #if defined(RAJA_ENABLE_OPENMP)
 #include "RAJA/policy/openmp/atomic.hpp"
 #endif
-#if defined(RAJA_ENABLE_TBB)
-#include "RAJA/policy/tbb/atomic.hpp"
-#endif
 
 #include "RAJA/util/Operators.hpp"
 #include "RAJA/util/TypeConvert.hpp"

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -26,6 +26,14 @@
 #include <type_traits>
 
 #include "RAJA/policy/loop/atomic.hpp"
+#include "RAJA/policy/sequential/atomic.hpp"
+#include "RAJA/policy/atomic_builtin.hpp"
+#if defined(RAJA_ENABLE_OPENMP)
+#include "RAJA/policy/openmp/atomic.hpp"
+#endif
+#if defined(RAJA_ENABLE_TBB)
+#include "RAJA/policy/tbb/atomic.hpp"
+#endif
 
 #include "RAJA/util/Operators.hpp"
 #include "RAJA/util/TypeConvert.hpp"

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -27,6 +27,14 @@
 #include "hip/hip_runtime.h"
 
 #include "RAJA/policy/loop/atomic.hpp"
+#include "RAJA/policy/sequential/atomic.hpp"
+#include "RAJA/policy/atomic_builtin.hpp"
+#if defined(RAJA_ENABLE_OPENMP)
+#include "RAJA/policy/openmp/atomic.hpp"
+#endif
+#if defined(RAJA_ENABLE_TBB)
+#include "RAJA/policy/tbb/atomic.hpp"
+#endif
 
 #include "RAJA/util/Operators.hpp"
 #include "RAJA/util/TypeConvert.hpp"

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -32,9 +32,6 @@
 #if defined(RAJA_ENABLE_OPENMP)
 #include "RAJA/policy/openmp/atomic.hpp"
 #endif
-#if defined(RAJA_ENABLE_TBB)
-#include "RAJA/policy/tbb/atomic.hpp"
-#endif
 
 #include "RAJA/util/Operators.hpp"
 #include "RAJA/util/TypeConvert.hpp"

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -591,7 +591,7 @@ atomicAdd(hip_atomic_explicit<host_policy>, T volatile *acc, T value)
 #if defined(__HIP_DEVICE_COMPILE__)
   return detail::hip_atomicAdd(acc, value);
 #else
-  return atomicAdd(host_policy{}, acc, value);
+  return RAJA::atomicAdd(host_policy{}, acc, value);
 #endif
 }
 
@@ -603,7 +603,7 @@ atomicSub(hip_atomic_explicit<host_policy>, T volatile *acc, T value)
 #if defined(__HIP_DEVICE_COMPILE__)
   return detail::hip_atomicSub(acc, value);
 #else
-  return atomicSub(host_policy{}, acc, value);
+  return RAJA::atomicSub(host_policy{}, acc, value);
 #endif
 }
 
@@ -615,7 +615,7 @@ atomicMin(hip_atomic_explicit<host_policy>, T volatile *acc, T value)
 #if defined(__HIP_DEVICE_COMPILE__)
   return detail::hip_atomicMin(acc, value);
 #else
-  return atomicMin(host_policy{}, acc, value);
+  return RAJA::atomicMin(host_policy{}, acc, value);
 #endif
 }
 
@@ -627,7 +627,7 @@ atomicMax(hip_atomic_explicit<host_policy>, T volatile *acc, T value)
 #if defined(__HIP_DEVICE_COMPILE__)
   return detail::hip_atomicMax(acc, value);
 #else
-  return atomicMax(host_policy{}, acc, value);
+  return RAJA::atomicMax(host_policy{}, acc, value);
 #endif
 }
 
@@ -639,7 +639,7 @@ atomicInc(hip_atomic_explicit<host_policy>, T volatile *acc, T val)
 #if defined(__HIP_DEVICE_COMPILE__)
   return detail::hip_atomicInc(acc, val);
 #else
-  return atomicInc(host_policy{}, acc, val);
+  return RAJA::atomicInc(host_policy{}, acc, val);
 #endif
 }
 
@@ -651,7 +651,7 @@ atomicInc(hip_atomic_explicit<host_policy>, T volatile *acc)
 #if defined(__HIP_DEVICE_COMPILE__)
   return detail::hip_atomicInc(acc);
 #else
-  return atomicInc(host_policy{}, acc);
+  return RAJA::atomicInc(host_policy{}, acc);
 #endif
 }
 
@@ -663,7 +663,7 @@ atomicDec(hip_atomic_explicit<host_policy>, T volatile *acc, T val)
 #if defined(__HIP_DEVICE_COMPILE__)
   return detail::hip_atomicDec(acc, val);
 #else
-  return atomicDec(host_policy{}, acc, val);
+  return RAJA::atomicDec(host_policy{}, acc, val);
 #endif
 }
 
@@ -675,7 +675,7 @@ atomicDec(hip_atomic_explicit<host_policy>, T volatile *acc)
 #if defined(__HIP_DEVICE_COMPILE__)
   return detail::hip_atomicDec(acc);
 #else
-  return atomicDec(host_policy{}, acc);
+  return RAJA::atomicDec(host_policy{}, acc);
 #endif
 }
 
@@ -687,7 +687,7 @@ atomicAnd(hip_atomic_explicit<host_policy>, T volatile *acc, T value)
 #if defined(__HIP_DEVICE_COMPILE__)
   return detail::hip_atomicAnd(acc, value);
 #else
-  return atomicAnd(host_policy{}, acc, value);
+  return RAJA::atomicAnd(host_policy{}, acc, value);
 #endif
 }
 
@@ -699,7 +699,7 @@ atomicOr(hip_atomic_explicit<host_policy>, T volatile *acc, T value)
 #if defined(__HIP_DEVICE_COMPILE__)
   return detail::hip_atomicOr(acc, value);
 #else
-  return atomicOr(host_policy{}, acc, value);
+  return RAJA::atomicOr(host_policy{}, acc, value);
 #endif
 }
 
@@ -711,7 +711,7 @@ atomicXor(hip_atomic_explicit<host_policy>, T volatile *acc, T value)
 #if defined(__HIP_DEVICE_COMPILE__)
   return detail::hip_atomicXor(acc, value);
 #else
-  return atomicXor(host_policy{}, acc, value);
+  return RAJA::atomicXor(host_policy{}, acc, value);
 #endif
 }
 
@@ -723,7 +723,7 @@ atomicExchange(hip_atomic_explicit<host_policy>, T volatile *acc, T value)
 #if defined(__HIP_DEVICE_COMPILE__)
   return detail::hip_atomicExchange(acc, value);
 #else
-  return atomicExchange(host_policy{}, acc, value);
+  return RAJA::atomicExchange(host_policy{}, acc, value);
 #endif
 }
 
@@ -735,7 +735,7 @@ atomicCAS(hip_atomic_explicit<host_policy>, T volatile *acc, T compare, T value)
 #if defined(__HIP_DEVICE_COMPILE__)
   return detail::hip_atomicCAS(acc, compare, value);
 #else
-  return atomicCAS(host_policy{}, acc, compare, value);
+  return RAJA::atomicCAS(host_policy{}, acc, compare, value);
 #endif
 }
 

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -168,6 +168,14 @@ RAJA_INLINE __device__ T hip_atomic_CAS_oper(T volatile *acc, OPER &&oper)
  * These are atomic in hip device code and non-atomic otherwise
  */
 template <typename T>
+RAJA_INLINE __host__ T hip_atomicAdd(T volatile *acc, T value)
+{
+  T old = *acc;
+  *acc = old + value;
+  return old;
+}
+///
+template <typename T>
 RAJA_INLINE __device__ T hip_atomicAdd(T volatile *acc, T value)
 {
   return hip_atomic_CAS_oper(acc, [=] __device__(T a) {
@@ -217,6 +225,14 @@ RAJA_INLINE __device__ float hip_atomicAdd<float>(float volatile *acc,
 #endif
 
 template <typename T>
+RAJA_INLINE __host__ T hip_atomicSub(T volatile *acc, T value)
+{
+  T old = *acc;
+  *acc = old - value;
+  return old;
+}
+///
+template <typename T>
 RAJA_INLINE __device__ T hip_atomicSub(T volatile *acc, T value)
 {
   return hip_atomic_CAS_oper(acc, [=] __device__(T a) {
@@ -242,6 +258,14 @@ RAJA_INLINE __device__ unsigned hip_atomicSub<unsigned>(unsigned volatile *acc,
 }
 #endif
 
+template <typename T>
+RAJA_INLINE __host__ T hip_atomicMin(T volatile *acc, T value)
+{
+  T old = *acc;
+  if (value < old) *acc = value;
+  return old;
+}
+///
 template <typename T>
 RAJA_INLINE __device__ T hip_atomicMin(T volatile *acc, T value)
 {
@@ -280,6 +304,14 @@ RAJA_INLINE __device__ unsigned long long hip_atomicMin<unsigned long long>(
 #endif
 
 template <typename T>
+RAJA_INLINE __host__ T hip_atomicMax(T volatile *acc, T value)
+{
+  T old = *acc;
+  if (value > old) *acc = value;
+  return old;
+}
+///
+template <typename T>
 RAJA_INLINE __device__ T hip_atomicMax(T volatile *acc, T value)
 {
   return hip_atomic_CAS_oper(acc, [=] __device__(T a) {
@@ -317,6 +349,14 @@ RAJA_INLINE __device__ unsigned long long hip_atomicMax<unsigned long long>(
 #endif
 
 template <typename T>
+RAJA_INLINE __host__ T hip_atomicInc(T volatile *acc, T val)
+{
+  T old = *acc;
+  *acc = ((old >= val) ? 0 : (old + 1));
+  return old;
+}
+///
+template <typename T>
 RAJA_INLINE __device__ T hip_atomicInc(T volatile *acc, T val)
 {
   return hip_atomic_CAS_oper(acc, [=] __device__(T old) {
@@ -335,6 +375,14 @@ RAJA_INLINE __device__ unsigned hip_atomicInc<unsigned>(unsigned volatile *acc,
 #endif
 
 template <typename T>
+RAJA_INLINE __host__ T hip_atomicInc(T volatile *acc)
+{
+  T old = *acc;
+  *acc = old + 1;
+  return old;
+}
+///
+template <typename T>
 RAJA_INLINE __device__ T hip_atomicInc(T volatile *acc)
 {
   return hip_atomic_CAS_oper(acc,
@@ -342,6 +390,16 @@ RAJA_INLINE __device__ T hip_atomicInc(T volatile *acc)
 }
 
 
+template <typename T>
+RAJA_INLINE __host__ T hip_atomicDec(T volatile *acc, T val)
+{
+  // See:
+  // http://docs.nvidia.com/hip/hip-c-programming-guide/index.html#atomicdec
+  T old = *acc;
+  *acc = (((old == 0) | (old > val)) ? val : (old - 1));
+  return old;
+}
+///
 template <typename T>
 RAJA_INLINE __device__ T hip_atomicDec(T volatile *acc, T val)
 {
@@ -363,6 +421,14 @@ RAJA_INLINE __device__ unsigned hip_atomicDec<unsigned>(unsigned volatile *acc,
 #endif
 
 template <typename T>
+RAJA_INLINE __host__ T hip_atomicDec(T volatile *acc)
+{
+  T old = *acc;
+  *acc = old - 1;
+  return old;
+}
+///
+template <typename T>
 RAJA_INLINE __device__ T hip_atomicDec(T volatile *acc)
 {
   return hip_atomic_CAS_oper(acc,
@@ -370,6 +436,14 @@ RAJA_INLINE __device__ T hip_atomicDec(T volatile *acc)
 }
 
 
+template <typename T>
+RAJA_INLINE __host__ T hip_atomicAnd(T volatile *acc, T value)
+{
+  T old = *acc;
+  *acc = old & value;
+  return old;
+}
+///
 template <typename T>
 RAJA_INLINE __device__ T hip_atomicAnd(T volatile *acc, T value)
 {
@@ -409,6 +483,14 @@ RAJA_INLINE __device__ unsigned long long hip_atomicAnd<unsigned long long>(
 #endif
 
 template <typename T>
+RAJA_INLINE __host__ T hip_atomicOr(T volatile *acc, T value)
+{
+  T old = *acc;
+  *acc = old | value;
+  return old;
+}
+///
+template <typename T>
 RAJA_INLINE __device__ T hip_atomicOr(T volatile *acc, T value)
 {
   return hip_atomic_CAS_oper(acc, [=] __device__(T a) {
@@ -447,6 +529,14 @@ RAJA_INLINE __device__ unsigned long long hip_atomicOr<unsigned long long>(
 #endif
 
 template <typename T>
+RAJA_INLINE __host__ T hip_atomicXor(T volatile *acc, T value)
+{
+  T old = *acc;
+  *acc = old ^ value;
+  return old;
+}
+///
+template <typename T>
 RAJA_INLINE __device__ T hip_atomicXor(T volatile *acc, T value)
 {
   return hip_atomic_CAS_oper(acc, [=] __device__(T a) {
@@ -484,6 +574,14 @@ RAJA_INLINE __device__ unsigned long long hip_atomicXor<unsigned long long>(
 }
 #endif
 
+template <typename T>
+RAJA_INLINE __host__ T hip_atomicExchange(T volatile *acc, T value)
+{
+  T old = *acc;
+  *acc = value;
+  return old;
+}
+///
 template <typename T>
 RAJA_INLINE __device__ T hip_atomicExchange(T volatile *acc, T value)
 {
@@ -527,6 +625,14 @@ RAJA_INLINE __device__ float hip_atomicExchange<float>(
 }
 #endif
 
+template <typename T>
+RAJA_INLINE __host__ T hip_atomicCAS(T volatile *acc, T compare, T value)
+{
+  T old = *acc;
+  if (old == compare) *acc = value;
+  return old;
+}
+///
 template <typename T>
 RAJA_INLINE __device__ T hip_atomicCAS(T volatile *acc, T compare, T value)
 {

--- a/test/functional/forall/CMakeLists.txt
+++ b/test/functional/forall/CMakeLists.txt
@@ -55,7 +55,8 @@ endif()
 
 if(RAJA_ENABLE_TBB)
 # TBB atomics are not available in RAJA currently
-#  list(APPEND FORALL_BACKENDS TBB)
+# so built-in atomics are used
+  list(APPEND FORALL_ATOMIC_BACKENDS TBB)
 endif()
 
 if(RAJA_ENABLE_CUDA)

--- a/test/functional/forall/atomic-view/tests/test-forall-AtomicMultiView.hpp
+++ b/test/functional/forall/atomic-view/tests/test-forall-AtomicMultiView.hpp
@@ -38,18 +38,18 @@ void ForallAtomicMultiViewTestImpl( IdxType N )
   T * check_array = host_res.allocate<T>(N/2);
 
   // assumes each source[] will be 2x size of each dest[], src_side x dst_side
-  T ** source = new T * [src_side];
-  for ( int ii = 0; ii < src_side; ++ii )
+  T ** source = work_res.allocate<T*>(src_side);
+  RAJA::forall<ExecPolicy>(seg_srcside, [=] RAJA_HOST_DEVICE(IdxType ii)
   {
     source[ii] = actualsource+(ii*dst_side);
-  }
+  });
 
   // assumes each dest[] will be a square matrix, dst_side x dst_side
-  T ** dest = new T * [dst_side];
-  for ( int ii = 0; ii < dst_side; ++ii )
+  T ** dest = work_res.allocate<T*>(dst_side);
+  RAJA::forall<ExecPolicy>(seg_dstside, [=] RAJA_HOST_DEVICE(IdxType ii)
   {
     dest[ii] = actualdest+(ii*dst_side);
-  }
+  });
 
 #if defined(RAJA_ENABLE_CUDA)
   cudaErrchk(cudaDeviceSynchronize());
@@ -59,8 +59,9 @@ void ForallAtomicMultiViewTestImpl( IdxType N )
   hipErrchk(hipDeviceSynchronize());
 #endif
 
-  RAJA::forall<RAJA::seq_exec>(seg,
-                               [=](IdxType i) { actualsource[i] = (T)1; });
+  RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(IdxType i) {
+    actualsource[i] = (T)1;
+  });
 
   // use atomic add to reduce the array
   // 1D defaut MultiView
@@ -104,6 +105,8 @@ void ForallAtomicMultiViewTestImpl( IdxType N )
   work_res.deallocate( actualsource );
   work_res.deallocate( actualdest );
   host_res.deallocate( check_array );
+  work_res.deallocate( source );
+  work_res.deallocate( dest );
 }
 
 TYPED_TEST_SUITE_P(ForallAtomicMultiViewTest);

--- a/test/functional/forall/atomic-view/tests/test-forall-AtomicMultiView.hpp
+++ b/test/functional/forall/atomic-view/tests/test-forall-AtomicMultiView.hpp
@@ -33,23 +33,11 @@ void ForallAtomicMultiViewTestImpl( IdxType N )
   camp::resources::Resource work_res{WORKINGRES()};
   camp::resources::Resource host_res{camp::resources::Host()};
 
-  T * actualsource = work_res.allocate<T>(N);
-  T * actualdest = work_res.allocate<T>(N/2);
-  T * check_array = host_res.allocate<T>(N/2);
-
-  // assumes each source[] will be 2x size of each dest[], src_side x dst_side
-  T ** source = work_res.allocate<T*>(src_side);
-  RAJA::forall<ExecPolicy>(seg_srcside, [=] RAJA_HOST_DEVICE(IdxType ii)
-  {
-    source[ii] = actualsource+(ii*dst_side);
-  });
-
-  // assumes each dest[] will be a square matrix, dst_side x dst_side
-  T ** dest = work_res.allocate<T*>(dst_side);
-  RAJA::forall<ExecPolicy>(seg_dstside, [=] RAJA_HOST_DEVICE(IdxType ii)
-  {
-    dest[ii] = actualdest+(ii*dst_side);
-  });
+  T *  actualsource = work_res.allocate<T> (N);
+  T ** source       = work_res.allocate<T*>(src_side);
+  T *  actualdest   = work_res.allocate<T> (N/2);
+  T ** dest         = work_res.allocate<T*>(dst_side);
+  T *  check_array  = host_res.allocate<T> (N/2);
 
 #if defined(RAJA_ENABLE_CUDA)
   cudaErrchk(cudaDeviceSynchronize());
@@ -58,6 +46,18 @@ void ForallAtomicMultiViewTestImpl( IdxType N )
 #if defined(RAJA_ENABLE_HIP)
   hipErrchk(hipDeviceSynchronize());
 #endif
+
+  // assumes each source[] will be 2x size of each dest[], src_side x dst_side
+  RAJA::forall<ExecPolicy>(seg_srcside, [=] RAJA_HOST_DEVICE(IdxType ii)
+  {
+    source[ii] = actualsource+(ii*dst_side);
+  });
+
+  // assumes each dest[] will be a square matrix, dst_side x dst_side
+  RAJA::forall<ExecPolicy>(seg_dstside, [=] RAJA_HOST_DEVICE(IdxType ii)
+  {
+    dest[ii] = actualdest+(ii*dst_side);
+  });
 
   RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(IdxType i) {
     actualsource[i] = (T)1;
@@ -103,10 +103,10 @@ void ForallAtomicMultiViewTestImpl( IdxType N )
   }
 
   work_res.deallocate( actualsource );
-  work_res.deallocate( actualdest );
-  host_res.deallocate( check_array );
   work_res.deallocate( source );
+  work_res.deallocate( actualdest );
   work_res.deallocate( dest );
+  host_res.deallocate( check_array );
 }
 
 TYPED_TEST_SUITE_P(ForallAtomicMultiViewTest);

--- a/test/include/RAJA_test-atomicpol.hpp
+++ b/test/include/RAJA_test-atomicpol.hpp
@@ -14,8 +14,25 @@
 using SequentialAtomicPols =
   camp::list<
 #if defined(RAJA_TEST_EXHAUSTIVE)
+              RAJA::loop_atomic,
               RAJA::auto_atomic,
               RAJA::builtin_atomic,
+#endif
+#if defined(RAJA_ENABLE_CUDA)
+              RAJA::cuda_atomic_explicit<RAJA::seq_atomic>,
+#if defined(RAJA_TEST_EXHAUSTIVE)
+              RAJA::cuda_atomic_explicit<RAJA::loop_atomic>,
+              RAJA::cuda_atomic_explicit<RAJA::auto_atomic>,
+              RAJA::cuda_atomic_explicit<RAJA::builtin_atomic>,
+#endif
+#endif
+#if defined(RAJA_ENABLE_HIP)
+              RAJA::hip_atomic_explicit<RAJA::seq_atomic>,
+#if defined(RAJA_TEST_EXHAUSTIVE)
+              RAJA::hip_atomic_explicit<RAJA::loop_atomic>,
+              RAJA::hip_atomic_explicit<RAJA::auto_atomic>,
+              RAJA::hip_atomic_explicit<RAJA::builtin_atomic>,
+#endif
 #endif
               RAJA::seq_atomic
             >;
@@ -27,15 +44,37 @@ using OpenMPAtomicPols =
               RAJA::omp_atomic,
               RAJA::builtin_atomic,
 #endif
+#if defined(RAJA_ENABLE_CUDA)
+              RAJA::cuda_atomic_explicit<RAJA::auto_atomic>,
+#if defined(RAJA_TEST_EXHAUSTIVE)
+              RAJA::cuda_atomic_explicit<RAJA::omp_atomic>,
+              RAJA::cuda_atomic_explicit<RAJA::builtin_atomic>,
+#endif
+#endif
+#if defined(RAJA_ENABLE_HIP)
+              RAJA::hip_atomic_explicit<RAJA::auto_atomic>,
+#if defined(RAJA_TEST_EXHAUSTIVE)
+              RAJA::hip_atomic_explicit<RAJA::omp_atomic>,
+              RAJA::hip_atomic_explicit<RAJA::builtin_atomic>,
+#endif
+#endif
               RAJA::auto_atomic
             >;
 #endif  // RAJA_ENABLE_OPENMP
+
 
 #if defined(RAJA_ENABLE_CUDA)
 using CudaAtomicPols =
   camp::list<
 #if defined(RAJA_TEST_EXHAUSTIVE)
               RAJA::auto_atomic,
+              RAJA::cuda_atomic_explicit<RAJA::seq_atomic>,
+              RAJA::cuda_atomic_explicit<RAJA::loop_atomic>,
+              RAJA::cuda_atomic_explicit<RAJA::auto_atomic>,
+              RAJA::cuda_atomic_explicit<RAJA::builtin_atomic>,
+#if defined(RAJA_ENABLE_OPENMP)
+              RAJA::cuda_atomic_explicit<RAJA::omp_atomic>,
+#endif
 #endif
               RAJA::cuda_atomic
             >;
@@ -46,6 +85,13 @@ using HipAtomicPols =
   camp::list<
 #if defined(RAJA_TEST_EXHAUSTIVE)
                RAJA::auto_atomic,
+               RAJA::hip_atomic_explicit<RAJA::seq_atomic>,
+               RAJA::hip_atomic_explicit<RAJA::loop_atomic>,
+               RAJA::hip_atomic_explicit<RAJA::auto_atomic>,
+               RAJA::hip_atomic_explicit<RAJA::builtin_atomic>,
+#if defined(RAJA_ENABLE_OPENMP)
+               RAJA::hip_atomic_explicit<RAJA::omp_atomic>,
+#endif
 #endif
                RAJA::hip_atomic
             >;

--- a/test/include/RAJA_test-atomicpol.hpp
+++ b/test/include/RAJA_test-atomicpol.hpp
@@ -62,6 +62,18 @@ using OpenMPAtomicPols =
             >;
 #endif  // RAJA_ENABLE_OPENMP
 
+#if defined(RAJA_ENABLE_TBB)
+using TBBAtomicPols =
+  camp::list<
+#if defined(RAJA_ENABLE_CUDA)
+              RAJA::cuda_atomic_explicit<RAJA::builtin_atomic>,
+#endif
+#if defined(RAJA_ENABLE_HIP)
+              RAJA::hip_atomic_explicit<RAJA::builtin_atomic>,
+#endif
+              RAJA::builtin_atomic
+            >;
+#endif  // RAJA_ENABLE_TBB
 
 #if defined(RAJA_ENABLE_CUDA)
 using CudaAtomicPols =

--- a/test/include/RAJA_test-atomicpol.hpp
+++ b/test/include/RAJA_test-atomicpol.hpp
@@ -22,7 +22,6 @@ using SequentialAtomicPols =
               RAJA::cuda_atomic_explicit<RAJA::seq_atomic>,
 #if defined(RAJA_TEST_EXHAUSTIVE)
               RAJA::cuda_atomic_explicit<RAJA::loop_atomic>,
-              RAJA::cuda_atomic_explicit<RAJA::auto_atomic>,
               RAJA::cuda_atomic_explicit<RAJA::builtin_atomic>,
 #endif
 #endif
@@ -30,7 +29,6 @@ using SequentialAtomicPols =
               RAJA::hip_atomic_explicit<RAJA::seq_atomic>,
 #if defined(RAJA_TEST_EXHAUSTIVE)
               RAJA::hip_atomic_explicit<RAJA::loop_atomic>,
-              RAJA::hip_atomic_explicit<RAJA::auto_atomic>,
               RAJA::hip_atomic_explicit<RAJA::builtin_atomic>,
 #endif
 #endif
@@ -45,16 +43,14 @@ using OpenMPAtomicPols =
               RAJA::builtin_atomic,
 #endif
 #if defined(RAJA_ENABLE_CUDA)
-              RAJA::cuda_atomic_explicit<RAJA::auto_atomic>,
-#if defined(RAJA_TEST_EXHAUSTIVE)
               RAJA::cuda_atomic_explicit<RAJA::omp_atomic>,
+#if defined(RAJA_TEST_EXHAUSTIVE)
               RAJA::cuda_atomic_explicit<RAJA::builtin_atomic>,
 #endif
 #endif
 #if defined(RAJA_ENABLE_HIP)
-              RAJA::hip_atomic_explicit<RAJA::auto_atomic>,
-#if defined(RAJA_TEST_EXHAUSTIVE)
               RAJA::hip_atomic_explicit<RAJA::omp_atomic>,
+#if defined(RAJA_TEST_EXHAUSTIVE)
               RAJA::hip_atomic_explicit<RAJA::builtin_atomic>,
 #endif
 #endif
@@ -82,7 +78,6 @@ using CudaAtomicPols =
               RAJA::auto_atomic,
               RAJA::cuda_atomic_explicit<RAJA::seq_atomic>,
               RAJA::cuda_atomic_explicit<RAJA::loop_atomic>,
-              RAJA::cuda_atomic_explicit<RAJA::auto_atomic>,
               RAJA::cuda_atomic_explicit<RAJA::builtin_atomic>,
 #if defined(RAJA_ENABLE_OPENMP)
               RAJA::cuda_atomic_explicit<RAJA::omp_atomic>,
@@ -99,7 +94,6 @@ using HipAtomicPols =
                RAJA::auto_atomic,
                RAJA::hip_atomic_explicit<RAJA::seq_atomic>,
                RAJA::hip_atomic_explicit<RAJA::loop_atomic>,
-               RAJA::hip_atomic_explicit<RAJA::auto_atomic>,
                RAJA::hip_atomic_explicit<RAJA::builtin_atomic>,
 #if defined(RAJA_ENABLE_OPENMP)
                RAJA::hip_atomic_explicit<RAJA::omp_atomic>,

--- a/test/unit/atomic/test-atomic-ref.hpp
+++ b/test/unit/atomic/test-atomic-ref.hpp
@@ -12,7 +12,7 @@
 #include <RAJA/RAJA.hpp>
 #include "RAJA_gtest.hpp"
 
-using basic_types = 
+using basic_types =
     ::testing::Types<
                       std::tuple<int, RAJA::builtin_atomic>,
                       std::tuple<int, RAJA::seq_atomic>,
@@ -45,10 +45,23 @@ using basic_types =
                       std::tuple<double, RAJA::auto_atomic>,
                       std::tuple<double, RAJA::cuda_atomic>
 #endif
+#if defined(RAJA_ENABLE_HIP)
+                      ,
+                      std::tuple<int, RAJA::auto_atomic>,
+                      std::tuple<int, RAJA::hip_atomic>,
+                      std::tuple<unsigned int, RAJA::auto_atomic>,
+                      std::tuple<unsigned int, RAJA::hip_atomic>,
+                      std::tuple<unsigned long long int, RAJA::auto_atomic>,
+                      std::tuple<unsigned long long int, RAJA::hip_atomic>,
+                      std::tuple<float, RAJA::auto_atomic>,
+                      std::tuple<float, RAJA::hip_atomic>,
+                      std::tuple<double, RAJA::auto_atomic>,
+                      std::tuple<double, RAJA::hip_atomic>
+#endif
                     >;
 
 #if defined(RAJA_ENABLE_CUDA)
-using CUDA_types = 
+using CUDA_types =
     ::testing::Types<
                       std::tuple<int, RAJA::auto_atomic>,
                       std::tuple<int, RAJA::cuda_atomic>,


### PR DESCRIPTION
# Summary
Add host implemention of hip atomics to match cuda implementation.
Note this is needed because usage of the hip atomics in so host device contexts fails to compile.
Added the gpu atomic explicit policies to the functional tests to test device side and host side functionality.

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes ability to use hip atomics