### PR TITLE
Add cuda/hip error string to exception

### DIFF
--- a/include/RAJA/policy/cuda/raja_cudaerrchk.hpp
+++ b/include/RAJA/policy/cuda/raja_cudaerrchk.hpp
@@ -54,9 +54,19 @@ inline void cudaAssert(cudaError_t code,
                        bool abort = true)
 {
   if (code != cudaSuccess) {
-    fprintf(
-        stderr, "CUDAassert: %s %s %d\n", cudaGetErrorString(code), file, line);
-    if (abort) RAJA_ABORT_OR_THROW("CUDAassert");
+    if (abort) {
+      std::string msg;
+      msg += "CUDAassert: ";
+      msg += cudaGetErrorString(code);
+      msg += " ";
+      msg += file;
+      msg += ":";
+      msg += std::to_string(line);
+      throw std::runtime_error(msg);
+    } else {
+      fprintf(stderr, "CUDAassert: %s %s %d\n",
+              cudaGetErrorString(code), file, line);
+    }
   }
 }
 

--- a/include/RAJA/policy/hip/raja_hiperrchk.hpp
+++ b/include/RAJA/policy/hip/raja_hiperrchk.hpp
@@ -53,9 +53,19 @@ inline void hipAssert(hipError_t code,
                        bool abort = true)
 {
   if (code != hipSuccess) {
-    fprintf(
-        stderr, "HIPassert: %s %s %d\n", hipGetErrorString(code), file, line);
-    if (abort) RAJA_ABORT_OR_THROW("HIPassert");
+    if (abort) {
+      std::string msg;
+      msg += "HIPassert: ";
+      msg += hipGetErrorString(code);
+      msg += " ";
+      msg += file;
+      msg += ":";
+      msg += std::to_string(line);
+      throw std::runtime_error(msg);
+    } else {
+      fprintf(stderr, "HIPassert: %s %s %d\n",
+              hipGetErrorString(code), file, line);
+    }
   }
 }
 


### PR DESCRIPTION
# Summary
Make the details of a cuda or hip error part of the exception
string instead of printing to stderr.

- This PR is a feature, 
- It does the following:
  - Fixes #1129 
  - Adds error name to exception at the request of multiple people
