### PR TITLE
Improve WorkGroup function signatures

### DIFF
--- a/include/RAJA/pattern/WorkGroup/Vtable.hpp
+++ b/include/RAJA/pattern/WorkGroup/Vtable.hpp
@@ -30,26 +30,52 @@ namespace RAJA
 namespace detail
 {
 
+template < typename >
+struct VtableVoidPtrWrapper
+{
+  void* ptr;
+  VtableVoidPtrWrapper() = default;
+  // implicit constructor from void*
+  RAJA_DEVICE VtableVoidPtrWrapper(void* p) : ptr(p) { }
+};
+
+template < typename >
+struct VtableVoidConstPtrWrapper
+{
+  const void* ptr;
+  VtableVoidConstPtrWrapper() = default;
+  // implicit constructor from const void*
+  RAJA_DEVICE VtableVoidConstPtrWrapper(const void* p) : ptr(p) { }
+};
+
 /*!
  * A vtable abstraction
  *
  * Provides function pointers for basic functions.
+ *
+ * VtableID is used to differentiate function pointers based on their
+ * function signature. This is helpful to avoid function signature collisions
+ * with functions that will not be used through this class. This is useful
+ * during device linking when functions with high register counts may cause
+ * device linking to fail.
  */
-template < typename ... CallArgs >
+template < typename VtableID, typename ... CallArgs >
 struct Vtable {
-  using move_sig = void(*)(void* /*dest*/, void* /*src*/);
-  using call_sig = void(*)(const void* /*obj*/, CallArgs... /*args*/);
-  using destroy_sig = void(*)(void* /*obj*/);
+  using void_ptr_wrapper = VtableVoidPtrWrapper<VtableID>;
+  using void_cptr_wrapper = VtableVoidConstPtrWrapper<VtableID>;
+  using move_sig = void(*)(void_ptr_wrapper /*dest*/, void_ptr_wrapper /*src*/);
+  using call_sig = void(*)(void_cptr_wrapper /*obj*/, CallArgs... /*args*/);
+  using destroy_sig = void(*)(void_ptr_wrapper /*obj*/);
 
   ///
   /// move construct an object of type T in dest as a copy of a T from src and
   /// destroy the T obj in src
   ///
   template < typename T >
-  static void move_construct_destroy(void* dest, void* src)
+  static void move_construct_destroy(void_ptr_wrapper dest, void_ptr_wrapper src)
   {
-    T* dest_as_T = static_cast<T*>(dest);
-    T* src_as_T = static_cast<T*>(src);
+    T* dest_as_T = static_cast<T*>(dest.ptr);
+    T* src_as_T = static_cast<T*>(src.ptr);
     new(dest_as_T) T(std::move(*src_as_T));
     (*src_as_T).~T();
   }
@@ -58,16 +84,16 @@ struct Vtable {
   /// call the call operator of the object of type T in obj with args
   ///
   template < typename T >
-  static void host_call(const void* obj, CallArgs... args)
+  static void host_call(void_cptr_wrapper obj, CallArgs... args)
   {
-    const T* obj_as_T = static_cast<const T*>(obj);
+    const T* obj_as_T = static_cast<const T*>(obj.ptr);
     (*obj_as_T)(std::forward<CallArgs>(args)...);
   }
   ///
   template < typename T >
-  static RAJA_DEVICE void device_call(const void* obj, CallArgs... args)
+  static RAJA_DEVICE void device_call(void_cptr_wrapper obj, CallArgs... args)
   {
-    const T* obj_as_T = static_cast<const T*>(obj);
+    const T* obj_as_T = static_cast<const T*>(obj.ptr);
     (*obj_as_T)(std::forward<CallArgs>(args)...);
   }
 
@@ -75,9 +101,9 @@ struct Vtable {
   /// destoy the object of type T in obj
   ///
   template < typename T >
-  static void destroy(void* obj)
+  static void destroy(void_ptr_wrapper obj)
   {
-    T* obj_as_T = static_cast<T*>(obj);
+    T* obj_as_T = static_cast<T*>(obj.ptr);
     (*obj_as_T).~T();
   }
 

--- a/include/RAJA/pattern/WorkGroup/Vtable.hpp
+++ b/include/RAJA/pattern/WorkGroup/Vtable.hpp
@@ -36,7 +36,7 @@ struct VtableVoidPtrWrapper
   void* ptr;
   VtableVoidPtrWrapper() = default;
   // implicit constructor from void*
-  RAJA_DEVICE VtableVoidPtrWrapper(void* p) : ptr(p) { }
+  RAJA_HOST_DEVICE VtableVoidPtrWrapper(void* p) : ptr(p) { }
 };
 
 template < typename >
@@ -45,7 +45,7 @@ struct VtableVoidConstPtrWrapper
   const void* ptr;
   VtableVoidConstPtrWrapper() = default;
   // implicit constructor from const void*
-  RAJA_DEVICE VtableVoidConstPtrWrapper(const void* p) : ptr(p) { }
+  RAJA_HOST_DEVICE VtableVoidConstPtrWrapper(const void* p) : ptr(p) { }
 };
 
 /*!

--- a/include/RAJA/pattern/WorkGroup/WorkRunner.hpp
+++ b/include/RAJA/pattern/WorkGroup/WorkRunner.hpp
@@ -162,7 +162,7 @@ struct WorkRunnerForallOrdered_base
   using index_type = INDEX_T;
 
   using forall_exec_policy = FORALL_EXEC_POLICY;
-  using vtable_type = Vtable<Args...>;
+  using vtable_type = Vtable<void, Args...>;
 
   WorkRunnerForallOrdered_base() = default;
 

--- a/include/RAJA/pattern/WorkGroup/WorkStruct.hpp
+++ b/include/RAJA/pattern/WorkGroup/WorkStruct.hpp
@@ -47,10 +47,10 @@ struct WorkStruct;
 template < typename Vtable_T >
 using GenericWorkStruct = WorkStruct<alignof(std::max_align_t), Vtable_T>;
 
-template < size_t size, typename ... CallArgs >
-struct WorkStruct<size, Vtable<CallArgs...>>
+template < size_t size, typename VtableID, typename ... CallArgs >
+struct WorkStruct<size, Vtable<VtableID, CallArgs...>>
 {
-  using vtable_type = Vtable<CallArgs...>;
+  using vtable_type = Vtable<VtableID, CallArgs...>;
 
   // construct a WorkStruct with a value of type holder from the args and
   // check a variety of constraints at compile time

--- a/include/RAJA/policy/cuda/WorkGroup/Vtable.hpp
+++ b/include/RAJA/policy/cuda/WorkGroup/Vtable.hpp
@@ -47,7 +47,7 @@ __global__ void get_Vtable_cuda_device_call_global(
 inline void* get_Vtable_cuda_device_call_ptrptr()
 {
   void* ptrptr = nullptr;
-  cudaErrchk(cudaMallocHost(&ptrptr, sizeof(typename Vtable<>::call_sig)));
+  cudaErrchk(cudaMallocHost(&ptrptr, sizeof(typename Vtable<void>::call_sig)));
   return ptrptr;
 }
 

--- a/include/RAJA/policy/cuda/WorkGroup/WorkRunner.hpp
+++ b/include/RAJA/policy/cuda/WorkGroup/WorkRunner.hpp
@@ -213,7 +213,7 @@ struct WorkRunner<
   using Allocator = ALLOCATOR_T;
   using index_type = INDEX_T;
 
-  using vtable_type = Vtable<Args...>;
+  using vtable_type = Vtable<RAJA::cuda_work<BLOCK_SIZE, true>, Args...>;
 
   WorkRunner() = default;
 

--- a/include/RAJA/policy/hip/WorkGroup/Vtable.hpp
+++ b/include/RAJA/policy/hip/WorkGroup/Vtable.hpp
@@ -49,7 +49,7 @@ __global__ void get_Vtable_hip_device_call_global(
 inline void* get_Vtable_hip_device_call_ptrptr()
 {
   void* ptrptr = nullptr;
-  hipErrchk(hipHostMalloc(&ptrptr, sizeof(typename Vtable<>::call_sig)));
+  hipErrchk(hipHostMalloc(&ptrptr, sizeof(typename Vtable<void>::call_sig)));
   return ptrptr;
 }
 

--- a/include/RAJA/policy/hip/WorkGroup/WorkRunner.hpp
+++ b/include/RAJA/policy/hip/WorkGroup/WorkRunner.hpp
@@ -215,7 +215,7 @@ struct WorkRunner<
   using Allocator = ALLOCATOR_T;
   using index_type = INDEX_T;
 
-  using vtable_type = Vtable<Args...>;
+  using vtable_type = Vtable<RAJA::hip_work<BLOCK_SIZE, true>, Args...>;
 
   WorkRunner() = default;
 

--- a/test/unit/workgroup/tests/test-workgroup-Vtable.hpp
+++ b/test/unit/workgroup/tests/test-workgroup-Vtable.hpp
@@ -111,7 +111,8 @@ void testWorkGroupVtableSingle(RAJA::xargs<Args...>)
   camp::resources::Resource work_res{WORKING_RES()};
   camp::resources::Resource host_res{camp::resources::Host()};
 
-  using Vtable_type = RAJA::detail::Vtable<IndexType, Args...>;
+  using Vtable_type = RAJA::detail::Vtable<void, IndexType, Args...>;
+  using Vtable_cptr_type = typename Vtable_type::void_cptr_wrapper;
   const Vtable_type* vtable =
       RAJA::detail::get_Vtable<TestCallable, Vtable_type>(ExecPolicy{});
 
@@ -174,7 +175,7 @@ void testWorkGroupVtableSingle(RAJA::xargs<Args...>)
   work_res.memcpy(wrk_obj, new_obj, sizeof(TestCallable) * 1);
 
   // move a value onto device and fiddle
-  call_dispatcher<ForOnePol, const void*, IndexType, Args...>(
+  call_dispatcher<ForOnePol, Vtable_cptr_type, IndexType, Args...>(
       vtable->call_function_ptr, wrk_obj, (IndexType)1, Args{}...);
 
   work_res.memcpy(testCall, workCall, sizeof(IndexType) * 3);

--- a/test/unit/workgroup/tests/test-workgroup-WorkStorage.hpp
+++ b/test/unit/workgroup/tests/test-workgroup-WorkStorage.hpp
@@ -66,7 +66,7 @@ void testWorkGroupWorkStorageConstructor()
 {
   bool success = true;
 
-  using Vtable_type = RAJA::detail::Vtable<void*, bool*, bool*>;
+  using Vtable_type = RAJA::detail::Vtable<void, void*, bool*, bool*>;
   using WorkStorage_type = RAJA::detail::WorkStorage<
                                                       StoragePolicy,
                                                       Allocator,
@@ -113,7 +113,7 @@ void testWorkGroupWorkStorageIterator()
 {
   bool success = true;
 
-  using Vtable_type = RAJA::detail::Vtable<void*, bool*, bool*>;
+  using Vtable_type = RAJA::detail::Vtable<void, void*, bool*, bool*>;
   using WorkStorage_type = RAJA::detail::WorkStorage<
                                                       StoragePolicy,
                                                       Allocator,
@@ -176,7 +176,7 @@ void testWorkGroupWorkStorageInsertCall()
 {
   bool success = true;
 
-  using Vtable_type = RAJA::detail::Vtable<void*, bool*, bool*>;
+  using Vtable_type = RAJA::detail::Vtable<void, void*, bool*, bool*>;
   using WorkStorage_type = RAJA::detail::WorkStorage<
                                                       StoragePolicy,
                                                       Allocator,
@@ -297,7 +297,7 @@ void testWorkGroupWorkStorageMultiple(
 {
   bool success = true;
 
-  using Vtable_type = RAJA::detail::Vtable<void*, bool*, bool*>;
+  using Vtable_type = RAJA::detail::Vtable<void, void*, bool*, bool*>;
   using WorkStorage_type = RAJA::detail::WorkStorage<
                                                       StoragePolicy,
                                                       Allocator,


### PR DESCRIPTION
# Summary
Reduce collisions during device linking of function signatures used in WorkGroup cuda unordered policies.

- This PR is a refactoring
- It does the following:
  - Modifies/refactors the WorkGroup device function signatures to avoid collisions during device linking.
  - Specifically adds information from the WorkGroup policy like the number of threads per block.
