### PR TITLE
Run gitlab ci jobs on ruby instead of quartz

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,12 +42,12 @@ variables:
 # Normally, stages are blocking in Gitlab. However, using the keyword "needs" we
 # can express dependencies between job that break the ordering of stages, in
 # favor of a DAG.
-# In practice q_*, l_* and b_* stages are independently run and start immediately.
+# In practice r_*, l_* and b_* stages are independently run and start immediately.
 
 stages:
-  - q_allocate_resources
-  - q_build_and_test
-  - q_release_resources
+  - r_allocate_resources
+  - r_build_and_test
+  - r_release_resources
   - l_build_and_test
   - b_build_and_test
   - c_build_and_test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@
 # Tells Gitlab to recursively update the submodules when cloning umpire
 #
 # ALLOC_NAME:
-# On LLNL's quartz, this pipeline creates only one allocation shared among jobs
+# On LLNL's ruby, this pipeline creates only one allocation shared among jobs
 # in order to save time and resources. This allocation has to be uniquely named
 # so that we are sure to retrieve it.
 #
@@ -105,8 +105,8 @@ trigger-chai:
 
 # This is where jobs are included.
 include:
-  - local: .gitlab/quartz-templates.yml
-  - local: .gitlab/quartz-jobs.yml
+  - local: .gitlab/ruby-templates.yml
+  - local: .gitlab/ruby-jobs.yml
   - local: .gitlab/lassen-templates.yml
   - local: .gitlab/lassen-jobs.yml
   - local: .gitlab/corona-templates.yml

--- a/.gitlab/ruby-jobs.yml
+++ b/.gitlab/ruby-jobs.yml
@@ -8,36 +8,36 @@
 clang_10:
   variables:
     SPEC: "%clang@10.0.1"
-  extends: .build_and_test_on_quartz
+  extends: .build_and_test_on_ruby
 
 clang_9:
   variables:
     SPEC: "%clang@9.0.0"
-  extends: .build_and_test_on_quartz
+  extends: .build_and_test_on_ruby
 
 gcc_8_1_0:
   variables:
     SPEC: "%gcc@8.1.0"
     DEFAULT_TIME: 40
-  extends: .build_and_test_on_quartz
+  extends: .build_and_test_on_ruby
 
 icpc_17_0_2:
   variables:
     SPEC: "%intel@17.0.2"
     DEFAULT_TIME: 40
-  extends: .build_and_test_on_quartz
+  extends: .build_and_test_on_ruby
 
 icpc_18_0_2:
   variables:
     SPEC: " tests=none %intel@18.0.2"
     DEFAULT_TIME: 40
-  extends: .build_and_test_on_quartz
+  extends: .build_and_test_on_ruby
 
 icpc_19_1_0:
   variables:
     SPEC: "%intel@19.1.0"
     DEFAULT_TIME: 40
-  extends: .build_and_test_on_quartz
+  extends: .build_and_test_on_ruby
 
 # EXTRAS
 
@@ -45,4 +45,4 @@ gcc_4_9_3:
   variables:
     SPEC: "%gcc@4.9.3"
     DEFAULT_TIME: 40
-  extends: .build_and_test_on_quartz
+  extends: .build_and_test_on_ruby

--- a/.gitlab/ruby-templates.yml
+++ b/.gitlab/ruby-templates.yml
@@ -6,16 +6,16 @@
 ##############################################################################
 
 ####
-# This is the shared configuration of jobs for quartz
+# This is the shared configuration of jobs for ruby
 
 ####
 # In pre-build phase, allocate a node for builds
-.on_quartz:
+.on_ruby:
   tags:
     - shell
-    - quartz
+    - ruby
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_QUARTZ == "OFF"' #run except if ...
+    - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_RUBY == "OFF"' #run except if ...
       when: never
     - if: '$CI_JOB_NAME =~ /release_resources/'
       when: always
@@ -23,10 +23,10 @@
 
 ####
 # In pre-build phase, allocate a node for builds
