### PR TITLE
Remove an extra template argument

### DIFF
--- a/examples/tut_halo-exchange.cpp
+++ b/examples/tut_halo-exchange.cpp
@@ -105,13 +105,13 @@ struct memory_manager_allocator
   }
 };
 
-template <typename T, typename U, typename Resource>
+template <typename T, typename U>
 bool operator==(memory_manager_allocator<T> const&, memory_manager_allocator<U> const&)
 {
   return true;
 }
 
-template <typename T, typename U, typename Resource>
+template <typename T, typename U>
 bool operator!=(memory_manager_allocator<T> const& lhs, memory_manager_allocator<U> const& rhs)
 {
   return !(lhs == rhs);
@@ -161,13 +161,13 @@ struct pinned_allocator
   }
 };
 
-template <typename T, typename U, typename Resource>
+template <typename T, typename U>
 bool operator==(pinned_allocator<T> const&, pinned_allocator<U> const&)
 {
   return true;
 }
 
-template <typename T, typename U, typename Resource>
+template <typename T, typename U>
 bool operator!=(pinned_allocator<T> const& lhs, pinned_allocator<U> const& rhs)
 {
   return !(lhs == rhs);


### PR DESCRIPTION
Remove an extra template argument from equality operators
in halo exchange example.

# Summary

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes equality operators in example
