### PR TITLE
Update kernel reduce loc tests.

### DIFF
--- a/test/functional/kernel/reduce-loc/test-kernel-reduceloc.cpp.in
+++ b/test/functional/kernel/reduce-loc/test-kernel-reduceloc.cpp.in
@@ -46,6 +46,22 @@ using SequentialKernelLocExecPols =
           RAJA::statement::Lambda<0>
         >
       >
+    >,
+
+    RAJA::KernelPolicy<
+      RAJA::statement::For<1, RAJA::seq_exec,  // row
+        RAJA::statement::For<0, RAJA::loop_exec,  // col
+          RAJA::statement::Lambda<0>
+        >
+      >
+    >,
+
+    RAJA::KernelPolicy<
+      RAJA::statement::For<1, RAJA::loop_exec,  // row
+        RAJA::statement::For<0, RAJA::seq_exec,  // col
+          RAJA::statement::Lambda<0>
+        >
+      >
     >
 
   >;
@@ -180,12 +196,42 @@ using CudaKernelLocExecPols =
 
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernel<
-      RAJA::statement::For<1, RAJA::cuda_thread_x_loop,  // row
-        RAJA::statement::For<0, RAJA::cuda_thread_y_loop,  // col
-          RAJA::statement::Lambda<0>
+        RAJA::statement::For<1, RAJA::cuda_thread_x_loop,  // row
+          RAJA::statement::For<0, RAJA::cuda_thread_y_loop,  // col
+            RAJA::statement::Lambda<0>
+          >
         >
       >
-      > // end CudaKernel
+    >,
+
+    RAJA::KernelPolicy<
+      RAJA::statement::For<1, RAJA::seq_exec,  // row
+        RAJA::statement::CudaKernel<
+          RAJA::statement::For<0, RAJA::cuda_thread_x_loop,  // col
+            RAJA::statement::Lambda<0>
+          >
+        >
+      >
+    >,
+
+    RAJA::KernelPolicy<
+      RAJA::statement::CudaKernel<
+        RAJA::statement::For<1, RAJA::seq_exec,  // row
+          RAJA::statement::For<0, RAJA::cuda_thread_x_loop,  // col
+            RAJA::statement::Lambda<0>
+          >
+        >
+      >
+    >,
+
+    RAJA::KernelPolicy<
+      RAJA::statement::CudaKernel<
+        RAJA::statement::For<1, RAJA::cuda_thread_x_loop,  // row
+          RAJA::statement::For<0, RAJA::seq_exec,  // col
+            RAJA::statement::Lambda<0>
+          >
+        >
+      >
     >
 
   >;
@@ -209,12 +255,42 @@ using HipKernelLocExecPols =
 
     RAJA::KernelPolicy<
       RAJA::statement::HipKernel<
-      RAJA::statement::For<1, RAJA::hip_thread_x_loop,  // row
-        RAJA::statement::For<0, RAJA::hip_thread_y_loop,  // col
-          RAJA::statement::Lambda<0>
+        RAJA::statement::For<1, RAJA::hip_thread_x_loop,  // row
+          RAJA::statement::For<0, RAJA::hip_thread_y_loop,  // col
+            RAJA::statement::Lambda<0>
+          >
         >
       >
-      > // end HipKernel
+    >,
+
+    RAJA::KernelPolicy<
+      RAJA::statement::For<1, RAJA::seq_exec,  // row
+        RAJA::statement::HipKernel<
+          RAJA::statement::For<0, RAJA::hip_thread_x_loop,  // col
+            RAJA::statement::Lambda<0>
+          >
+        >
+      >,
+    >,
+
+    RAJA::KernelPolicy<
+      RAJA::statement::HipKernel<
+        RAJA::statement::For<1, RAJA::seq_exec,  // row
+          RAJA::statement::For<0, RAJA::hip_thread_x_loop,  // col
+            RAJA::statement::Lambda<0>
+          >
+        >
+      >
+    >,
+
+    RAJA::KernelPolicy<
+      RAJA::statement::HipKernel<
+        RAJA::statement::For<1, RAJA::hip_thread_x_loop,  // row
+          RAJA::statement::For<0, RAJA::seq_exec,  // col
+            RAJA::statement::Lambda<0>
+          >
+        >
+      >
     >
 
   >;

--- a/test/functional/kernel/reduce-loc/test-kernel-reduceloc.cpp.in
+++ b/test/functional/kernel/reduce-loc/test-kernel-reduceloc.cpp.in
@@ -270,7 +270,7 @@ using HipKernelLocExecPols =
             RAJA::statement::Lambda<0>
           >
         >
-      >,
+      >
     >,
 
     RAJA::KernelPolicy<


### PR DESCRIPTION
# Summary

- This PR is a task
- It does the following:
  - Adds seq-loop policies to CUDA, HIP, and CPU reduce-loc kernel tests. This seems to increase XL OpenMP compilation time by a couple minutes, but still finishes in under 10 minutes.