-allocate_resources (on quartz):
+allocate_resources (on ruby):
   variables:
     GIT_STRATEGY: none
-  extends: .on_quartz
+  extends: .on_ruby
   stage: q_allocate_resources
   script:
     - salloc -N 1 -c 36 -p pdebug -t 45 --no-shell --job-name=${ALLOC_NAME}
@@ -34,21 +34,21 @@ allocate_resources (on quartz):
 ####
 # In post-build phase, deallocate resources
 # Note : make sure this is run even on build phase failure
-release_resources (on quartz):
+release_resources (on ruby):
   variables:
     GIT_STRATEGY: none
-  extends: .on_quartz
+  extends: .on_ruby
   stage: q_release_resources
   script:
     - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
     - ([[ -n "${JOBID}" ]] && scancel ${JOBID})
 
 ####
-# Generic quartz build job, extending build script
-.build_and_test_on_quartz:
-  extends: [.build_toss_3_x86_64_ib_script, .on_quartz]
+# Generic ruby build job, extending build script
+.build_and_test_on_ruby:
+  extends: [.build_toss_3_x86_64_ib_script, .on_ruby]
   stage: q_build_and_test
 
-.build_and_test_on_quartz_advanced:
-  extends: [.build_and_test_on_quartz, .advanced_pipeline]
+.build_and_test_on_ruby_advanced:
+  extends: [.build_and_test_on_ruby, .advanced_pipeline]
 

--- a/.gitlab/ruby-templates.yml
+++ b/.gitlab/ruby-templates.yml
@@ -27,7 +27,7 @@ allocate_resources (on ruby):
   variables:
     GIT_STRATEGY: none
   extends: .on_ruby
-  stage: q_allocate_resources
+  stage: r_allocate_resources
   script:
     - salloc -N 1 -c 36 -p pdebug -t 45 --no-shell --job-name=${ALLOC_NAME}
 
@@ -38,7 +38,7 @@ release_resources (on ruby):
   variables:
     GIT_STRATEGY: none
   extends: .on_ruby
-  stage: q_release_resources
+  stage: r_release_resources
   script:
     - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
     - ([[ -n "${JOBID}" ]] && scancel ${JOBID})
@@ -47,7 +47,7 @@ release_resources (on ruby):
 # Generic ruby build job, extending build script
 .build_and_test_on_ruby:
   extends: [.build_toss_3_x86_64_ib_script, .on_ruby]
-  stage: q_build_and_test
+  stage: r_build_and_test
 
 .build_and_test_on_ruby_advanced:
   extends: [.build_and_test_on_ruby, .advanced_pipeline]

--- a/docs/sphinx/dev_guide/ci.rst
+++ b/docs/sphinx/dev_guide/ci.rst
@@ -69,21 +69,21 @@ testing process. These can be viewed by looking at files in the RAJA
 
   $ ls -c1 .gitlab/*jobs.yml
   .gitlab/lassen-jobs.yml
-  .gitlab/quartz-jobs.yml
+  .gitlab/ruby-jobs.yml
 
-lists the yaml files containing the Gitlab CI jobs for the lassen and quartz
+lists the yaml files containing the Gitlab CI jobs for the lassen and ruby 
 machines.
 
 Then, executing a command such as:
 
 .. code-block:: bash
 
-  $ git grep -h "SPEC" .gitlab/quartz-jobs.yml | grep "gcc"
+  $ git grep -h "SPEC" .gitlab/ruby-jobs.yml | grep "gcc"
       SPEC: "%gcc@4.9.3"
       SPEC: "%gcc@6.1.0"
       SPEC: "%gcc@7.3.0"
       SPEC: "%gcc@8.1.0"
 
-will list the specs vetted on the quartz platform.
+will list the specs vetted on the ruby platform.
 
 More details to come...


### PR DESCRIPTION
# Summary

- This PR is improving the gitlab ci
- It moves the gitlab ci tests from quartz to ruby instead (less traffic)

