### PR TITLE
Task/kernel 3level segment tests

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -2,7 +2,7 @@
 
 RAJA: ................................, version 0.10.0
 
-Copyright (c) 2016-19, Lawrence Livermore National Security, LLC. 
+Copyright (c) 2016-21, Lawrence Livermore National Security, LLC. 
 Produced at the Lawrence Livermore National Laboratory.
 All rights reserved. See details in the RAJA/LICENSE file.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 
 [comment]: # (#################################################################)
-[comment]: # (Copyright 2016-20, Lawrence Livermore National Security, LLC)
+[comment]: # (Copyright 2016-21, Lawrence Livermore National Security, LLC)
 [comment]: # (and RAJA project contributors. See the RAJA/COPYRIGHT file)
 [comment]: # (for details.)
 [comment]: # 

--- a/include/RAJA/policy/openmp_target/kernel/Collapse.hpp
+++ b/include/RAJA/policy/openmp_target/kernel/Collapse.hpp
@@ -24,9 +24,6 @@ struct StatementExecutor<statement::Collapse<omp_target_parallel_collapse_exec,
     auto l0 = segment_length<Arg0>(data);
     auto l1 = segment_length<Arg1>(data);
 
-    auto i0 = l0;
-    auto i1 = l1;
-
     // Set the argument types for this loop
     using NewTypes0 = setSegmentTypeFromData<Types, Arg0, Data>;
     using NewTypes1 = setSegmentTypeFromData<NewTypes0, Arg1, Data>;
@@ -61,10 +58,6 @@ struct StatementExecutor<statement::Collapse<omp_target_parallel_collapse_exec,
     auto l0 = segment_length<Arg0>(data);
     auto l1 = segment_length<Arg1>(data);
     auto l2 = segment_length<Arg2>(data);
-
-    auto i0 = l0;
-    auto i1 = l1;
-    auto i2 = l2;
 
     // Set the argument types for this loop
     using NewTypes0 = setSegmentTypeFromData<Types, Arg0, Data>;
@@ -106,11 +99,6 @@ struct StatementExecutor<statement::Collapse<omp_target_parallel_collapse_exec,
     auto l1 = segment_length<Arg1>(data);
     auto l2 = segment_length<Arg2>(data);
     auto l3 = segment_length<Arg3>(data);
-
-    auto i0 = l0;
-    auto i1 = l1;
-    auto i2 = l2;
-    auto i3 = l3;
 
     // Set the argument types for this loop
     using NewTypes0 = setSegmentTypeFromData<Types, Arg0, Data>;

--- a/scripts/update_copyright.sh
+++ b/scripts/update_copyright.sh
@@ -27,7 +27,7 @@
 #=============================================================================
 #
 # If you need to modify this script, you may want to run each of these 
-# commands individual from the command line to make sure things are doing 
+# commands individually from the command line to make sure things are doing 
 # what you think they should be doing. This is why they are separated into 
 # steps here.
 # 
@@ -52,13 +52,12 @@ echo LICENSE
 cp LICENSE LICENSE.sed.bak
 sed "s/Copyright (c) 2016-2020/Copyright (c) 2016-2021/" LICENSE.sed.bak > LICENSE
 
-echo CONTRIBUTING
-cp CONTRIBUTING.md CONTRIBUTING.md.sed.bak
-sed "s/2016-20/2016-21/" CONTRIBUTING.md.sed.bak > CONTRIBUTING.md
-
-echo README
-cp README.md README.md.sed.bak
-sed "s/2016-20/2016-21/" README.md.sed.bak > README.md
+for i in README.md RELEASE_NOTES.md CONTRIBUTING.md RELEASE 
+do 
+    echo $i
+    cp $i $i.sed.bak
+    sed "s/2016-20/2016-21/" $i.sed.bak > $i
+done
 
 #=============================================================================
 # Remove temporary files created in the process

--- a/test/functional/kernel/CMakeLists.txt
+++ b/test/functional/kernel/CMakeLists.txt
@@ -29,6 +29,8 @@ endif()
 
 add_subdirectory(basic-single-loop)
 
