### PR TITLE
Install targets for thirdparty exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 ###############################################################################
 # Copyright (c) 2016-21, Lawrence Livermore National Security, LLC
 # and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
-
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ###############################################################################
 # Copyright (c) 2016-21, Lawrence Livermore National Security, LLC
 # and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
-#
+
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
@@ -72,6 +72,8 @@ option(RAJA_TEST_OPENMP_TARGET_SUBSET "Build subset of RAJA OpenMP target tests 
 option(RAJA_ENABLE_RUNTIME_PLUGINS "Enable support for loading plugins at runtime" Off)
 
 set(TEST_DRIVER "" CACHE STRING "driver used to wrap test commands")
+
+set(BLT_EXPORT_THIRDPARTY ON CACHE BOOL "")
 
 cmake_minimum_required(VERSION 3.9)
 

--- a/cmake/SetupPackages.cmake
+++ b/cmake/SetupPackages.cmake
@@ -28,3 +28,21 @@ if (ENABLE_TBB)
     set(ENABLE_TBB Off)
   endif()
 endif ()
+
+set(TPL_DEPS)
+blt_list_append(TO TPL_DEPS ELEMENTS cuda cuda_runtime IF ENABLE_CUDA)
+blt_list_append(TO TPL_DEPS ELEMENTS hip hip_runtime IF ENABLE_HIP)
+blt_list_append(TO TPL_DEPS ELEMENTS openmp IF ENABLE_OPENMP)
+blt_list_append(TO TPL_DEPS ELEMENTS mpi IF ENABLE_MPI)
+
+foreach(dep ${TPL_DEPS})
+    # If the target is EXPORTABLE, add it to the export set
+    get_target_property(_is_imported ${dep} IMPORTED)
+    if(NOT ${_is_imported})
+        install(TARGETS              ${dep}
+                EXPORT               RAJA
+                DESTINATION          lib)
+        # Namespace target to avoid conflicts
+        set_target_properties(${dep} PROPERTIES EXPORT_NAME RAJA::${dep})
+    endif()
+endforeach()


### PR DESCRIPTION
This PR is a bugfix, and exports targets for third-party dependencies provided by BLT (e.g. CUDA and HIP) - this allows non-BLT projects to use the imported RAJA target.

