### PR TITLE
Bugfix/burmark1/use blt cxx std

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
     env:
     - COMPILER=/opt/intel/bin/icpc
     - IMG=icc18
-    - CMAKE_EXTRA_FLAGS="-DENABLE_FORCEINLINE_RECURSIVE=Off -DENABLE_TBB=On"
+    - CMAKE_EXTRA_FLAGS="-DENABLE_FORCEINLINE_RECURSIVE=Off -DENABLE_TBB=On -DBLT_CXX_STD=c++14"
   - compiler: nvcc10.2
     env:
     - COMPILER=g++

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,10 @@ if(NOT DEFINED BLT_CXX_STD)
       endif()
     endforeach(flag_var)
   endif()
+else() #check BLT_CXX_STD is high enough by disallowing the only invalid option
+  if("${BLT_CXX_STD}" STREQUAL "c++98")
+    message(FATAL_ERROR "RAJA requires minimum C++ standard of c++11")
+  endif()
 endif(NOT DEFINED BLT_CXX_STD)
 
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,9 +49,7 @@ set(ENABLE_COPY_HEADERS Off CACHE BOOL "")
 set(ENABLE_WARNINGS_AS_ERRORS Off CACHE BOOL "")
 set(ENABLE_GTEST_DEATH_TESTS On CACHE BOOL "Enable tests asserting failure.")
 
-set(RAJA_CXX_STANDARD_FLAG "default" CACHE STRING "Specific c++ standard flag to use, default attempts to autodetect the highest available")
-
-## NOTE: CMake-dependent options are placed AFTER BLT is loaded so they 
+## NOTE: CMake-dependent options are placed AFTER BLT is loaded so they
 ##       work as intended. BLT has variables defined for these and we use
 ##       the same names with 'RAJA_' prepended to them.
 
@@ -109,27 +107,27 @@ endif()
 set(COMPILERS_KNOWN_TO_CMAKE33 AppleClang Clang GNU MSVC)
 
 include(CheckCXXCompilerFlag)
-if(RAJA_CXX_STANDARD_FLAG MATCHES default)
+if(NOT DEFINED BLT_CXX_STD)
   if("cxx_std_17" IN_LIST CMAKE_CXX_KNOWN_FEATURES)
-    #TODO set BLT_CXX_STANDARD
-    set(CMAKE_CXX_STANDARD 17)
+    set(BLT_CXX_STD c++17 CACHE STRING "Version of C++ standard")
+    message("Using C++ standard: ${BLT_CXX_STD}")
   elseif("cxx_std_14" IN_LIST CMAKE_CXX_KNOWN_FEATURES)
-    set(CMAKE_CXX_STANDARD 14)
+    set(BLT_CXX_STD c++14 CACHE STRING "Version of C++ standard")
+    message("Using C++ standard: ${BLT_CXX_STD}")
   elseif("${CMAKE_CXX_COMPILER_ID}" IN_LIST COMPILERS_KNOWN_TO_CMAKE33)
-    set(CMAKE_CXX_STANDARD 14)
+    set(BLT_CXX_STD c++14 CACHE STRING "Version of C++ standard")
+    message("Using C++ standard: ${BLT_CXX_STD}")
   else() #cmake has no idea what to do, do it ourselves...
-    foreach(flag_var "-std=c++17" "-std=c++1z" "-std=c++14" "-std=c++1y" "-std=c++11")
-      CHECK_CXX_COMPILER_FLAG(${flag_var} COMPILER_SUPPORTS_${flag_var})
+    foreach(flag_var "c++17" "c++14" "c++11")
+      CHECK_CXX_COMPILER_FLAG("-std=${flag_var}" COMPILER_SUPPORTS_${flag_var})
       if(COMPILER_SUPPORTS_${flag_var})
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag_var}")
+        set(BLT_CXX_STD ${flag_var} CACHE STRING "Version of C++ standard")
+        message("Using C++ standard: ${BLT_CXX_STD}")
         break()
       endif()
     endforeach(flag_var)
   endif()
