### PR TITLE
Enable hip device functions automatically

### DIFF
--- a/cmake/SetupRajaConfig.cmake
+++ b/cmake/SetupRajaConfig.cmake
@@ -66,8 +66,6 @@ set(RAJA_ENABLE_HIP ${ENABLE_HIP})
 set(RAJA_ENABLE_SYCL ${ENABLE_SYCL})
 set(RAJA_ENABLE_CUB ${ENABLE_CUB})
 
-option(RAJA_ENABLE_HIP_INDIRECT_FUNCTION_CALL "Enable use of device function pointers in hip backend" OFF)
-
 # Configure a header file with all the variables we found.
 configure_file(${PROJECT_SOURCE_DIR}/include/RAJA/config.hpp.in
   ${PROJECT_BINARY_DIR}/include/RAJA/config.hpp)

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -104,8 +104,6 @@
 #cmakedefine RAJA_ENABLE_NV_TOOLS_EXT
 #cmakedefine RAJA_ENABLE_ROCTX
 
-#cmakedefine RAJA_ENABLE_HIP_INDIRECT_FUNCTION_CALL
-
 /*!
  ******************************************************************************
  *
@@ -183,6 +181,13 @@ namespace RAJA {
 
 #if defined(RAJA_ENABLE_HIP) && defined(__HIPCC__)
 #define RAJA_HIP_ACTIVE
+
+// enable device function pointers with rocm version >= 4.3
+#include <hip/hip_version.h>
+#if (HIP_VERSION_MAJOR > 4) || \
+    (HIP_VERSION_MAJOR == 4 && HIP_VERSION_MINOR >= 3)
+#define RAJA_ENABLE_HIP_INDIRECT_FUNCTION_CALL
+#endif
 #endif // RAJA_ENABLE_HIP && __HIPCC__
 
 #if defined(RAJA_CUDA_ACTIVE) || \


### PR DESCRIPTION
# Summary
Remove the cmake option RAJA_ENABLE_HIP_INDIRECT_FUNCTION_CALL and choose to define it in the config based on the hip version instead.

- This PR is a feature
- It does the following (modify list as needed):
  - Adds automatic hip device call support detection

# Design review

I chose to remove the cmake option RAJA_ENABLE_HIP_INDIRECT_FUNCTION_CALL in favor of checking and defining/not defining the var in the config because my original intention was to not allow this to be configurable. It is also possible to make this user configurable in cmake with the default checking the compiler version in cmake to set RAJA_ENABLE_HIP_INDIRECT_FUNCTION_CALL appropriately.