### PR TITLE
We're compiling with pedantic, sorry for the noise

### DIFF
--- a/src/PluginStrategy.cpp
+++ b/src/PluginStrategy.cpp
@@ -7,7 +7,7 @@
 
 #include "RAJA/util/PluginStrategy.hpp"
 
-RAJA_INSTANTIATE_REGISTRY(PluginRegistry);
+RAJA_INSTANTIATE_REGISTRY(PluginRegistry)
 
 namespace RAJA {
 namespace util {


### PR DESCRIPTION
# Summary

- This PR is a bugfix for pedantic compilers
- It does the following (modify list as needed):
  - removes an extra semicolon

Let me know if this is problematic, sorry for the noise