### PR TITLE
Fix compile issues for clang11 builds.

### DIFF
--- a/examples/red-black-gauss-seidel.cpp
+++ b/examples/red-black-gauss-seidel.cpp
@@ -179,8 +179,8 @@ RAJA::TypedIndexSet<RAJA::ListSegment>
 {
   RAJA::TypedIndexSet<RAJA::ListSegment> colorSet;
 
-  int redN = ceil(N * N / 2);
-  int blkN = floor(N * N / 2);
+  int redN = static_cast<int>( std::ceil( static_cast<double>(N * N / 2) ) );
+  int blkN = static_cast<int>( std::floor( static_cast<double>(N * N / 2) ) );
   RAJA::Index_type *Red = new RAJA::Index_type[redN];
   RAJA::Index_type *Blk = new RAJA::Index_type[blkN];
 

--- a/scripts/lc-builds/blueos_clang11.0.0.sh
+++ b/scripts/lc-builds/blueos_clang11.0.0.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2016-21, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+BUILD_SUFFIX=lc_blueos-clang-11.0.0
+
+rm -rf build_${BUILD_SUFFIX} 2>/dev/null
+mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
+
+module load cmake/3.14.5
+
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_COMPILER=/usr/tce/packages/clang/clang-11.0.0/bin/clang++ \
+  -C ../host-configs/lc-builds/blueos/clang_X.cmake \
+  -DENABLE_OPENMP=On \
+  -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
+  "$@" \
+  .. 

--- a/scripts/lc-builds/blueos_clang11.0.0_omptarget.sh
+++ b/scripts/lc-builds/blueos_clang11.0.0_omptarget.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2016-21, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+BUILD_SUFFIX=lc_blueos-clang-11.0.0_omptarget
+
+rm -rf build_${BUILD_SUFFIX} 2>/dev/null
+mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
+
+module load cmake/3.14.5
+
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_COMPILER=/usr/tce/packages/clang/clang-11.0.0/bin/clang++ \
+  -C ../host-configs/lc-builds/blueos/clang_X.cmake \
+  -DENABLE_OPENMP=On \
+  -DENABLE_CUDA=Off \
+  -DENABLE_TARGET_OPENMP=On \
+  -DOpenMP_CXX_FLAGS="-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda" \
+  -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
+  "$@" \
+  .. 

--- a/test/functional/forall/atomic-view/tests/test-forall-AtomicMultiView.hpp
+++ b/test/functional/forall/atomic-view/tests/test-forall-AtomicMultiView.hpp
@@ -12,7 +12,7 @@
 #ifndef __TEST_FORALL_ATOMIC_MULTIVIEW_HPP__
 #define __TEST_FORALL_ATOMIC_MULTIVIEW_HPP__
 
-#include <math.h>
+#include <cmath>
 
 template <typename ExecPolicy,
           typename AtomicPolicy,
@@ -23,7 +23,7 @@ void ForallAtomicMultiViewTestImpl( IdxType N )
 {
   // Functionally similar to ForallAtomicViewTestImpl
 
-  int dst_side = (int)(sqrt(N/2)); // dest[] dimension
+  int dst_side = static_cast<int>( std::sqrt( static_cast<double>(N/2) ) ); // dest[] dimension
   int src_side = dst_side*2; // source[] dimension
 
   RAJA::TypedRangeSegment<IdxType> seg(0, N);


### PR DESCRIPTION
# Summary

- This PR fixes some compilation issues that arise when using clang11 compilers. It also add some build scripts.

Note that there are still other (mostly linking) issues, but this fixes the most obvious ones.