### PR TITLE
Fix CUDA tests to align with CAMP resource default Device memory.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/NVlabs/cub.git
 [submodule "include/camp"]
 	path = tpl/camp
-	url = https://github.com/llnl/camp
+	url = https://github.com/trws/camp
 [submodule "tpl/rocPRIM"]
 	path = tpl/rocPRIM
 	url = https://github.com/ROCmSoftwarePlatform/rocPRIM.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/NVlabs/cub.git
 [submodule "include/camp"]
 	path = tpl/camp
-	url = https://github.com/trws/camp
+	url = https://github.com/llnl/camp
 [submodule "tpl/rocPRIM"]
 	path = tpl/rocPRIM
 	url = https://github.com/ROCmSoftwarePlatform/rocPRIM.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/NVlabs/cub.git
 [submodule "include/camp"]
 	path = tpl/camp
-	url = https://github.com/rchen20/camp
+	url = https://github.com/llnl/camp
 [submodule "tpl/rocPRIM"]
 	path = tpl/rocPRIM
 	url = https://github.com/ROCmSoftwarePlatform/rocPRIM.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/NVlabs/cub.git
 [submodule "include/camp"]
 	path = tpl/camp
-	url = https://github.com/llnl/camp
+	url = https://github.com/rchen20/camp
 [submodule "tpl/rocPRIM"]
 	path = tpl/rocPRIM
 	url = https://github.com/ROCmSoftwarePlatform/rocPRIM.git

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefAdd.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefAdd.hpp
@@ -15,7 +15,7 @@
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct PreIncCountOp {
   PreIncCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dcounter(dcount), hcounter(hcount), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
+    : dcounter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
   {
     hcount[0] = (T)0;
     work_res.memcpy(dcount, hcount, sizeof(T));
@@ -25,14 +25,13 @@ struct PreIncCountOp {
       return (++dcounter) - (T)1;
     }
   RAJA::AtomicRef<T, AtomicPolicy> dcounter;
-  RAJA::AtomicRef<T, AtomicPolicy> hcounter;
   T min, max, final;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct PostIncCountOp {
   PostIncCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dcounter(dcount), hcounter(hcount), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
+    : dcounter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
   {
     hcount[0] = (T)0;
     work_res.memcpy(dcount, hcount, sizeof(T));
@@ -42,14 +41,13 @@ struct PostIncCountOp {
       return (dcounter++);
     }
   RAJA::AtomicRef<T, AtomicPolicy> dcounter;
-  RAJA::AtomicRef<T, AtomicPolicy> hcounter;
   T min, max, final;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct AddEqCountOp {
   AddEqCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dcounter(dcount), hcounter(hcount), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
+    : dcounter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
   {
     hcount[0] = (T)0;
     work_res.memcpy(dcount, hcount, sizeof(T));
@@ -59,14 +57,13 @@ struct AddEqCountOp {
       return (dcounter += (T)1) - (T)1;
     }
   RAJA::AtomicRef<T, AtomicPolicy> dcounter;
-  RAJA::AtomicRef<T, AtomicPolicy> hcounter;
   T min, max, final;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchAddCountOp {
   FetchAddCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dcounter(dcount), hcounter(hcount), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
+    : dcounter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
   {
     hcount[0] = (T)0;
     work_res.memcpy(dcount, hcount, sizeof(T));
@@ -76,7 +73,6 @@ struct FetchAddCountOp {
       return dcounter.fetch_add((T)1);
     }
   RAJA::AtomicRef<T, AtomicPolicy> dcounter;
-  RAJA::AtomicRef<T, AtomicPolicy> hcounter;
   T min, max, final;
 };
 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefAdd.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefAdd.hpp
@@ -140,9 +140,9 @@ void ForallAtomicRefAddTestImpl( IdxType N )
 
   camp::resources::Resource host_res{camp::resources::Host()};
 
-  T * count   = work_res.allocate<T>(1);
-  T * list    = work_res.allocate<T>(N);
-  bool * hit  = work_res.allocate<bool>(N);
+  T * count   = work_res.allocate<T>(1, camp::resources::MemoryAccess::Managed);
+  T * list    = work_res.allocate<T>(N, camp::resources::MemoryAccess::Managed);
+  bool * hit  = work_res.allocate<bool>(N, camp::resources::MemoryAccess::Managed);
 
   T * hcount   = host_res.allocate<T>(1);
   T * hlist    = host_res.allocate<T>(N);
@@ -165,9 +165,9 @@ void ForallAtomicRefAddTestImpl( IdxType N )
   testAtomicRefAdd<ExecPolicy, AtomicPolicy, IdxType, T, 
                      FetchAddCountOp>(seg, count, list, hit, hcount, hlist, hhit, &work_res, N);
 
-  work_res.deallocate( count );
-  work_res.deallocate( list );
-  work_res.deallocate( hit );
+  work_res.deallocate( count, camp::resources::MemoryAccess::Managed );
+  work_res.deallocate( list, camp::resources::MemoryAccess::Managed );
+  work_res.deallocate( hit, camp::resources::MemoryAccess::Managed );
   host_res.deallocate( hcount );
   host_res.deallocate( hlist );
   host_res.deallocate( hhit ); 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefAdd.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefAdd.hpp
@@ -70,17 +70,15 @@ template <typename ExecPolicy,
          typename T,
          template <typename, typename, typename> class CountOp>
 void testAtomicRefAdd(RAJA::TypedRangeSegment<IdxType> seg,
-    T* count, T* list, bool* hit)
+    T* count, T* list, bool* hit,
+    T* hcount, T* hlist, bool* hhit,
+    camp::resources::Resource * work_res, IdxType N)
 {
+  printf("RCC 1\n");
   CountOp<T, AtomicPolicy, IdxType> countop(count, seg);
-  RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(IdxType i) {
+  RAJA::forall<ExecPolicy>(seg, [=] RAJA_DEVICE(IdxType i) {
       list[i] = countop.max + (T)1;
       hit[i] = false;
-      });
-  RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(IdxType i) {
-      T val = countop(i);
-      list[i] = val;
-      hit[(IdxType)val] = true;
       });
 #if defined(RAJA_ENABLE_CUDA)
   cudaErrchk(cudaDeviceSynchronize());
@@ -88,13 +86,44 @@ void testAtomicRefAdd(RAJA::TypedRangeSegment<IdxType> seg,
 #if defined(RAJA_ENABLE_HIP)
   hipErrchk(hipDeviceSynchronize());
 #endif
+  printf("RCC 1.5\n");
+  RAJA::forall<ExecPolicy>(seg, [=] RAJA_DEVICE(IdxType i) {
+      T val = countop(i);
+      list[i] = val;
+      hit[(IdxType)val] = true;
+      });
 
-  EXPECT_EQ(countop.final, count[0]);
+#if defined(RAJA_ENABLE_CUDA)
+  cudaErrchk(cudaDeviceSynchronize());
+#endif
+#if defined(RAJA_ENABLE_HIP)
+  hipErrchk(hipDeviceSynchronize());
+#endif
+
+  printf("RCC 2\n");
+  work_res->memcpy( hcount, count, sizeof(T) );
+  printf("RCC 3\n");
+  work_res->memcpy( hlist, list, sizeof(T) * N );
+  printf("RCC 4\n");
+  work_res->memcpy( hhit, hit, sizeof(bool) * N );
+  printf("RCC 5\n");
+
+#if defined(RAJA_ENABLE_CUDA)
+  cudaErrchk(cudaDeviceSynchronize());
+#endif
+
+#if defined(RAJA_ENABLE_HIP)
+  hipErrchk(hipDeviceSynchronize());
+#endif
+
+  EXPECT_EQ(countop.final, hcount[0]);
+  printf("RCC 6\n");
   for (IdxType i = 0; i < seg.size(); i++) {
-    EXPECT_LE(countop.min, list[i]);
-    EXPECT_GE(countop.max, list[i]);
-    EXPECT_TRUE(hit[i]);
+    EXPECT_LE(countop.min, hlist[i]);
+    EXPECT_GE(countop.max, hlist[i]);
+    EXPECT_TRUE(hhit[i]);
   }
+  printf("RCC 7\n");
 }
 
 
@@ -107,13 +136,17 @@ void ForallAtomicRefAddTestImpl( IdxType N )
 {
   RAJA::TypedRangeSegment<IdxType> seg(0, N);
 
-  camp::resources::Resource count_res{WORKINGRES()};
-  camp::resources::Resource list_res{WORKINGRES()};
-  camp::resources::Resource hit_res{WORKINGRES()};
+  camp::resources::Resource work_res{WORKINGRES()};
 
-  T * count   = count_res.allocate<T>(1);
-  T * list    = list_res.allocate<T>(N);
-  bool * hit  = hit_res.allocate<bool>(N);
+  camp::resources::Resource host_res{camp::resources::Host()};
+
+  T * count   = work_res.allocate<T>(1);
+  T * list    = work_res.allocate<T>(N);
+  bool * hit  = work_res.allocate<bool>(N);
+
+  T * hcount   = host_res.allocate<T>(1);
+  T * hlist    = host_res.allocate<T>(N);
+  bool * hhit  = host_res.allocate<bool>(N);
 
 #if defined(RAJA_ENABLE_CUDA)
   cudaErrchk(cudaDeviceSynchronize());
@@ -124,17 +157,20 @@ void ForallAtomicRefAddTestImpl( IdxType N )
 #endif
 
   testAtomicRefAdd<ExecPolicy, AtomicPolicy, IdxType, T, 
-                     PreIncCountOp  >(seg, count, list, hit);
+                     PreIncCountOp  >(seg, count, list, hit, hcount, hlist, hhit, &work_res, N);
   testAtomicRefAdd<ExecPolicy, AtomicPolicy, IdxType, T, 
-                     PostIncCountOp >(seg, count, list, hit);
+                     PostIncCountOp >(seg, count, list, hit, hcount, hlist, hhit, &work_res, N);
   testAtomicRefAdd<ExecPolicy, AtomicPolicy, IdxType, T, 
-                     AddEqCountOp   >(seg, count, list, hit);
+                     AddEqCountOp   >(seg, count, list, hit, hcount, hlist, hhit, &work_res, N);
   testAtomicRefAdd<ExecPolicy, AtomicPolicy, IdxType, T, 
-                     FetchAddCountOp>(seg, count, list, hit);
+                     FetchAddCountOp>(seg, count, list, hit, hcount, hlist, hhit, &work_res, N);
 
-  count_res.deallocate( count );
-  list_res.deallocate( list );
-  hit_res.deallocate( hit );
+  work_res.deallocate( count );
+  work_res.deallocate( list );
+  work_res.deallocate( hit );
+  host_res.deallocate( hcount );
+  host_res.deallocate( hlist );
+  host_res.deallocate( hhit ); 
 }
 
 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefAdd.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefAdd.hpp
@@ -15,64 +15,64 @@
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct PreIncCountOp {
   PreIncCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dcounter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
+    : counter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
   {
     hcount[0] = (T)0;
     work_res.memcpy(dcount, hcount, sizeof(T));
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const {
-      return (++dcounter) - (T)1;
+      return (++counter) - (T)1;
     }
-  RAJA::AtomicRef<T, AtomicPolicy> dcounter;
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
   T min, max, final;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct PostIncCountOp {
   PostIncCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dcounter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
+    : counter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
   {
     hcount[0] = (T)0;
     work_res.memcpy(dcount, hcount, sizeof(T));
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const {
-      return (dcounter++);
+      return (counter++);
     }
-  RAJA::AtomicRef<T, AtomicPolicy> dcounter;
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
   T min, max, final;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct AddEqCountOp {
   AddEqCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dcounter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
+    : counter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
   {
     hcount[0] = (T)0;
     work_res.memcpy(dcount, hcount, sizeof(T));
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const {
-      return (dcounter += (T)1) - (T)1;
+      return (counter += (T)1) - (T)1;
     }
-  RAJA::AtomicRef<T, AtomicPolicy> dcounter;
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
   T min, max, final;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchAddCountOp {
   FetchAddCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dcounter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
+    : counter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)seg.size())
   {
     hcount[0] = (T)0;
     work_res.memcpy(dcount, hcount, sizeof(T));
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const {
-      return dcounter.fetch_add((T)1);
+      return counter.fetch_add((T)1);
     }
-  RAJA::AtomicRef<T, AtomicPolicy> dcounter;
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
   T min, max, final;
 };
 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefAdd.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefAdd.hpp
@@ -94,7 +94,7 @@ void testAtomicRefAdd(RAJA::TypedRangeSegment<IdxType> seg,
 
   RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(IdxType i) {
       list[i] = countop.max + (T)1;
-      hhit[i] = false;
+      hit[i] = false;
       });
 
   RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(IdxType i) {
@@ -144,13 +144,13 @@ void ForallAtomicRefAddTestImpl( IdxType N )
 
   camp::resources::Resource host_res{camp::resources::Host()};
 
-  T * count   = work_res.allocate<T>(RAJA::stripIndexType(1));
-  T * list    = work_res.allocate<T>(RAJA::stripIndexType(N));
-  bool * hit  = work_res.allocate<bool>(RAJA::stripIndexType(N));
+  T * count   = work_res.allocate<T>(1);
+  T * list    = work_res.allocate<T>(N);
+  bool * hit  = work_res.allocate<bool>(N);
 
-  T * hcount   = host_res.allocate<T>(RAJA::stripIndexType(1));
-  T * hlist    = host_res.allocate<T>(RAJA::stripIndexType(N));
-  bool * hhit  = host_res.allocate<bool>(RAJA::stripIndexType(N));
+  T * hcount   = host_res.allocate<T>(1);
+  T * hlist    = host_res.allocate<T>(N);
+  bool * hhit  = host_res.allocate<bool>(N);
 
 #if defined(RAJA_ENABLE_CUDA)
   cudaErrchk(cudaDeviceSynchronize());

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefCAS.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefCAS.hpp
@@ -14,54 +14,66 @@
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct CASOtherOp : all_op {
-  CASOtherOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : other(count), min((T)0), max((T)seg.size() - (T)1),
+  CASOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dother(dcount), hother(hcount), min((T)0), max((T)seg.size() - (T)1),
     final_min(min), final_max(max)
-  { count[0] = (T)0; }
+  {
+    hcount[0] = (T)0;
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
     {
       T received, expect = (T)0;
-      while ((received = other.CAS(expect, (T)i)) != expect) {
+      while ((received = dother.CAS(expect, (T)i)) != expect) {
         expect = received;
       }
       return received;
     }
-  RAJA::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct CompareExchangeWeakOtherOp : all_op {
-  CompareExchangeWeakOtherOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : other(count), min((T)0), max((T)seg.size() - (T)1),
+  CompareExchangeWeakOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dother(dcount), hother(hcount), min((T)0), max((T)seg.size() - (T)1),
     final_min(min), final_max(max)
-  { count[0] = (T)0; }
+  {
+    hcount[0] = (T)0;
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
     {
       T expect = (T)0;
-      while (!other.compare_exchange_weak(expect, (T)i)) {}
+      while (!dother.compare_exchange_weak(expect, (T)i)) {}
       return expect;
     }
-  RAJA::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct CompareExchangeStrongOtherOp : all_op {
-  CompareExchangeStrongOtherOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : other(count), min((T)0), max((T)seg.size() - (T)1),
+  CompareExchangeStrongOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dother(dcount), hother(hcount), min((T)0), max((T)seg.size() - (T)1),
     final_min(min), final_max(max)
-  { count[0] = (T)0; }
+  {
+    hcount[0] = (T)0;
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
     {
       T expect = (T)0;
-      while (!other.compare_exchange_strong(expect, (T)i)) {}
+      while (!dother.compare_exchange_strong(expect, (T)i)) {}
       return expect;
     }
-  RAJA::AtomicRef<T, AtomicPolicy> other;
+  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
@@ -71,9 +83,11 @@ template  < typename ExecPolicy,
             typename T,
             template <typename, typename, typename> class OtherOp>
 void
-testAtomicRefCASOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list)
+testAtomicRefCASOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list,
+    T* hcount, T* hlist,
+    camp::resources::Resource work_res, IdxType N)
 {
-  OtherOp<T, AtomicPolicy, IdxType> otherop(count, seg);
+  OtherOp<T, AtomicPolicy, IdxType> otherop(count, hcount, work_res, seg);
   RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(IdxType i) {
       list[i] = otherop.max + (T)1;
   });
@@ -87,11 +101,15 @@ testAtomicRefCASOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list)
 #if defined(RAJA_ENABLE_HIP)
   hipErrchk(hipDeviceSynchronize());
 #endif
-  EXPECT_LE(otherop.final_min, count[0]);
-  EXPECT_GE(otherop.final_max, count[0]);
+
+  work_res.memcpy( hcount, count, sizeof(T) );
+  work_res.memcpy( hlist, list, sizeof(T) * N );
+
+  EXPECT_LE(otherop.final_min, hcount[0]);
+  EXPECT_GE(otherop.final_max, hcount[0]);
   for (IdxType i = 0; i < seg.size(); i++) {
-    EXPECT_LE(otherop.min, list[i]);
-    EXPECT_GE(otherop.max, list[i]);
+    EXPECT_LE(otherop.min, hlist[i]);
+    EXPECT_GE(otherop.max, hlist[i]);
   }
 }
 
@@ -105,11 +123,15 @@ void ForallAtomicRefCASTestImpl( IdxType N )
 {
   RAJA::TypedRangeSegment<IdxType> seg(0, N);
 
-  camp::resources::Resource count_res{WORKINGRES()};
-  camp::resources::Resource list_res{WORKINGRES()};
+  camp::resources::Resource work_res{WORKINGRES()};
 
-  T * count   = count_res.allocate<T>(1);
-  T * list    = list_res.allocate<T>(N);
+  camp::resources::Resource host_res{camp::resources::Host()};
+
+  T * count   = work_res.allocate<T>(1);
+  T * list    = work_res.allocate<T>(N);
+
+  T * hcount   = host_res.allocate<T>(1);
+  T * hlist    = host_res.allocate<T>(N);
 
 #if defined(RAJA_ENABLE_CUDA)
   cudaErrchk(cudaDeviceSynchronize());
@@ -120,14 +142,16 @@ void ForallAtomicRefCASTestImpl( IdxType N )
 #endif
 
   testAtomicRefCASOp<ExecPolicy, AtomicPolicy, IdxType, T, 
-                       CASOtherOp                  >(seg, count, list);
+                       CASOtherOp                  >(seg, count, list, hcount, hlist, work_res, N);
   testAtomicRefCASOp<ExecPolicy, AtomicPolicy, IdxType, T, 
-                       CompareExchangeWeakOtherOp  >(seg, count, list);
+                       CompareExchangeWeakOtherOp  >(seg, count, list, hcount, hlist, work_res, N);
   testAtomicRefCASOp<ExecPolicy, AtomicPolicy, IdxType, T, 
-                       CompareExchangeStrongOtherOp>(seg, count, list);
+                       CompareExchangeStrongOtherOp>(seg, count, list, hcount, hlist, work_res, N);
 
-  count_res.deallocate( count );
-  list_res.deallocate( list );
+  work_res.deallocate( count );
+  work_res.deallocate( list );
+  host_res.deallocate( hcount );
+  host_res.deallocate( hlist );
 }
 
 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefCAS.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefCAS.hpp
@@ -15,7 +15,7 @@
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct CASOtherOp : all_op {
   CASOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), min((T)0), max((T)seg.size() - (T)1),
+    : other(dcount), min((T)0), max((T)seg.size() - (T)1),
     final_min(min), final_max(max)
   {
     hcount[0] = (T)0;
@@ -25,19 +25,19 @@ struct CASOtherOp : all_op {
     T operator()(IdxType i) const
     {
       T received, expect = (T)0;
-      while ((received = dother.CAS(expect, (T)i)) != expect) {
+      while ((received = other.CAS(expect, (T)i)) != expect) {
         expect = received;
       }
       return received;
     }
-  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct CompareExchangeWeakOtherOp : all_op {
   CompareExchangeWeakOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), min((T)0), max((T)seg.size() - (T)1),
+    : other(dcount), min((T)0), max((T)seg.size() - (T)1),
     final_min(min), final_max(max)
   {
     hcount[0] = (T)0;
@@ -47,17 +47,17 @@ struct CompareExchangeWeakOtherOp : all_op {
     T operator()(IdxType i) const
     {
       T expect = (T)0;
-      while (!dother.compare_exchange_weak(expect, (T)i)) {}
+      while (!other.compare_exchange_weak(expect, (T)i)) {}
       return expect;
     }
-  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct CompareExchangeStrongOtherOp : all_op {
   CompareExchangeStrongOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), min((T)0), max((T)seg.size() - (T)1),
+    : other(dcount), min((T)0), max((T)seg.size() - (T)1),
     final_min(min), final_max(max)
   {
     hcount[0] = (T)0;
@@ -67,10 +67,10 @@ struct CompareExchangeStrongOtherOp : all_op {
     T operator()(IdxType i) const
     {
       T expect = (T)0;
-      while (!dother.compare_exchange_strong(expect, (T)i)) {}
+      while (!other.compare_exchange_strong(expect, (T)i)) {}
       return expect;
     }
-  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefCAS.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefCAS.hpp
@@ -15,7 +15,7 @@
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct CASOtherOp : all_op {
   CASOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), hother(hcount), min((T)0), max((T)seg.size() - (T)1),
+    : dother(dcount), min((T)0), max((T)seg.size() - (T)1),
     final_min(min), final_max(max)
   {
     hcount[0] = (T)0;
@@ -31,14 +31,13 @@ struct CASOtherOp : all_op {
       return received;
     }
   RAJA::AtomicRef<T, AtomicPolicy> dother;
-  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct CompareExchangeWeakOtherOp : all_op {
   CompareExchangeWeakOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), hother(hcount), min((T)0), max((T)seg.size() - (T)1),
+    : dother(dcount), min((T)0), max((T)seg.size() - (T)1),
     final_min(min), final_max(max)
   {
     hcount[0] = (T)0;
@@ -52,14 +51,13 @@ struct CompareExchangeWeakOtherOp : all_op {
       return expect;
     }
   RAJA::AtomicRef<T, AtomicPolicy> dother;
-  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct CompareExchangeStrongOtherOp : all_op {
   CompareExchangeStrongOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), hother(hcount), min((T)0), max((T)seg.size() - (T)1),
+    : dother(dcount), min((T)0), max((T)seg.size() - (T)1),
     final_min(min), final_max(max)
   {
     hcount[0] = (T)0;
@@ -73,7 +71,6 @@ struct CompareExchangeStrongOtherOp : all_op {
       return expect;
     }
   RAJA::AtomicRef<T, AtomicPolicy> dother;
-  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefLoadStore.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefLoadStore.hpp
@@ -15,7 +15,7 @@
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct LoadOtherOp : all_op {
   LoadOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), min((T)seg.size()), max(min),
+    : other(dcount), min((T)seg.size()), max(min),
     final_min(min), final_max(min)
   {
     hcount[0] = min;
@@ -23,15 +23,15 @@ struct LoadOtherOp : all_op {
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const
-    { return dother.load(); }
-  RAJA::AtomicRef<T, AtomicPolicy> dother;
+    { return other.load(); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct OperatorTOtherOp : all_op {
   OperatorTOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> RAJA_UNUSED_ARG(seg))
-    : dother(dcount), min(T(0)), max(min),
+    : other(dcount), min(T(0)), max(min),
     final_min(min), final_max(min)
   {
     hcount[0] = min;
@@ -39,15 +39,15 @@ struct OperatorTOtherOp : all_op {
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const
-    { return dother; }
-  RAJA::AtomicRef<T, AtomicPolicy> dother;
+    { return other; }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct StoreOtherOp : all_op {
   StoreOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), min((T)0), max((T)seg.size() - (T)1),
+    : other(dcount), min((T)0), max((T)seg.size() - (T)1),
     final_min(min), final_max(max)
   {
     hcount[0] = (T)seg.size();
@@ -55,15 +55,15 @@ struct StoreOtherOp : all_op {
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { dother.store((T)i); return (T)i; }
-  RAJA::AtomicRef<T, AtomicPolicy> dother;
+    { other.store((T)i); return (T)i; }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct AssignOtherOp : all_op {
   AssignOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), min(T(0)), max((T)seg.size() - (T)1),
+    : other(dcount), min(T(0)), max((T)seg.size() - (T)1),
     final_min(min), final_max(max)
   {
     hcount[0] = (T)seg.size();
@@ -71,8 +71,8 @@ struct AssignOtherOp : all_op {
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return (dother = (T)i); }
-  RAJA::AtomicRef<T, AtomicPolicy> dother;
+    { return (other = (T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefLoadStore.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefLoadStore.hpp
@@ -15,7 +15,7 @@
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct LoadOtherOp : all_op {
   LoadOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), hother(hcount), min((T)seg.size()), max(min),
+    : dother(dcount), min((T)seg.size()), max(min),
     final_min(min), final_max(min)
   {
     hcount[0] = min;
@@ -25,14 +25,13 @@ struct LoadOtherOp : all_op {
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const
     { return dother.load(); }
   RAJA::AtomicRef<T, AtomicPolicy> dother;
-  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct OperatorTOtherOp : all_op {
   OperatorTOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> RAJA_UNUSED_ARG(seg))
-    : dother(dcount), hother(hcount), min(T(0)), max(min),
+    : dother(dcount), min(T(0)), max(min),
     final_min(min), final_max(min)
   {
     hcount[0] = min;
@@ -42,14 +41,13 @@ struct OperatorTOtherOp : all_op {
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const
     { return dother; }
   RAJA::AtomicRef<T, AtomicPolicy> dother;
-  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct StoreOtherOp : all_op {
   StoreOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), hother(hcount), min((T)0), max((T)seg.size() - (T)1),
+    : dother(dcount), min((T)0), max((T)seg.size() - (T)1),
     final_min(min), final_max(max)
   {
     hcount[0] = (T)seg.size();
@@ -59,14 +57,13 @@ struct StoreOtherOp : all_op {
     T operator()(IdxType i) const
     { dother.store((T)i); return (T)i; }
   RAJA::AtomicRef<T, AtomicPolicy> dother;
-  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct AssignOtherOp : all_op {
   AssignOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), hother(hcount), min(T(0)), max((T)seg.size() - (T)1),
+    : dother(dcount), min(T(0)), max((T)seg.size() - (T)1),
     final_min(min), final_max(max)
   {
     hcount[0] = (T)seg.size();
@@ -76,7 +73,6 @@ struct AssignOtherOp : all_op {
     T operator()(IdxType i) const
     { return (dother = (T)i); }
   RAJA::AtomicRef<T, AtomicPolicy> dother;
-  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefLoadStore.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefLoadStore.hpp
@@ -14,53 +14,69 @@
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct LoadOtherOp : all_op {
-  LoadOtherOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : other(count), min((T)seg.size()), max(min),
+  LoadOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dother(dcount), hother(hcount), min((T)seg.size()), max(min),
     final_min(min), final_max(min)
-  { count[0] = min; }
+  {
+    hcount[0] = min;
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const
-    { return other.load(); }
-  RAJA::AtomicRef<T, AtomicPolicy> other;
+    { return dother.load(); }
+  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct OperatorTOtherOp : all_op {
-  OperatorTOtherOp(T* count, RAJA::TypedRangeSegment<IdxType> RAJA_UNUSED_ARG(seg))
-    : other(count), min(T(0)), max(min),
+  OperatorTOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> RAJA_UNUSED_ARG(seg))
+    : dother(dcount), hother(hcount), min(T(0)), max(min),
     final_min(min), final_max(min)
-  { count[0] = min; }
+  {
+    hcount[0] = min;
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const
-    { return other; }
-  RAJA::AtomicRef<T, AtomicPolicy> other;
+    { return dother; }
+  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct StoreOtherOp : all_op {
-  StoreOtherOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : other(count), min((T)0), max((T)seg.size() - (T)1),
+  StoreOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dother(dcount), hother(hcount), min((T)0), max((T)seg.size() - (T)1),
     final_min(min), final_max(max)
-  { count[0] = (T)seg.size(); }
+  {
+    hcount[0] = (T)seg.size();
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { other.store((T)i); return (T)i; }
-  RAJA::AtomicRef<T, AtomicPolicy> other;
+    { dother.store((T)i); return (T)i; }
+  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct AssignOtherOp : all_op {
-  AssignOtherOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : other(count), min(T(0)), max((T)seg.size() - (T)1),
+  AssignOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dother(dcount), hother(hcount), min(T(0)), max((T)seg.size() - (T)1),
     final_min(min), final_max(max)
-  { count[0] = (T)seg.size(); }
+  {
+    hcount[0] = (T)seg.size();
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return (other = (T)i); }
-  RAJA::AtomicRef<T, AtomicPolicy> other;
+    { return (dother = (T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
@@ -70,9 +86,11 @@ template  < typename ExecPolicy,
             typename T,
             template <typename, typename, typename> class OtherOp>
 void
-testAtomicRefLoadStoreOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list)
+testAtomicRefLoadStoreOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list,
+    T* hcount, T* hlist,
+    camp::resources::Resource work_res, IdxType N)
 {
-  OtherOp<T, AtomicPolicy, IdxType> otherop(count, seg);
+  OtherOp<T, AtomicPolicy, IdxType> otherop(count, hcount, work_res, seg);
   RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(IdxType i) {
       list[i] = otherop.max + (T)1;
   });
@@ -86,11 +104,15 @@ testAtomicRefLoadStoreOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list
 #if defined(RAJA_ENABLE_HIP)
   hipErrchk(hipDeviceSynchronize());
 #endif
-  EXPECT_LE(otherop.final_min, count[0]);
-  EXPECT_GE(otherop.final_max, count[0]);
+
+  work_res.memcpy( hcount, count, sizeof(T) );
+  work_res.memcpy( hlist, list, sizeof(T) * N );
+
+  EXPECT_LE(otherop.final_min, hcount[0]);
+  EXPECT_GE(otherop.final_max, hcount[0]);
   for (IdxType i = 0; i < seg.size(); i++) {
-    EXPECT_LE(otherop.min, list[i]);
-    EXPECT_GE(otherop.max, list[i]);
+    EXPECT_LE(otherop.min, hlist[i]);
+    EXPECT_GE(otherop.max, hlist[i]);
   }
 }
 
@@ -104,11 +126,15 @@ void ForallAtomicRefLoadStoreTestImpl( IdxType N )
 {
   RAJA::TypedRangeSegment<IdxType> seg(0, N);
 
-  camp::resources::Resource count_res{WORKINGRES()};
-  camp::resources::Resource list_res{WORKINGRES()};
+  camp::resources::Resource work_res{WORKINGRES()};
 
-  T * count   = count_res.allocate<T>(1);
-  T * list    = list_res.allocate<T>(N);
+  camp::resources::Resource host_res{camp::resources::Host()};
+
+  T * count   = work_res.allocate<T>(1);
+  T * list    = work_res.allocate<T>(N);
+
+  T * hcount   = host_res.allocate<T>(1);
+  T * hlist    = host_res.allocate<T>(N);
 
 #if defined(RAJA_ENABLE_CUDA)
   cudaErrchk(cudaDeviceSynchronize());
@@ -119,16 +145,18 @@ void ForallAtomicRefLoadStoreTestImpl( IdxType N )
 #endif
 
   testAtomicRefLoadStoreOp<ExecPolicy, AtomicPolicy, IdxType, T, 
-                       LoadOtherOp     >(seg, count, list);
+                       LoadOtherOp     >(seg, count, list, hcount, hlist, work_res, N);
   testAtomicRefLoadStoreOp<ExecPolicy, AtomicPolicy, IdxType, T, 
-                       OperatorTOtherOp>(seg, count, list);
+                       OperatorTOtherOp>(seg, count, list, hcount, hlist, work_res, N);
   testAtomicRefLoadStoreOp<ExecPolicy, AtomicPolicy, IdxType, T, 
-                       StoreOtherOp    >(seg, count, list);
+                       StoreOtherOp    >(seg, count, list, hcount, hlist, work_res, N);
   testAtomicRefLoadStoreOp<ExecPolicy, AtomicPolicy, IdxType, T, 
-                       AssignOtherOp   >(seg, count, list);
+                       AssignOtherOp   >(seg, count, list, hcount, hlist, work_res, N);
 
-  count_res.deallocate( count );
-  list_res.deallocate( list );
+  work_res.deallocate( count );
+  work_res.deallocate( list );
+  host_res.deallocate( hcount );
+  host_res.deallocate( hlist );
 }
 
 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefLogical.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefLogical.hpp
@@ -15,7 +15,7 @@
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct AndEqOtherOp : int_op {
   AndEqOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), hother(hcount), min(T(0)), max((T)seg.size()),
+    : dother(dcount), min(T(0)), max((T)seg.size()),
     final_min(min), final_max(min)
   {
     hcount[0] = np2m1((T)seg.size());
@@ -25,14 +25,13 @@ struct AndEqOtherOp : int_op {
     T operator()(IdxType i) const
     { return dother &= (T)i; }
   RAJA::AtomicRef<T, AtomicPolicy> dother;
-  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchAndOtherOp : int_op {
   FetchAndOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), hother(hcount), min(T(0)), max(np2m1((T)seg.size())),
+    : dother(dcount), min(T(0)), max(np2m1((T)seg.size())),
     final_min(min), final_max(min)
   {
     hcount[0] = max;
@@ -42,14 +41,13 @@ struct FetchAndOtherOp : int_op {
     T operator()(IdxType i) const
     { return dother.fetch_and((T)i); }
   RAJA::AtomicRef<T, AtomicPolicy> dother;
-  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct OrEqOtherOp : int_op {
   OrEqOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), hother(hcount), min(T(0)), max(np2m1((T)seg.size())),
+    : dother(dcount), min(T(0)), max(np2m1((T)seg.size())),
     final_min(max), final_max(max)
   {
     hcount[0] = T(0);
@@ -59,14 +57,13 @@ struct OrEqOtherOp : int_op {
     T operator()(IdxType i) const
     { return dother |= (T)i; }
   RAJA::AtomicRef<T, AtomicPolicy> dother;
-  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchOrOtherOp : int_op {
   FetchOrOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), hother(hcount), min(T(0)), max(np2m1((T)seg.size())),
+    : dother(dcount), min(T(0)), max(np2m1((T)seg.size())),
     final_min(max), final_max(max)
   {
     hcount[0] = T(0);
@@ -76,14 +73,13 @@ struct FetchOrOtherOp : int_op {
     T operator()(IdxType i) const
     { return dother.fetch_or((T)i); }
   RAJA::AtomicRef<T, AtomicPolicy> dother;
-  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct XorEqOtherOp : int_op {
   XorEqOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), hother(hcount), min(T(0)), max(np2m1((T)seg.size())),
+    : dother(dcount), min(T(0)), max(np2m1((T)seg.size())),
     final_min(min), final_max(min)
   {
     hcount[0] = T(0);
@@ -96,14 +92,13 @@ struct XorEqOtherOp : int_op {
     T operator()(IdxType i) const
     { return dother ^= (T)i; }
   RAJA::AtomicRef<T, AtomicPolicy> dother;
-  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchXorOtherOp : int_op {
   FetchXorOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), hother(hcount), min(T(0)), max(np2m1((T)seg.size())),
+    : dother(dcount), min(T(0)), max(np2m1((T)seg.size())),
     final_min(min), final_max(min)
   {
     hcount[0] = T(0);
@@ -116,7 +111,6 @@ struct FetchXorOtherOp : int_op {
     T operator()(IdxType i) const
     { return dother.fetch_xor((T)i); }
   RAJA::AtomicRef<T, AtomicPolicy> dother;
-  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefLogical.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefLogical.hpp
@@ -14,85 +14,109 @@
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct AndEqOtherOp : int_op {
-  AndEqOtherOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : other(count), min(T(0)), max((T)seg.size()),
+  AndEqOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dother(dcount), hother(hcount), min(T(0)), max((T)seg.size()),
     final_min(min), final_max(min)
-  { count[0] = np2m1((T)seg.size()); }
+  {
+    hcount[0] = np2m1((T)seg.size());
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return other &= (T)i; }
-  RAJA::AtomicRef<T, AtomicPolicy> other;
+    { return dother &= (T)i; }
+  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchAndOtherOp : int_op {
-  FetchAndOtherOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : other(count), min(T(0)), max(np2m1((T)seg.size())),
+  FetchAndOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dother(dcount), hother(hcount), min(T(0)), max(np2m1((T)seg.size())),
     final_min(min), final_max(min)
-  { count[0] = max; }
+  {
+    hcount[0] = max;
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return other.fetch_and((T)i); }
-  RAJA::AtomicRef<T, AtomicPolicy> other;
+    { return dother.fetch_and((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct OrEqOtherOp : int_op {
-  OrEqOtherOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : other(count), min(T(0)), max(np2m1((T)seg.size())),
+  OrEqOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dother(dcount), hother(hcount), min(T(0)), max(np2m1((T)seg.size())),
     final_min(max), final_max(max)
-  { count[0] = T(0); }
+  {
+    hcount[0] = T(0);
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return other |= (T)i; }
-  RAJA::AtomicRef<T, AtomicPolicy> other;
+    { return dother |= (T)i; }
+  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchOrOtherOp : int_op {
-  FetchOrOtherOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : other(count), min(T(0)), max(np2m1((T)seg.size())),
+  FetchOrOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dother(dcount), hother(hcount), min(T(0)), max(np2m1((T)seg.size())),
     final_min(max), final_max(max)
-  { count[0] = T(0); }
+  {
+    hcount[0] = T(0);
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return other.fetch_or((T)i); }
-  RAJA::AtomicRef<T, AtomicPolicy> other;
+    { return dother.fetch_or((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct XorEqOtherOp : int_op {
-  XorEqOtherOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : other(count), min(T(0)), max(np2m1((T)seg.size())),
+  XorEqOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dother(dcount), hother(hcount), min(T(0)), max(np2m1((T)seg.size())),
     final_min(min), final_max(min)
-  { count[0] = T(0);
+  {
+    hcount[0] = T(0);
+    work_res.memcpy(dcount, hcount, sizeof(T));
     for (IdxType i = 0; i < seg.size(); ++i) {
       final_min ^= (T)i; final_max ^= (T)i;
-    } }
+    }
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return other ^= (T)i; }
-  RAJA::AtomicRef<T, AtomicPolicy> other;
+    { return dother ^= (T)i; }
+  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchXorOtherOp : int_op {
-  FetchXorOtherOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : other(count), min(T(0)), max(np2m1((T)seg.size())),
+  FetchXorOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dother(dcount), hother(hcount), min(T(0)), max(np2m1((T)seg.size())),
     final_min(min), final_max(min)
-  { count[0] = T(0);
+  {
+    hcount[0] = T(0);
+    work_res.memcpy(dcount, hcount, sizeof(T));
     for (IdxType i = 0; i < seg.size(); ++i) {
       final_min ^= (T)i; final_max ^= (T)i;
-    } }
+    }
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return other.fetch_xor((T)i); }
-  RAJA::AtomicRef<T, AtomicPolicy> other;
+    { return dother.fetch_xor((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
@@ -107,7 +131,9 @@ typename std::enable_if<
             std::is_base_of<int_op, OtherOp<T,AtomicPolicy, IdxType>>::value)
          >::type
 testAtomicRefLogicalOp(RAJA::TypedRangeSegment<IdxType> RAJA_UNUSED_ARG(seg), 
-                     T* RAJA_UNUSED_ARG(count), T* RAJA_UNUSED_ARG(list))
+                     T* RAJA_UNUSED_ARG(count), T* RAJA_UNUSED_ARG(list),
+                     T* RAJA_UNUSED_ARG(hcount), T* RAJA_UNUSED_ARG(hlist),
+                     camp::resources::Resource RAJA_UNUSED_ARG(work_res), IdxType RAJA_UNUSED_ARG(N))
 {
 }
 
@@ -122,9 +148,11 @@ typename std::enable_if<
             std::is_base_of<int_op, OtherOp<T,AtomicPolicy, IdxType>>::value) || 
             (std::is_base_of<all_op, OtherOp<T,AtomicPolicy, IdxType>>::value)
          >::type
-testAtomicRefLogicalOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list)
+testAtomicRefLogicalOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list,
+    T* hcount, T* hlist,
+    camp::resources::Resource work_res, IdxType N)
 {
-  OtherOp<T, AtomicPolicy, IdxType> otherop(count, seg);
+  OtherOp<T, AtomicPolicy, IdxType> otherop(count, hcount, work_res, seg);
   RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(IdxType i) {
       list[i] = otherop.max + (T)1;
   });
@@ -138,11 +166,15 @@ testAtomicRefLogicalOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list)
 #if defined(RAJA_ENABLE_HIP)
   hipErrchk(hipDeviceSynchronize());
 #endif
-  EXPECT_LE(otherop.final_min, count[0]);
-  EXPECT_GE(otherop.final_max, count[0]);
+
+  work_res.memcpy( hcount, count, sizeof(T) );
+  work_res.memcpy( hlist, list, sizeof(T) * N );
+
+  EXPECT_LE(otherop.final_min, hcount[0]);
+  EXPECT_GE(otherop.final_max, hcount[0]);
   for (IdxType i = 0; i < seg.size(); i++) {
-    EXPECT_LE(otherop.min, list[i]);
-    EXPECT_GE(otherop.max, list[i]);
+    EXPECT_LE(otherop.min, hlist[i]);
+    EXPECT_GE(otherop.max, hlist[i]);
   }
 }
 
@@ -156,11 +188,15 @@ void ForallAtomicRefLogicalTestImpl( IdxType N )
 {
   RAJA::TypedRangeSegment<IdxType> seg(0, N);
 
-  camp::resources::Resource count_res{WORKINGRES()};
-  camp::resources::Resource list_res{WORKINGRES()};
+  camp::resources::Resource work_res{WORKINGRES()};
 
-  T * count   = count_res.allocate<T>(1);
-  T * list    = list_res.allocate<T>(N);
+  camp::resources::Resource host_res{camp::resources::Host()};
+
+  T * count   = work_res.allocate<T>(1);
+  T * list    = work_res.allocate<T>(N);
+
+  T * hcount   = host_res.allocate<T>(1);
+  T * hlist    = host_res.allocate<T>(N);
 
 #if defined(RAJA_ENABLE_CUDA)
   cudaErrchk(cudaDeviceSynchronize());
@@ -173,20 +209,22 @@ void ForallAtomicRefLogicalTestImpl( IdxType N )
   // Note: These integral tests require return type conditional overloading 
   //       of testAtomicRefLogicalOp
   testAtomicRefLogicalOp<ExecPolicy, AtomicPolicy, IdxType, T, 
-                       AndEqOtherOp   >(seg, count, list);
+                       AndEqOtherOp   >(seg, count, list, hcount, hlist, work_res, N);
   testAtomicRefLogicalOp<ExecPolicy, AtomicPolicy, IdxType, T, 
-                       FetchAndOtherOp>(seg, count, list);
+                       FetchAndOtherOp>(seg, count, list, hcount, hlist, work_res, N);
   testAtomicRefLogicalOp<ExecPolicy, AtomicPolicy, IdxType, T, 
-                       OrEqOtherOp    >(seg, count, list);
+                       OrEqOtherOp    >(seg, count, list, hcount, hlist, work_res, N);
   testAtomicRefLogicalOp<ExecPolicy, AtomicPolicy, IdxType, T, 
-                       FetchOrOtherOp >(seg, count, list);
+                       FetchOrOtherOp >(seg, count, list, hcount, hlist, work_res, N);
   testAtomicRefLogicalOp<ExecPolicy, AtomicPolicy, IdxType, T, 
-                       XorEqOtherOp   >(seg, count, list);
+                       XorEqOtherOp   >(seg, count, list, hcount, hlist, work_res, N);
   testAtomicRefLogicalOp<ExecPolicy, AtomicPolicy, IdxType, T, 
-                       FetchXorOtherOp>(seg, count, list);
+                       FetchXorOtherOp>(seg, count, list, hcount, hlist, work_res, N);
 
-  count_res.deallocate( count );
-  list_res.deallocate( list );
+  work_res.deallocate( count );
+  work_res.deallocate( list );
+  host_res.deallocate( hcount );
+  host_res.deallocate( hlist );
 }
 
 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefLogical.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefLogical.hpp
@@ -15,7 +15,7 @@
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct AndEqOtherOp : int_op {
   AndEqOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), min(T(0)), max((T)seg.size()),
+    : other(dcount), min(T(0)), max((T)seg.size()),
     final_min(min), final_max(min)
   {
     hcount[0] = np2m1((T)seg.size());
@@ -23,15 +23,15 @@ struct AndEqOtherOp : int_op {
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return dother &= (T)i; }
-  RAJA::AtomicRef<T, AtomicPolicy> dother;
+    { return other &= (T)i; }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchAndOtherOp : int_op {
   FetchAndOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), min(T(0)), max(np2m1((T)seg.size())),
+    : other(dcount), min(T(0)), max(np2m1((T)seg.size())),
     final_min(min), final_max(min)
   {
     hcount[0] = max;
@@ -39,15 +39,15 @@ struct FetchAndOtherOp : int_op {
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return dother.fetch_and((T)i); }
-  RAJA::AtomicRef<T, AtomicPolicy> dother;
+    { return other.fetch_and((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct OrEqOtherOp : int_op {
   OrEqOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), min(T(0)), max(np2m1((T)seg.size())),
+    : other(dcount), min(T(0)), max(np2m1((T)seg.size())),
     final_min(max), final_max(max)
   {
     hcount[0] = T(0);
@@ -55,15 +55,15 @@ struct OrEqOtherOp : int_op {
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return dother |= (T)i; }
-  RAJA::AtomicRef<T, AtomicPolicy> dother;
+    { return other |= (T)i; }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchOrOtherOp : int_op {
   FetchOrOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), min(T(0)), max(np2m1((T)seg.size())),
+    : other(dcount), min(T(0)), max(np2m1((T)seg.size())),
     final_min(max), final_max(max)
   {
     hcount[0] = T(0);
@@ -71,15 +71,15 @@ struct FetchOrOtherOp : int_op {
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return dother.fetch_or((T)i); }
-  RAJA::AtomicRef<T, AtomicPolicy> dother;
+    { return other.fetch_or((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct XorEqOtherOp : int_op {
   XorEqOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), min(T(0)), max(np2m1((T)seg.size())),
+    : other(dcount), min(T(0)), max(np2m1((T)seg.size())),
     final_min(min), final_max(min)
   {
     hcount[0] = T(0);
@@ -90,15 +90,15 @@ struct XorEqOtherOp : int_op {
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return dother ^= (T)i; }
-  RAJA::AtomicRef<T, AtomicPolicy> dother;
+    { return other ^= (T)i; }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchXorOtherOp : int_op {
   FetchXorOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), min(T(0)), max(np2m1((T)seg.size())),
+    : other(dcount), min(T(0)), max(np2m1((T)seg.size())),
     final_min(min), final_max(min)
   {
     hcount[0] = T(0);
@@ -109,8 +109,8 @@ struct FetchXorOtherOp : int_op {
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return dother.fetch_xor((T)i); }
-  RAJA::AtomicRef<T, AtomicPolicy> dother;
+    { return other.fetch_xor((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefMinMax.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefMinMax.hpp
@@ -15,7 +15,7 @@
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct MaxEqOtherOp : all_op {
   MaxEqOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), hother(hcount), min(T(0)), max((T)seg.size() - (T)1),
+    : dother(dcount), min(T(0)), max((T)seg.size() - (T)1),
     final_min(max), final_max(max)
   {
     hcount[0] = (T)0;
@@ -25,14 +25,13 @@ struct MaxEqOtherOp : all_op {
     T operator()(IdxType i) const
     { return dother.max((T)i); }
   RAJA::AtomicRef<T, AtomicPolicy> dother;
-  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchMaxOtherOp : all_op {
   FetchMaxOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), hother(hcount), min(T(0)), max((T)seg.size() - (T)1),
+    : dother(dcount), min(T(0)), max((T)seg.size() - (T)1),
     final_min(max), final_max(max)
   {
     hcount[0] = (T)0;
@@ -42,14 +41,13 @@ struct FetchMaxOtherOp : all_op {
     T operator()(IdxType i) const
     { return dother.fetch_max((T)i); }
   RAJA::AtomicRef<T, AtomicPolicy> dother;
-  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct MinEqOtherOp : all_op {
   MinEqOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), hother(hcount), min(T(0)), max((T)seg.size() - (T)1),
+    : dother(dcount), min(T(0)), max((T)seg.size() - (T)1),
     final_min(min), final_max(min)
   {
     hcount[0] = (T)seg.size();
@@ -59,14 +57,13 @@ struct MinEqOtherOp : all_op {
     T operator()(IdxType i) const
     { return dother.min((T)i); }
   RAJA::AtomicRef<T, AtomicPolicy> dother;
-  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchMinOtherOp : all_op {
   FetchMinOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), hother(hcount), min(T(0)), max((T)seg.size()),
+    : dother(dcount), min(T(0)), max((T)seg.size()),
     final_min(min), final_max(min)
   {
     hcount[0] = (T)seg.size();
@@ -76,7 +73,6 @@ struct FetchMinOtherOp : all_op {
     T operator()(IdxType i) const
     { return dother.fetch_min((T)i); }
   RAJA::AtomicRef<T, AtomicPolicy> dother;
-  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefMinMax.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefMinMax.hpp
@@ -15,7 +15,7 @@
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct MaxEqOtherOp : all_op {
   MaxEqOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), min(T(0)), max((T)seg.size() - (T)1),
+    : other(dcount), min(T(0)), max((T)seg.size() - (T)1),
     final_min(max), final_max(max)
   {
     hcount[0] = (T)0;
@@ -23,15 +23,15 @@ struct MaxEqOtherOp : all_op {
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return dother.max((T)i); }
-  RAJA::AtomicRef<T, AtomicPolicy> dother;
+    { return other.max((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchMaxOtherOp : all_op {
   FetchMaxOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), min(T(0)), max((T)seg.size() - (T)1),
+    : other(dcount), min(T(0)), max((T)seg.size() - (T)1),
     final_min(max), final_max(max)
   {
     hcount[0] = (T)0;
@@ -39,15 +39,15 @@ struct FetchMaxOtherOp : all_op {
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return dother.fetch_max((T)i); }
-  RAJA::AtomicRef<T, AtomicPolicy> dother;
+    { return other.fetch_max((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct MinEqOtherOp : all_op {
   MinEqOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), min(T(0)), max((T)seg.size() - (T)1),
+    : other(dcount), min(T(0)), max((T)seg.size() - (T)1),
     final_min(min), final_max(min)
   {
     hcount[0] = (T)seg.size();
@@ -55,15 +55,15 @@ struct MinEqOtherOp : all_op {
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return dother.min((T)i); }
-  RAJA::AtomicRef<T, AtomicPolicy> dother;
+    { return other.min((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchMinOtherOp : all_op {
   FetchMinOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dother(dcount), min(T(0)), max((T)seg.size()),
+    : other(dcount), min(T(0)), max((T)seg.size()),
     final_min(min), final_max(min)
   {
     hcount[0] = (T)seg.size();
@@ -71,8 +71,8 @@ struct FetchMinOtherOp : all_op {
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return dother.fetch_min((T)i); }
-  RAJA::AtomicRef<T, AtomicPolicy> dother;
+    { return other.fetch_min((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> other;
   T min, max, final_min, final_max;
 };
 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefMinMax.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefMinMax.hpp
@@ -14,53 +14,69 @@
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct MaxEqOtherOp : all_op {
-  MaxEqOtherOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : other(count), min(T(0)), max((T)seg.size() - (T)1),
+  MaxEqOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dother(dcount), hother(hcount), min(T(0)), max((T)seg.size() - (T)1),
     final_min(max), final_max(max)
-  { count[0] = (T)0; }
+  {
+    hcount[0] = (T)0;
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return other.max((T)i); }
-  RAJA::AtomicRef<T, AtomicPolicy> other;
+    { return dother.max((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchMaxOtherOp : all_op {
-  FetchMaxOtherOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : other(count), min(T(0)), max((T)seg.size() - (T)1),
+  FetchMaxOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dother(dcount), hother(hcount), min(T(0)), max((T)seg.size() - (T)1),
     final_min(max), final_max(max)
-  { count[0] = (T)0; }
+  {
+    hcount[0] = (T)0;
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return other.fetch_max((T)i); }
-  RAJA::AtomicRef<T, AtomicPolicy> other;
+    { return dother.fetch_max((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct MinEqOtherOp : all_op {
-  MinEqOtherOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : other(count), min(T(0)), max((T)seg.size() - (T)1),
+  MinEqOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dother(dcount), hother(hcount), min(T(0)), max((T)seg.size() - (T)1),
     final_min(min), final_max(min)
-  { count[0] = (T)seg.size(); }
+  {
+    hcount[0] = (T)seg.size();
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return other.min((T)i); }
-  RAJA::AtomicRef<T, AtomicPolicy> other;
+    { return dother.min((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchMinOtherOp : all_op {
-  FetchMinOtherOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : other(count), min(T(0)), max((T)seg.size()),
+  FetchMinOtherOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dother(dcount), hother(hcount), min(T(0)), max((T)seg.size()),
     final_min(min), final_max(min)
-  { count[0] = (T)seg.size(); }
+  {
+    hcount[0] = (T)seg.size();
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType i) const
-    { return other.fetch_min((T)i); }
-  RAJA::AtomicRef<T, AtomicPolicy> other;
+    { return dother.fetch_min((T)i); }
+  RAJA::AtomicRef<T, AtomicPolicy> dother;
+  RAJA::AtomicRef<T, AtomicPolicy> hother;
   T min, max, final_min, final_max;
 };
 
@@ -70,9 +86,11 @@ template  < typename ExecPolicy,
             typename T,
             template <typename, typename, typename> class OtherOp>
 void
-testAtomicRefMinMaxOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list)
+testAtomicRefMinMaxOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list,
+    T* hcount, T* hlist,
+    camp::resources::Resource work_res, IdxType N)
 {
-  OtherOp<T, AtomicPolicy, IdxType> otherop(count, seg);
+  OtherOp<T, AtomicPolicy, IdxType> otherop(count, hcount, work_res, seg);
   RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(IdxType i) {
       list[i] = otherop.max + (T)1;
   });
@@ -86,11 +104,15 @@ testAtomicRefMinMaxOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list)
 #if defined(RAJA_ENABLE_HIP)
   hipErrchk(hipDeviceSynchronize());
 #endif
-  EXPECT_LE(otherop.final_min, count[0]);
-  EXPECT_GE(otherop.final_max, count[0]);
+
+  work_res.memcpy( hcount, count, sizeof(T) );
+  work_res.memcpy( hlist, list, sizeof(T) * N );
+
+  EXPECT_LE(otherop.final_min, hcount[0]);
+  EXPECT_GE(otherop.final_max, hcount[0]);
   for (IdxType i = 0; i < seg.size(); i++) {
-    EXPECT_LE(otherop.min, list[i]);
-    EXPECT_GE(otherop.max, list[i]);
+    EXPECT_LE(otherop.min, hlist[i]);
+    EXPECT_GE(otherop.max, hlist[i]);
   }
 }
 
@@ -104,11 +126,15 @@ void ForallAtomicRefMinMaxTestImpl( IdxType N )
 {
   RAJA::TypedRangeSegment<IdxType> seg(0, N);
 
-  camp::resources::Resource count_res{WORKINGRES()};
-  camp::resources::Resource list_res{WORKINGRES()};
+  camp::resources::Resource work_res{WORKINGRES()};
 
-  T * count   = count_res.allocate<T>(1);
-  T * list    = list_res.allocate<T>(N);
+  camp::resources::Resource host_res{camp::resources::Host()};
+
+  T * count   = work_res.allocate<T>(1);
+  T * list    = work_res.allocate<T>(N);
+
+  T * hcount   = host_res.allocate<T>(1);
+  T * hlist    = host_res.allocate<T>(N);
 
 #if defined(RAJA_ENABLE_CUDA)
   cudaErrchk(cudaDeviceSynchronize());
@@ -119,16 +145,18 @@ void ForallAtomicRefMinMaxTestImpl( IdxType N )
 #endif
 
   testAtomicRefMinMaxOp<ExecPolicy, AtomicPolicy, IdxType, T, 
-                       MaxEqOtherOp   >(seg, count, list);
+                       MaxEqOtherOp   >(seg, count, list, hcount, hlist, work_res, N);
   testAtomicRefMinMaxOp<ExecPolicy, AtomicPolicy, IdxType, T, 
-                       FetchMaxOtherOp>(seg, count, list);
+                       FetchMaxOtherOp>(seg, count, list, hcount, hlist, work_res, N);
   testAtomicRefMinMaxOp<ExecPolicy, AtomicPolicy, IdxType, T, 
-                       MinEqOtherOp   >(seg, count, list);
+                       MinEqOtherOp   >(seg, count, list, hcount, hlist, work_res, N);
   testAtomicRefMinMaxOp<ExecPolicy, AtomicPolicy, IdxType, T, 
-                       FetchMinOtherOp>(seg, count, list);
+                       FetchMinOtherOp>(seg, count, list, hcount, hlist, work_res, N);
 
-  count_res.deallocate( count );
-  list_res.deallocate( list );
+  work_res.deallocate( count );
+  work_res.deallocate( list );
+  host_res.deallocate( hcount );
+  host_res.deallocate( hlist );
 }
 
 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefSub.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefSub.hpp
@@ -14,53 +14,69 @@
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct PreDecCountOp {
-  PreDecCountOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : counter(count), min((T)0), max((T)seg.size()-(T)1), final((T)0)
-  { count[0] = (T)seg.size(); }
+  PreDecCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dcounter(dcount), hcounter(hcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
+  {
+    hcount[0] = (T)seg.size();
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const {
-      return (--counter);
+      return (--dcounter);
     }
-  RAJA::AtomicRef<T, AtomicPolicy> counter;
+  RAJA::AtomicRef<T, AtomicPolicy> dcounter;
+  RAJA::AtomicRef<T, AtomicPolicy> hcounter;
   T min, max, final;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct PostDecCountOp {
-  PostDecCountOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : counter(count), min((T)0), max((T)seg.size()-(T)1), final((T)0)
-  { count[0] = (T)seg.size(); }
+  PostDecCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dcounter(dcount), hcounter(hcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
+  {
+    hcount[0] = (T)seg.size();
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const {
-      return (counter--) - (T)1;
+      return (dcounter--) - (T)1;
     }
-  RAJA::AtomicRef<T, AtomicPolicy> counter;
+  RAJA::AtomicRef<T, AtomicPolicy> dcounter;
+  RAJA::AtomicRef<T, AtomicPolicy> hcounter;
   T min, max, final;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct SubEqCountOp {
-  SubEqCountOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : counter(count), min((T)0), max((T)seg.size()-(T)1), final((T)0)
-  { count[0] = (T)seg.size(); }
+  SubEqCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dcounter(dcount), hcounter(hcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
+  {
+    hcount[0] = (T)seg.size();
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const {
-      return (counter -= (T)1);
+      return (dcounter -= (T)1);
     }
-  RAJA::AtomicRef<T, AtomicPolicy> counter;
+  RAJA::AtomicRef<T, AtomicPolicy> dcounter;
+  RAJA::AtomicRef<T, AtomicPolicy> hcounter;
   T min, max, final;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchSubCountOp {
-  FetchSubCountOp(T* count, RAJA::TypedRangeSegment<IdxType> seg)
-    : counter(count), min((T)0), max((T)seg.size()-(T)1), final((T)0)
-  { count[0] = (T)seg.size(); }
+  FetchSubCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
+    : dcounter(dcount), hcounter(hcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
+  {
+    hcount[0] = (T)seg.size();
+    work_res.memcpy(dcount, hcount, sizeof(T));
+  }
   RAJA_HOST_DEVICE
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const {
-      return counter.fetch_sub((T)1) - (T)1;
+      return dcounter.fetch_sub((T)1) - (T)1;
     }
-  RAJA::AtomicRef<T, AtomicPolicy> counter;
+  RAJA::AtomicRef<T, AtomicPolicy> dcounter;
+  RAJA::AtomicRef<T, AtomicPolicy> hcounter;
   T min, max, final;
 };
 
@@ -70,9 +86,11 @@ template <typename ExecPolicy,
          typename T,
          template <typename, typename, typename> class CountOp>
 void testAtomicRefSub(RAJA::TypedRangeSegment<IdxType> seg,
-    T* count, T* list, bool* hit)
+    T* count, T* list, bool* hit,
+    T* hcount, T* hlist, bool* hhit,
+    camp::resources::Resource work_res, IdxType N)
 {
-  CountOp<T, AtomicPolicy, IdxType> countop(count, seg);
+  CountOp<T, AtomicPolicy, IdxType> countop(count, hcount, work_res, seg);
   RAJA::forall<ExecPolicy>(seg, [=] RAJA_HOST_DEVICE(IdxType i) {
       list[i] = countop.max + (T)1;
       hit[i] = false;
@@ -89,11 +107,15 @@ void testAtomicRefSub(RAJA::TypedRangeSegment<IdxType> seg,
   hipErrchk(hipDeviceSynchronize());
 #endif
 
-  EXPECT_EQ(countop.final, count[0]);
+  work_res.memcpy( hcount, count, sizeof(T) );
+  work_res.memcpy( hlist, list, sizeof(T) * N );
+  work_res.memcpy( hhit, hit, sizeof(bool) * N );
+
+  EXPECT_EQ(countop.final, hcount[0]);
   for (IdxType i = 0; i < seg.size(); i++) {
-    EXPECT_LE(countop.min, list[i]);
-    EXPECT_GE(countop.max, list[i]);
-    EXPECT_TRUE(hit[i]);
+    EXPECT_LE(countop.min, hlist[i]);
+    EXPECT_GE(countop.max, hlist[i]);
+    EXPECT_TRUE(hhit[i]);
   }
 }
 
@@ -107,13 +129,17 @@ void ForallAtomicRefSubTestImpl( IdxType N )
 {
   RAJA::TypedRangeSegment<IdxType> seg(0, N);
 
-  camp::resources::Resource count_res{WORKINGRES()};
-  camp::resources::Resource list_res{WORKINGRES()};
-  camp::resources::Resource hit_res{WORKINGRES()};
+  camp::resources::Resource work_res{WORKINGRES()};
 
-  T * count   = count_res.allocate<T>(1);
-  T * list    = list_res.allocate<T>(N);
-  bool * hit  = hit_res.allocate<bool>(N);
+  camp::resources::Resource host_res{camp::resources::Host()};
+
+  T * count   = work_res.allocate<T>(1);
+  T * list    = work_res.allocate<T>(N);
+  bool * hit  = work_res.allocate<bool>(N);
+
+  T * hcount   = host_res.allocate<T>(1);
+  T * hlist    = host_res.allocate<T>(N);
+  bool * hhit  = host_res.allocate<bool>(N);
 
 #if defined(RAJA_ENABLE_CUDA)
   cudaErrchk(cudaDeviceSynchronize());
@@ -124,17 +150,20 @@ void ForallAtomicRefSubTestImpl( IdxType N )
 #endif
 
   testAtomicRefSub<ExecPolicy, AtomicPolicy, IdxType, T, 
-                     PreDecCountOp  >(seg, count, list, hit);
+                     PreDecCountOp  >(seg, count, list, hit, hcount, hlist, hhit, work_res, N);
   testAtomicRefSub<ExecPolicy, AtomicPolicy, IdxType, T, 
-                     PostDecCountOp >(seg, count, list, hit);
+                     PostDecCountOp >(seg, count, list, hit, hcount, hlist, hhit, work_res, N);
   testAtomicRefSub<ExecPolicy, AtomicPolicy, IdxType, T, 
-                     SubEqCountOp   >(seg, count, list, hit);
+                     SubEqCountOp   >(seg, count, list, hit, hcount, hlist, hhit, work_res, N);
   testAtomicRefSub<ExecPolicy, AtomicPolicy, IdxType, T, 
-                     FetchSubCountOp>(seg, count, list, hit);
+                     FetchSubCountOp>(seg, count, list, hit, hcount, hlist, hhit, work_res, N);
 
-  count_res.deallocate( count );
-  list_res.deallocate( list );
-  hit_res.deallocate( hit );
+  work_res.deallocate( count );
+  work_res.deallocate( list );
+  work_res.deallocate( hit );
+  host_res.deallocate( hcount );
+  host_res.deallocate( hlist );
+  host_res.deallocate( hhit ); 
 }
 
 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefSub.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefSub.hpp
@@ -15,64 +15,64 @@
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct PreDecCountOp {
   PreDecCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dcounter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
+    : counter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
   {
     hcount[0] = (T)seg.size();
     work_res.memcpy(dcount, hcount, sizeof(T));
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const {
-      return (--dcounter);
+      return (--counter);
     }
-  RAJA::AtomicRef<T, AtomicPolicy> dcounter;
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
   T min, max, final;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct PostDecCountOp {
   PostDecCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dcounter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
+    : counter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
   {
     hcount[0] = (T)seg.size();
     work_res.memcpy(dcount, hcount, sizeof(T));
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const {
-      return (dcounter--) - (T)1;
+      return (counter--) - (T)1;
     }
-  RAJA::AtomicRef<T, AtomicPolicy> dcounter;
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
   T min, max, final;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct SubEqCountOp {
   SubEqCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dcounter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
+    : counter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
   {
     hcount[0] = (T)seg.size();
     work_res.memcpy(dcount, hcount, sizeof(T));
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const {
-      return (dcounter -= (T)1);
+      return (counter -= (T)1);
     }
-  RAJA::AtomicRef<T, AtomicPolicy> dcounter;
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
   T min, max, final;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchSubCountOp {
   FetchSubCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dcounter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
+    : counter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
   {
     hcount[0] = (T)seg.size();
     work_res.memcpy(dcount, hcount, sizeof(T));
   }
   RAJA_HOST_DEVICE
     T operator()(IdxType RAJA_UNUSED_ARG(i)) const {
-      return dcounter.fetch_sub((T)1) - (T)1;
+      return counter.fetch_sub((T)1) - (T)1;
     }
-  RAJA::AtomicRef<T, AtomicPolicy> dcounter;
+  RAJA::AtomicRef<T, AtomicPolicy> counter;
   T min, max, final;
 };
 

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefSub.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefSub.hpp
@@ -15,7 +15,7 @@
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct PreDecCountOp {
   PreDecCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dcounter(dcount), hcounter(hcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
+    : dcounter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
   {
     hcount[0] = (T)seg.size();
     work_res.memcpy(dcount, hcount, sizeof(T));
@@ -25,14 +25,13 @@ struct PreDecCountOp {
       return (--dcounter);
     }
   RAJA::AtomicRef<T, AtomicPolicy> dcounter;
-  RAJA::AtomicRef<T, AtomicPolicy> hcounter;
   T min, max, final;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct PostDecCountOp {
   PostDecCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dcounter(dcount), hcounter(hcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
+    : dcounter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
   {
     hcount[0] = (T)seg.size();
     work_res.memcpy(dcount, hcount, sizeof(T));
@@ -42,14 +41,13 @@ struct PostDecCountOp {
       return (dcounter--) - (T)1;
     }
   RAJA::AtomicRef<T, AtomicPolicy> dcounter;
-  RAJA::AtomicRef<T, AtomicPolicy> hcounter;
   T min, max, final;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct SubEqCountOp {
   SubEqCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dcounter(dcount), hcounter(hcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
+    : dcounter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
   {
     hcount[0] = (T)seg.size();
     work_res.memcpy(dcount, hcount, sizeof(T));
@@ -59,14 +57,13 @@ struct SubEqCountOp {
       return (dcounter -= (T)1);
     }
   RAJA::AtomicRef<T, AtomicPolicy> dcounter;
-  RAJA::AtomicRef<T, AtomicPolicy> hcounter;
   T min, max, final;
 };
 
 template < typename T, typename AtomicPolicy, typename IdxType >
 struct FetchSubCountOp {
   FetchSubCountOp(T* dcount, T* hcount, camp::resources::Resource work_res, RAJA::TypedRangeSegment<IdxType> seg)
-    : dcounter(dcount), hcounter(hcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
+    : dcounter(dcount), min((T)0), max((T)seg.size()-(T)1), final((T)0)
   {
     hcount[0] = (T)seg.size();
     work_res.memcpy(dcount, hcount, sizeof(T));
@@ -76,7 +73,6 @@ struct FetchSubCountOp {
       return dcounter.fetch_sub((T)1) - (T)1;
     }
   RAJA::AtomicRef<T, AtomicPolicy> dcounter;
-  RAJA::AtomicRef<T, AtomicPolicy> hcounter;
   T min, max, final;
 };
 

--- a/test/functional/forall/atomic-view/tests/test-forall-AtomicView.hpp
+++ b/test/functional/forall/atomic-view/tests/test-forall-AtomicView.hpp
@@ -25,6 +25,7 @@ void ForallAtomicViewTestImpl( IdxType N )
   camp::resources::Resource work_res{WORKINGRES()};
   camp::resources::Resource host_res{camp::resources::Host()};
 
+  T * hsource = host_res.allocate<T>(N);
   T * source = work_res.allocate<T>(N);
   T * dest = work_res.allocate<T>(N/2);
   T * check_array = host_res.allocate<T>(N/2);
@@ -38,7 +39,9 @@ void ForallAtomicViewTestImpl( IdxType N )
 #endif
 
   RAJA::forall<RAJA::seq_exec>(seg,
-                               [=](IdxType i) { source[i] = (T)1; });
+                               [=](IdxType i) { hsource[i] = (T)1; });
+
+  work_res.memcpy( source, hsource, sizeof(T) * N );
 
   // use atomic add to reduce the array
   RAJA::View<T, RAJA::Layout<1>> vec_view(source, N);
@@ -71,6 +74,7 @@ void ForallAtomicViewTestImpl( IdxType N )
     EXPECT_EQ((T)2, check_array[i]);
   }
 
+  host_res.deallocate( hsource );
   work_res.deallocate( source );
   work_res.deallocate( dest );
   host_res.deallocate( check_array );

--- a/test/include/RAJA_test-workgroup.hpp
+++ b/test/include/RAJA_test-workgroup.hpp
@@ -48,7 +48,7 @@ struct ResourceAllocator
         throw std::bad_alloc();
       }
 
-      value_type* ptr = m_res.template allocate<value_type>(num);
+      value_type* ptr = m_res.template allocate<value_type>(num, camp::resources::MemoryAccess::Pinned);
 
       if (!ptr) {
         throw std::bad_alloc();
@@ -59,7 +59,7 @@ struct ResourceAllocator
 
     void deallocate(value_type* ptr, size_t) noexcept
     {
-      m_res.deallocate(ptr);
+      m_res.deallocate(ptr, camp::resources::MemoryAccess::Pinned);
     }
 
     Resource const& get_resource() const

--- a/test/unit/algorithm/tests/test-algorithm-sort-utils.hpp
+++ b/test/unit/algorithm/tests/test-algorithm-sort-utils.hpp
@@ -102,8 +102,8 @@ struct SortData<Res, sort_interface_tag, K, V>
     : m_res(res)
   {
     if (N > 0) {
-      orig_keys = m_res.template allocate<K>(N);
-      sorted_keys = m_res.template allocate<K>(N);
+      orig_keys = m_res.template allocate<K>(N, camp::resources::MemoryAccess::Managed);
+      sorted_keys = m_res.template allocate<K>(N, camp::resources::MemoryAccess::Managed);
     }
 
     for (size_t i = 0; i < N; i++) {
@@ -128,8 +128,8 @@ struct SortData<Res, sort_interface_tag, K, V>
   ~SortData()
   {
     if (orig_keys != nullptr) {
-      m_res.deallocate(orig_keys);
-      m_res.deallocate(sorted_keys);
+      m_res.deallocate(orig_keys, camp::resources::MemoryAccess::Managed);
+      m_res.deallocate(sorted_keys, camp::resources::MemoryAccess::Managed);
     }
   }
 };
@@ -148,8 +148,8 @@ struct SortData<Res, sort_pairs_interface_tag, K, V> : SortData<Res, sort_interf
     : base(N, res, gen_random)
   {
     if (N > 0) {
-      orig_vals = this->m_res.template allocate<V>(N);
-      sorted_vals = this->m_res.template allocate<V>(N);
+      orig_vals = this->m_res.template allocate<V>(N, camp::resources::MemoryAccess::Managed);
+      sorted_vals = this->m_res.template allocate<V>(N, camp::resources::MemoryAccess::Managed);
     }
 
     for (size_t i = 0; i < N; i++) {
@@ -170,8 +170,8 @@ struct SortData<Res, sort_pairs_interface_tag, K, V> : SortData<Res, sort_interf
   ~SortData()
   {
     if (orig_vals != nullptr) {
-      this->m_res.deallocate(orig_vals);
-      this->m_res.deallocate(sorted_vals);
+      this->m_res.deallocate(orig_vals, camp::resources::MemoryAccess::Managed);
+      this->m_res.deallocate(sorted_vals, camp::resources::MemoryAccess::Managed);
     }
   }
 };


### PR DESCRIPTION
# Summary

- This PR is a refactoring
- It does the following:
  - CAMP https://github.com/LLNL/camp/pull/73 makes the resource default to Device allocations. This PR fixes the atomic-ref tests to use Device memory, and temporarily uses Managed memory to shore up the WorkGroup and Sort tests.
  - Updates CAMP to v0.2.1.
