### PR TITLE
Adding basic ForICount Kernel testing.

### DIFF
--- a/test/functional/kernel/CMakeLists.txt
+++ b/test/functional/kernel/CMakeLists.txt
@@ -29,6 +29,8 @@ endif()
 
 add_subdirectory(basic-single-loop)
 
+add_subdirectory(basic-single-icount-loop)
+
 add_subdirectory(nested-loop)
 
 add_subdirectory(nested-loop-segment-types)

--- a/test/functional/kernel/basic-single-icount-loop/CMakeLists.txt
+++ b/test/functional/kernel/basic-single-icount-loop/CMakeLists.txt
@@ -1,0 +1,33 @@
+###############################################################################
+# Copyright (c) 2016-21, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+#
+# List of test types for future expansion, if needed. 
+#
+#set(TESTTYPES Segments)
+#
+#set( USE_RESOURCE "-resource-" "-" )
+
+#
+# Generate tests for each enabled RAJA back-end. 
+# 
+# Note: KERNEL_BACKENDS is defined in ../CMakeLists.txt
+#
+foreach( BACKEND ${KERNEL_BACKENDS} )
+  #  foreach( RESOURCE ${USE_RESOURCE} )
+  #foreach( TESTTYPE ${TESTTYPES} )
+      configure_file( test-kernel-basic-single-icount-loop.cpp.in
+                      test-kernel-basic-single-icount-loop-${BACKEND}.cpp )
+      raja_add_test( NAME test-kernel-basic-single-icount-loop-${BACKEND}
+                     SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-kernel-basic-single-icount-loop-${BACKEND}.cpp )
+      target_include_directories(test-kernel-basic-single-icount-loop-${BACKEND}.exe
+                                 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+                               #endforeach()
+    #endforeach()
+endforeach()
+
+unset( TEST_TYPES )

--- a/test/functional/kernel/basic-single-icount-loop/CMakeLists.txt
+++ b/test/functional/kernel/basic-single-icount-loop/CMakeLists.txt
@@ -6,28 +6,17 @@
 ###############################################################################
 
 #
-# List of test types for future expansion, if needed. 
-#
-#set(TESTTYPES Segments)
-#
-#set( USE_RESOURCE "-resource-" "-" )
-
-#
 # Generate tests for each enabled RAJA back-end. 
 # 
 # Note: KERNEL_BACKENDS is defined in ../CMakeLists.txt
 #
 foreach( BACKEND ${KERNEL_BACKENDS} )
-  #  foreach( RESOURCE ${USE_RESOURCE} )
-  #foreach( TESTTYPE ${TESTTYPES} )
       configure_file( test-kernel-basic-single-icount-loop.cpp.in
                       test-kernel-basic-single-icount-loop-${BACKEND}.cpp )
       raja_add_test( NAME test-kernel-basic-single-icount-loop-${BACKEND}
                      SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-kernel-basic-single-icount-loop-${BACKEND}.cpp )
       target_include_directories(test-kernel-basic-single-icount-loop-${BACKEND}.exe
                                  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-                               #endforeach()
-    #endforeach()
 endforeach()
 
 unset( TEST_TYPES )

--- a/test/functional/kernel/basic-single-icount-loop/test-kernel-basic-single-icount-loop.cpp.in
+++ b/test/functional/kernel/basic-single-icount-loop/test-kernel-basic-single-icount-loop.cpp.in
@@ -1,0 +1,214 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-21, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+//
+// test/include headers
+//
+#include "RAJA_test-base.hpp"
+#include "RAJA_test-camp.hpp"
+#include "RAJA_test-index-types.hpp"
+
+#include "RAJA_test-forall-data.hpp"
+
+//
+// Header for tests in ./tests directory
+//
+// Note: CMake adds ./tests as an include dir for these tests.
+//
+#include "test-kernel-basic-single-icount-loop-segments.hpp"
+
+// Sequential execution policy types
+using SequentialKernelExecPols = camp::list< 
+    
+  RAJA::KernelPolicy<
+    RAJA::statement::ForICount<0, RAJA::statement::Param<0> , RAJA::seq_exec,
+      RAJA::statement::Lambda<0>
+    >
+  >,
+
+  RAJA::KernelPolicy<
+    RAJA::statement::ForICount<0, RAJA::statement::Param<0> , RAJA::loop_exec,
+      RAJA::statement::Lambda<0>
+    >
+  >,
+
+  RAJA::KernelPolicy<
+    RAJA::statement::ForICount<0, RAJA::statement::Param<0> , RAJA::simd_exec,
+      RAJA::statement::Lambda<0>
+    >
+  >
+
+>;
+
+#if defined(RAJA_ENABLE_OPENMP)
+using OpenMPKernelExecPols = camp::list< 
+    
+  RAJA::KernelPolicy<
+    RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::omp_parallel_for_exec,
+      RAJA::statement::Lambda<0>
+    >
+  >,
+
+  RAJA::KernelPolicy<
+    RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::omp_parallel_for_static_exec< >,
+      RAJA::statement::Lambda<0>
+    >
+  >,
+
+#if defined(RAJA_TEST_EXHAUSTIVE)
+  RAJA::KernelPolicy<
+    RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::omp_parallel_for_static_exec<4>,
+      RAJA::statement::Lambda<0>
+    >
+  >,
+
+  RAJA::KernelPolicy<
+    RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::omp_parallel_for_dynamic_exec<2>,
+      RAJA::statement::Lambda<0>
+    >
+  >,
+
+  RAJA::KernelPolicy<
+    RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::omp_parallel_for_guided_exec<3>,
+      RAJA::statement::Lambda<0>
+    >
+  >,
+#endif
+
+  RAJA::KernelPolicy<
+    RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::omp_parallel_for_exec,
+      RAJA::statement::Lambda<0>
+    >
+  >
+
+>;
+#endif  // if defined(RAJA_ENABLE_OPENMP)
+
+#if defined(RAJA_ENABLE_TBB)
+using TBBKernelExecPols = 
+camp::list< 
+
+  RAJA::KernelPolicy<
+    RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::tbb_for_exec,
+      RAJA::statement::Lambda<0>
+    >
+  >,
+
+  RAJA::KernelPolicy<
+    RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::tbb_for_static< >,
+      RAJA::statement::Lambda<0>
+    >
+  >,
+
+#if defined(RAJA_TEST_EXHAUSTIVE)
+  RAJA::KernelPolicy<
+    RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::tbb_for_static< 2 >,
+      RAJA::statement::Lambda<0>
+    >
+  >,
+
+  RAJA::KernelPolicy<
+    RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::tbb_for_static< 4 >,
+      RAJA::statement::Lambda<0>
+    >
+  >,
+
+  RAJA::KernelPolicy<
+    RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::tbb_for_static< 8 >,
+      RAJA::statement::Lambda<0>
+    >
+  >
+#endif
+
+  RAJA::KernelPolicy<
+    RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::tbb_for_dynamic,
+      RAJA::statement::Lambda<0>
+    >
+  >
+
+>;
+#endif  // if defined(RAJA_ENABLE_TBB)
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+using OpenMPTargetKernelExecPols =
+camp::list< 
+
+  RAJA::KernelPolicy<
+     RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::omp_target_parallel_for_exec<4>,
+       RAJA::statement::Lambda<0>
+     >
+  >,
+
+  RAJA::KernelPolicy<
+     RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::omp_target_parallel_for_exec_nt,
+       RAJA::statement::Lambda<0>
+     >
+  >
+
+>;
+#endif  // if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#if defined(RAJA_ENABLE_CUDA)
+using CudaKernelExecPols = 
+camp::list< 
+
+  RAJA::KernelPolicy<
+    RAJA::statement::CudaKernel<
+      RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::cuda_thread_x_loop,
+        RAJA::statement::Lambda<0>
+      >
+    >
+  >,
+
+  RAJA::KernelPolicy<
+    RAJA::statement::CudaKernel<
+      RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::cuda_thread_y_loop,
+        RAJA::statement::Lambda<0>
+      >
+    >
+  >
+
+>;
+#endif  // if defined(RAJA_ENABLE_CUDA)
+
+#if defined(RAJA_ENABLE_HIP)
+using HipKernelExecPols = 
+camp::list< 
+
+  RAJA::KernelPolicy<
+    RAJA::statement::HipKernel<
+      RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::hip_thread_x_loop,  
+        RAJA::statement::Lambda<0>
+      >
+    >
+  >,
+
+  RAJA::KernelPolicy<
+    RAJA::statement::HipKernel<
+      RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::hip_thread_y_loop,
+        RAJA::statement::Lambda<0>
+      > 
+    >
+  >
+
+>;
+#endif  // if defined(RAJA_ENABLE_HIP)
+
+//
+// Cartesian product of types used in parameterized tests
+//
+using @BACKEND@KernelBasicSingleICountLoopTypes =
+  Test< camp::cartesian_product<StrongIdxTypeList,
+                                @BACKEND@ResourceList,
+                                @BACKEND@KernelExecPols>>::Types;
+
+//
+// Instantiate parameterized tests
+//
+INSTANTIATE_TYPED_TEST_SUITE_P(@BACKEND@,
+                               KernelBasicSingleICountLoopTest,
+                               @BACKEND@KernelBasicSingleICountLoopTypes);

--- a/test/functional/kernel/basic-single-icount-loop/tests/basic-single-icount-loop-impl.hpp
+++ b/test/functional/kernel/basic-single-icount-loop/tests/basic-single-icount-loop-impl.hpp
@@ -16,24 +16,7 @@
 #include <numeric>
 #include <vector>
 
-//template<typename EXEC_POL, bool USE_RESOURCE,
-//         typename SEGMENTS,
-//         typename WORKING_RES,
-//         typename... Args>
-//typename std::enable_if< USE_RESOURCE >::type call_kernel(SEGMENTS&& segs, WORKING_RES work_res, Args&&... args) {
-//  RAJA::kernel_resource<EXEC_POL>( segs, work_res, args...);
-//}
-//
-//template<typename EXEC_POL, bool USE_RESOURCE,
-//         typename SEGMENTS,
-//         typename WORKING_RES,
-//         typename... Args>
-//typename std::enable_if< !USE_RESOURCE >::type call_kernel(SEGMENTS&& segs, WORKING_RES, Args&&... args) {
-//  RAJA::kernel<EXEC_POL>( segs, args...);
-//}
-
-template <typename IDX_TYPE, typename EXEC_POLICY, typename WORKING_RES,
-          typename SEG_TYPE, bool USE_RESOURCE>
+template <typename IDX_TYPE, typename EXEC_POLICY, typename WORKING_RES, typename SEG_TYPE>
 void KernelBasicSingleICountLoopTestImpl(const SEG_TYPE& seg, 
                                    const std::vector<IDX_TYPE>& seg_idx,
                                    WORKING_RES working_res,
@@ -90,8 +73,6 @@ void KernelBasicSingleICountLoopTestImpl(const SEG_TYPE& seg,
       RAJA::make_tuple(seg),
       RAJA::make_tuple(IDX_TYPE(0)),
       
-      //working_res,
-
       [=] RAJA_HOST_DEVICE(IDX_TYPE idx, IDX_TYPE i_idx) {
         working_array[RAJA::stripIndexType(idx)] = IDX_TYPE(idx) ;
         working_array_i[RAJA::stripIndexType(i_idx)] = IDX_TYPE(i_idx) ;
@@ -104,8 +85,6 @@ void KernelBasicSingleICountLoopTestImpl(const SEG_TYPE& seg,
       RAJA::make_tuple(seg),
       RAJA::make_tuple(IDX_TYPE(0)),
       
-      //working_res,
-
       [=] RAJA_HOST_DEVICE(IDX_TYPE idx, IDX_TYPE i_idx) {
         (void) idx; (void) i_idx;
         working_array[0]++;

--- a/test/functional/kernel/basic-single-icount-loop/tests/basic-single-icount-loop-impl.hpp
+++ b/test/functional/kernel/basic-single-icount-loop/tests/basic-single-icount-loop-impl.hpp
@@ -1,0 +1,141 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-21, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef __BASIC_SINGLE_ICOUNT_LOOP_SEGMENTS_IMPL_HPP__
+#define __BASIC_SINGLE_ICOUNT_LOOP_SEGMENTS_IMPL_HPP__
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+//template<typename EXEC_POL, bool USE_RESOURCE,
+//         typename SEGMENTS,
+//         typename WORKING_RES,
+//         typename... Args>
+//typename std::enable_if< USE_RESOURCE >::type call_kernel(SEGMENTS&& segs, WORKING_RES work_res, Args&&... args) {
+//  RAJA::kernel_resource<EXEC_POL>( segs, work_res, args...);
+//}
+//
+//template<typename EXEC_POL, bool USE_RESOURCE,
+//         typename SEGMENTS,
+//         typename WORKING_RES,
+//         typename... Args>
+//typename std::enable_if< !USE_RESOURCE >::type call_kernel(SEGMENTS&& segs, WORKING_RES, Args&&... args) {
+//  RAJA::kernel<EXEC_POL>( segs, args...);
+//}
+
+template <typename IDX_TYPE, typename EXEC_POLICY, typename WORKING_RES,
+          typename SEG_TYPE, bool USE_RESOURCE>
+void KernelBasicSingleICountLoopTestImpl(const SEG_TYPE& seg, 
+                                   const std::vector<IDX_TYPE>& seg_idx,
+                                   WORKING_RES working_res,
+                                   camp::resources::Resource erased_working_res)
+{
+  IDX_TYPE idx_len = static_cast<IDX_TYPE>( seg_idx.size() );
+  IDX_TYPE data_len = IDX_TYPE(0);
+  if ( seg_idx.size() > 0 ) {
+    data_len = seg_idx[seg_idx.size() - 1] + 1;
+  }
+
+  IDX_TYPE* working_array;
+  IDX_TYPE* working_array_i;
+  IDX_TYPE* check_array;
+  IDX_TYPE* check_array_i;
+  IDX_TYPE* test_array;
+  IDX_TYPE* test_array_i;
+
+  if ( RAJA::stripIndexType(data_len) == 0 ) {
+    data_len++;
+  }
+
+  allocateForallTestData<IDX_TYPE>(data_len,
+                                   erased_working_res,
+                                   &working_array,
+                                   &check_array,
+                                   &test_array);
+
+  allocateForallTestData<IDX_TYPE>(data_len,
+                                   erased_working_res,
+                                   &working_array_i,
+                                   &check_array_i,
+                                   &test_array_i);
+
+  memset(static_cast<void*>(test_array), 0, 
+         sizeof(IDX_TYPE) * RAJA::stripIndexType(data_len));
+
+  working_res.memcpy(working_array, test_array, 
+                     sizeof(IDX_TYPE) * RAJA::stripIndexType(data_len));
+
+  working_res.memcpy(working_array_i, test_array_i, 
+                     sizeof(IDX_TYPE) * RAJA::stripIndexType(data_len));
+
+  if ( RAJA::stripIndexType(idx_len) > 0 ) {
+
+    for (IDX_TYPE i = IDX_TYPE(0); i < idx_len; ++i) {
+      test_array  [ RAJA::stripIndexType(seg_idx[RAJA::stripIndexType(i)]) ] = 
+        seg_idx[RAJA::stripIndexType(i)];
+      test_array_i[ RAJA::stripIndexType(RAJA::stripIndexType(i)) ] = 
+        IDX_TYPE(i);
+    }
+ 
+    RAJA::kernel_param<EXEC_POLICY>(
+      RAJA::make_tuple(seg),
+      RAJA::make_tuple(IDX_TYPE(0)),
+      
+      //working_res,
+
+      [=] RAJA_HOST_DEVICE(IDX_TYPE idx, IDX_TYPE i_idx) {
+        working_array[RAJA::stripIndexType(idx)] = IDX_TYPE(idx) ;
+        working_array_i[RAJA::stripIndexType(i_idx)] = IDX_TYPE(i_idx) ;
+      }
+    );
+
+  } else { // zero-length segment
+
+    RAJA::kernel_param<EXEC_POLICY>(
+      RAJA::make_tuple(seg),
+      RAJA::make_tuple(IDX_TYPE(0)),
+      
+      //working_res,
+
+      [=] RAJA_HOST_DEVICE(IDX_TYPE idx, IDX_TYPE i_idx) {
+        (void) idx; (void) i_idx;
+        working_array[0]++;
+        working_array_i[0]++;
+      }
+    );
+
+  }
+
+  working_res.memcpy(check_array, working_array, 
+                     sizeof(IDX_TYPE) * RAJA::stripIndexType(data_len));
+  working_res.memcpy(check_array_i, working_array_i, 
+                     sizeof(IDX_TYPE) * RAJA::stripIndexType(data_len));
+
+  for (IDX_TYPE i = IDX_TYPE(0); i < data_len; ++i) {
+    ASSERT_EQ( test_array[RAJA::stripIndexType(i)],
+               check_array[RAJA::stripIndexType(i)] );
+    ASSERT_EQ( test_array_i[RAJA::stripIndexType(i)],
+               check_array_i[RAJA::stripIndexType(i)] );
+  }
+
+  deallocateForallTestData<IDX_TYPE>(erased_working_res,
+                                     working_array,
+                                     check_array,
+                                     test_array);
+
+  deallocateForallTestData<IDX_TYPE>(erased_working_res,
+                                     working_array_i,
+                                     check_array_i,
+                                     test_array_i);
+}
+
+#endif  // __BASIC_SINGLE_ICOUNT_LOOP_SEGMENTS_IMPL_HPP__

--- a/test/functional/kernel/basic-single-icount-loop/tests/test-kernel-basic-single-icount-loop-segments.hpp
+++ b/test/functional/kernel/basic-single-icount-loop/tests/test-kernel-basic-single-icount-loop-segments.hpp
@@ -1,0 +1,105 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-21, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef __TEST_KERNEL_BASIC_SINGLE_ICOUNT_LOOP_HPP__
+#define __TEST_KERNEL_BASIC_SINGLE_ICOUNT_LOOP_HPP__
+
+#include "basic-single-icount-loop-impl.hpp"
+
+TYPED_TEST_SUITE_P(KernelBasicSingleICountLoopTest);
+template <typename T>
+class KernelBasicSingleICountLoopTest : public ::testing::Test
+{
+};
+
+TYPED_TEST_P(KernelBasicSingleICountLoopTest, BasicSingleICountLoopSegmentKernel)
+{
+  using IDX_TYPE    = typename camp::at<TypeParam, camp::num<0>>::type;
+  using WORKING_RES = typename camp::at<TypeParam, camp::num<1>>::type;
+  using EXEC_POLICY = typename camp::at<TypeParam, camp::num<2>>::type;
+
+  WORKING_RES working_res{WORKING_RES::get_default()};
+  camp::resources::Resource erased_working_res{working_res};
+
+  constexpr bool USE_RES = false;
+
+  std::vector<IDX_TYPE> seg_idx;
+
+// Range segment tests
+  RAJA::TypedRangeSegment<IDX_TYPE> r1( 0, 37 );
+  RAJA::getIndices(seg_idx, r1);
+
+  KernelBasicSingleICountLoopTestImpl<IDX_TYPE, EXEC_POLICY, WORKING_RES,
+                                RAJA::TypedRangeSegment<IDX_TYPE>, USE_RES>(
+                                  r1, seg_idx, working_res, erased_working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeSegment<IDX_TYPE> r2( 3, 2057 );
+  RAJA::getIndices(seg_idx, r2);
+  KernelBasicSingleICountLoopTestImpl<IDX_TYPE, EXEC_POLICY, WORKING_RES,
+                                RAJA::TypedRangeSegment<IDX_TYPE>, USE_RES>(
+                                  r2, seg_idx, working_res, erased_working_res);
+
+  // test zero-length range segment
+  seg_idx.clear();
+  RAJA::TypedRangeSegment<IDX_TYPE> r3( 5, 5 );
+  RAJA::getIndices(seg_idx, r3);
+
+  KernelBasicSingleICountLoopTestImpl<IDX_TYPE, EXEC_POLICY, WORKING_RES,
+                                RAJA::TypedRangeSegment<IDX_TYPE>, USE_RES>(
+                                  r3, seg_idx, working_res, erased_working_res);
+
+// Range-stride segment tests
+  seg_idx.clear();
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> rs1( 0, 188, 2 );
+  RAJA::getIndices(seg_idx, rs1);
+  KernelBasicSingleICountLoopTestImpl<IDX_TYPE, EXEC_POLICY, WORKING_RES,
+                                RAJA::TypedRangeStrideSegment<IDX_TYPE>, USE_RES>(
+                                  rs1, seg_idx, working_res, erased_working_res);
+
+  seg_idx.clear();
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> rs2( 2, 1029, 3 );
+  RAJA::getIndices(seg_idx, rs2);
+  KernelBasicSingleICountLoopTestImpl<IDX_TYPE, EXEC_POLICY, WORKING_RES,
+                                RAJA::TypedRangeStrideSegment<IDX_TYPE>, USE_RES>(
+                                  rs2, seg_idx, working_res, erased_working_res);
+
+  // test zero-length range-stride segment
+  seg_idx.clear();
+  RAJA::TypedRangeStrideSegment<IDX_TYPE> rs3( 2, 2, 3 );
+  RAJA::getIndices(seg_idx, rs3);
+  KernelBasicSingleICountLoopTestImpl<IDX_TYPE, EXEC_POLICY, WORKING_RES,
+                                RAJA::TypedRangeStrideSegment<IDX_TYPE>, USE_RES>(
+                                  rs3, seg_idx, working_res, erased_working_res);
+
+// List segment tests
+  seg_idx.clear();
+  IDX_TYPE last = IDX_TYPE(10567);
+  srand( time(NULL) );
+  for (IDX_TYPE i = IDX_TYPE(0); i < last; ++i) {
+    IDX_TYPE randval = IDX_TYPE( rand() % RAJA::stripIndexType(last) );
+    if ( i < randval ) {
+      seg_idx.push_back(i);
+    }
+  }
+  RAJA::TypedListSegment<IDX_TYPE> l1( &seg_idx[0], seg_idx.size(), erased_working_res);
+  KernelBasicSingleICountLoopTestImpl<IDX_TYPE, EXEC_POLICY, WORKING_RES,
+                                RAJA::TypedListSegment<IDX_TYPE>, USE_RES>(
+                                  l1, seg_idx, working_res, erased_working_res);
+
+  // test zero-length list segment
+  seg_idx.clear();
+  RAJA::TypedListSegment<IDX_TYPE> l2( nullptr, seg_idx.size(), erased_working_res);
+  KernelBasicSingleICountLoopTestImpl<IDX_TYPE, EXEC_POLICY, WORKING_RES,
+                                RAJA::TypedListSegment<IDX_TYPE>, USE_RES>(
+                                  l2, seg_idx, working_res, erased_working_res);
+}
+
+REGISTER_TYPED_TEST_SUITE_P(KernelBasicSingleICountLoopTest,
+                            BasicSingleICountLoopSegmentKernel);
+
+#endif  // __TEST_KERNEL_BASIC_SINGLE_ICOUNT_LOOP_HPP__

--- a/test/functional/kernel/basic-single-icount-loop/tests/test-kernel-basic-single-icount-loop-segments.hpp
+++ b/test/functional/kernel/basic-single-icount-loop/tests/test-kernel-basic-single-icount-loop-segments.hpp
@@ -25,8 +25,6 @@ TYPED_TEST_P(KernelBasicSingleICountLoopTest, BasicSingleICountLoopSegmentKernel
   WORKING_RES working_res{WORKING_RES::get_default()};
   camp::resources::Resource erased_working_res{working_res};
 
-  constexpr bool USE_RES = false;
-
   std::vector<IDX_TYPE> seg_idx;
 
 // Range segment tests
@@ -34,15 +32,15 @@ TYPED_TEST_P(KernelBasicSingleICountLoopTest, BasicSingleICountLoopSegmentKernel
   RAJA::getIndices(seg_idx, r1);
 
   KernelBasicSingleICountLoopTestImpl<IDX_TYPE, EXEC_POLICY, WORKING_RES,
-                                RAJA::TypedRangeSegment<IDX_TYPE>, USE_RES>(
-                                  r1, seg_idx, working_res, erased_working_res);
+                                      RAJA::TypedRangeSegment<IDX_TYPE>>(
+                                      r1, seg_idx, working_res, erased_working_res);
 
   seg_idx.clear();
   RAJA::TypedRangeSegment<IDX_TYPE> r2( 3, 2057 );
   RAJA::getIndices(seg_idx, r2);
   KernelBasicSingleICountLoopTestImpl<IDX_TYPE, EXEC_POLICY, WORKING_RES,
-                                RAJA::TypedRangeSegment<IDX_TYPE>, USE_RES>(
-                                  r2, seg_idx, working_res, erased_working_res);
+                                      RAJA::TypedRangeSegment<IDX_TYPE>>(
+                                      r2, seg_idx, working_res, erased_working_res);
 
   // test zero-length range segment
   seg_idx.clear();
@@ -50,31 +48,31 @@ TYPED_TEST_P(KernelBasicSingleICountLoopTest, BasicSingleICountLoopSegmentKernel
   RAJA::getIndices(seg_idx, r3);
 
   KernelBasicSingleICountLoopTestImpl<IDX_TYPE, EXEC_POLICY, WORKING_RES,
-                                RAJA::TypedRangeSegment<IDX_TYPE>, USE_RES>(
-                                  r3, seg_idx, working_res, erased_working_res);
+                                      RAJA::TypedRangeSegment<IDX_TYPE>>(
+                                      r3, seg_idx, working_res, erased_working_res);
 
 // Range-stride segment tests
   seg_idx.clear();
   RAJA::TypedRangeStrideSegment<IDX_TYPE> rs1( 0, 188, 2 );
   RAJA::getIndices(seg_idx, rs1);
   KernelBasicSingleICountLoopTestImpl<IDX_TYPE, EXEC_POLICY, WORKING_RES,
-                                RAJA::TypedRangeStrideSegment<IDX_TYPE>, USE_RES>(
-                                  rs1, seg_idx, working_res, erased_working_res);
+                                      RAJA::TypedRangeStrideSegment<IDX_TYPE>>(
+                                      rs1, seg_idx, working_res, erased_working_res);
 
   seg_idx.clear();
   RAJA::TypedRangeStrideSegment<IDX_TYPE> rs2( 2, 1029, 3 );
   RAJA::getIndices(seg_idx, rs2);
   KernelBasicSingleICountLoopTestImpl<IDX_TYPE, EXEC_POLICY, WORKING_RES,
-                                RAJA::TypedRangeStrideSegment<IDX_TYPE>, USE_RES>(
-                                  rs2, seg_idx, working_res, erased_working_res);
+                                      RAJA::TypedRangeStrideSegment<IDX_TYPE>>(
+                                      rs2, seg_idx, working_res, erased_working_res);
 
   // test zero-length range-stride segment
   seg_idx.clear();
   RAJA::TypedRangeStrideSegment<IDX_TYPE> rs3( 2, 2, 3 );
   RAJA::getIndices(seg_idx, rs3);
   KernelBasicSingleICountLoopTestImpl<IDX_TYPE, EXEC_POLICY, WORKING_RES,
-                                RAJA::TypedRangeStrideSegment<IDX_TYPE>, USE_RES>(
-                                  rs3, seg_idx, working_res, erased_working_res);
+                                      RAJA::TypedRangeStrideSegment<IDX_TYPE>>(
+                                      rs3, seg_idx, working_res, erased_working_res);
 
 // List segment tests
   seg_idx.clear();
@@ -88,15 +86,15 @@ TYPED_TEST_P(KernelBasicSingleICountLoopTest, BasicSingleICountLoopSegmentKernel
   }
   RAJA::TypedListSegment<IDX_TYPE> l1( &seg_idx[0], seg_idx.size(), erased_working_res);
   KernelBasicSingleICountLoopTestImpl<IDX_TYPE, EXEC_POLICY, WORKING_RES,
-                                RAJA::TypedListSegment<IDX_TYPE>, USE_RES>(
-                                  l1, seg_idx, working_res, erased_working_res);
+                                      RAJA::TypedListSegment<IDX_TYPE>>(
+                                      l1, seg_idx, working_res, erased_working_res);
 
   // test zero-length list segment
   seg_idx.clear();
   RAJA::TypedListSegment<IDX_TYPE> l2( nullptr, seg_idx.size(), erased_working_res);
   KernelBasicSingleICountLoopTestImpl<IDX_TYPE, EXEC_POLICY, WORKING_RES,
-                                RAJA::TypedListSegment<IDX_TYPE>, USE_RES>(
-                                  l2, seg_idx, working_res, erased_working_res);
+                                      RAJA::TypedListSegment<IDX_TYPE>>(
+                                      l2, seg_idx, working_res, erased_working_res);
 }
 
 REGISTER_TYPED_TEST_SUITE_P(KernelBasicSingleICountLoopTest,


### PR DESCRIPTION
# Summary

- This PR is a part of the test refactor
- It does the following:
  - Adds basic ForICount tests to the functional kernel test suite. 
  - Tests Kernel ForICount across common exec policies and index types.
  - Supports testing StronglyTyped types.

### TODO:
- [x] Remove or enable resource testing with ForICount. I temporarily left the Resource stuff commented in case we want to test with / without resources. I assume it's probably not really necessary.
