### PR TITLE
Add arg to specify CUDA compute arch.

### DIFF
--- a/scripts/lc-builds/blueos_nvcc_clang.sh
+++ b/scripts/lc-builds/blueos_nvcc_clang.sh
@@ -7,18 +7,23 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [[ $# -ne 2 ]]; then
+if [[ $# -ne 3 ]]; then
   echo
-  echo "You must pass to the script a compiler version number for nvcc followed"
-  echo "by a version number for clang. For example,"
-  echo "    blueos_nvcc_clang.sh 10.2.89 10.0.1"
+  echo "You must pass 3 arguments to the script (in this order): "
+  echo "   1) compiler version number for nvcc"  
+  echo "   2) CUDA compute architecture"
+  echo "   3) compiler version number for clang. "
+  echo 
+  echo "For example: "
+  echo "    blueos_nvcc_clang.sh 10.2.89 sm_70 10.0.1"
   exit
 fi
 
 COMP_NVCC_VER=$1
-COMP_CLANG_VER=$2
+COMP_ARCH=$2
+COMP_CLANG_VER=$3
 
-BUILD_SUFFIX=lc_blueos-nvcc${COMP_NVCC_VER}-clang${COMP_CLANG_VER}
+BUILD_SUFFIX=lc_blueos-nvcc${COMP_NVCC_VER}-${COMP_ARCH}-clang${COMP_CLANG_VER}
 
 echo
 echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
@@ -38,7 +43,7 @@ cmake \
   -DENABLE_CUDA=On \
   -DCUDA_TOOLKIT_ROOT_DIR=/usr/tce/packages/cuda/cuda-${COMP_NVCC_VER} \
   -DCMAKE_CUDA_COMPILER=/usr/tce/packages/cuda/cuda-${COMP_NVCC_VER}/bin/nvcc \
-  -DCUDA_ARCH=sm_70 \
+  -DCUDA_ARCH=${COMP_ARCH} \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
   "$@" \
   ..

--- a/scripts/lc-builds/blueos_nvcc_gcc.sh
+++ b/scripts/lc-builds/blueos_nvcc_gcc.sh
@@ -7,18 +7,23 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [[ $# -ne 2 ]]; then
+if [[ $# -ne 3 ]]; then
   echo
-  echo "You must pass to the script a compiler version number for nvcc followed"
-  echo "by a version number for gcc. For example,"
-  echo "    blueos_nvcc_gcc.sh 10.2.89 8.3.1"
+  echo "You must pass 3 arguments to the script (in this order): "
+  echo "   1) compiler version number for nvcc"
+  echo "   2) CUDA compute architecture"
+  echo "   3) compiler version number for gcc. "
+  echo
+  echo "For example: "
+  echo "    blueos_nvcc_gcc.sh 10.2.89 sm_70 8.3.1"
   exit
 fi
 
 COMP_NVCC_VER=$1
-COMP_GCC_VER=$2
+COMP_ARCH=$2
+COMP_GCC_VER=$3
 
-BUILD_SUFFIX=lc_blueos-nvcc${COMP_NVCC_VER}-gcc${COMP_GCC_VER}
+BUILD_SUFFIX=lc_blueos-nvcc${COMP_NVCC_VER}-${COMP_ARCH}-gcc${COMP_GCC_VER}
 
 echo
 echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
@@ -38,7 +43,7 @@ cmake \
   -DENABLE_CUDA=On \
   -DCUDA_TOOLKIT_ROOT_DIR=/usr/tce/packages/cuda/cuda-${COMP_NVCC_VER} \
   -DCMAKE_CUDA_COMPILER=/usr/tce/packages/cuda/cuda-${COMP_NVCC_VER}/bin/nvcc \
-  -DCUDA_ARCH=sm_70 \
+  -DCUDA_ARCH=${COMP_ARCH} \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
   "$@" \
   ..

--- a/scripts/lc-builds/blueos_nvcc_xl.sh
+++ b/scripts/lc-builds/blueos_nvcc_xl.sh
@@ -7,18 +7,23 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [[ $# -ne 2 ]]; then
+if [[ $# -ne 3 ]]; then
   echo
-  echo "You must pass to the script a compiler version number for nvcc followed"
-  echo "by a version number for xl. For example,"
-  echo "    blueos_nvcc_xl.sh 11.1.1 2020.03.31"
+  echo "You must pass 3 arguments to the script (in this order): "
+  echo "   1) compiler version number for nvcc"
+  echo "   2) CUDA compute architecture"
+  echo "   3) compiler version number for xl. "
+  echo
+  echo "For example: "
+  echo "    blueos_nvcc_xl.sh 11.1.1 sm_70 2021.03.31"
   exit
 fi
 
 COMP_NVCC_VER=$1
-COMP_XL_VER=$2
+COMP_ARCH=$2
+COMP_XL_VER=$3
 
-BUILD_SUFFIX=lc_blueos-nvcc${COMP_NVCC_VER}-xl${COMP_XL_VER}
+BUILD_SUFFIX=lc_blueos-nvcc${COMP_NVCC_VER}-${COMP_ARCH}-xl${COMP_XL_VER}
 
 echo
 echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
@@ -38,7 +43,7 @@ cmake \
   -DENABLE_CUDA=On \
   -DCUDA_TOOLKIT_ROOT_DIR=/usr/tce/packages/cuda/cuda-${COMP_NVCC_VER} \
   -DCMAKE_CUDA_COMPILER=/usr/tce/packages/cuda/cuda-${COMP_NVCC_VER}/bin/nvcc \
-  -DCUDA_ARCH=sm_70 \
+  -DCUDA_ARCH=${COMP_ARCH} \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
   "$@" \
   ..

--- a/scripts/lc-builds/toss3_hipcc.sh
+++ b/scripts/lc-builds/toss3_hipcc.sh
@@ -7,16 +7,21 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [ "$1" == "" ]; then
+if [[ $# -ne 2 ]]; then
   echo
-  echo "You must pass a compiler version number to script. For example,"
-  echo "    toss3_hipcc.sh 4.0.1"
+  echo "You must pass 2 arguments to the script (in this order): "
+  echo "   1) compiler version number"
+  echo "   2) HIP compute architecture"
+  echo
+  echo "For example: "
+  echo "    toss3_hipcc.sh 4.1.0 gfx906"
   exit
 fi
 
 COMP_VER=$1
+COMP_ARCH=$2
 
-BUILD_SUFFIX=lc_toss3-hipcc-${COMP_VER}
+BUILD_SUFFIX=lc_toss3-hipcc-${COMP_VER}-${COMP_ARCH}
 
 echo
 echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
@@ -34,6 +39,7 @@ cmake \
   -DHIP_CLANG_PATH=/opt/rocm-${COMP_VER}/llvm/bin \
   -DCMAKE_C_COMPILER=/opt/rocm-${COMP_VER}/llvm/bin/clang \
   -DCMAKE_CXX_COMPILER=/opt/rocm-${COMP_VER}/llvm/bin/clang++ \
+  -DHIP_HIPCC_FLAGS=--offload-arch=${COMP_ARCH} \
   -C ../host-configs/lc-builds/toss3/hip.cmake \
   -DENABLE_HIP=ON \
   -DENABLE_OPENMP=OFF \


### PR DESCRIPTION
# Summary

- This PR adds an arg to some of the build scripts to specify the cuda compute architecture.

@MrBurmark is this what you had in mind?

I'm not sure if it makes sense to have a default case for these scripts if no args are provided. Any thoughts on this?