### PR TITLE
Reduce segment test

### DIFF
--- a/test/functional/forall/atomic-basic/tests/test-forall-atomic-basic.hpp
+++ b/test/functional/forall/atomic-basic/tests/test-forall-atomic-basic.hpp
@@ -14,7 +14,7 @@
 
 #include <numeric>
 
-// range segment multiplexer
+// segment multiplexer
 template< typename IdxType, typename SegType >
 struct RSMultiplexer {};
 
@@ -49,7 +49,7 @@ struct RSMultiplexer < IdxType, RAJA::TypedListSegment<IdxType> >
     return RAJA::TypedListSegment<IdxType>( &temp[0], static_cast<size_t>(temp.size()), work_res );
   }
 };
-// end range segment multiplexer
+// end segment multiplexer
 
 
 template <typename ExecPolicy,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceBitAnd.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceBitAnd.hpp
@@ -9,20 +9,25 @@
 #define __TEST_FORALL_BASIC_REDUCEBITAND_HPP__
 
 #include <cstdlib>
+#include <ctime>
 #include <numeric>
+#include <vector>
 
-template <typename IDX_TYPE, typename DATA_TYPE, typename WORKING_RES, 
+template <typename IDX_TYPE, typename DATA_TYPE,
+          typename SEG_TYPE,
           typename EXEC_POLICY, typename REDUCE_POLICY>
-void ForallReduceBitAndBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
+void ForallReduceBitAndBasicTestImpl(const SEG_TYPE& seg,
+                                     const std::vector<IDX_TYPE>& seg_idx,
+                                     camp::resources::Resource& working_res)
 {
-  RAJA::TypedRangeSegment<IDX_TYPE> r1(first, last);
+  IDX_TYPE data_len = seg_idx[seg_idx.size() - 1] + 1;
+  IDX_TYPE idx_len = static_cast<IDX_TYPE>( seg_idx.size() );
 
-  camp::resources::Resource working_res{WORKING_RES::get_default()};
   DATA_TYPE* working_array;
   DATA_TYPE* check_array;
   DATA_TYPE* test_array;
 
-  allocateForallTestData<DATA_TYPE>(last,
+  allocateForallTestData<DATA_TYPE>(data_len,
                                     working_res,
                                     &working_array,
                                     &check_array,
@@ -31,14 +36,14 @@ void ForallReduceBitAndBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
   //
   // First a simple non-trivial test that is mildly interesting
   //
-  for (IDX_TYPE i = 0; i < last; ++i) {
+  for (IDX_TYPE i = 0; i < data_len; ++i) {
     test_array[i] = 13;
   }
-  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
+  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
   RAJA::ReduceBitAnd<REDUCE_POLICY, DATA_TYPE> simpand(21);
 
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     simpand &= working_array[idx];
   });
 
@@ -51,20 +56,20 @@ void ForallReduceBitAndBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
 
   const int modval = 100;
 
-  for (IDX_TYPE i = 0; i < last; ++i) {
+  for (IDX_TYPE i = 0; i < data_len; ++i) {
     test_array[i] = static_cast<DATA_TYPE>( rand() % modval );
   }
-  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
+  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
   DATA_TYPE ref_and = 0;
-  for (IDX_TYPE i = first; i < last; ++i) {
-    ref_and &= test_array[i];
+  for (IDX_TYPE i = 0; i < idx_len; ++i) {
+    ref_and &= test_array[ seg_idx[i] ];
   }
 
   RAJA::ReduceBitAnd<REDUCE_POLICY, DATA_TYPE> redand(0);
   RAJA::ReduceBitAnd<REDUCE_POLICY, DATA_TYPE> redand2(2);
 
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     redand  &= working_array[idx];
     redand2 &= working_array[idx];
   });
@@ -76,7 +81,7 @@ void ForallReduceBitAndBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
 
   const int nloops = 3;
   for (int j = 0; j < nloops; ++j) {
-    RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+    RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
       redand &= working_array[idx];
     });
   }
@@ -105,12 +110,67 @@ TYPED_TEST_P(ForallReduceBitAndBasicTest, ReduceBitAndBasicForall)
   using EXEC_POLICY   = typename camp::at<TypeParam, camp::num<3>>::type;
   using REDUCE_POLICY = typename camp::at<TypeParam, camp::num<4>>::type;
 
