### PR TITLE
Fix synchronization in examples

### DIFF
--- a/examples/raja-teams.cpp
+++ b/examples/raja-teams.cpp
@@ -42,11 +42,11 @@ using launch_policy = RAJA::expt::LaunchPolicy<
 #endif
 #if defined(RAJA_ENABLE_CUDA)
     ,
-    RAJA::expt::cuda_launch_t<true>
+    RAJA::expt::cuda_launch_t<false>
 #endif
 #if defined(RAJA_ENABLE_HIP)
     ,
-    RAJA::expt::hip_launch_t<true>
+    RAJA::expt::hip_launch_t<false>
 #endif
     >;
 

--- a/examples/teams_matrix-multiply.cpp
+++ b/examples/teams_matrix-multiply.cpp
@@ -41,11 +41,11 @@ using launch_policy = RAJA::expt::LaunchPolicy<
     RAJA::expt::seq_launch_t
 #if defined(RAJA_ENABLE_CUDA)
     ,
-    RAJA::expt::cuda_launch_t<true>
+    RAJA::expt::cuda_launch_t<false>
 #endif
 #if defined(RAJA_ENABLE_HIP)
     ,
-    RAJA::expt::hip_launch_t<true>
+    RAJA::expt::hip_launch_t<false>
 #endif
     >;
 
@@ -357,11 +357,11 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
                               RAJA::expt::omp_launch_t
 #if defined(RAJA_ENABLE_CUDA)
                               ,
-                              RAJA::expt::cuda_launch_t<true>
+                              RAJA::expt::cuda_launch_t<false>
 #endif
 #if defined(RAJA_ENABLE_HIP)
                               ,
-                              RAJA::expt::hip_launch_t<true>
+                              RAJA::expt::hip_launch_t<false>
 #endif
                               >;
 

--- a/examples/teams_reductions.cpp
+++ b/examples/teams_reductions.cpp
@@ -36,10 +36,10 @@ using host_loop = RAJA::loop_exec;
 #endif
 
 #if defined(RAJA_ENABLE_CUDA)
-using device_launch = RAJA::expt::cuda_launch_t<true>;
+using device_launch = RAJA::expt::cuda_launch_t<false>;
 using device_loop = RAJA::expt::cuda_global_thread_x;
 #elif defined(RAJA_ENABLE_HIP)
-using device_launch = RAJA::expt::hip_launch_t<true>;
+using device_launch = RAJA::expt::hip_launch_t<false>;
 using device_loop = RAJA::expt::hip_global_thread_x;
 #endif
 


### PR DESCRIPTION
Folks, I noticed that with the transition of running team kernels on the CAMP default stream we introduced some failing examples. This occurs since our examples draw from the CUDA default stream (different than CAMP default stream). 

This PR adds a fix by adding synchronization after kernels. 