### PR TITLE
hip ci version updates

### DIFF
--- a/.gitlab/corona-jobs.yml
+++ b/.gitlab/corona-jobs.yml
@@ -5,17 +5,17 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 #############################################################################
 
-hip_3_9_gcc_8_1_0 (build and test on corona):
+hip_4_0_gcc_8_1_0 (build and test on corona):
   variables:
-    SPEC: "+hip~openmp %gcc@8.1.0 ^hip@3.9.0"
+    SPEC: "+hip~openmp %gcc@8.1.0 ^hip@4.0.0"
   extends: .build_and_test_on_corona
 
-hip_3_10_gcc_8_1_0 (build and test on corona):
+hip_4_1_gcc_8_1_0 (build and test on corona):
   variables:
-    SPEC: "+hip~openmp %gcc@8.1.0 ^hip@3.10.0"
+    SPEC: "+hip~openmp %gcc@8.1.0 ^hip@4.1.0"
   extends: .build_and_test_on_corona
 
-hip_3_10_clang_9_0_0 (build and test on corona):
+hip_4_1_clang_9_0_0 (build and test on corona):
   variables:
-    SPEC: "+hip~openmp %clang@9.0.0 cxxflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.1.0 ^hip@3.10.0"
+    SPEC: "+hip~openmp %clang@9.0.0 cxxflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.1.0 ^hip@4.1.0"
   extends: .build_and_test_on_corona


### PR DESCRIPTION
# Summary

This PR is a  bugfix for hip versions in ci testing. Corona tests should no longer fail! (Using versions 4.0 and 4.1 now)

