### PR TITLE
Fixed documentation for cuda_exec policy.

### DIFF
--- a/docs/sphinx/user_guide/feature/atomic.rst
+++ b/docs/sphinx/user_guide/feature/atomic.rst
@@ -93,7 +93,7 @@ an integral sum on a CUDA GPU device::
   cudaDeviceSynchronize();
   *sum = 0;
 
-  RAJA::forall< RAJA::cuda_exec >(RAJA::RangeSegment(0, N), 
+  RAJA::forall< RAJA::cuda_exec<BLOCK_SIZE> >(RAJA::RangeSegment(0, N), 
     [=] RAJA_DEVICE (RAJA::Index_type i) {
 
     RAJA::atomicAdd< RAJA::cuda_atomic >(sum, 1);

--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -582,11 +582,11 @@ auto_atomic               seq_exec,     Atomic operation *compatible* with loop
 Here is an example illustrating use of the ``cuda_atomic_explicit`` policy::
 
   auto kernel = [=] RAJA_HOST_DEVICE (RAJA::Index_type i) {
-
     RAJA::atomicAdd< RAJA::cuda_atomic_explicit<omp_atomic> >(&sum, 1);
-
   };
-  RAJA::forall< RAJA::cuda_exec >(RAJA::RangeSegment seg(0, N), kernel);
+
+  RAJA::forall< RAJA::cuda_exec<BLOCK_SIZE> >(RAJA::RangeSegment seg(0, N), kernel);
+
   RAJA::forall< RAJA::omp_parallel_for_exec >(RAJA::RangeSegment seg(0, N),
       kernel);
 
@@ -597,7 +597,7 @@ used and the OpenMP version of the atomic operation is applied.
 
 Here is an example illustrating use of the ``auto_atomic`` policy::
 
-  RAJA::forall< RAJA::cuda_exec >(RAJA::RangeSegment seg(0, N),
+  RAJA::forall< RAJA::cuda_execBLOCK_SIZE> >(RAJA::RangeSegment seg(0, N),
     [=] RAJA_DEVICE (RAJA::Index_type i) {
 
     RAJA::atomicAdd< RAJA::auto_atomic >(&sum, 1);

--- a/docs/sphinx/user_guide/tutorial.rst
+++ b/docs/sphinx/user_guide/tutorial.rst
@@ -165,7 +165,7 @@ with respect to RAJA usage. We describe them here.
    CUDA device kernel, for that matter) must be decorated with 
    the ``__device__`` annotation; for example::
      
-     RAJA::forall<RAJA::cuda_exec>( range, [=] __device__ (int i) { ... } );
+     RAJA::forall<RAJA::cuda_exec<BLOCK_SIZE>>( range, [=] __device__ (int i) { ... } );
 
    Without this, the code will not compile and generate compiler errors
    indicating that a 'host' lambda cannot be called from 'device' code.
@@ -174,7 +174,7 @@ with respect to RAJA usage. We describe them here.
    between host-only or device-only CUDA compilation.
     
 
- * **Avoid 'host-device' annotation on a lambda that will run in host code.**
+ * **Use 'host-device' annotation on a lambda carefully.**
 
    RAJA provides the macro ``RAJA_HOST_DEVICE`` to support the dual
    CUDA annotation ``__ host__ __device__``. This makes a lambda or function
@@ -200,7 +200,7 @@ with respect to RAJA usage. We describe them here.
 
      double& ref_to_global_val = global_val;
 
-     RAJA::forall<RAJA::cuda_exec>( range, [=] __device__ (int i) { 
+     RAJA::forall<RAJA::cuda_exec<BLOCK_SIZE>>( range, [=] __device__ (int i) { 
        // use ref_to_global_val
      } );
     
@@ -220,7 +220,7 @@ with respect to RAJA usage. We describe them here.
 
      bounds.array = { 0, 1, 8, 9 };
 
-     RAJA::forall<RAJA::cuda_exec>(range, [=] __device__ (int i) {
+     RAJA::forall<RAJA::cuda_exec<BLOCK_SIZE>>(range, [=] __device__ (int i) {
        // access entries of bounds.array
      } );
 

--- a/docs/sphinx/user_guide/tutorial/add_vectors.rst
+++ b/docs/sphinx/user_guide/tutorial/add_vectors.rst
@@ -95,8 +95,6 @@ policy:
 Note that the CUDA execution policy type accepts a template argument 
 ``CUDA_BLOCK_SIZE``, which specifies that each CUDA thread block launched 
 to execute the kernel will have the given number threads in the block.
-The thread block size parameter is optional; if not provided, the RAJA policy 
-provides a default of 256, which is a reasonable choice for most cases. 
 
 Since the lambda defining the loop body will be passed to a device kernel, 
 it must be decorated with the ``__device__`` attribute when it is defined. 


### PR DESCRIPTION
# Summary

- This PR is a documentation bugfix.
- We no longer support a default thread block size parameter. This PR corrects the parts of the user guide that referred to earlier versions of RAJA when we did support that.

Resolves https://github.com/LLNL/RAJA/issues/1072