### PR TITLE
Fixing omp-target cmake test bug

### DIFF
--- a/test/functional/kernel/nested-loop/CMakeLists.txt
+++ b/test/functional/kernel/nested-loop/CMakeLists.txt
@@ -58,6 +58,7 @@ if(RAJA_ENABLE_TARGET_OPENMP)
     set(NESTED_LOOP_BACKEND OpenMPTarget)
     set(NESTED_LOOPTYPES Basic MultiLambdaParam)
 
+    set(RESOURCE "-")
     foreach( NESTED_LOOP_TYPE ${NESTED_LOOPTYPES} )
       configure_file( test-kernel-nested-loop.cpp.in
                       test-kernel-nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.cpp )


### PR DESCRIPTION
# Summary

- This PR is a bugfix
  - It fixes compiler errors from a missing cmake variable needed in some generated OpenMP Target cpp test files.