-  ForallReduceBitAndBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                                  EXEC_POLICY, REDUCE_POLICY>(0, 28);
-  ForallReduceBitAndBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                                  EXEC_POLICY, REDUCE_POLICY>(3, 642);
-  ForallReduceBitAndBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                                  EXEC_POLICY, REDUCE_POLICY>(0, 2057);
+  camp::resources::Resource working_res{WORKING_RES::get_default()};
+
+  std::vector<IDX_TYPE> seg_idx;
+
+// Range segment tests
+  RAJA::TypedRangeSegment<IDX_TYPE> r1( 0, 28 );
+  RAJA::getIndices(seg_idx, r1);
+  ForallReduceBitAndBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedRangeSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    r1, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeSegment<IDX_TYPE> r2( 3, 642 );
+  RAJA::getIndices(seg_idx, r2);
+  ForallReduceBitAndBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedRangeSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    r2, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeSegment<IDX_TYPE> r3( 0, 2057 );
+  RAJA::getIndices(seg_idx, r3);
+  ForallReduceBitAndBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedRangeSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    r3, seg_idx, working_res);
+
+// Range-stride segment tests
+  seg_idx.clear();
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> r4( 0, 188, 2 );
+  RAJA::getIndices(seg_idx, r4);
+  ForallReduceBitAndBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedRangeStrideSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    r4, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> r5( 3, 1029, 3 );
+  RAJA::getIndices(seg_idx, r5);
+  ForallReduceBitAndBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedRangeStrideSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    r5, seg_idx, working_res);
+
+  // List segment tests
+  seg_idx.clear();
+  IDX_TYPE last = 10567;
+  srand( time(NULL) );
+  for (IDX_TYPE i = 0; i < last; ++i) {
+    IDX_TYPE randval = IDX_TYPE( rand() % RAJA::stripIndexType(last) );
+    if ( i < randval ) {
+      seg_idx.push_back(i);
+    }
+  }
+  RAJA::TypedListSegment<IDX_TYPE> l1( &seg_idx[0], seg_idx.size(),
+                                       working_res );
+  ForallReduceBitAndBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedListSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    l1, seg_idx, working_res);
 }
 
 REGISTER_TYPED_TEST_SUITE_P(ForallReduceBitAndBasicTest,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceBitOr.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceBitOr.hpp
@@ -9,20 +9,25 @@
 #define __TEST_FORALL_BASIC_REDUCEBITOR_HPP__
 
 #include <cstdlib>
+#include <ctime>
 #include <numeric>
+#include <vector>
 
-template <typename IDX_TYPE, typename DATA_TYPE, typename WORKING_RES, 
+template <typename IDX_TYPE, typename DATA_TYPE,
+          typename SEG_TYPE,
           typename EXEC_POLICY, typename REDUCE_POLICY>
-void ForallReduceBitOrBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
+void ForallReduceBitOrBasicTestImpl(const SEG_TYPE& seg,
+                                     const std::vector<IDX_TYPE>& seg_idx,
+                                     camp::resources::Resource& working_res)
 {
-  RAJA::TypedRangeSegment<IDX_TYPE> r1(first, last);
+  IDX_TYPE data_len = seg_idx[seg_idx.size() - 1] + 1;
+  IDX_TYPE idx_len = static_cast<IDX_TYPE>( seg_idx.size() );
 
-  camp::resources::Resource working_res{WORKING_RES::get_default()};
   DATA_TYPE* working_array;
   DATA_TYPE* check_array;
   DATA_TYPE* test_array;
 
-  allocateForallTestData<DATA_TYPE>(last,
+  allocateForallTestData<DATA_TYPE>(data_len,
                                     working_res,
                                     &working_array,
                                     &check_array,
@@ -31,14 +36,14 @@ void ForallReduceBitOrBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
   //
   // First a simple non-trivial test that is mildly interesting
   //
-  for (IDX_TYPE i = 0; i < last; ++i) {
+  for (IDX_TYPE i = 0; i < data_len; ++i) {
     test_array[i] = 9;
   }
-  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
+  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
   RAJA::ReduceBitOr<REDUCE_POLICY, DATA_TYPE> simpor(5);
 
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     simpor |= working_array[idx];
   });
 
@@ -51,21 +56,21 @@ void ForallReduceBitOrBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
 
   const int modval = 100;
 
-  for (IDX_TYPE i = 0; i < last; ++i) {
+  for (IDX_TYPE i = 0; i < data_len; ++i) {
     test_array[i] = static_cast<DATA_TYPE>( rand() % modval );
   }
-  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
+  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
   DATA_TYPE ref_or = 0;
-  for (IDX_TYPE i = first; i < last; ++i) {
-    ref_or |= test_array[i]; 
+  for (IDX_TYPE i = 0; i < idx_len; ++i) {
+    ref_or |= test_array[ seg_idx[i] ];
   }
 
 
   RAJA::ReduceBitOr<REDUCE_POLICY, DATA_TYPE> redor(0);
   RAJA::ReduceBitOr<REDUCE_POLICY, DATA_TYPE> redor2(2);
 
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     redor  |= working_array[idx];
     redor2 |= working_array[idx];
   });
@@ -76,9 +81,8 @@ void ForallReduceBitOrBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
   redor.reset(0);
 
   const int nloops = 3;
-
   for (int j = 0; j < nloops; ++j) {
-    RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+    RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
       redor |= working_array[idx];
     });
   }
@@ -107,12 +111,67 @@ TYPED_TEST_P(ForallReduceBitOrBasicTest, ReduceBitOrBasicForall)
   using EXEC_POLICY   = typename camp::at<TypeParam, camp::num<3>>::type;
   using REDUCE_POLICY = typename camp::at<TypeParam, camp::num<4>>::type;
 
-  ForallReduceBitOrBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES,
-                                 EXEC_POLICY, REDUCE_POLICY>(0, 28);
-  ForallReduceBitOrBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                                 EXEC_POLICY, REDUCE_POLICY>(3, 642);
-  ForallReduceBitOrBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                                 EXEC_POLICY, REDUCE_POLICY>(0, 2057);
+    camp::resources::Resource working_res{WORKING_RES::get_default()};
+
+  std::vector<IDX_TYPE> seg_idx;
+
+// Range segment tests
+  RAJA::TypedRangeSegment<IDX_TYPE> r1( 0, 28 );
+  RAJA::getIndices(seg_idx, r1);
+  ForallReduceBitOrBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                 RAJA::TypedRangeSegment<IDX_TYPE>,
+                                 EXEC_POLICY, REDUCE_POLICY>(
+                                   r1, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeSegment<IDX_TYPE> r2( 3, 642 );
+  RAJA::getIndices(seg_idx, r2);
+  ForallReduceBitOrBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                 RAJA::TypedRangeSegment<IDX_TYPE>,
+                                 EXEC_POLICY, REDUCE_POLICY>(
+                                   r2, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeSegment<IDX_TYPE> r3( 0, 2057 );
+  RAJA::getIndices(seg_idx, r3);
+  ForallReduceBitOrBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                 RAJA::TypedRangeSegment<IDX_TYPE>,
+                                 EXEC_POLICY, REDUCE_POLICY>(
+                                   r3, seg_idx, working_res);
+
+// Range-stride segment tests
+  seg_idx.clear();
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> r4( 0, 188, 2 );
+  RAJA::getIndices(seg_idx, r4);
+  ForallReduceBitOrBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                 RAJA::TypedRangeStrideSegment<IDX_TYPE>,
+                                 EXEC_POLICY, REDUCE_POLICY>(
+                                   r4, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> r5( 3, 1029, 3 );
+  RAJA::getIndices(seg_idx, r5);
+  ForallReduceBitOrBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                 RAJA::TypedRangeStrideSegment<IDX_TYPE>,
+                                 EXEC_POLICY, REDUCE_POLICY>(
+                                   r5, seg_idx, working_res);
+
+  // List segment tests
+  seg_idx.clear();
+  IDX_TYPE last = 10567;
+  srand( time(NULL) );
+  for (IDX_TYPE i = 0; i < last; ++i) {
+    IDX_TYPE randval = IDX_TYPE( rand() % RAJA::stripIndexType(last) );
+    if ( i < randval ) {
+      seg_idx.push_back(i);
+    }
+  }
+  RAJA::TypedListSegment<IDX_TYPE> l1( &seg_idx[0], seg_idx.size(),
+                                       working_res );
+  ForallReduceBitOrBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                 RAJA::TypedListSegment<IDX_TYPE>,
+                                 EXEC_POLICY, REDUCE_POLICY>(
+                                   l1, seg_idx, working_res);
 }
 
 REGISTER_TYPED_TEST_SUITE_P(ForallReduceBitOrBasicTest,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceMax.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceMax.hpp
@@ -9,20 +9,25 @@
 #define __TEST_FORALL_BASIC_REDUCEMAX_HPP__
 
 #include <cstdlib>
+#include <ctime>
 #include <numeric>
+#include <vector>
 
-template <typename IDX_TYPE, typename DATA_TYPE, typename WORKING_RES, 
+template <typename IDX_TYPE, typename DATA_TYPE,
+          typename SEG_TYPE,
           typename EXEC_POLICY, typename REDUCE_POLICY>
-void ForallReduceMaxBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
+void ForallReduceMaxBasicTestImpl(const SEG_TYPE& seg,
+                                  const std::vector<IDX_TYPE>& seg_idx,
+                                  camp::resources::Resource& working_res)
 {
-  RAJA::TypedRangeSegment<IDX_TYPE> r1(first, last);
-
-  camp::resources::Resource working_res{WORKING_RES::get_default()};
+  IDX_TYPE data_len = seg_idx[seg_idx.size() - 1] + 1;
+  IDX_TYPE idx_len = static_cast<IDX_TYPE>( seg_idx.size() );
+ 
   DATA_TYPE* working_array;
   DATA_TYPE* check_array;
   DATA_TYPE* test_array;
 
-  allocateForallTestData<DATA_TYPE>(last,
+  allocateForallTestData<DATA_TYPE>(data_len,
                                     working_res,
                                     &working_array,
                                     &check_array,
@@ -32,21 +37,21 @@ void ForallReduceMaxBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
   const DATA_TYPE max_init = -1;
   const DATA_TYPE big_max = modval + 1;
 
-  for (IDX_TYPE i = 0; i < last; ++i) {
+  for (IDX_TYPE i = 0; i < data_len; ++i) {
     test_array[i] = static_cast<DATA_TYPE>( rand() % modval );
   }
 
   DATA_TYPE ref_max = max_init;
-  for (IDX_TYPE i = first; i < last; ++i) {
-    ref_max = RAJA_MAX(test_array[i], ref_max); 
+  for (IDX_TYPE i = 0; i < idx_len; ++i) {
+    ref_max = RAJA_MAX(test_array[ seg_idx[i] ], ref_max); 
   }
 
-  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
+  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
   RAJA::ReduceMax<REDUCE_POLICY, DATA_TYPE> maxinit(big_max);
   RAJA::ReduceMax<REDUCE_POLICY, DATA_TYPE> max(max_init);
 
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     maxinit.max( working_array[idx] );
     max.max( working_array[idx] );
   });
@@ -58,13 +63,13 @@ void ForallReduceMaxBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
   ASSERT_EQ(static_cast<DATA_TYPE>(max.get()), max_init);
 
   DATA_TYPE factor = 2;
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     max.max( working_array[idx] * factor);
   });
   ASSERT_EQ(static_cast<DATA_TYPE>(max.get()), ref_max * factor);
    
   factor = 3;
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     max.max( working_array[idx] * factor);
   });
   ASSERT_EQ(static_cast<DATA_TYPE>(max.get()), ref_max * factor);
@@ -90,12 +95,67 @@ TYPED_TEST_P(ForallReduceMaxBasicTest, ReduceMaxBasicForall)
   using EXEC_POLICY   = typename camp::at<TypeParam, camp::num<3>>::type;
   using REDUCE_POLICY = typename camp::at<TypeParam, camp::num<4>>::type;
 
-  ForallReduceMaxBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                                EXEC_POLICY, REDUCE_POLICY>(0, 28);
-  ForallReduceMaxBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                                EXEC_POLICY, REDUCE_POLICY>(3, 642);
-  ForallReduceMaxBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                                EXEC_POLICY, REDUCE_POLICY>(0, 2057);
+  camp::resources::Resource working_res{WORKING_RES::get_default()};
+
+  std::vector<IDX_TYPE> seg_idx;
+
+// Range segment tests
+  RAJA::TypedRangeSegment<IDX_TYPE> r1( 0, 28 );
+  RAJA::getIndices(seg_idx, r1);
+  ForallReduceMaxBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedRangeSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 r1, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeSegment<IDX_TYPE> r2( 3, 642 );
+  RAJA::getIndices(seg_idx, r2);
+  ForallReduceMaxBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedRangeSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 r2, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeSegment<IDX_TYPE> r3( 0, 2057 );
+  RAJA::getIndices(seg_idx, r3);
+  ForallReduceMaxBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedRangeSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 r3, seg_idx, working_res);
+
+// Range-stride segment tests
+  seg_idx.clear();
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> r4( 0, 188, 2 );
+  RAJA::getIndices(seg_idx, r4);
+  ForallReduceMaxBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedRangeStrideSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 r4, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> r5( 3, 1029, 3 );
+  RAJA::getIndices(seg_idx, r5);
+  ForallReduceMaxBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedRangeStrideSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 r5, seg_idx, working_res);
+
+// List segment tests
+  seg_idx.clear();
+  IDX_TYPE last = 10567;
+  srand( time(NULL) );
+  for (IDX_TYPE i = 0; i < last; ++i) {
+    IDX_TYPE randval = IDX_TYPE( rand() % RAJA::stripIndexType(last) );
+    if ( i < randval ) {
+      seg_idx.push_back(i);
+    }
+  }
+  RAJA::TypedListSegment<IDX_TYPE> l1( &seg_idx[0], seg_idx.size(),
+                                       working_res );
+  ForallReduceMaxBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedListSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 l1, seg_idx, working_res);
 }
 
 REGISTER_TYPED_TEST_SUITE_P(ForallReduceMaxBasicTest,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceMaxLoc.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceMaxLoc.hpp
@@ -9,21 +9,25 @@
 #define __TEST_FORALL_BASIC_REDUCEMAXLOC_HPP__
 
 #include <cstdlib>
+#include <ctime>
 #include <numeric>
-#include <iostream>
+#include <vector>
 
-template <typename IDX_TYPE, typename DATA_TYPE, typename WORKING_RES, 
+template <typename IDX_TYPE, typename DATA_TYPE,
+          typename SEG_TYPE,
           typename EXEC_POLICY, typename REDUCE_POLICY>
-void ForallReduceMaxLocBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
+void ForallReduceMaxLocBasicTestImpl(const SEG_TYPE& seg,
+                                     const std::vector<IDX_TYPE>& seg_idx,
+                                     camp::resources::Resource& working_res)
 {
-  RAJA::TypedRangeSegment<IDX_TYPE> r1(first, last);
+  IDX_TYPE data_len = seg_idx[seg_idx.size() - 1] + 1;
+  IDX_TYPE idx_len = static_cast<IDX_TYPE>( seg_idx.size() );
 
-  camp::resources::Resource working_res{WORKING_RES::get_default()};
   DATA_TYPE* working_array;
   DATA_TYPE* check_array;
   DATA_TYPE* test_array;
 
-  allocateForallTestData<DATA_TYPE>(last,
+  allocateForallTestData<DATA_TYPE>(data_len,
                                     working_res,
                                     &working_array,
                                     &check_array,
@@ -32,31 +36,31 @@ void ForallReduceMaxLocBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
   const int modval = 100;
   const DATA_TYPE max_init = -modval;
   const IDX_TYPE maxloc_init = -1;
-  const IDX_TYPE maxloc_idx = (last - first) * 2/3 + first;
+  const IDX_TYPE maxloc_idx = seg_idx[ idx_len * 2/3 ];
   const DATA_TYPE big_max = modval+1;
   const IDX_TYPE big_maxloc = maxloc_init;
 
-  for (IDX_TYPE i = 0; i < last; ++i) {
+  for (IDX_TYPE i = 0; i < data_len; ++i) {
     test_array[i] = static_cast<DATA_TYPE>( rand() % modval );
   }
   test_array[maxloc_idx] = static_cast<DATA_TYPE>(big_max);
 
   DATA_TYPE ref_max = max_init;
   IDX_TYPE ref_maxloc = maxloc_init;
-  for (IDX_TYPE i = first; i < last; ++i) {
-    if ( test_array[i] > ref_max ) {
-       ref_max = test_array[i];
-       ref_maxloc = i;
+  for (IDX_TYPE i = 0; i < idx_len; ++i) {
+    if ( test_array[ seg_idx[i] ] > ref_max ) {
+       ref_max = test_array[ seg_idx[i] ];
+       ref_maxloc = seg_idx[i];
     } 
   }
 
-  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
+  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
 
   RAJA::ReduceMaxLoc<REDUCE_POLICY, DATA_TYPE, IDX_TYPE> maxinit(big_max, maxloc_init);
   RAJA::ReduceMaxLoc<REDUCE_POLICY, DATA_TYPE, IDX_TYPE> max(max_init, maxloc_init);
 
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     maxinit.maxloc( working_array[idx], idx );
     max.maxloc( working_array[idx], idx );
   });
@@ -71,14 +75,14 @@ void ForallReduceMaxLocBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
   ASSERT_EQ(static_cast<IDX_TYPE>(max.getLoc()), maxloc_init);
 
   DATA_TYPE factor = 2;
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     max.maxloc( working_array[idx] * factor, idx);
   });
   ASSERT_EQ(static_cast<DATA_TYPE>(max.get()), ref_max * factor);
   ASSERT_EQ(static_cast<IDX_TYPE>(max.getLoc()), ref_maxloc);
   
   factor = 3;
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) { 
+  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) { 
     max.maxloc( working_array[idx] * factor, idx);
   });
   ASSERT_EQ(static_cast<DATA_TYPE>(max.get()), ref_max * factor);
@@ -105,12 +109,67 @@ TYPED_TEST_P(ForallReduceMaxLocBasicTest, ReduceMaxLocBasicForall)
   using EXEC_POLICY   = typename camp::at<TypeParam, camp::num<3>>::type;
   using REDUCE_POLICY = typename camp::at<TypeParam, camp::num<4>>::type;
 
-  ForallReduceMaxLocBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                                  EXEC_POLICY, REDUCE_POLICY>(0, 28);
-  ForallReduceMaxLocBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                                  EXEC_POLICY, REDUCE_POLICY>(3, 642);
-  ForallReduceMaxLocBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                                  EXEC_POLICY, REDUCE_POLICY>(0, 2057);
+  camp::resources::Resource working_res{WORKING_RES::get_default()};
+
+  std::vector<IDX_TYPE> seg_idx;
+
+// Range segment tests
+  RAJA::TypedRangeSegment<IDX_TYPE> r1( 0, 28 );
+  RAJA::getIndices(seg_idx, r1);
+  ForallReduceMaxLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedRangeSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    r1, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeSegment<IDX_TYPE> r2( 3, 642 );
+  RAJA::getIndices(seg_idx, r2);
+  ForallReduceMaxLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedRangeSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    r2, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeSegment<IDX_TYPE> r3( 0, 2057 );
+  RAJA::getIndices(seg_idx, r3);
+  ForallReduceMaxLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedRangeSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    r3, seg_idx, working_res);
+
+// Range-stride segment tests
+  seg_idx.clear();
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> r4( 0, 188, 2 );
+  RAJA::getIndices(seg_idx, r4);
+  ForallReduceMaxLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedRangeStrideSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    r4, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> r5( 3, 1029, 3 );
+  RAJA::getIndices(seg_idx, r5);
+  ForallReduceMaxLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedRangeStrideSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    r5, seg_idx, working_res);
+
+// List segment tests
+  seg_idx.clear();
+  IDX_TYPE last = 10567;
+  srand( time(NULL) );
+  for (IDX_TYPE i = 0; i < last; ++i) {
+    IDX_TYPE randval = IDX_TYPE( rand() % RAJA::stripIndexType(last) );
+    if ( i < randval ) {
+      seg_idx.push_back(i);
+    }
+  }
+  RAJA::TypedListSegment<IDX_TYPE> l1( &seg_idx[0], seg_idx.size(),
+                                       working_res );
+  ForallReduceMaxLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedListSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    l1, seg_idx, working_res);
 }
 
 REGISTER_TYPED_TEST_SUITE_P(ForallReduceMaxLocBasicTest,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceMin.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceMin.hpp
@@ -9,20 +9,25 @@
 #define __TEST_FORALL_BASIC_REDUCEMIN_HPP__
 
 #include <cstdlib>
+#include <ctime>
 #include <numeric>
+#include <vector>
 
-template <typename IDX_TYPE, typename DATA_TYPE, typename WORKING_RES, 
+template <typename IDX_TYPE, typename DATA_TYPE,
+          typename SEG_TYPE,
           typename EXEC_POLICY, typename REDUCE_POLICY>
-void ForallReduceMinBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
+void ForallReduceMinBasicTestImpl(const SEG_TYPE& seg,
+                                  const std::vector<IDX_TYPE>& seg_idx,
+                                  camp::resources::Resource& working_res)
 {
-  RAJA::TypedRangeSegment<IDX_TYPE> r1(first, last);
+  IDX_TYPE data_len = seg_idx[seg_idx.size() - 1] + 1;
+  IDX_TYPE idx_len = static_cast<IDX_TYPE>( seg_idx.size() );
 
-  camp::resources::Resource working_res{WORKING_RES::get_default()};
   DATA_TYPE* working_array;
   DATA_TYPE* check_array;
   DATA_TYPE* test_array;
 
-  allocateForallTestData<DATA_TYPE>(last,
+  allocateForallTestData<DATA_TYPE>(data_len,
                                     working_res,
                                     &working_array,
                                     &check_array,
@@ -32,22 +37,22 @@ void ForallReduceMinBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
   const DATA_TYPE min_init = modval+1;
   const DATA_TYPE small_min = -modval;
 
-  for (IDX_TYPE i = 0; i < last; ++i) {
+  for (IDX_TYPE i = 0; i < data_len; ++i) {
     test_array[i] = static_cast<DATA_TYPE>( rand() % modval );
   }
 
   DATA_TYPE ref_min = min_init;
-  for (IDX_TYPE i = first; i < last; ++i) {
-    ref_min = RAJA_MIN(test_array[i], ref_min); 
+  for (IDX_TYPE i = 0; i < idx_len; ++i) {
+    ref_min = RAJA_MIN(test_array[ seg_idx[i] ], ref_min); 
   }
 
-  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
+  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
 
   RAJA::ReduceMin<REDUCE_POLICY, DATA_TYPE> mininit(small_min);
   RAJA::ReduceMin<REDUCE_POLICY, DATA_TYPE> min(min_init);
 
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     mininit.min( working_array[idx] );
     min.min( working_array[idx] );
   });
@@ -59,15 +64,17 @@ void ForallReduceMinBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
   ASSERT_EQ(static_cast<DATA_TYPE>(min.get()), min_init);
 
   DATA_TYPE factor = 3; 
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     min.min( working_array[idx] * factor);
   });
+
   ASSERT_EQ(static_cast<DATA_TYPE>(min.get()), ref_min * factor);
 
   factor = 2;
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) { 
+  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) { 
     min.min( working_array[idx] * factor);
   });
