### PR TITLE
Update hip launch wrapper

### DIFF
--- a/include/RAJA/policy/hip/MemUtils_HIP.hpp
+++ b/include/RAJA/policy/hip/MemUtils_HIP.hpp
@@ -204,12 +204,10 @@ void launch(hipStream_t stream)
 }
 
 //! Launch kernel and indicate stream is asynchronous
-template<typename Func, typename... Args>
 RAJA_INLINE
-void launch(Func &func, hip_dim_t gridDim, hip_dim_t blockDim, size_t shmem, hipStream_t stream, Args&&... args)
+void launch(const void* func, hip_dim_t gridDim, hip_dim_t blockDim, void** args, size_t shmem, hipStream_t stream)
 {
-  hipLaunchKernelGGL(func, dim3(gridDim), dim3(blockDim), shmem, stream, std::forward<Args>(args)...);
-  hipErrchk(hipGetLastError());
+  hipErrchk(hipLaunchKernel(func, dim3(gridDim), dim3(blockDim), args, shmem, stream));
   launch(stream);
 }
 

--- a/include/RAJA/policy/hip/MemUtils_HIP.hpp
+++ b/include/RAJA/policy/hip/MemUtils_HIP.hpp
@@ -204,11 +204,11 @@ void launch(hipStream_t stream)
 }
 
 //! Launch kernel and indicate stream is asynchronous
-template<typename Func, typename Data>
+template<typename Func, typename... Args>
 RAJA_INLINE
-void launch(Func &func, hip_dim_t gridDim, hip_dim_t blockDim, Data &&data, size_t shmem, hipStream_t stream)
+void launch(Func &func, hip_dim_t gridDim, hip_dim_t blockDim, size_t shmem, hipStream_t stream, Args&&... args)
 {
-  hipLaunchKernelGGL(func, dim3(gridDim), dim3(blockDim), shmem, stream, data);
+  hipLaunchKernelGGL(func, dim3(gridDim), dim3(blockDim), shmem, stream, std::forward<Args>(args)...);
   hipErrchk(hipGetLastError());
   launch(stream);
 }

--- a/include/RAJA/policy/hip/WorkGroup/WorkRunner.hpp
+++ b/include/RAJA/policy/hip/WorkGroup/WorkRunner.hpp
@@ -326,10 +326,8 @@ struct WorkRunner<
         //
         // Launch the kernel
         //
-        RAJA::hip::launch(func,
-                          dim3(gridSize), dim3(blockSize), shmem, stream,
-                          std::move(begin),
-                          std::forward<Args>(args)...);
+        void* func_args[] = { (void*)&begin, (void*)&args... };
+        RAJA::hip::launch((const void*)func, gridSize, blockSize, func_args, shmem, stream);
       }
 
       if (!Async) { RAJA::hip::synchronize(stream); }

--- a/include/RAJA/policy/hip/WorkGroup/WorkRunner.hpp
+++ b/include/RAJA/policy/hip/WorkGroup/WorkRunner.hpp
@@ -326,11 +326,10 @@ struct WorkRunner<
         //
         // Launch the kernel
         //
-        hipLaunchKernelGGL(func,
-                           dim3(gridSize), dim3(blockSize), shmem, stream,
-                           std::move(begin),
-                           std::forward<Args>(args)...);
-        RAJA::hip::launch(stream);
+        RAJA::hip::launch(func,
+                          dim3(gridSize), dim3(blockSize), shmem, stream,
+                          std::move(begin),
+                          std::forward<Args>(args)...);
       }
 
       if (!Async) { RAJA::hip::synchronize(stream); }

--- a/include/RAJA/policy/hip/forall.hpp
+++ b/include/RAJA/policy/hip/forall.hpp
@@ -207,12 +207,11 @@ RAJA_INLINE resources::EventProxy<resources::Hip> forall_impl(resources::Hip &hi
       //
       // Launch the kernels
       //
-      hipLaunchKernelGGL(func,
+      RAJA::hip::launch(func,
                          dim3(gridSize), dim3(BlockSize), shmem, stream,
                          body,
                          std::move(begin),
                          len);
-      RAJA::hip::launch(stream);
     }
 
     if (!Async) { RAJA::hip::synchronize(stream); }

--- a/include/RAJA/policy/hip/forall.hpp
+++ b/include/RAJA/policy/hip/forall.hpp
@@ -207,11 +207,8 @@ RAJA_INLINE resources::EventProxy<resources::Hip> forall_impl(resources::Hip &hi
       //
       // Launch the kernels
       //
-      RAJA::hip::launch(func,
-                         dim3(gridSize), dim3(BlockSize), shmem, stream,
-                         body,
-                         std::move(begin),
-                         len);
+      void *args[] = {(void*)&body, (void*)&begin, (void*)&len};
+      RAJA::hip::launch((const void*)func, gridSize, BlockSize, args, shmem, stream);
     }
 
     if (!Async) { RAJA::hip::synchronize(stream); }

--- a/include/RAJA/policy/hip/kernel/HipKernel.hpp
+++ b/include/RAJA/policy/hip/kernel/HipKernel.hpp
@@ -366,7 +366,8 @@ struct HipLaunchHelper<hip_launch<async0, num_blocks, num_threads>,StmtList,Data
   {
     auto func = kernelGetter_t::get();
 
-    RAJA::hip::launch(func, launch_dims.blocks, launch_dims.threads, shmem, stream, std::move(data));
+    void *args[] = {(void*)&data};
+    RAJA::hip::launch((const void*)func, launch_dims.blocks, launch_dims.threads, args, shmem, stream);
   }
 };
 

--- a/include/RAJA/policy/hip/kernel/HipKernel.hpp
+++ b/include/RAJA/policy/hip/kernel/HipKernel.hpp
@@ -366,7 +366,7 @@ struct HipLaunchHelper<hip_launch<async0, num_blocks, num_threads>,StmtList,Data
   {
     auto func = kernelGetter_t::get();
 
-    RAJA::hip::launch(func, launch_dims.blocks, launch_dims.threads, std::move(data), shmem, stream);
+    RAJA::hip::launch(func, launch_dims.blocks, launch_dims.threads, shmem, stream, std::move(data));
   }
 };
 


### PR DESCRIPTION
Update hip launch wrapper and use consistently when launching kernels in hip backend.

# Summary

- This PR is a refactoring
- It does the following:
  - Modifies/refactors hip kernel launches