-else(RAJA_CXX_STANDARD_FLAG MATCHES default)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${RAJA_CXX_STANDARD_FLAG}")
-  message("Using C++ standard flag: ${RAJA_CXX_STANDARD_FLAG}")
-endif(RAJA_CXX_STANDARD_FLAG MATCHES default)
+endif(NOT DEFINED BLT_CXX_STD)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/scripts/lc-builds/blueos_nvcc_clang.sh
+++ b/scripts/lc-builds/blueos_nvcc_clang.sh
@@ -10,10 +10,10 @@
 if [[ $# -ne 3 ]]; then
   echo
   echo "You must pass 3 arguments to the script (in this order): "
-  echo "   1) compiler version number for nvcc"  
+  echo "   1) compiler version number for nvcc"
   echo "   2) CUDA compute architecture"
   echo "   3) compiler version number for clang. "
-  echo 
+  echo
   echo "For example: "
   echo "    blueos_nvcc_clang.sh 10.2.89 sm_70 10.0.1"
   exit
@@ -37,7 +37,6 @@ module load cmake/3.14.5
 cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_COMPILER=/usr/tce/packages/clang/clang-${COMP_CLANG_VER}/bin/clang++ \
-  -DBLT_CXX_STD=c++11 \
   -C ../host-configs/lc-builds/blueos/nvcc_clang_X.cmake \
   -DENABLE_OPENMP=On \
   -DENABLE_CUDA=On \

--- a/scripts/lc-builds/blueos_nvcc_gcc.sh
+++ b/scripts/lc-builds/blueos_nvcc_gcc.sh
@@ -37,7 +37,6 @@ module load cmake/3.14.5
 cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_COMPILER=/usr/tce/packages/gcc/gcc-${COMP_GCC_VER}/bin/g++ \
-  -DBLT_CXX_STD=c++11 \
   -C ../host-configs/lc-builds/blueos/nvcc_gcc_X.cmake \
   -DENABLE_OPENMP=On \
   -DENABLE_CUDA=On \

--- a/scripts/lc-builds/blueos_nvcc_xl.sh
+++ b/scripts/lc-builds/blueos_nvcc_xl.sh
@@ -37,7 +37,6 @@ module load cmake/3.14.5
 cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_COMPILER=/usr/tce/packages/xl/xl-${COMP_XL_VER}/bin/xlc++_r \
-  -DBLT_CXX_STD=c++11 \
   -C ../host-configs/lc-builds/blueos/nvcc_xl_X.cmake \
   -DENABLE_OPENMP=On \
   -DENABLE_CUDA=On \

--- a/scripts/lc-builds/blueos_xl.sh
+++ b/scripts/lc-builds/blueos_xl.sh
@@ -30,7 +30,6 @@ module load cmake/3.14.5
 cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_COMPILER=/usr/tce/packages/xl/xl-${COMP_VER}/bin/xlc++_r \
-  -DBLT_CXX_STD=c++11 \
   -C ../host-configs/lc-builds/blueos/xl_X.cmake \
   -DENABLE_OPENMP=On \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \

--- a/scripts/lc-builds/blueos_xl_omptarget.sh
+++ b/scripts/lc-builds/blueos_xl_omptarget.sh
@@ -30,7 +30,6 @@ module load cmake/3.14.5
 cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_COMPILER=/usr/tce/packages/xl/xl-${COMP_VER}/bin/xlc++_r \
-  -DBLT_CXX_STD=c++11 \
   -C ../host-configs/lc-builds/blueos/xl_X.cmake \
   -DENABLE_OPENMP=On \
   -DENABLE_TARGET_OPENMP=On \

--- a/scripts/lc-builds/toss3_icpc.sh
+++ b/scripts/lc-builds/toss3_icpc.sh
@@ -21,11 +21,11 @@ USE_TBB=On
 
 if [ ${COMP_MAJOR_VER} -gt 18 ]
 then
-  GCC_HEADER_VER=8 
+  GCC_HEADER_VER=8
 fi
 
 if [ ${COMP_MAJOR_VER} -lt 18 ]
-then 
+then
   USE_TBB=Off
 fi
 
@@ -41,7 +41,7 @@ mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
 module load cmake/3.14.5
 
 ##
-# CMake option -DENABLE_FORCEINLINE_RECURSIVE=Off used to speed up compile 
+# CMake option -DENABLE_FORCEINLINE_RECURSIVE=Off used to speed up compile
 # times at a potential cost of slower 'forall' execution.
 ##
 
@@ -49,7 +49,6 @@ cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_COMPILER=/usr/tce/packages/intel/intel-${COMP_VER}/bin/icpc \
   -DCMAKE_C_COMPILER=/usr/tce/packages/intel/intel-${COMP_VER}/bin/icc \
-  -DBLT_CXX_STD=c++11 \
   -C ../host-configs/lc-builds/toss3/icpc_X_gcc${GCC_HEADER_VER}headers.cmake \
   -DENABLE_FORCEINLINE_RECURSIVE=Off \
   -DENABLE_OPENMP=On \

--- a/scripts/uberenv/packages/raja/package.py
+++ b/scripts/uberenv/packages/raja/package.py
@@ -231,6 +231,10 @@ class Raja(CMakePackage, CudaPackage):
                 cfg.write(cmake_cache_entry("BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE",
                 "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/x86_64-unknown-linux-gnu/4.9.3"))
 
+        compilers_using_cxx14 = ["intel-17", "intel-18"]
+        if any(compiler in cpp_compiler for compiler in compilers_using_cxx14):
+            cfg.write(cmake_cache_entry("BLT_CXX_STD", "c++14"))
+
         if "+cuda" in spec:
             cfg.write("#------------------{0}\n".format("-" * 60))
             cfg.write("# Cuda\n")


### PR DESCRIPTION
# Summary
Set BLT_CXX_STD where we find the cxx std version. Remove RAJA_CXX_STANDARD_FLAG and use BLT_CXX_STD  instead.

- This PR is a refactoring, bugfix
- It does the following:
  - Modifies/refactors the way we set the cxx std version in cmake
  - Fixes #1049 