+add_subdirectory(nested-loop-segment-types)
+
 add_subdirectory(reduce-loc)
 
 unset( KERNEL_BACKENDS )

--- a/test/functional/kernel/basic-single-loop/CMakeLists.txt
+++ b/test/functional/kernel/basic-single-loop/CMakeLists.txt
@@ -6,7 +6,7 @@
 ###############################################################################
 
 #
-# List of segment types for generating test files.
+# List of test types for future expansion, if needed. 
 #
 set(TESTTYPES Segments)
 

--- a/test/functional/kernel/nested-loop-segment-types/CMakeLists.txt
+++ b/test/functional/kernel/nested-loop-segment-types/CMakeLists.txt
@@ -1,0 +1,22 @@
+###############################################################################
+# Copyright (c) 2016-21, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+#
+# Generate tests for each enabled RAJA back-end. 
+# 
+# Note: KERNEL_BACKENDS is defined in ../CMakeLists.txt
+#
+
+foreach( BACKEND ${KERNEL_BACKENDS} )
+  configure_file( test-kernel-nested-loop-segments.cpp.in
+                  test-kernel-nested-loop-segments-${BACKEND}.cpp )
+  raja_add_test( NAME test-kernel-nested-loop-segments-${BACKEND}
+                 SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-kernel-nested-loop-segments-${BACKEND}.cpp )
+
+  target_include_directories(test-kernel-nested-loop-segments-${BACKEND}.exe
+                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+endforeach()

--- a/test/functional/kernel/nested-loop-segment-types/test-kernel-nested-loop-segments.cpp.in
+++ b/test/functional/kernel/nested-loop-segment-types/test-kernel-nested-loop-segments.cpp.in
@@ -1,0 +1,174 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-21, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+//
+// test/include headers
+//
+#include "RAJA_test-base.hpp"
+#include "RAJA_test-camp.hpp"
+#include "RAJA_test-index-types.hpp"
+
+#include "RAJA_test-forall-data.hpp"
+
+
+//
+// Header for tests in ./tests directory
+//
+// Note: CMake adds ./tests as an include dir for these tests.
+//
+#include "test-kernel-nested-loops-segment-types.hpp"
+
+
+// Sequential execution policy types
+using SequentialKernelExecPols = camp::list< 
+    
+  RAJA::KernelPolicy<
+    RAJA::statement::For<0, RAJA::loop_exec,
+      RAJA::statement::For<1, RAJA::seq_exec,
+        RAJA::statement::For<2, RAJA::loop_exec,
+          RAJA::statement::Lambda<0, RAJA::Segs<0, 1, 2>>
+        >
+      >
+    >
+  >
+
+>;
+
+#if defined(RAJA_ENABLE_OPENMP)
+using OpenMPKernelExecPols = camp::list< 
+    
+  RAJA::KernelPolicy<
+    RAJA::statement::For<0, RAJA::omp_parallel_for_exec,
+      RAJA::statement::For<1, RAJA::seq_exec,
+        RAJA::statement::For<2, RAJA::loop_exec,
+          RAJA::statement::Lambda<0, RAJA::Segs<0, 1, 2>>
+        >
+      >
+    >
+  >
+
+>;
+#endif  // if defined(RAJA_ENABLE_OPENMP)
+
+#if defined(RAJA_ENABLE_TBB)
+using TBBKernelExecPols = 
+camp::list< 
+
+  RAJA::KernelPolicy<
+    RAJA::statement::For<0, RAJA::tbb_for_exec,
+      RAJA::statement::For<1, RAJA::seq_exec,
+        RAJA::statement::For<2, RAJA::loop_exec,
+          RAJA::statement::Lambda<0, RAJA::Segs<0, 1, 2>>
+        >
+      >
+    >
+  >
+
+>;
+#endif  // if defined(RAJA_ENABLE_TBB)
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+using OpenMPTargetKernelExecPols =
+camp::list< 
+
+  RAJA::KernelPolicy<
+    RAJA::statement::For<0, RAJA::omp_target_parallel_for_exec<8>,
+      RAJA::statement::For<1, RAJA::seq_exec,
+        RAJA::statement::For<2, RAJA::seq_exec,
+          RAJA::statement::Lambda<0, RAJA::Segs<0, 1, 2>>
+        >
+      >
+    >
+  >,
+
+  RAJA::KernelPolicy<
+    RAJA::statement::Collapse<RAJA::omp_target_parallel_collapse_exec,
+                               RAJA::ArgList<0, 1, 2>,
+       RAJA::statement::Lambda<0>
+    >
+  >
+
+>;
+#endif  // if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#if defined(RAJA_ENABLE_CUDA)
+using CudaKernelExecPols = 
+camp::list< 
+
+  RAJA::KernelPolicy<
+    RAJA::statement::CudaKernelAsync<
+      RAJA::statement::For<0, RAJA::cuda_block_z_loop,
+        RAJA::statement::For<1, RAJA::cuda_block_y_loop,
+          RAJA::statement::For<2, RAJA::cuda_thread_x_loop,
+            RAJA::statement::Lambda<0, RAJA::Segs<0, 1, 2>>
+          >
+        >
+      >
+    >
+  >,
+
+  RAJA::KernelPolicy<
+    RAJA::statement::CudaKernel<
+      RAJA::statement::For<0, RAJA::cuda_thread_x_loop,
+        RAJA::statement::For<1, RAJA::seq_exec,
+          RAJA::statement::For<2, RAJA::seq_exec,
+            RAJA::statement::Lambda<0, RAJA::Segs<0, 1, 2>>
+          >
+        >
+      >
+    >
+  >
+
+>;
+#endif  // if defined(RAJA_ENABLE_CUDA)
+
+#if defined(RAJA_ENABLE_HIP)
+using HipKernelExecPols = 
+camp::list< 
+
+  RAJA::KernelPolicy<
+    RAJA::statement::HipKernelAsync<
+      RAJA::statement::For<0, RAJA::hip_block_z_loop,
+        RAJA::statement::For<1, RAJA::hip_block_y_loop,
+          RAJA::statement::For<2, RAJA::hip_thread_x_loop,
+            RAJA::statement::Lambda<0, RAJA::Segs<0, 1, 2>>
+          >
+        >
+      >
+    >
+  >,
+
+  RAJA::KernelPolicy<
+    RAJA::statement::HipKernel<
+      RAJA::statement::For<0, RAJA::hip_thread_x_loop,
+        RAJA::statement::For<1, RAJA::seq_exec,
+          RAJA::statement::For<2, RAJA::seq_exec,
+            RAJA::statement::Lambda<0, RAJA::Segs<0, 1, 2>>
+          >
+        >
+      >
+    >
+  >
+
+>;
+#endif  // if defined(RAJA_ENABLE_HIP)
+
+
+//
+// Cartesian product of types used in parameterized tests
+//
+using @BACKEND@KernelNestedLoopsSegmentTypes =
+  Test< camp::cartesian_product<IdxTypeList,
+                                @BACKEND@ResourceList,
+                                @BACKEND@KernelExecPols>>::Types;
+
+//
+// Instantiate parameterized tests
+//
+INSTANTIATE_TYPED_TEST_SUITE_P(@BACKEND@,
+                               KernelNestedLoopsSegmentTypesTest,
+                               @BACKEND@KernelNestedLoopsSegmentTypes);

--- a/test/functional/kernel/nested-loop-segment-types/tests/test-kernel-nested-loops-segment-types.hpp
+++ b/test/functional/kernel/nested-loop-segment-types/tests/test-kernel-nested-loops-segment-types.hpp
@@ -1,0 +1,183 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-21, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef __TEST_KERNEL_NESTED_LOOPS_SEGMENT_TYPES_HPP__
+#define __TEST_KERNEL_NESTED_LOOPS_SEGMENT_TYPES_HPP__
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+
+template <typename IDX_TYPE, typename DATA_TYPE, typename EXEC_POLICY>
+void KernelNestedLoopsSegmentTypesTestImpl(
+  const RAJA::TypedRangeSegment<IDX_TYPE>& s1, 
+  const std::vector<IDX_TYPE>& s1_idx,
+  const RAJA::TypedRangeStrideSegment<IDX_TYPE>& s2,
+  const std::vector<IDX_TYPE>& s2_idx,
+  const RAJA::TypedListSegment<IDX_TYPE>& s3,
+  const std::vector<IDX_TYPE>& s3_idx,
+  camp::resources::Resource& working_res,
+  int perm)
+{
+  IDX_TYPE dim1 = s1_idx[s1_idx.size() - 1] + 1;
+  IDX_TYPE dim2 = s2_idx[s2_idx.size() - 1] + 1;
+  IDX_TYPE dim3 = s3_idx[s3_idx.size() - 1] + 1;
+
+  IDX_TYPE data_len = dim1 * dim2 * dim3;
+
+  IDX_TYPE idx1_len = static_cast<IDX_TYPE>(s1_idx.size());
+  IDX_TYPE idx2_len = static_cast<IDX_TYPE>(s2_idx.size());
+  IDX_TYPE idx3_len = static_cast<IDX_TYPE>(s3_idx.size());
+
+  DATA_TYPE* work_array;
+  DATA_TYPE* check_array;
+  DATA_TYPE* test_array;
+
+  allocateForallTestData<DATA_TYPE>(data_len,
+                                    working_res,
+                                    &work_array,
+                                    &check_array,
+                                    &test_array);
+
+  RAJA::View< DATA_TYPE, RAJA::Layout<3> > work_view(work_array, 
+                                                     dim1, dim2, dim3);
+  RAJA::View< DATA_TYPE, RAJA::Layout<3> > test_view(test_array, 
+                                                     dim1, dim2, dim3);
+
+  for (IDX_TYPE i = 0; i < data_len; ++i) {
+    test_array[RAJA::stripIndexType(i)] = static_cast<DATA_TYPE>(0);
+  }
+ 
+  working_res.memcpy(work_array, test_array, 
+                     sizeof(DATA_TYPE) * RAJA::stripIndexType(data_len));
+
+  for (IDX_TYPE i1 = 0; i1 < idx1_len; ++i1) {
+    for (IDX_TYPE i2 = 0; i2 < idx2_len; ++i2) {
+      for (IDX_TYPE i3 = 0; i3 < idx3_len; ++i3) {
+        auto ii1 = RAJA::stripIndexType(i1);
+        auto ii2 = RAJA::stripIndexType(i2);
+        auto ii3 = RAJA::stripIndexType(i3);
+        test_view( s1_idx[ii1], s2_idx[ii2], s3_idx[ii3] ) = 
+          static_cast<DATA_TYPE>( RAJA::stripIndexType(
+                                    s1_idx[ii1] + s2_idx[ii2] + s3_idx[ii3]) );
+      }
+    }
+  }
+
+  if ( perm == 1 ) {
+    RAJA::kernel<EXEC_POLICY>( RAJA::make_tuple( s1, s2, s3 ),
+      [=] RAJA_HOST_DEVICE (IDX_TYPE i1, IDX_TYPE i2, IDX_TYPE i3) {
+        work_view(i1, i2, i3) = 
+          static_cast<DATA_TYPE>( RAJA::stripIndexType(i1 + i2 + i3) );
+      }
+    );
+  }
+ 
+  if ( perm == 2 ) {
+    RAJA::kernel<EXEC_POLICY>( RAJA::make_tuple( s2, s3, s1 ),
+      [=] RAJA_HOST_DEVICE (IDX_TYPE i2, IDX_TYPE i3, IDX_TYPE i1) {
+        work_view(i1, i2, i3) = 
+          static_cast<DATA_TYPE>( RAJA::stripIndexType(i1 + i2 + i3) );
+      }
+    );
+  } 
+
+  if ( perm == 3 ) {
+    RAJA::kernel<EXEC_POLICY>( RAJA::make_tuple( s3, s1, s2 ),
+      [=] RAJA_HOST_DEVICE (IDX_TYPE i3, IDX_TYPE i1, IDX_TYPE i2) {
+        work_view(i1, i2, i3) = 
+          static_cast<DATA_TYPE>( RAJA::stripIndexType(i1 + i2 + i3) );
+      }
+    );
+  } 
+
+  working_res.memcpy(check_array, work_array, 
+                     sizeof(DATA_TYPE) * RAJA::stripIndexType(data_len));
+
+  for (IDX_TYPE i = 0; i < data_len; ++i) {
+    auto ii = RAJA::stripIndexType(i);
+    ASSERT_EQ( test_array[ii], check_array[ii] );
+  }
+
+  deallocateForallTestData<DATA_TYPE>(working_res,
+                                      work_array,
+                                      check_array,
+                                      test_array);
+}
+
+
+TYPED_TEST_SUITE_P(KernelNestedLoopsSegmentTypesTest);
+template <typename T>
+class KernelNestedLoopsSegmentTypesTest : public ::testing::Test
+{
+};
+
+TYPED_TEST_P(KernelNestedLoopsSegmentTypesTest, NestedLoopsSegmentTypesKernel)
+{
+  using IDX_TYPE    = typename camp::at<TypeParam, camp::num<0>>::type;
+  using WORKING_RES = typename camp::at<TypeParam, camp::num<1>>::type;
+  using EXEC_POLICY = typename camp::at<TypeParam, camp::num<2>>::type;
+
+  camp::resources::Resource working_res{WORKING_RES::get_default()};
+
+  std::vector<IDX_TYPE> s1_idx;
+  std::vector<IDX_TYPE> s2_idx;
+  std::vector<IDX_TYPE> s3_idx;
+
+// Create a segment of each basic type RAJA provides
+
+  RAJA::TypedRangeSegment<IDX_TYPE> s1( 0, 69 );
+  RAJA::getIndices(s1_idx, s1);
+
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> s2( 3, 188, 2 );
+  RAJA::getIndices(s2_idx, s2);
+
+  IDX_TYPE last = IDX_TYPE(427);
+  srand( time(NULL) );
+  for (IDX_TYPE i = IDX_TYPE(0); i < last; ++i) {
+    IDX_TYPE randval = IDX_TYPE( rand() % RAJA::stripIndexType(last) );
+    if ( i < randval ) {
+      s3_idx.push_back(i);
+    }
+  }
+  RAJA::TypedListSegment<IDX_TYPE> s3( &s3_idx[0], s3_idx.size(),
+                                       working_res );
+
+  int perm = 1;
+  KernelNestedLoopsSegmentTypesTestImpl<IDX_TYPE, int, EXEC_POLICY>(
+                                        s1, s1_idx,    
+                                        s2, s2_idx,    
+                                        s3, s3_idx,
+                                        working_res,
+                                        perm);
+
+  perm = 2;
+  KernelNestedLoopsSegmentTypesTestImpl<IDX_TYPE, int, EXEC_POLICY>(
+                                        s1, s1_idx,
+                                        s2, s2_idx,
+                                        s3, s3_idx,
+                                        working_res,
+                                        perm);
+
+  perm = 3;
+  KernelNestedLoopsSegmentTypesTestImpl<IDX_TYPE, int, EXEC_POLICY>(
+                                        s1, s1_idx,
+                                        s2, s2_idx,
+                                        s3, s3_idx,
+                                        working_res,
+                                        perm);
+}
+
+REGISTER_TYPED_TEST_SUITE_P(KernelNestedLoopsSegmentTypesTest,
+                            NestedLoopsSegmentTypesKernel);
+
+#endif  // __TEST_KERNEL_NESTED_LOOPS_SEGMENT_TYPES_HPP__


### PR DESCRIPTION
# Summary

- This PR adds nested kernel tests that use multiple segment types in each kernel.
- It also updates copyright year in some files that we missed earlier and script to cover these files.
- Removed some unused variables in openmp target policy implementations to squash compiler warnings.