### PR TITLE
Improving Gitlab CI performance.

### DIFF
--- a/.gitlab/ruby-templates.yml
+++ b/.gitlab/ruby-templates.yml
@@ -23,13 +23,14 @@
 
 ####
 # In pre-build phase, allocate a node for builds
+# NOTE: Not specifying 'salloc -c 56' should allocate the max number of CPU cores
 allocate_resources (on ruby):
   variables:
     GIT_STRATEGY: none
   extends: .on_ruby
   stage: r_allocate_resources
   script:
-    - salloc -N 1 -c 36 -p pdebug -t 45 --no-shell --job-name=${ALLOC_NAME}
+    - salloc -N 1 -p pdebug -t 45 --no-shell --job-name=${ALLOC_NAME}
 
 ####
 # In post-build phase, deallocate resources

--- a/.gitlab/ruby-templates.yml
+++ b/.gitlab/ruby-templates.yml
@@ -31,6 +31,7 @@ allocate_resources (on ruby):
   stage: r_allocate_resources
   script:
     - salloc -N 1 -p pdebug -t 45 --no-shell --job-name=${ALLOC_NAME}
+    
 
 ####
 # In post-build phase, deallocate resources
@@ -52,4 +53,3 @@ release_resources (on ruby):
 
 .build_and_test_on_ruby_advanced:
   extends: [.build_and_test_on_ruby, .advanced_pipeline]
-

--- a/.gitlab/ruby-templates.yml
+++ b/.gitlab/ruby-templates.yml
@@ -31,7 +31,6 @@ allocate_resources (on ruby):
   stage: r_allocate_resources
   script:
     - salloc -N 1 -p pdebug -t 45 --no-shell --job-name=${ALLOC_NAME}
-    
 
 ####
 # In post-build phase, deallocate resources

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -113,7 +113,7 @@ then
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
     # Map CPU core allocations
-    declare -A core_counts=(["lassen"]=40 ["ruby"]=24 ["corona"]=32)
+    declare -A core_counts=(["lassen"]=40 ["ruby"]=28 ["corona"]=32)
 
     # If building, then delete everything first
     # NOTE: 'cmake --build . -j core_counts' attempts to reduce individual build resources.

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -112,6 +112,7 @@ then
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
     # If building, then delete everything first
+    # NOTE: 'cmake --build . -j 12' is an attempt to reduce individual build resources
     rm -rf ${build_dir} 2>/dev/null
     mkdir -p ${build_dir} && cd ${build_dir}
 
@@ -119,7 +120,7 @@ then
     cmake \
       -C ${hostconfig_path} \
       ${project_dir}
-    cmake --build . -j 32
+    cmake --build . -j 12
     date
 fi
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -113,7 +113,7 @@ then
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
     # Map CPU core allocations
-    declare -A core_counts=(["lassen"]=32 ["ruby"]=24 ["corona"]=32)
+    declare -A core_counts=(["lassen"]=40 ["ruby"]=24 ["corona"]=32)
 
     # If building, then delete everything first
     # NOTE: 'cmake --build . -j core_counts' attempts to reduce individual build resources.


### PR DESCRIPTION
# Summary

- This PR is an improvement
- It does the following:
  - Reduces CPU resources requested during each build of the Gitlab CI. Hopefully build_and_test times will improve.
  - Request max number of CPU resources per allocation, rather than specifying limited amounts.
  - Discussed with @adrienbernede and @kab163. The strategy is to first throw more resources at the jobs, while restricting the build phases to fewer cores to allow more tasks to run in parallel. We would like the inherent scheduler to distribute the work for us, rather than maintaining a complicated set of scripts and dependencies. Failing that, we may need to sub-divide the current stages into more stages and jobs.
