### PR TITLE
Docs for naming RAJA Teams based kernels

### DIFF
--- a/docs/sphinx/user_guide/tutorial.rst
+++ b/docs/sphinx/user_guide/tutorial.rst
@@ -13,7 +13,7 @@ RAJA Tutorial
 **********************
 
 In addition to the tutorial portion of this RAJA User Guide, we maintain
-a repository of tutorial presntation materials here `RAJA Tutorials Repo <https://github.com/LLNL/RAJA-tutorials>`_.
+a repository of tutorial presentation materials here `RAJA Tutorials Repo <https://github.com/LLNL/RAJA-tutorials>`_.
 
 This RAJA tutorial introduces RAJA concepts and capabilities via a 
 sequence of examples of increasing complexity. Complete working codes for 
@@ -308,3 +308,4 @@ in terms of threads and teams.
    :maxdepth: 1
 
    tutorial/teams_basic.rst
+   tutorial/naming_kernels.rst

--- a/docs/sphinx/user_guide/tutorial/naming_kernels.rst
+++ b/docs/sphinx/user_guide/tutorial/naming_kernels.rst
@@ -1,0 +1,52 @@
+.. ##
+.. ## Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+.. ## and RAJA project contributors. See the RAJA/COPYRIGHT file
+.. ## for details.
+.. ##
+.. ## SPDX-License-Identifier: (BSD-3-Clause)
+.. ##
+
+.. _teamsbasic-label:
+
+------------------------------
+Naming kernels with NVTX tools
+------------------------------
+
+Key RAJA feature shown in the following example:
+
+  *  Naming kernels using the ``Resources`` object in ``RAJA::ext::Launch`` methods.  
+
+In this example, we illustrate kernel naming capabilities within the RAJA Teams
+framework for use with NVIDIA's NVTX tools.  
+
+Recalling the ``RAJA::expt::launch`` API, naming a kernel is done using the third
+argument of the ``Resources`` constructor as illustrated below::
+  RAJA::expt::launch<launch_policy>(RAJA::expt::ExecPlace ,
+  RAJA::expt::Resources(RAJA::expt::Teams(Nteams,Nteams),
+                        RAJA::expt::Threads(Nthreads,Nthreads)
+                        "myKernel"),
+  [=] RAJA_HOST_DEVICE (RAJA::expt::LaunchContext ctx) {
+
+    /* Express code here */
+
+  });
+  
+The kernel name is used to create NVTX ranges enabling developers to identify 
+kernels using the NVIDIA `Nsight <https://developer.nvidia.com/nsight-visual-studio-edition>`_ 
+and NVIDIA `Nvprof <https://docs.nvidia.com/cuda/profiler-users-guide/index.html>`_ profiling
+tools. As an illustration, using Nvprof, kernels are identified as ranges of GPU activity through the 
+user specified name::
+
+  ==73220== NVTX result:
+  ==73220==   Thread "<unnamed>" (id = 290832)
+  ==73220==     Domain "<unnamed>"
+  ==73220==       Range "myKernel"
+              Type  Time(%)      Time     Calls       Avg       Min       Max  Name
+              Range:  100.00%  32.868us         1  32.868us  32.868us  32.868us  myKernel
+     GPU activities:  100.00%  2.0307ms         1  2.0307ms  2.0307ms  2.0307ms  _ZN4RAJA4expt17launch_global_fcnIZ4mainEUlNS0_13LaunchContextEE_EEvS2_T_
+          API calls:  100.00%  27.030us         1  27.030us  27.030us  27.030us  cudaLaunchKernel
+
+As future work we plan to add support to other profiling tools. Enabling NVTX profiling
+with RAJA Teams requires RAJA to be configured with ENABLE_NV_TOOLS_EXT=ON.
+
+The file RAJA/examples/teams_reductions.cpp contains a complete working example code.

--- a/docs/sphinx/user_guide/tutorial/naming_kernels.rst
+++ b/docs/sphinx/user_guide/tutorial/naming_kernels.rst
@@ -46,7 +46,8 @@ user specified name::
      GPU activities:  100.00%  2.0307ms         1  2.0307ms  2.0307ms  2.0307ms  _ZN4RAJA4expt17launch_global_fcnIZ4mainEUlNS0_13LaunchContextEE_EEvS2_T_
           API calls:  100.00%  27.030us         1  27.030us  27.030us  27.030us  cudaLaunchKernel
 
-As future work we plan to add support to other profiling tools. Enabling NVTX profiling
+As future work we plan to add support to other profiling tools; API changes may occur 
+based on user feedback and integration with other tools. Enabling NVTX profiling
 with RAJA Teams requires RAJA to be configured with ENABLE_NV_TOOLS_EXT=ON.
 
 The file RAJA/examples/teams_reductions.cpp contains a complete working example code.


### PR DESCRIPTION
# Summary

Adds a short documentation on using the kernel_name parameter in RAJA Team methods. 
Currently we only support NVTX tools. I noted in the docs that there may be some API changes as we integrate with other tools. 
