### PR TITLE
OpenMP Target Resource Fixes

### DIFF
--- a/include/RAJA/pattern/kernel/For.hpp
+++ b/include/RAJA/pattern/kernel/For.hpp
@@ -101,7 +101,8 @@ struct StatementExecutor<
     auto len = segment_length<ArgumentId>(data);
     using len_t = decltype(len);
 
-    auto r = data.res;
+    using EnclosedResourceNeed = resources::resource_from_pol_t<ExecPolicy>;
+    auto r = EnclosedResourceNeed{};
 
     forall_impl(r, ExecPolicy{}, TypedRangeSegment<len_t>(0, len), for_wrapper);
   }

--- a/include/RAJA/pattern/kernel/For.hpp
+++ b/include/RAJA/pattern/kernel/For.hpp
@@ -101,8 +101,7 @@ struct StatementExecutor<
     auto len = segment_length<ArgumentId>(data);
     using len_t = decltype(len);
 
-    using EnclosedResourceNeed = resources::resource_from_pol_t<ExecPolicy>;
-    auto r = EnclosedResourceNeed{};
+    auto r = data.res;
 
     forall_impl(r, ExecPolicy{}, TypedRangeSegment<len_t>(0, len), for_wrapper);
   }

--- a/include/RAJA/policy/loop/forall.hpp
+++ b/include/RAJA/policy/loop/forall.hpp
@@ -52,8 +52,8 @@ namespace loop
 //
 
 
-template <typename Iterable, typename Func>
-RAJA_INLINE resources::EventProxy<resources::Host> forall_impl(RAJA::resources::Host host_res,
+template <typename Iterable, typename Func, typename Resource>
+RAJA_INLINE resources::EventProxy<Resource> forall_impl(Resource res,
                                                     const loop_exec &,
                                                     Iterable &&iter,
                                                     Func &&body)
@@ -63,9 +63,8 @@ RAJA_INLINE resources::EventProxy<resources::Host> forall_impl(RAJA::resources::
   for (decltype(distance_it) i = 0; i < distance_it; ++i) {
     body(*(begin_it + i));
   }
-  return RAJA::resources::EventProxy<resources::Host>(host_res);
+  return RAJA::resources::EventProxy<Resource>(res);
 }
-
 }  // namespace loop
 
 }  // namespace policy

--- a/include/RAJA/policy/openmp_target/policy.hpp
+++ b/include/RAJA/policy/openmp_target/policy.hpp
@@ -35,29 +35,32 @@ struct Collapse {
 
 template <size_t ThreadsPerTeam>
 struct omp_target_parallel_for_exec
-    : make_policy_pattern_t<Policy::target_openmp,
+    : make_policy_pattern_platform_t<Policy::target_openmp,
                             Pattern::forall,
+                            Platform::omp_target,
                             omp::Target,
                             omp::Teams<ThreadsPerTeam>,
                             omp::Distribute> {
 };
 
 struct omp_target_parallel_for_exec_nt
-    : make_policy_pattern_t<Policy::target_openmp,
+    : make_policy_pattern_platform_t<Policy::target_openmp,
                             Pattern::forall,
+                            Platform::omp_target,
                             omp::Target,
                             omp::Distribute> {
 };
 
 struct omp_target_parallel_collapse_exec
-    : make_policy_pattern_t<Policy::target_openmp,
+    : make_policy_pattern_platform_t<Policy::target_openmp,
                             Pattern::forall,
+                            Platform::omp_target,
                             omp::Target,
                             omp::Collapse> {
 };
 
 struct omp_target_reduce
-    : make_policy_pattern_t<Policy::target_openmp, Pattern::reduce> {
+    : make_policy_pattern_platform_t<Policy::target_openmp, Pattern::reduce, Platform::omp_target> {
 };
 
 ///

--- a/include/RAJA/policy/sequential/forall.hpp
+++ b/include/RAJA/policy/sequential/forall.hpp
@@ -53,8 +53,8 @@ namespace sequential
 //////////////////////////////////////////////////////////////////////
 //
 
-template <typename Iterable, typename Func>
-RAJA_INLINE resources::EventProxy<resources::Host> forall_impl(resources::Host host_res,
+template <typename Iterable, typename Func, typename Resource>
+RAJA_INLINE resources::EventProxy<Resource> forall_impl(Resource res,
                                                                const seq_exec &,
                                                                Iterable &&iter,
                                                                Func &&body)
@@ -65,7 +65,7 @@ RAJA_INLINE resources::EventProxy<resources::Host> forall_impl(resources::Host h
   for (decltype(distance_it) i = 0; i < distance_it; ++i) {
     body(*(begin_it + i));
   }
-  return resources::EventProxy<resources::Host>(host_res);
+  return resources::EventProxy<Resource>(res);
 }
 
 }  // namespace sequential

--- a/include/RAJA/util/resource.hpp
+++ b/include/RAJA/util/resource.hpp
@@ -90,6 +90,11 @@ namespace RAJA
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
   template<>
+  struct get_resource_from_platform<Platform::omp_target>{
+    using type = camp::resources::Omp;
+  };
+
+  template<>
   struct get_resource<omp_target_parallel_for_exec_nt>{
     using type = camp::resources::Omp;
   };


### PR DESCRIPTION
# Summary

- This PR is a bug fix 
- It does the following:
  - Fixes #1092 and #1093 
  - Fixes resource selection process for nested kernels.

The existence of these bugs also suggests there should be more CI/CD testing of OpenMP target offloading, as without these changes, OpenMP target offloading tests do not build at all. 
 
Thank you @trws for the help figuring out what was causing the issues!