+
   ASSERT_EQ(static_cast<DATA_TYPE>(min.get()), ref_min * factor);
    
 
@@ -92,12 +99,67 @@ TYPED_TEST_P(ForallReduceMinBasicTest, ReduceMinBasicForall)
   using EXEC_POLICY   = typename camp::at<TypeParam, camp::num<3>>::type;
   using REDUCE_POLICY = typename camp::at<TypeParam, camp::num<4>>::type;
 
-  ForallReduceMinBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                               EXEC_POLICY, REDUCE_POLICY>(0, 28);
-  ForallReduceMinBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                               EXEC_POLICY, REDUCE_POLICY>(3, 642);
-  ForallReduceMinBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                               EXEC_POLICY, REDUCE_POLICY>(0, 2057);
+  camp::resources::Resource working_res{WORKING_RES::get_default()};
+
+  std::vector<IDX_TYPE> seg_idx;
+
+// Range segment tests
+  RAJA::TypedRangeSegment<IDX_TYPE> r1( 0, 28 );
+  RAJA::getIndices(seg_idx, r1);
+  ForallReduceMinBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedRangeSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 r1, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeSegment<IDX_TYPE> r2( 3, 642 );
+  RAJA::getIndices(seg_idx, r2);
+  ForallReduceMinBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedRangeSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 r2, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeSegment<IDX_TYPE> r3( 0, 2057 );
+  RAJA::getIndices(seg_idx, r3);
+  ForallReduceMinBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedRangeSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 r3, seg_idx, working_res);
+
+// Range-stride segment tests
+  seg_idx.clear();
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> r4( 0, 188, 2 );
+  RAJA::getIndices(seg_idx, r4);
+  ForallReduceMinBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedRangeStrideSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 r4, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> r5( 3, 1029, 3 );
+  RAJA::getIndices(seg_idx, r5);
+  ForallReduceMinBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedRangeStrideSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 r5, seg_idx, working_res);
+
+// List segment tests
+  seg_idx.clear();
+  IDX_TYPE last = 10567;
+  srand( time(NULL) );
+  for (IDX_TYPE i = 0; i < last; ++i) {
+    IDX_TYPE randval = IDX_TYPE( rand() % RAJA::stripIndexType(last) );
+    if ( i < randval ) {
+      seg_idx.push_back(i);
+    }
+  }
+  RAJA::TypedListSegment<IDX_TYPE> l1( &seg_idx[0], seg_idx.size(),
+                                       working_res );
+  ForallReduceMinBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedListSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 l1, seg_idx, working_res);
 }
 
 REGISTER_TYPED_TEST_SUITE_P(ForallReduceMinBasicTest,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceMinLoc.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceMinLoc.hpp
@@ -9,21 +9,25 @@
 #define __TEST_FORALL_BASIC_REDUCEMINLOC_HPP__
 
 #include <cstdlib>
+#include <ctime>
 #include <numeric>
-#include <iostream>
+#include <vector>
 
-template <typename IDX_TYPE, typename DATA_TYPE, typename WORKING_RES, 
+template <typename IDX_TYPE, typename DATA_TYPE,
+          typename SEG_TYPE,
           typename EXEC_POLICY, typename REDUCE_POLICY>
-void ForallReduceMinLocBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
+void ForallReduceMinLocBasicTestImpl(const SEG_TYPE& seg,
+                                     const std::vector<IDX_TYPE>& seg_idx,
+                                     camp::resources::Resource& working_res)
 {
-  RAJA::TypedRangeSegment<IDX_TYPE> r1(first, last);
+  IDX_TYPE data_len = seg_idx[seg_idx.size() - 1] + 1;
+  IDX_TYPE idx_len = static_cast<IDX_TYPE>( seg_idx.size() );
 
-  camp::resources::Resource working_res{WORKING_RES::get_default()};
   DATA_TYPE* working_array;
   DATA_TYPE* check_array;
   DATA_TYPE* test_array;
 
-  allocateForallTestData<DATA_TYPE>(last,
+  allocateForallTestData<DATA_TYPE>(data_len,
                                     working_res,
                                     &working_array,
                                     &check_array,
@@ -32,31 +36,31 @@ void ForallReduceMinLocBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
   const int modval = 100;
   const DATA_TYPE min_init = modval+1;
   const IDX_TYPE minloc_init = -1;
-  const IDX_TYPE minloc_idx = (last - first) * 2/3 + first;
+  const IDX_TYPE minloc_idx = seg_idx[ idx_len * 2/3 ];
   const DATA_TYPE small_min = -modval;
   const IDX_TYPE small_minloc = minloc_init;
 
-  for (IDX_TYPE i = 0; i < last; ++i) {
+  for (IDX_TYPE i = 0; i < data_len; ++i) {
     test_array[i] = static_cast<DATA_TYPE>( rand() % modval );
   }
   test_array[minloc_idx] = static_cast<DATA_TYPE>(small_min);
 
   DATA_TYPE ref_min = min_init;
   IDX_TYPE ref_minloc = minloc_init;
-  for (IDX_TYPE i = first; i < last; ++i) {
-    if ( test_array[i] < ref_min ) {
-       ref_min = test_array[i];
-       ref_minloc = i;
+  for (IDX_TYPE i = 0; i < idx_len; ++i) {
+    if ( test_array[ seg_idx[i] ] < ref_min ) {
+       ref_min = test_array[ seg_idx[i] ];
+       ref_minloc = seg_idx[i];
     } 
   }
 
-  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
+  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
 
   RAJA::ReduceMinLoc<REDUCE_POLICY, DATA_TYPE, IDX_TYPE> mininit(small_min, minloc_init);
   RAJA::ReduceMinLoc<REDUCE_POLICY, DATA_TYPE, IDX_TYPE> min(min_init, minloc_init);
 
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     mininit.minloc( working_array[idx], idx );
     min.minloc( working_array[idx], idx );
   });
@@ -71,14 +75,14 @@ void ForallReduceMinLocBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
   ASSERT_EQ(static_cast<IDX_TYPE>(min.getLoc()), minloc_init);
 
   DATA_TYPE factor = 2;
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     min.minloc( working_array[idx] * factor, idx);
   });
   ASSERT_EQ(static_cast<DATA_TYPE>(min.get()), ref_min * factor);
   ASSERT_EQ(static_cast<IDX_TYPE>(min.getLoc()), ref_minloc);
 
   factor = 3;
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) { 
+  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) { 
     min.minloc( working_array[idx] * factor, idx);
   });
   ASSERT_EQ(static_cast<DATA_TYPE>(min.get()), ref_min * factor);
@@ -105,12 +109,67 @@ TYPED_TEST_P(ForallReduceMinLocBasicTest, ReduceMinLocBasicForall)
   using EXEC_POLICY   = typename camp::at<TypeParam, camp::num<3>>::type;
   using REDUCE_POLICY = typename camp::at<TypeParam, camp::num<4>>::type;
 
-  ForallReduceMinLocBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                                  EXEC_POLICY, REDUCE_POLICY>(0, 28);
-  ForallReduceMinLocBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                                  EXEC_POLICY, REDUCE_POLICY>(3, 642);
-  ForallReduceMinLocBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                                  EXEC_POLICY, REDUCE_POLICY>(0, 2057);
+  camp::resources::Resource working_res{WORKING_RES::get_default()};
+
+  std::vector<IDX_TYPE> seg_idx;
+
+// Range segment tests
+  RAJA::TypedRangeSegment<IDX_TYPE> r1( 0, 28 );
+  RAJA::getIndices(seg_idx, r1);
+  ForallReduceMinLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedRangeSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    r1, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeSegment<IDX_TYPE> r2( 3, 642 );
+  RAJA::getIndices(seg_idx, r2);
+  ForallReduceMinLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedRangeSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    r2, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeSegment<IDX_TYPE> r3( 0, 2057 );
+  RAJA::getIndices(seg_idx, r3);
+  ForallReduceMinLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedRangeSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    r3, seg_idx, working_res);
+
+// Range-stride segment tests
+  seg_idx.clear();
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> r4( 0, 188, 2 );
+  RAJA::getIndices(seg_idx, r4);
+  ForallReduceMinLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedRangeStrideSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    r4, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> r5( 3, 1029, 3 );
+  RAJA::getIndices(seg_idx, r5);
+  ForallReduceMinLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedRangeStrideSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    r5, seg_idx, working_res);
+
+// List segment tests
+  seg_idx.clear();
+  IDX_TYPE last = 10567;
+  srand( time(NULL) );
+  for (IDX_TYPE i = 0; i < last; ++i) {
+    IDX_TYPE randval = IDX_TYPE( rand() % RAJA::stripIndexType(last) );
+    if ( i < randval ) {
+      seg_idx.push_back(i);
+    }
+  }
+  RAJA::TypedListSegment<IDX_TYPE> l1( &seg_idx[0], seg_idx.size(),
+                                       working_res );
+  ForallReduceMinLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                                  RAJA::TypedListSegment<IDX_TYPE>,
+                                  EXEC_POLICY, REDUCE_POLICY>(
+                                    l1, seg_idx, working_res);
 }
 
 REGISTER_TYPED_TEST_SUITE_P(ForallReduceMinLocBasicTest,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceSum.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceSum.hpp
@@ -9,20 +9,25 @@
 #define __TEST_FORALL_BASIC_REDUCESUM_HPP__
 
 #include <cstdlib>
+#include <ctime>
 #include <numeric>
+#include <vector>
 
-template <typename IDX_TYPE, typename DATA_TYPE, typename WORKING_RES, 
+template <typename IDX_TYPE, typename DATA_TYPE,
+          typename SEG_TYPE,
           typename EXEC_POLICY, typename REDUCE_POLICY>
-void ForallReduceSumBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
+void ForallReduceSumBasicTestImpl(const SEG_TYPE& seg, 
+                                  const std::vector<IDX_TYPE>& seg_idx,
+                                  camp::resources::Resource& working_res)
 {
-  RAJA::TypedRangeSegment<IDX_TYPE> r1(first, last);
+  IDX_TYPE data_len = seg_idx[seg_idx.size() - 1] + 1;
+  IDX_TYPE idx_len = static_cast<IDX_TYPE>( seg_idx.size() );
 
-  camp::resources::Resource working_res{WORKING_RES::get_default()};
   DATA_TYPE* working_array;
   DATA_TYPE* check_array;
   DATA_TYPE* test_array;
 
-  allocateForallTestData<DATA_TYPE>(last,
+  allocateForallTestData<DATA_TYPE>(data_len,
                                     working_res,
                                     &working_array,
                                     &check_array,
@@ -30,22 +35,22 @@ void ForallReduceSumBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
 
   const int modval = 100;
 
-  for (IDX_TYPE i = 0; i < last; ++i) {
+  for (IDX_TYPE i = 0; i < data_len; ++i) {
     test_array[i] = static_cast<DATA_TYPE>( rand() % modval );
   }
 
   DATA_TYPE ref_sum = 0;
-  for (IDX_TYPE i = first; i < last; ++i) {
-    ref_sum += test_array[i]; 
+  for (IDX_TYPE i = 0; i < idx_len; ++i) {
+    ref_sum += test_array[ seg_idx[i] ];
   }
 
-  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
+  working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
 
   RAJA::ReduceSum<REDUCE_POLICY, DATA_TYPE> sum(0);
   RAJA::ReduceSum<REDUCE_POLICY, DATA_TYPE> sum2(2);
 
-  RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     sum  += working_array[idx];
     sum2 += working_array[idx];
   });
@@ -58,13 +63,13 @@ void ForallReduceSumBasicTestImpl(IDX_TYPE first, IDX_TYPE last)
   const int nloops = 2;
 
   for (int j = 0; j < nloops; ++j) {
-    RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+    RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
       sum += working_array[idx];
     });
   }
 
   ASSERT_EQ(static_cast<DATA_TYPE>(sum.get()), nloops * ref_sum);
-   
+
 
   deallocateForallTestData<DATA_TYPE>(working_res,
                                       working_array,
@@ -87,12 +92,67 @@ TYPED_TEST_P(ForallReduceSumBasicTest, ReduceSumBasicForall)
   using EXEC_POLICY   = typename camp::at<TypeParam, camp::num<3>>::type;
   using REDUCE_POLICY = typename camp::at<TypeParam, camp::num<4>>::type;
 
-  ForallReduceSumBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                               EXEC_POLICY, REDUCE_POLICY>(0, 28);
-  ForallReduceSumBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                               EXEC_POLICY, REDUCE_POLICY>(3, 642);
-  ForallReduceSumBasicTestImpl<IDX_TYPE, DATA_TYPE, WORKING_RES, 
-                               EXEC_POLICY, REDUCE_POLICY>(0, 2057);
+  camp::resources::Resource working_res{WORKING_RES::get_default()};
+
+  std::vector<IDX_TYPE> seg_idx;
+
+// Range segment tests
+  RAJA::TypedRangeSegment<IDX_TYPE> r1( 0, 28 );
+  RAJA::getIndices(seg_idx, r1);
+  ForallReduceSumBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedRangeSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 r1, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeSegment<IDX_TYPE> r2( 3, 642 );
+  RAJA::getIndices(seg_idx, r2);
+  ForallReduceSumBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedRangeSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 r2, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeSegment<IDX_TYPE> r3( 0, 2057 );
+  RAJA::getIndices(seg_idx, r3);
+  ForallReduceSumBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedRangeSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 r3, seg_idx, working_res);
+
+// Range-stride segment tests
+  seg_idx.clear();
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> r4( 0, 188, 2 );
+  RAJA::getIndices(seg_idx, r4);
+  ForallReduceSumBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedRangeStrideSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 r4, seg_idx, working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> r5( 3, 1029, 3 );
+  RAJA::getIndices(seg_idx, r5);
+  ForallReduceSumBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedRangeStrideSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 r5, seg_idx, working_res);
+
+// List segment tests
+  seg_idx.clear(); 
+  IDX_TYPE last = 10567;
+  srand( time(NULL) );
+  for (IDX_TYPE i = 0; i < last; ++i) {
+    IDX_TYPE randval = IDX_TYPE( rand() % RAJA::stripIndexType(last) );
+    if ( i < randval ) {
+      seg_idx.push_back(i);
+    }
+  }
+  RAJA::TypedListSegment<IDX_TYPE> l1( &seg_idx[0], seg_idx.size(), 
+                                       working_res );
+  ForallReduceSumBasicTestImpl<IDX_TYPE, DATA_TYPE,
+                               RAJA::TypedListSegment<IDX_TYPE>,
+                               EXEC_POLICY, REDUCE_POLICY>(
+                                 l1, seg_idx, working_res);
 }
 
 REGISTER_TYPED_TEST_SUITE_P(ForallReduceSumBasicTest,


### PR DESCRIPTION
# Summary

- This PR enhances the basic forall-reduction functional tests to include all basic segment types we support. Specifically, tests that use range-stride and list segments have been added to tests for all reduction types.