### PR TITLE
docs: fix alignment in cuda/hip policy table

### DIFF
--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -135,7 +135,7 @@ policies have the prefix ``hip_``.
                                                         given, the default
                                                         of 256 threads/block is 
                                                         used. 
- cuda/hip_thread_x_direct                kernel (For)  Map loop iterates
+ cuda/hip_thread_x_direct                 kernel (For)  Map loop iterates
                                                         directly to GPU threads
                                                         in x-dimension, one
                                                         iterate per thread


### PR DESCRIPTION
The cuda/hip policy table does not render in the current version of the documentation. This PR fixes a misaligned entry in the cuda/hip policy table so that it renders.