### PR TITLE
changes to CMake to check the versions of cuda and hip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,18 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" AND CMAKE_CXX_COMPILER_VERSION V
   message(WARNING "RAJA::simd_exec support requires Intel-17 or greater")
 endif()
 
+if(ENABLE_CUDA)
+  if("${CUDA_VERSION_STRING}" VERSION_LESS "9.2")
+    message(FATAL_ERROR "Trying to use CUDA version ${CUDA_VERSION_STRING}. RAJA dependency Googletest requires CUDA version 9.2.x or newer.")
+  endif()
+endif()
+
+if(ENABLE_HIP)
+  if("${HIP_VERSION_STRING}" VERSION_LESS "3.5")
+    message(FATAL_ERROR "Trying to use HIP/ROCm version ${HIP_VERSION_STRING}. RAJA requires HIP/ROCm version 3.5 or newer. ")
+  endif()
+endif()
+
 if (ENABLE_CUDA)
   set(raja_depends
     ${raja_depends}


### PR DESCRIPTION
This PR is a build system improvement.
It does the following:
* Checks the CUDA and HIP version numbers against the minimums given in the documentation.
* Fixes #947  