### PR TITLE
Added blocks per sm option to CUDA kernel.

### DIFF
--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -714,6 +714,10 @@ explanation along with examples of how they are used can be found in
 
   * ``statement::CudaKernelFixedAsync<num_threads, EnclosedStatements>`` asynchronous version of CudaKernelFixed.
 
+  * ``statement::CudaKernelFixedSM<num_threads, min_blocks_per_sm, EnclosedStatements>`` similar to CudaKernelFixed but enables a minimum number of blocks per sm (specified by min_blocks_per_sm), this can help increase occupancy. This kernel launch is synchronous.
+
+  * ``statement::CudaKernelFixedSMASync<num_threads, min_blocks_per_sm, EnclosedStatements>`` asynchronous version of CudaKernelFixedSM.
+
   * ``statement::CudaKernelOcc<EnclosedStatements>`` similar to CudaKernel but uses the CUDA occupancy calculator to determine the optimal number of threads/blocks. Statement is intended for RAJA::cuda_block_{xyz}_loop policies. This kernel launch is synchronous.
 
   * ``statement::CudaKernelOccAsync<EnclosedStatements>`` asynchronous version of CudaKernelOcc.

--- a/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
+++ b/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
@@ -56,7 +56,7 @@ namespace RAJA
  * runtime.
  * Num_threads is 1024, which may not be appropriate for all kernels.
  */
-template <bool async0, size_t num_blocks, size_t blocks_per_sm, size_t num_threads>
+template <bool async0, size_t num_blocks, size_t num_threads, size_t blocks_per_sm>
 struct cuda_launch {};
 
 /*!
@@ -65,8 +65,8 @@ struct cuda_launch {};
  * If num_blocks is 0 then num_blocks is chosen at runtime.
  * Num_blocks is chosen to maximize the number of blocks running concurrently.
  */
-template <bool async0, size_t num_blocks, size_t blocks_per_sm, size_t num_threads>
-using cuda_explicit_launch = cuda_launch<async0, num_blocks, blocks_per_sm, num_threads>;
+template <bool async0, size_t num_blocks, size_t num_threads, size_t blocks_per_sm>
+using cuda_explicit_launch = cuda_launch<async0, num_blocks, num_threads, blocks_per_sm>;
 
 
 /*!
@@ -75,7 +75,7 @@ using cuda_explicit_launch = cuda_launch<async0, num_blocks, blocks_per_sm, num_
  * If num_threads is 0 then num_threads is chosen at runtime.
  */
 template <size_t num_threads0, bool async0>
