### PR TITLE
Enable RAJA Teams to run on CAMP default resource

### DIFF
--- a/.gitlab/corona-jobs.yml
+++ b/.gitlab/corona-jobs.yml
@@ -7,12 +7,12 @@
 
 hip_4_0_gcc_8_1_0 (build and test on corona):
   variables:
-    SPEC: "+hip~openmp %gcc@8.1.0 ^hip@4.0.0"
+    SPEC: "+hip~openmp %gcc@8.1.0 cxxflags='-finline-functions -finline-limit=20000' cflags='-finline-functions -finline-limit=20000' ^hip@4.0.0"
   extends: .build_and_test_on_corona
 
 hip_4_1_gcc_8_1_0 (build and test on corona):
   variables:
-    SPEC: "+hip~openmp %gcc@8.1.0 ^hip@4.1.0"
+    SPEC: "+hip~openmp %gcc@8.1.0 cxxflags='-finline-functions -finline-limit=20000' cflags='-finline-functions -finline-limit=20000' ^hip@4.1.0"
   extends: .build_and_test_on_corona
 
 hip_4_1_clang_9_0_0 (build and test on corona):

--- a/include/RAJA/policy/cuda/teams.hpp
+++ b/include/RAJA/policy/cuda/teams.hpp
@@ -55,7 +55,7 @@ struct LaunchExecute<RAJA::expt::cuda_launch_t<async, 0>> {
 
     resources::Cuda cuda_res = resources::Cuda::get_default();
     /* Use the zero stream until resource is better supported */
-    cudaStream_t stream = 0;//cuda_res.get_stream();
+    cudaStream_t stream = cuda_res.get_stream();
 
     //
     // Compute the number of blocks and threads

--- a/include/RAJA/policy/hip/teams.hpp
+++ b/include/RAJA/policy/hip/teams.hpp
@@ -55,7 +55,7 @@ struct LaunchExecute<RAJA::expt::hip_launch_t<async, 0>> {
 
     resources::Hip hip_res = resources::Hip::get_default();
     /* Use the zero stream until resource is better supported */
-    hipStream_t stream = 0;//hip_res.get_stream();
+    hipStream_t stream = hip_res.get_stream();
 
     //
     // Compute the number of blocks and threads

--- a/test/functional/teams/tests/test-teams-BasicShared.hpp
+++ b/test/functional/teams/tests/test-teams-BasicShared.hpp
@@ -14,7 +14,7 @@ template <typename WORKING_RES, typename LAUNCH_POLICY, typename TEAM_POLICY, ty
 void TeamsBasicSharedTestImpl()
 {
 
-  int N = 100;
+  int N = 1000;
 
   camp::resources::Resource working_res{WORKING_RES::get_default()};
   int* working_array;

--- a/test/include/RAJA_test-teams-execpol.hpp
+++ b/test/include/RAJA_test-teams-execpol.hpp
@@ -18,7 +18,7 @@
 //Launch policies
 #if defined(RAJA_ENABLE_CUDA)
 using seq_cuda_policies = camp::list<
-  RAJA::expt::LaunchPolicy<RAJA::expt::seq_launch_t,RAJA::expt::cuda_launch_t<false>>,
+  RAJA::expt::LaunchPolicy<RAJA::expt::seq_launch_t,RAJA::expt::cuda_launch_t<true>>,
   RAJA::expt::LoopPolicy<RAJA::loop_exec, RAJA::cuda_block_x_direct>,
   RAJA::expt::LoopPolicy<RAJA::loop_exec,RAJA::cuda_thread_x_loop>>;
 
@@ -28,7 +28,7 @@ using Sequential_launch_policies = camp::list<
 
 #elif defined(RAJA_ENABLE_HIP)
 using seq_hip_policies = camp::list<
-  RAJA::expt::LaunchPolicy<RAJA::expt::seq_launch_t,RAJA::expt::hip_launch_t<false>>,
+  RAJA::expt::LaunchPolicy<RAJA::expt::seq_launch_t,RAJA::expt::hip_launch_t<true>>,
   RAJA::expt::LoopPolicy<RAJA::loop_exec, RAJA::hip_block_x_direct>,
   RAJA::expt::LoopPolicy<RAJA::loop_exec,RAJA::hip_thread_x_loop>>;
 


### PR DESCRIPTION
# Summary

This PR modifies kernel launches on Teams so they may run on the CAMP default stream.

Future work will expand the interface to users may pass in a resource object.  