### PR TITLE
Task/kab163/set up multi-project CI with RAJAPerf

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,7 +96,7 @@ stages:
 trigger-rajaperf:
   stage: multi_project
   rules:
-    - if: '$CI_COMMIT_BRANCH == ${MY_BRANCH}' || '$MULTI_PROJECT == "ON"' #run only if ...
+    - if: '$CI_COMMIT_BRANCH == ${MY_BRANCH} || $MULTI_PROJECT == "ON"' #run only if ...
   variables:
     UPDATE_RAJA: ${MY_BRANCH}
   trigger:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,15 +92,15 @@ stages:
 # TODO: Once spack allows to clone a specific commit on demand, then point to the exact commit.
 #       This will prevent from sticking to a branch (here develop).
 #       To turn back on chai trigger, add '$CI_COMMIT_BRANCH == "develop" to rule.
-trigger-chai:
+trigger-rajaperf:
   stage: multi_project
   rules:
-    - if: '$MULTI_PROJECT == "ON"' #run only if ...
+    - if: '$CI_COMMIT_BRANCH == "develop"' || '$MULTI_PROJECT == "ON"' #run only if ...
   variables:
-    UPDATE_RAJA: develop
+    UPDATE_RAJA: task/kab163/setup-multiproject-ci
   trigger:
-    project: radiuss/chai
-    branch: develop
+    project: radiuss/rajaperf
+    branch: task/kab163/setup-multiproject-ci
     strategy: depend
 
 # This is where jobs are included.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,7 @@ variables:
   ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
   BUILD_ROOT: ${CI_PROJECT_DIR}
   DEFAULT_TIME: 30
+  MY_BRANCH: "task/kab163/setup-multiproject-ci"
 
 # Normally, stages are blocking in Gitlab. However, using the keyword "needs" we
 # can express dependencies between job that break the ordering of stages, in
@@ -95,12 +96,12 @@ stages:
 trigger-rajaperf:
   stage: multi_project
   rules:
-    - if: '$CI_COMMIT_BRANCH == "develop"' || '$MULTI_PROJECT == "ON"' #run only if ...
+    - if: '$CI_COMMIT_BRANCH == ${MY_BRANCH}' || '$MULTI_PROJECT == "ON"' #run only if ...
   variables:
-    UPDATE_RAJA: task/kab163/setup-multiproject-ci
+    UPDATE_RAJA: ${MY_BRANCH}
   trigger:
     project: radiuss/rajaperf
-    branch: task/kab163/setup-multiproject-ci
+    branch: ${MY_BRANCH}
     strategy: depend
 
 # This is where jobs are included.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,7 +96,7 @@ stages:
 trigger-rajaperf:
   stage: multi_project
   rules:
-    - if: '$CI_COMMIT_BRANCH == ${MY_BRANCH} || $MULTI_PROJECT == "ON"' #run only if ...
+    - if: '$CI_COMMIT_BRANCH == "${MY_BRANCH}" || $MULTI_PROJECT == "ON"' #run only if ...
   variables:
     UPDATE_RAJA: ${MY_BRANCH}
   trigger:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ variables:
   ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
   BUILD_ROOT: ${CI_PROJECT_DIR}
   DEFAULT_TIME: 30
-  MY_BRANCH: "task/kab163/setup-multiproject-ci"
+  MP_BRANCH: "develop"
 
 # Normally, stages are blocking in Gitlab. However, using the keyword "needs" we
 # can express dependencies between job that break the ordering of stages, in
@@ -92,16 +92,16 @@ stages:
 # If testing develop branch, trigger CHAI pipeline with this version of RAJA.
 # TODO: Once spack allows to clone a specific commit on demand, then point to the exact commit.
 #       This will prevent from sticking to a branch (here develop).
-#       To turn back on chai trigger, add '$CI_COMMIT_BRANCH == "develop" to rule.
+#       MP_BRANCH is short for "Multi-Project Branch" and will usually be develop.
 trigger-rajaperf:
   stage: multi_project
   rules:
-    - if: '$CI_COMMIT_BRANCH == "${MY_BRANCH}" || $MULTI_PROJECT == "ON"' #run only if ...
+    - if: '$CI_COMMIT_BRANCH == "${MP_BRANCH}" || $MULTI_PROJECT == "ON"' #run only if ...
   variables:
-    UPDATE_RAJA: ${MY_BRANCH}
+    UPDATE_RAJA: ${MP_BRANCH}
   trigger:
     project: radiuss/rajaperf
-    branch: ${MY_BRANCH}
+    branch: ${MP_BRANCH}
     strategy: depend
 
 # This is where jobs are included.


### PR DESCRIPTION
# Summary

- This PR is a adding a new Gitlab CI feature
- It does the following adds a multi-project trigger so that whenever there is a new version of the RAJA submodule, the RAJAPerf CI is triggered with that version.

NOTE: This PR should not be merged before RAJAPerf's [PR#192](https://github.com/LLNL/RAJAPerf/pull/192)