-using cuda_occ_calc_launch = cuda_launch<async0, 0, 0, num_threads0>;
+using cuda_occ_calc_launch = cuda_launch<async0, 0, num_threads0, 0>;
 
 namespace statement
 {
@@ -97,9 +97,9 @@ struct CudaKernelExt
  * calculator determine the unspecified values.
  * The kernel launch is synchronous.
  */
-template <size_t num_blocks, size_t blocks_per_sm, size_t num_threads, typename... EnclosedStmts>
+template <size_t num_blocks, size_t num_threads, size_t blocks_per_sm, typename... EnclosedStmts>
 using CudaKernelExp =
-    CudaKernelExt<cuda_launch<false, num_blocks, blocks_per_sm, num_threads>, EnclosedStmts...>;
+    CudaKernelExt<cuda_launch<false, num_blocks, num_threads, blocks_per_sm>, EnclosedStmts...>;
 
 /*!
  * A RAJA::kernel statement that launches a CUDA kernel with the flexibility
@@ -107,9 +107,9 @@ using CudaKernelExp =
  * calculator determine the unspecified values.
  * The kernel launch is asynchronous.
  */
-template <size_t num_blocks, size_t blocks_per_sm, size_t num_threads, typename... EnclosedStmts>
+template <size_t num_blocks, size_t num_threads, size_t blocks_per_sm, typename... EnclosedStmts>
 using CudaKernelExpAsync =
-    CudaKernelExt<cuda_launch<true, num_blocks, blocks_per_sm, num_threads>, EnclosedStmts...>;
+    CudaKernelExt<cuda_launch<true, num_blocks, num_threads, blocks_per_sm>, EnclosedStmts...>;
 
 /*!
  * A RAJA::kernel statement that launches a CUDA kernel using the
@@ -136,7 +136,7 @@ using CudaKernelOccAsync =
  */
 template <size_t num_threads, typename... EnclosedStmts>
 using CudaKernelFixed =
-    CudaKernelExt<cuda_explicit_launch<false, operators::limits<size_t>::max(), 1, num_threads>,
+    CudaKernelExt<cuda_explicit_launch<false, operators::limits<size_t>::max(), num_threads, 1>,
                   EnclosedStmts...>;
 
 /*!
@@ -146,7 +146,7 @@ using CudaKernelFixed =
  */
 template <size_t num_threads, size_t blocks_per_sm, typename... EnclosedStmts>
 using CudaKernelFixedSM =
-    CudaKernelExt<cuda_explicit_launch<false, operators::limits<size_t>::max(), blocks_per_sm, num_threads>,
+    CudaKernelExt<cuda_explicit_launch<false, operators::limits<size_t>::max(), num_threads, blocks_per_sm>,
                   EnclosedStmts...>;
 
 /*!
@@ -156,7 +156,7 @@ using CudaKernelFixedSM =
  */
 template <size_t num_threads, typename... EnclosedStmts>
 using CudaKernelFixedAsync =
-    CudaKernelExt<cuda_explicit_launch<true, operators::limits<size_t>::max(), 1, num_threads>,
+    CudaKernelExt<cuda_explicit_launch<true, operators::limits<size_t>::max(), num_threads, 1>,
                   EnclosedStmts...>;
 
 /*!
@@ -165,8 +165,8 @@ using CudaKernelFixedAsync =
  * The kernel launch is asynchronous.
  */
 template <size_t num_threads, size_t blocks_per_sm, typename... EnclosedStmts>
-using CudaKernelFixedAsyncSM =
-    CudaKernelExt<cuda_explicit_launch<true, operators::limits<size_t>::max(), blocks_per_sm, num_threads>,
+using CudaKernelFixedSMAsync =
+    CudaKernelExt<cuda_explicit_launch<true, operators::limits<size_t>::max(), num_threads, blocks_per_sm>,
                   EnclosedStmts...>;
 
 /*!
@@ -270,8 +270,8 @@ struct CudaLaunchHelper;
  * The user may specify the number of threads and blocks or let one or both be
  * determined at runtime using the CUDA occupancy calculator.
  */
-template<bool async0, size_t num_blocks, size_t blocks_per_sm, size_t num_threads, typename StmtList, typename Data, typename Types>
-struct CudaLaunchHelper<cuda_launch<async0, num_blocks, blocks_per_sm, num_threads>,StmtList,Data,Types>
+template<bool async0, size_t num_blocks, size_t num_threads, size_t blocks_per_sm, typename StmtList, typename Data, typename Types>
+struct CudaLaunchHelper<cuda_launch<async0, num_blocks, num_threads, blocks_per_sm>,StmtList,Data,Types>
 {
   using Self = CudaLaunchHelper;
 

--- a/test/old-tests/unit/test-kernel.cpp
+++ b/test/old-tests/unit/test-kernel.cpp
@@ -2048,7 +2048,7 @@ GPU_TEST(Kernel, CudaExec1c)
 
   // Loop Fusion
   using Pol = KernelPolicy<
-      CudaKernelExt<cuda_explicit_launch<false, 5, 3>,
+      CudaKernelExt<cuda_explicit_launch<false, 5, 1, 3>,
            statement::Tile<2, tile_fixed<2>, cuda_block_z_loop,
                     For<0, cuda_block_x_loop,
                         For<1, cuda_block_y_loop,
@@ -2585,6 +2585,58 @@ GPU_TEST(Kernel, CudaExec_fixedspillexec)
   // Loop Fusion
   using Pol = KernelPolicy<CudaKernelFixed<1024,
       statement::Tile<0, tile_fixed<1024>, cuda_block_x_loop,
+        For<0, cuda_thread_x_direct,
+          Lambda<0>
+        >
+      >
+    >
+  >;
+
+
+  long *x = nullptr;
+  cudaErrchk(cudaMallocManaged(&x, (N+M) * sizeof(long)));
+  long *y = x;
+
+  RAJA::ReduceSum<cuda_reduce, long> trip_count(0);
+
+  kernel<Pol>(
+
+      RAJA::make_tuple(RangeSegment(0, N)),
+
+      [=] __device__(Index_type i) {
+        constexpr long M = (long)32; // M must be constexpr on the device
+        long a[M];
+        for (int j = 0; j < M; ++j) {
+          a[j] = x[i+j];
+          y[i+j] = a[j];
+        }
+        trip_count += 1;
+        for (int j = 0; j < M; ++j) {
+          x[i+j] = a[j];
+        }
+      });
+
+  cudaErrchk(cudaDeviceSynchronize());
+
+
+  long result = (long)trip_count;
+
+  ASSERT_EQ(result, N);
+
+  cudaErrchk(cudaFree(x));
+}
+
+GPU_TEST(Kernel, CudaExec_fixedsmspillexec)
+{
+  using namespace RAJA;
+
+
+  constexpr long N = (long)2048;
+  constexpr long M = (long)32;
+
+  // Loop Fusion
+  using Pol = KernelPolicy<CudaKernelFixedSM<512, 3,
+      statement::Tile<0, tile_fixed<512>, cuda_block_x_loop,
         For<0, cuda_thread_x_direct,
           Lambda<0>
         >

--- a/test/old-tests/unit/test-kernel.cpp
+++ b/test/old-tests/unit/test-kernel.cpp
@@ -2048,7 +2048,7 @@ GPU_TEST(Kernel, CudaExec1c)
 
   // Loop Fusion
   using Pol = KernelPolicy<
-      CudaKernelExt<cuda_explicit_launch<false, 5, 1, 3>,
+      CudaKernelExt<cuda_explicit_launch<false, 5, 3, 1>,
            statement::Tile<2, tile_fixed<2>, cuda_block_z_loop,
                     For<0, cuda_block_x_loop,
                         For<1, cuda_block_y_loop,


### PR DESCRIPTION
Adds a new CUDA kernel which can specify the minimum number of blocks per SM. I have a few kernels where doing this has improved perfomance by 20%.

I'm not sure about the tests but the only place I saw `CudaKernelFixed` tested was in `test/old-tests/unit/test-kernel.cpp`.

Also not sold on the name.
