### PR TITLE
Remove volatile from non-volatile type conversion

### DIFF
--- a/include/RAJA/util/TypeConvert.hpp
+++ b/include/RAJA/util/TypeConvert.hpp
@@ -40,7 +40,7 @@ template <typename A, typename B>
 RAJA_INLINE RAJA_HOST_DEVICE constexpr B reinterp_A_as_B(A const &val)
 {
   static_assert(sizeof(A) == sizeof(B), "A and B must be same size");
-  return reinterpret_cast<B const volatile &>(val);
+  return reinterpret_cast<B const &>(val);
 }
 
 template <typename A, typename B>


### PR DESCRIPTION
# Summary
Remove volatile from the reintepret_cast in the non-volatile version of
the type conversion function used in the raja atomics.

This fixes a performance issue with hip where the value was written
to the stack during type conversion.

- This PR is something else
- It does the following:
  - Modifies RAJA::reinterp_A_as_B(non-volatile) to remove volatile in the reinterpret_cast
  - Fixes issue where hip writes values to the stack