### PR TITLE
Cuda and Hip block reduction tweak

### DIFF
--- a/include/RAJA/policy/cuda/reduce.hpp
+++ b/include/RAJA/policy/cuda/reduce.hpp
@@ -408,6 +408,9 @@ RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
   // reduce per warp values
   if (numThreads > policy::cuda::WARP_SIZE) {
 
+    static_assert(policy::cuda::MAX_WARPS <= policy::cuda::WARP_SIZE,
+        "Max Warps must be less than or equal to Warp Size for this algorithm to work");
+
     // Need to separate declaration and initialization for clang-cuda
     __shared__ unsigned char tmpsd[sizeof(RAJA::detail::SoAArray<T, policy::cuda::MAX_WARPS>)];
 
@@ -431,7 +434,7 @@ RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
         temp = identity;
       }
 
-      for (int i = 1; i < policy::cuda::WARP_SIZE; i *= 2) {
+      for (int i = 1; i < policy::cuda::MAX_WARPS; i *= 2) {
         T rhs = shfl_xor_sync(temp, i);
         Combiner{}(temp, rhs);
       }

--- a/include/RAJA/policy/hip/reduce.hpp
+++ b/include/RAJA/policy/hip/reduce.hpp
@@ -289,6 +289,9 @@ RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
   // reduce per warp values
   if (numThreads > policy::hip::WARP_SIZE) {
 
+    static_assert(policy::hip::MAX_WARPS <= policy::hip::WARP_SIZE,
+        "Max Warps must be less than or equal to Warp Size for this algorithm to work");
+
     __shared__ unsigned char tmpsd[sizeof(RAJA::detail::SoAArray<T, policy::hip::MAX_WARPS>)];
     RAJA::detail::SoAArray<T, policy::hip::MAX_WARPS>* sd =
       reinterpret_cast<RAJA::detail::SoAArray<T, policy::hip::MAX_WARPS> *>(tmpsd);
@@ -309,7 +312,7 @@ RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
         temp = identity;
       }
 
-      for (int i = 1; i < policy::hip::WARP_SIZE; i *= 2) {
+      for (int i = 1; i < policy::hip::MAX_WARPS; i *= 2) {
         T rhs = shfl_xor_sync(temp, i);
         Combiner{}(temp, rhs);
       }


### PR DESCRIPTION
# Summary
Tweak the hip and cuda block reduction to fix the number of steps in the final warp reduction. This was not wrong before but was inconsistent with the maximum amount of data. This saves a couple rounds of warp shfls with hip. This also adds a static assert so we can change the block reduction algorithm if max number of warps exceeds warp size in the future.

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes number of shfl steps in block reduction
