### PR TITLE
Kokkos Tools first attempt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,13 +192,17 @@ set (raja_sources
   src/MemUtils_CUDA.cpp
   src/MemUtils_HIP.cpp
   src/MemUtils_SYCL.cpp
-  src/PluginStrategy.cpp)
+  src/PluginStrategy.cpp
+)
 
 if (RAJA_ENABLE_RUNTIME_PLUGINS)
   set (raja_sources
     ${raja_sources}
     src/RuntimePluginLoader.cpp
-    src/KokkosPluginLoader.cpp)
+    src/KokkosPluginLoader.cpp
+    src/Kokkos_Command_Line_Parsing.cpp
+    src/Kokkos_Profiling.cpp
+)
 endif ()
 
 set (raja_depends)
@@ -312,7 +316,7 @@ blt_add_library(
   DEPENDS_ON ${raja_depends} camp ${CMAKE_DL_LIBS}
   DEFINES ${raja_defines})
 
-
+target_compile_definitions(RAJA PUBLIC KOKKOS_TOOLS_INDEPENDENT_BUILD)
 install(TARGETS RAJA
   EXPORT RAJA
   ARCHIVE DESTINATION lib
@@ -322,11 +326,20 @@ install(TARGETS RAJA
 
 install(EXPORT RAJA DESTINATION share/raja/cmake/)
 
+#target_include_directories(RAJA
+#  PUBLIC
+#  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+#  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/RAJA/tools/>
+#  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+#  $<INSTALL_INTERFACE:include>
+#  $<INSTALL_INTERFACE:${PROJECT_BINARY_DIR}/include/RAJA/tools/>
+#)
 target_include_directories(RAJA
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
+  $<INSTALL_INTERFACE:include>
+)
 if (ENABLE_CUDA AND NOT ENABLE_EXTERNAL_CUB)
   target_include_directories(RAJA SYSTEM
     PUBLIC

--- a/include/impl/Kokkos_Command_Line_Parsing.hpp
+++ b/include/impl/Kokkos_Command_Line_Parsing.hpp
@@ -1,0 +1,63 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_COMMAND_LINE_PARSING_HPP
+#define KOKKOS_COMMAND_LINE_PARSING_HPP
+
+#include <string>
+#include <iosfwd>
+
+namespace Kokkos {
+namespace Impl {
+bool is_unsigned_int(const char* str);
+bool check_arg(char const* arg, char const* expected);
+// void throw_runtime_exception(const std::string& msg);
+bool check_int_arg(char const* arg, char const* expected, int* value);
+bool check_str_arg(char const* arg, char const* expected, std::string& value);
+void warn_deprecated_command_line_argument(std::string deprecated,
+                                           std::string valid);
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif

--- a/include/impl/Kokkos_Profiling.hpp
+++ b/include/impl/Kokkos_Profiling.hpp
@@ -1,0 +1,405 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_IMPL_KOKKOS_PROFILING_HPP
+#define KOKKOS_IMPL_KOKKOS_PROFILING_HPP
+
+#include <impl/Kokkos_Profiling_Interface.hpp>
+#include <memory>
+#include <iosfwd>
+#include <unordered_map>
+#include <map>
+#include <string>
+#include <type_traits>
+#include <mutex>
+namespace Kokkos {
+
+// forward declaration
+bool tune_internals() noexcept;
+
+namespace Tools {
+
+struct InitArguments {
+  // NOTE DZP: PossiblyUnsetOption was introduced
+  // before C++17, std::optional is a better choice
+  // for this long-term
+  static const std::string unset_string_option;
+  enum PossiblyUnsetOption { unset, off, on };
+  PossiblyUnsetOption tune_internals = unset;
+  PossiblyUnsetOption help           = unset;
+  std::string lib                    = unset_string_option;
+  std::string args                   = unset_string_option;
+};
+
+namespace Impl {
+
+struct InitializationStatus {
+  enum InitializationResult {
+    success,
+    failure,
+    help_request,
+    environment_argument_mismatch
+  };
+  InitializationResult result;
+  std::string error_message;
+};
+InitializationStatus initialize_tools_subsystem(
+    const Kokkos::Tools::InitArguments& args);
+
+void parse_command_line_arguments(int& narg, char* arg[],
+                                  InitArguments& arguments);
+Kokkos::Tools::Impl::InitializationStatus parse_environment_variables(
+    InitArguments& arguments);
+
+}  // namespace Impl
+
+bool profileLibraryLoaded();
+
+void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
+                      uint64_t* kernelID);
+void endParallelFor(const uint64_t kernelID);
+void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
+                       uint64_t* kernelID);
+void endParallelScan(const uint64_t kernelID);
+void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
+                         uint64_t* kernelID);
+void endParallelReduce(const uint64_t kernelID);
+
+void pushRegion(const std::string& kName);
+void popRegion();
+
+void createProfileSection(const std::string& sectionName, uint32_t* secID);
+void startSection(const uint32_t secID);
+void stopSection(const uint32_t secID);
+void destroyProfileSection(const uint32_t secID);
+
+void markEvent(const std::string& evName);
+
+void allocateData(const SpaceHandle space, const std::string label,
+                  const void* ptr, const uint64_t size);
+void deallocateData(const SpaceHandle space, const std::string label,
+                    const void* ptr, const uint64_t size);
+
+void beginDeepCopy(const SpaceHandle dst_space, const std::string dst_label,
+                   const void* dst_ptr, const SpaceHandle src_space,
+                   const std::string src_label, const void* src_ptr,
+                   const uint64_t size);
+void endDeepCopy();
+void beginFence(const std::string name, const uint32_t deviceId,
+                uint64_t* handle);
+void endFence(const uint64_t handle);
+
+/**
+ * syncDualView declares to the tool that a given DualView
+ * has been synced.
+ *
+ * Arguments:
+ *
+ * label:     name of the View within the DualView
+ * ptr:       that View's data ptr
+ * to_device: true if the data is being synchronized to the device
+ * 		false otherwise
+ */
+void syncDualView(const std::string& label, const void* const ptr,
+                  bool to_device);
+/**
+ * modifyDualView declares to the tool that a given DualView
+ * has been modified. Note: this means that somebody *called*
+ * modify on the DualView, this doesn't get called any time
+ * somebody touches the data
+ *
+ * Arguments:
+ *
+ * label:     name of the View within the DualView
+ * ptr:       that View's data ptr
+ * on_device: true if the data is being modified on the device
+ * 		false otherwise
+ */
+void modifyDualView(const std::string& label, const void* const ptr,
+                    bool on_device);
+
+void declareMetadata(const std::string& key, const std::string& value);
+void initialize(
+    const std::string& = {});  // should rename to impl_initialize ASAP
+void initialize(const Kokkos::Tools::InitArguments&);
+void initialize(int argc, char* argv[]);
+void finalize();
+bool printHelp(const std::string&);
+void parseArgs(const std::string&);
+
+Kokkos_Profiling_SpaceHandle make_space_handle(const char* space_name);
+
+namespace Experimental {
+
+namespace Impl {
+struct DirectFenceIDHandle {
+  uint32_t value;
+};
+//
+template <typename Space>
+uint32_t idForInstance(const uintptr_t instance) {
+  static std::mutex instance_mutex;
+  const std::lock_guard<std::mutex> lock(instance_mutex);
+  /** Needed to be a ptr due to initialization order problems*/
+  using map_type = std::map<uintptr_t, uint32_t>;
+
+  static std::shared_ptr<map_type> map;
+  if (map.get() == nullptr) {
+    map = std::make_shared<map_type>(map_type());
+  }
+
+  static uint32_t value = 0;
+  constexpr const uint32_t offset =
+      Kokkos::Tools::Experimental::NumReservedDeviceIDs;
+
+  auto find = map->find(instance);
+  if (find == map->end()) {
+    auto ret         = offset + value++;
+    (*map)[instance] = ret;
+    return ret;
+  }
+
+  return find->second;
+}
+
+template <typename Space, typename FencingFunctor>
+void profile_fence_event(const std::string& name, DirectFenceIDHandle devIDTag,
+                         const FencingFunctor& func) {
+  uint64_t handle = 0;
+  Kokkos::Tools::beginFence(
+      name,
+      Kokkos::Tools::Experimental::device_id_root<Space>() + devIDTag.value,
+      &handle);
+  func();
+  Kokkos::Tools::endFence(handle);
+}
+
+inline uint32_t int_for_synchronization_reason(
+    Kokkos::Tools::Experimental::SpecialSynchronizationCases reason) {
+  switch (reason) {
+    case GlobalDeviceSynchronization: return 0;
+    case DeepCopyResourceSynchronization: return 0x00ffffff;
+  }
+  return 0;
+}
+
+template <typename Space, typename FencingFunctor>
+void profile_fence_event(
+    const std::string& name,
+    Kokkos::Tools::Experimental::SpecialSynchronizationCases reason,
+    const FencingFunctor& func) {
+  uint64_t handle = 0;
+  Kokkos::Tools::beginFence(
+      name, device_id_root<Space>() + int_for_synchronization_reason(reason),
+      &handle);  // TODO: correct ID
+  func();
+  Kokkos::Tools::endFence(handle);
+}
+}  // namespace Impl
+void set_init_callback(initFunction callback);
+void set_finalize_callback(finalizeFunction callback);
+void set_parse_args_callback(parseArgsFunction callback);
+void set_print_help_callback(printHelpFunction callback);
+void set_begin_parallel_for_callback(beginFunction callback);
+void set_end_parallel_for_callback(endFunction callback);
+void set_begin_parallel_reduce_callback(beginFunction callback);
+void set_end_parallel_reduce_callback(endFunction callback);
+void set_begin_parallel_scan_callback(beginFunction callback);
+void set_end_parallel_scan_callback(endFunction callback);
+void set_push_region_callback(pushFunction callback);
+void set_pop_region_callback(popFunction callback);
+void set_allocate_data_callback(allocateDataFunction callback);
+void set_deallocate_data_callback(deallocateDataFunction callback);
+void set_create_profile_section_callback(createProfileSectionFunction callback);
+void set_start_profile_section_callback(startProfileSectionFunction callback);
+void set_stop_profile_section_callback(stopProfileSectionFunction callback);
+void set_destroy_profile_section_callback(
+    destroyProfileSectionFunction callback);
+void set_profile_event_callback(profileEventFunction callback);
+void set_begin_deep_copy_callback(beginDeepCopyFunction callback);
+void set_end_deep_copy_callback(endDeepCopyFunction callback);
+void set_begin_fence_callback(beginFenceFunction callback);
+void set_end_fence_callback(endFenceFunction callback);
+void set_dual_view_sync_callback(dualViewSyncFunction callback);
+void set_dual_view_modify_callback(dualViewModifyFunction callback);
+void set_declare_metadata_callback(declareMetadataFunction callback);
+void set_request_tool_settings_callback(requestToolSettingsFunction callback);
+void set_provide_tool_programming_interface_callback(
+    provideToolProgrammingInterfaceFunction callback);
+void set_declare_output_type_callback(outputTypeDeclarationFunction callback);
+void set_declare_input_type_callback(inputTypeDeclarationFunction callback);
+void set_request_output_values_callback(requestValueFunction callback);
+void set_declare_optimization_goal_callback(
+    optimizationGoalDeclarationFunction callback);
+void set_end_context_callback(contextEndFunction callback);
+void set_begin_context_callback(contextBeginFunction callback);
+
+void pause_tools();
+void resume_tools();
+
+EventSet get_callbacks();
+void set_callbacks(EventSet new_events);
+}  // namespace Experimental
+
+namespace Experimental {
+// forward declarations
+size_t get_new_context_id();
+size_t get_current_context_id();
+}  // namespace Experimental
+
+}  // namespace Tools
+namespace Profiling {
+
+bool profileLibraryLoaded();
+
+void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
+                      uint64_t* kernelID);
+void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
+                         uint64_t* kernelID);
+void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
+                       uint64_t* kernelID);
+void endParallelFor(const uint64_t kernelID);
+void endParallelReduce(const uint64_t kernelID);
+void endParallelScan(const uint64_t kernelID);
+void pushRegion(const std::string& kName);
+void popRegion();
+
+void createProfileSection(const std::string& sectionName, uint32_t* secID);
+void destroyProfileSection(const uint32_t secID);
+void startSection(const uint32_t secID);
+
+void stopSection(const uint32_t secID);
+
+void markEvent(const std::string& eventName);
+void allocateData(const SpaceHandle handle, const std::string name,
+                  const void* data, const uint64_t size);
+void deallocateData(const SpaceHandle space, const std::string label,
+                    const void* ptr, const uint64_t size);
+void beginDeepCopy(const SpaceHandle dst_space, const std::string dst_label,
+                   const void* dst_ptr, const SpaceHandle src_space,
+                   const std::string src_label, const void* src_ptr,
+                   const uint64_t size);
+void endDeepCopy();
+void finalize();
+void initialize(const std::string& = {});
+
+SpaceHandle make_space_handle(const char* space_name);
+
+namespace Experimental {
+using Kokkos::Tools::Experimental::set_allocate_data_callback;
+using Kokkos::Tools::Experimental::set_begin_deep_copy_callback;
+using Kokkos::Tools::Experimental::set_begin_parallel_for_callback;
+using Kokkos::Tools::Experimental::set_begin_parallel_reduce_callback;
+using Kokkos::Tools::Experimental::set_begin_parallel_scan_callback;
+using Kokkos::Tools::Experimental::set_create_profile_section_callback;
+using Kokkos::Tools::Experimental::set_deallocate_data_callback;
+using Kokkos::Tools::Experimental::set_destroy_profile_section_callback;
+using Kokkos::Tools::Experimental::set_end_deep_copy_callback;
+using Kokkos::Tools::Experimental::set_end_parallel_for_callback;
+using Kokkos::Tools::Experimental::set_end_parallel_reduce_callback;
+using Kokkos::Tools::Experimental::set_end_parallel_scan_callback;
+using Kokkos::Tools::Experimental::set_finalize_callback;
+using Kokkos::Tools::Experimental::set_init_callback;
+using Kokkos::Tools::Experimental::set_parse_args_callback;
+using Kokkos::Tools::Experimental::set_pop_region_callback;
+using Kokkos::Tools::Experimental::set_print_help_callback;
+using Kokkos::Tools::Experimental::set_profile_event_callback;
+using Kokkos::Tools::Experimental::set_push_region_callback;
+using Kokkos::Tools::Experimental::set_start_profile_section_callback;
+using Kokkos::Tools::Experimental::set_stop_profile_section_callback;
+
+using Kokkos::Tools::Experimental::EventSet;
+
+using Kokkos::Tools::Experimental::pause_tools;
+using Kokkos::Tools::Experimental::resume_tools;
+
+using Kokkos::Tools::Experimental::get_callbacks;
+using Kokkos::Tools::Experimental::set_callbacks;
+
+}  // namespace Experimental
+}  // namespace Profiling
+
+namespace Tools {
+namespace Experimental {
+
+VariableValue make_variable_value(size_t id, int64_t val);
+VariableValue make_variable_value(size_t id, double val);
+VariableValue make_variable_value(size_t id, const std::string& val);
+
+SetOrRange make_candidate_set(size_t size, std::string* data);
+SetOrRange make_candidate_set(size_t size, int64_t* data);
+SetOrRange make_candidate_set(size_t size, double* data);
+SetOrRange make_candidate_range(double lower, double upper, double step,
+                                bool openLower, bool openUpper);
+
+SetOrRange make_candidate_range(int64_t lower, int64_t upper, int64_t step,
+                                bool openLower, bool openUpper);
+
+void declare_optimization_goal(const size_t context,
+                               const OptimizationGoal& goal);
+
+size_t declare_output_type(const std::string& typeName, VariableInfo info);
+
+size_t declare_input_type(const std::string& typeName, VariableInfo info);
+
+void set_input_values(size_t contextId, size_t count, VariableValue* values);
+
+void end_context(size_t contextId);
+void begin_context(size_t contextId);
+
+void request_output_values(size_t contextId, size_t count,
+                           VariableValue* values);
+
+bool have_tuning_tool();
+
+size_t get_new_context_id();
+size_t get_current_context_id();
+
+size_t get_new_variable_id();
+}  // namespace Experimental
+}  // namespace Tools
+
+}  // namespace Kokkos
+
+#endif

--- a/include/impl/Kokkos_Profiling_C_Interface.h
+++ b/include/impl/Kokkos_Profiling_C_Interface.h
@@ -1,0 +1,296 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_PROFILING_C_INTERFACE_HPP
+#define KOKKOS_PROFILING_C_INTERFACE_HPP
+
+#ifdef __cplusplus
+#include <cstddef>
+#include <cstdint>
+#else
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#endif
+
+#define KOKKOSP_INTERFACE_VERSION 20211015
+
+// Profiling
+
+struct Kokkos_Profiling_KokkosPDeviceInfo {
+  size_t deviceID;
+};
+
+struct Kokkos_Profiling_SpaceHandle {
+  char name[64];
+};
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_initFunction)(
+    const int, const uint64_t, const uint32_t,
+    struct Kokkos_Profiling_KokkosPDeviceInfo*);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_finalizeFunction)();
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_parseArgsFunction)(int, char**);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_printHelpFunction)(char*);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_beginFunction)(const char*, const uint32_t,
+                                               uint64_t*);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_endFunction)(uint64_t);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_pushFunction)(const char*);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_popFunction)();
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_allocateDataFunction)(
+    const struct Kokkos_Profiling_SpaceHandle, const char*, const void*,
+    const uint64_t);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_deallocateDataFunction)(
+    const struct Kokkos_Profiling_SpaceHandle, const char*, const void*,
+    const uint64_t);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_createProfileSectionFunction)(const char*,
+                                                              uint32_t*);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_startProfileSectionFunction)(const uint32_t);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_stopProfileSectionFunction)(const uint32_t);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_destroyProfileSectionFunction)(const uint32_t);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_profileEventFunction)(const char*);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_beginDeepCopyFunction)(
+    struct Kokkos_Profiling_SpaceHandle, const char*, const void*,
+    struct Kokkos_Profiling_SpaceHandle, const char*, const void*, uint64_t);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_endDeepCopyFunction)();
+typedef void (*Kokkos_Profiling_beginFenceFunction)(const char*, const uint32_t,
+                                                    uint64_t*);
+typedef void (*Kokkos_Profiling_endFenceFunction)(uint64_t);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_dualViewSyncFunction)(const char*,
+                                                      const void* const, bool);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_dualViewModifyFunction)(const char*,
+                                                        const void* const,
+                                                        bool);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_declareMetadataFunction)(const char*,
+                                                         const char*);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Tools_toolInvokedFenceFunction)(const uint32_t);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Tools_functionPointer)();
+struct Kokkos_Tools_ToolProgrammingInterface {
+  Kokkos_Tools_toolInvokedFenceFunction fence;
+  // allow addition of more actions
+  Kokkos_Tools_functionPointer padding[31];
+};
+
+struct Kokkos_Tools_ToolSettings {
+  bool requires_global_fencing;
+  bool padding[255];
+};
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Tools_provideToolProgrammingInterfaceFunction)(
+    const uint32_t, struct Kokkos_Tools_ToolProgrammingInterface);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Tools_requestToolSettingsFunction)(
+    const uint32_t, struct Kokkos_Tools_ToolSettings*);
+
+// Tuning
+
+#define KOKKOS_TOOLS_TUNING_STRING_LENGTH 64
+typedef char Kokkos_Tools_Tuning_String[KOKKOS_TOOLS_TUNING_STRING_LENGTH];
+union Kokkos_Tools_VariableValue_ValueUnion {
+  int64_t int_value;
+  double double_value;
+  Kokkos_Tools_Tuning_String string_value;
+};
+
+union Kokkos_Tools_VariableValue_ValueUnionSet {
+  int64_t* int_value;
+  double* double_value;
+  Kokkos_Tools_Tuning_String* string_value;
+};
+
+struct Kokkos_Tools_ValueSet {
+  size_t size;
+  union Kokkos_Tools_VariableValue_ValueUnionSet values;
+};
+
+enum Kokkos_Tools_OptimizationType {
+  Kokkos_Tools_Minimize,
+  Kokkos_Tools_Maximize
+};
+
+struct Kokkos_Tools_OptimzationGoal {
+  size_t type_id;
+  enum Kokkos_Tools_OptimizationType goal;
+};
+
+struct Kokkos_Tools_ValueRange {
+  union Kokkos_Tools_VariableValue_ValueUnion lower;
+  union Kokkos_Tools_VariableValue_ValueUnion upper;
+  union Kokkos_Tools_VariableValue_ValueUnion step;
+  bool openLower;
+  bool openUpper;
+};
+
+enum Kokkos_Tools_VariableInfo_ValueType {
+  kokkos_value_double,
+  kokkos_value_int64,
+  kokkos_value_string,
+};
+
+enum Kokkos_Tools_VariableInfo_StatisticalCategory {
+  kokkos_value_categorical,  // unordered distinct objects
+  kokkos_value_ordinal,      // ordered distinct objects
+  kokkos_value_interval,  // ordered distinct objects for which distance matters
+  kokkos_value_ratio  // ordered distinct objects for which distance matters,
+                      // division matters, and the concept of zero exists
+};
+
+enum Kokkos_Tools_VariableInfo_CandidateValueType {
+  kokkos_value_set,       // I am one of [2,3,4,5]
+  kokkos_value_range,     // I am somewhere in [2,12)
+  kokkos_value_unbounded  // I am [text/int/float], but we don't know at
+                          // declaration time what values are appropriate. Only
+                          // valid for Context Variables
+};
+
+union Kokkos_Tools_VariableInfo_SetOrRange {
+  struct Kokkos_Tools_ValueSet set;
+  struct Kokkos_Tools_ValueRange range;
+};
+
+struct Kokkos_Tools_VariableInfo {
+  enum Kokkos_Tools_VariableInfo_ValueType type;
+  enum Kokkos_Tools_VariableInfo_StatisticalCategory category;
+  enum Kokkos_Tools_VariableInfo_CandidateValueType valueQuantity;
+  union Kokkos_Tools_VariableInfo_SetOrRange candidates;
+  void* toolProvidedInfo;
+};
+
+struct Kokkos_Tools_VariableValue {
+  size_t type_id;
+  union Kokkos_Tools_VariableValue_ValueUnion value;
+  struct Kokkos_Tools_VariableInfo* metadata;
+};
+
+typedef void (*Kokkos_Tools_outputTypeDeclarationFunction)(
+    const char*, const size_t, struct Kokkos_Tools_VariableInfo* info);
+typedef void (*Kokkos_Tools_inputTypeDeclarationFunction)(
+    const char*, const size_t, struct Kokkos_Tools_VariableInfo* info);
+
+typedef void (*Kokkos_Tools_requestValueFunction)(
+    const size_t, const size_t, const struct Kokkos_Tools_VariableValue*,
+    const size_t count, struct Kokkos_Tools_VariableValue*);
+typedef void (*Kokkos_Tools_contextBeginFunction)(const size_t);
+typedef void (*Kokkos_Tools_contextEndFunction)(
+    const size_t, struct Kokkos_Tools_VariableValue);
+typedef void (*Kokkos_Tools_optimizationGoalDeclarationFunction)(
+    const size_t, const struct Kokkos_Tools_OptimzationGoal goal);
+
+struct Kokkos_Profiling_EventSet {
+  Kokkos_Profiling_initFunction init;
+  Kokkos_Profiling_finalizeFunction finalize;
+  Kokkos_Profiling_parseArgsFunction parse_args;
+  Kokkos_Profiling_printHelpFunction print_help;
+  Kokkos_Profiling_beginFunction begin_parallel_for;
+  Kokkos_Profiling_endFunction end_parallel_for;
+  Kokkos_Profiling_beginFunction begin_parallel_reduce;
+  Kokkos_Profiling_endFunction end_parallel_reduce;
+  Kokkos_Profiling_beginFunction begin_parallel_scan;
+  Kokkos_Profiling_endFunction end_parallel_scan;
+  Kokkos_Profiling_pushFunction push_region;
+  Kokkos_Profiling_popFunction pop_region;
+  Kokkos_Profiling_allocateDataFunction allocate_data;
+  Kokkos_Profiling_deallocateDataFunction deallocate_data;
+  Kokkos_Profiling_createProfileSectionFunction create_profile_section;
+  Kokkos_Profiling_startProfileSectionFunction start_profile_section;
+  Kokkos_Profiling_stopProfileSectionFunction stop_profile_section;
+  Kokkos_Profiling_destroyProfileSectionFunction destroy_profile_section;
+  Kokkos_Profiling_profileEventFunction profile_event;
+  Kokkos_Profiling_beginDeepCopyFunction begin_deep_copy;
+  Kokkos_Profiling_endDeepCopyFunction end_deep_copy;
+  Kokkos_Profiling_beginFenceFunction begin_fence;
+  Kokkos_Profiling_endFenceFunction end_fence;
+  Kokkos_Profiling_dualViewSyncFunction sync_dual_view;
+  Kokkos_Profiling_dualViewModifyFunction modify_dual_view;
+  Kokkos_Profiling_declareMetadataFunction declare_metadata;
+  Kokkos_Tools_provideToolProgrammingInterfaceFunction
+      provide_tool_programming_interface;
+  Kokkos_Tools_requestToolSettingsFunction request_tool_settings;
+  char profiling_padding[9 * sizeof(Kokkos_Tools_functionPointer)];
+  Kokkos_Tools_outputTypeDeclarationFunction declare_output_type;
+  Kokkos_Tools_inputTypeDeclarationFunction declare_input_type;
+  Kokkos_Tools_requestValueFunction request_output_values;
+  Kokkos_Tools_contextBeginFunction begin_tuning_context;
+  Kokkos_Tools_contextEndFunction end_tuning_context;
+  Kokkos_Tools_optimizationGoalDeclarationFunction declare_optimization_goal;
+  char padding[232 *
+               sizeof(
+                   Kokkos_Tools_functionPointer)];  // allows us to add another
+                                                    // 256 events to the Tools
+                                                    // interface without
+                                                    // changing struct layout
+};
+
+#endif  // KOKKOS_PROFILING_C_INTERFACE_HPP

--- a/include/impl/Kokkos_Profiling_DeviceInfo.hpp
+++ b/include/impl/Kokkos_Profiling_DeviceInfo.hpp
@@ -1,0 +1,56 @@
+/*
+ //@HEADER
+ // ************************************************************************
+ //
+ //                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+ //
+ // Under the terms of Contract DE-NA0003525 with NTESS,
+ // the U.S. Government retains certain rights in this software.
+ //
+ // Redistribution and use in source and binary forms, with or without
+ // modification, are permitted provided that the following conditions are
+ // met:
+ //
+ // 1. Redistributions of source code must retain the above copyright
+ // notice, this list of conditions and the following disclaimer.
+ //
+ // 2. Redistributions in binary form must reproduce the above copyright
+ // notice, this list of conditions and the following disclaimer in the
+ // documentation and/or other materials provided with the distribution.
+ //
+ // 3. Neither the name of the Corporation nor the names of the
+ // contributors may be used to endorse or promote products derived from
+ // this software without specific prior written permission.
+ //
+ // THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+ // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ // PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+ // CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ // EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ // PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ // PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ //
+ // Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+ //
+ // ************************************************************************
+ //@HEADER
+*/
+
+#ifndef KOKKOSP_DEVICE_INFO_HPP
+#define KOKKOSP_DEVICE_INFO_HPP
+
+#include <cstdint>
+#include <impl/Kokkos_Profiling_C_Interface.h>
+namespace Kokkos {
+namespace Profiling {
+using KokkosPDeviceInfo = Kokkos_Profiling_KokkosPDeviceInfo;
+}  // namespace Profiling
+}  // namespace Kokkos
+
+#endif

--- a/include/impl/Kokkos_Profiling_Interface.hpp
+++ b/include/impl/Kokkos_Profiling_Interface.hpp
@@ -1,0 +1,265 @@
+/*
+ //@HEADER
+ // ************************************************************************
+ //
+ //                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+ //
+ // Under the terms of Contract DE-NA0003525 with NTESS,
+ // the U.S. Government retains certain rights in this software.
+ //
+ // Redistribution and use in source and binary forms, with or without
+ // modification, are permitted provided that the following conditions are
+ // met:
+ //
+ // 1. Redistributions of source code must retain the above copyright
+ // notice, this list of conditions and the following disclaimer.
+ //
+ // 2. Redistributions in binary form must reproduce the above copyright
+ // notice, this list of conditions and the following disclaimer in the
+ // documentation and/or other materials provided with the distribution.
+ //
+ // 3. Neither the name of the Corporation nor the names of the
+ // contributors may be used to endorse or promote products derived from
+ // this software without specific prior written permission.
+ //
+ // THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+ // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ // PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+ // CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ // EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ // PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ // PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ //
+ // Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+ //
+ // ************************************************************************
+ //@HEADER
+ */
+
+#ifndef KOKKOSP_INTERFACE_HPP
+#define KOKKOSP_INTERFACE_HPP
+
+#include <cinttypes>
+#include <cstddef>
+
+#include <cstdlib>
+
+// NOTE: in this Kokkos::Profiling block, do not define anything that shouldn't
+// exist should Profiling be disabled
+
+namespace Kokkos {
+namespace Tools {
+namespace Experimental {
+
+constexpr const uint32_t NumReservedDeviceIDs = 1;
+
+enum SpecialSynchronizationCases : int {
+  GlobalDeviceSynchronization     = 1,
+  DeepCopyResourceSynchronization = 2,
+};
+
+enum struct DeviceType {
+  Serial,
+  OpenMP,
+  Cuda,
+  HIP,
+  OpenMPTarget,
+  HPX,
+  Threads,
+  SYCL,
+  Unknown
+};
+
+struct ExecutionSpaceIdentifier {
+  DeviceType type;
+  uint32_t device_id;
+  uint32_t instance_id;
+};
+inline DeviceType devicetype_from_uint32t(const uint32_t in) {
+  switch (in) {
+    case 0: return DeviceType::Serial;
+    case 1: return DeviceType::OpenMP;
+    case 2: return DeviceType::Cuda;
+    case 3: return DeviceType::HIP;
+    case 4: return DeviceType::OpenMPTarget;
+    case 5: return DeviceType::HPX;
+    case 6: return DeviceType::Threads;
+    case 7: return DeviceType::SYCL;
+    default: return DeviceType::Unknown;  // TODO: error out?
+  }
+}
+
+inline ExecutionSpaceIdentifier identifier_from_devid(const uint32_t in) {
+  // ExecutionSpaceIdentifier out;
+  // out.type = in >> 24;
+  // out.device_id = in >> 17;
+  // out.instance_id = ((uint32_t(-1)) << 17 ) & in;
+  return {devicetype_from_uint32t(in >> 24),
+          (~((uint32_t(-1)) << 24)) & (in >> 17),
+          (~((uint32_t(-1)) << 17)) & in};
+}
+
+template <typename ExecutionSpace>
+struct DeviceTypeTraits;
+
+constexpr const size_t device_type_bits = 8;
+constexpr const size_t instance_bits    = 24;
+template <typename ExecutionSpace>
+constexpr uint32_t device_id_root() {
+  constexpr auto device_id =
+      static_cast<uint32_t>(DeviceTypeTraits<ExecutionSpace>::id);
+  return (device_id << instance_bits);
+}
+template <typename ExecutionSpace>
+inline uint32_t device_id(ExecutionSpace const& space) noexcept {
+  return device_id_root<ExecutionSpace>() + space.impl_instance_id();
+}
+}  // namespace Experimental
+}  // namespace Tools
+}  // end namespace Kokkos
+
+#if defined(KOKKOS_ENABLE_LIBDL)
+// We check at configure time that libdl is available.
+#include <dlfcn.h>
+#endif
+
+#include <impl/Kokkos_Profiling_DeviceInfo.hpp>
+#include <impl/Kokkos_Profiling_C_Interface.h>
+
+namespace Kokkos {
+namespace Tools {
+
+using SpaceHandle = Kokkos_Profiling_SpaceHandle;
+
+}  // namespace Tools
+
+namespace Tools {
+
+namespace Experimental {
+using EventSet = Kokkos_Profiling_EventSet;
+static_assert(sizeof(EventSet) / sizeof(Kokkos_Tools_functionPointer) == 275,
+              "sizeof EventSet has changed, this is an error on the part of a "
+              "Kokkos developer");
+static_assert(sizeof(Kokkos_Tools_ToolSettings) / sizeof(bool) == 256,
+              "sizeof EventSet has changed, this is an error on the part of a "
+              "Kokkos developer");
+static_assert(sizeof(Kokkos_Tools_ToolProgrammingInterface) /
+                      sizeof(Kokkos_Tools_functionPointer) ==
+                  32,
+              "sizeof EventSet has changed, this is an error on the part of a "
+              "Kokkos developer");
+
+using toolInvokedFenceFunction = Kokkos_Tools_toolInvokedFenceFunction;
+using provideToolProgrammingInterfaceFunction =
+    Kokkos_Tools_provideToolProgrammingInterfaceFunction;
+using requestToolSettingsFunction = Kokkos_Tools_requestToolSettingsFunction;
+using ToolSettings                = Kokkos_Tools_ToolSettings;
+using ToolProgrammingInterface    = Kokkos_Tools_ToolProgrammingInterface;
+}  // namespace Experimental
+using initFunction           = Kokkos_Profiling_initFunction;
+using finalizeFunction       = Kokkos_Profiling_finalizeFunction;
+using parseArgsFunction      = Kokkos_Profiling_parseArgsFunction;
+using printHelpFunction      = Kokkos_Profiling_printHelpFunction;
+using beginFunction          = Kokkos_Profiling_beginFunction;
+using endFunction            = Kokkos_Profiling_endFunction;
+using pushFunction           = Kokkos_Profiling_pushFunction;
+using popFunction            = Kokkos_Profiling_popFunction;
+using allocateDataFunction   = Kokkos_Profiling_allocateDataFunction;
+using deallocateDataFunction = Kokkos_Profiling_deallocateDataFunction;
+using createProfileSectionFunction =
+    Kokkos_Profiling_createProfileSectionFunction;
+using startProfileSectionFunction =
+    Kokkos_Profiling_startProfileSectionFunction;
+using stopProfileSectionFunction = Kokkos_Profiling_stopProfileSectionFunction;
+using destroyProfileSectionFunction =
+    Kokkos_Profiling_destroyProfileSectionFunction;
+using profileEventFunction    = Kokkos_Profiling_profileEventFunction;
+using beginDeepCopyFunction   = Kokkos_Profiling_beginDeepCopyFunction;
+using endDeepCopyFunction     = Kokkos_Profiling_endDeepCopyFunction;
+using beginFenceFunction      = Kokkos_Profiling_beginFenceFunction;
+using endFenceFunction        = Kokkos_Profiling_endFenceFunction;
+using dualViewSyncFunction    = Kokkos_Profiling_dualViewSyncFunction;
+using dualViewModifyFunction  = Kokkos_Profiling_dualViewModifyFunction;
+using declareMetadataFunction = Kokkos_Profiling_declareMetadataFunction;
+
+}  // namespace Tools
+
+}  // namespace Kokkos
+
+// Profiling
+
+namespace Kokkos {
+
+namespace Profiling {
+
+/** The Profiling namespace is being renamed to Tools.
+ * This is reexposing the contents of what used to be the Profiling
+ * Interface with their original names, to avoid breaking old code
+ */
+
+namespace Experimental {
+
+using Kokkos::Tools::Experimental::device_id;
+using Kokkos::Tools::Experimental::DeviceType;
+using Kokkos::Tools::Experimental::DeviceTypeTraits;
+
+}  // namespace Experimental
+
+using Kokkos::Tools::allocateDataFunction;
+using Kokkos::Tools::beginDeepCopyFunction;
+using Kokkos::Tools::beginFunction;
+using Kokkos::Tools::createProfileSectionFunction;
+using Kokkos::Tools::deallocateDataFunction;
+using Kokkos::Tools::destroyProfileSectionFunction;
+using Kokkos::Tools::endDeepCopyFunction;
+using Kokkos::Tools::endFunction;
+using Kokkos::Tools::finalizeFunction;
+using Kokkos::Tools::initFunction;
+using Kokkos::Tools::parseArgsFunction;
+using Kokkos::Tools::popFunction;
+using Kokkos::Tools::printHelpFunction;
+using Kokkos::Tools::profileEventFunction;
+using Kokkos::Tools::pushFunction;
+using Kokkos::Tools::SpaceHandle;
+using Kokkos::Tools::startProfileSectionFunction;
+using Kokkos::Tools::stopProfileSectionFunction;
+
+}  // namespace Profiling
+}  // namespace Kokkos
+
+// Tuning
+
+namespace Kokkos {
+namespace Tools {
+namespace Experimental {
+using ValueSet            = Kokkos_Tools_ValueSet;
+using ValueRange          = Kokkos_Tools_ValueRange;
+using StatisticalCategory = Kokkos_Tools_VariableInfo_StatisticalCategory;
+using ValueType           = Kokkos_Tools_VariableInfo_ValueType;
+using CandidateValueType  = Kokkos_Tools_VariableInfo_CandidateValueType;
+using SetOrRange          = Kokkos_Tools_VariableInfo_SetOrRange;
+using VariableInfo        = Kokkos_Tools_VariableInfo;
+using OptimizationGoal    = Kokkos_Tools_OptimzationGoal;
+using TuningString        = Kokkos_Tools_Tuning_String;
+using VariableValue       = Kokkos_Tools_VariableValue;
+
+using outputTypeDeclarationFunction =
+    Kokkos_Tools_outputTypeDeclarationFunction;
+using inputTypeDeclarationFunction = Kokkos_Tools_inputTypeDeclarationFunction;
+using requestValueFunction         = Kokkos_Tools_requestValueFunction;
+using contextBeginFunction         = Kokkos_Tools_contextBeginFunction;
+using contextEndFunction           = Kokkos_Tools_contextEndFunction;
+using optimizationGoalDeclarationFunction =
+    Kokkos_Tools_optimizationGoalDeclarationFunction;
+}  // end namespace Experimental
+}  // end namespace Tools
+
+}  // end namespace Kokkos
+
+#endif

--- a/src/Kokkos_Command_Line_Parsing.cpp
+++ b/src/Kokkos_Command_Line_Parsing.cpp
@@ -1,0 +1,133 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <cstring>
+#include <impl/Kokkos_Command_Line_Parsing.hpp>
+/** Duplicates of Kokkos_Error.cpp/hpp, reproduced here
+ * for use in non-Kokkos applications
+ */
+namespace {
+void traceback_callstack(std::ostream& msg) {
+  msg << std::endl << "Traceback functionality not available" << std::endl;
+}
+void throw_runtime_exception(const std::string& msg) {
+  std::ostringstream o;
+  o << msg;
+  traceback_callstack(o);
+  throw std::runtime_error(o.str());
+}
+}  // namespace
+
+bool Kokkos::Impl::is_unsigned_int(const char* str) {
+  const size_t len = strlen(str);
+  for (size_t i = 0; i < len; ++i) {
+    if (!isdigit(str[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Kokkos::Impl::check_arg(char const* arg, char const* expected) {
+  std::size_t arg_len = std::strlen(arg);
+  std::size_t exp_len = std::strlen(expected);
+  if (arg_len < exp_len) return false;
+  if (std::strncmp(arg, expected, exp_len) != 0) return false;
+  if (arg_len == exp_len) return true;
+
+  if (std::isalnum(arg[exp_len]) || arg[exp_len] == '-' ||
+      arg[exp_len] == '_') {
+    return false;
+  }
+  return true;
+}
+
+bool Kokkos::Impl::check_int_arg(char const* arg, char const* expected,
+                                 int* value) {
+  if (!check_arg(arg, expected)) return false;
+  std::size_t arg_len = std::strlen(arg);
+  std::size_t exp_len = std::strlen(expected);
+  bool okay           = true;
+  if (arg_len == exp_len || arg[exp_len] != '=') okay = false;
+  char const* number = arg + exp_len + 1;
+  if (!Kokkos::Impl::is_unsigned_int(number) || strlen(number) == 0)
+    okay = false;
+  *value = std::stoi(number);
+  if (!okay) {
+    std::ostringstream ss;
+    ss << "Error: expecting an '=INT' after command line argument '" << expected
+       << "'";
+    ss << ". Raised by Kokkos::initialize(int narg, char* argc[]).";
+    throw_runtime_exception(ss.str());
+  }
+  return true;
+}
+bool Kokkos::Impl::check_str_arg(char const* arg, char const* expected,
+                                 std::string& value) {
+  if (!check_arg(arg, expected)) return false;
+  std::size_t arg_len = std::strlen(arg);
+  std::size_t exp_len = std::strlen(expected);
+  bool okay           = true;
+  if (arg_len == exp_len || arg[exp_len] != '=') okay = false;
+  char const* remain = arg + exp_len + 1;
+  value              = remain;
+  if (!okay) {
+    std::ostringstream ss;
+    ss << "Error: expecting an '=STRING' after command line argument '"
+       << expected << "'";
+    ss << ". Raised by Kokkos::initialize(int narg, char* argc[]).";
+    throw_runtime_exception(ss.str());
+  }
+  return true;
+}
+void Kokkos::Impl::warn_deprecated_command_line_argument(std::string deprecated,
+                                                         std::string valid) {
+  std::cerr
+      << "Warning: command line argument '" << deprecated
+      << "' is deprecated. Use '" << valid
+      << "' instead. Raised by Kokkos::initialize(int narg, char* argc[])."
+      << std::endl;
+}

--- a/src/Kokkos_Profiling.cpp
+++ b/src/Kokkos_Profiling.cpp
@@ -1,0 +1,1251 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_TOOLS_INDEPENDENT_BUILD
+#include <Kokkos_Macros.hpp>
+#include <Kokkos_Tuners.hpp>
+#endif
+
+#include <impl/Kokkos_Profiling.hpp>
+#include <impl/Kokkos_Profiling_Interface.hpp>
+#include <impl/Kokkos_Command_Line_Parsing.hpp>
+
+#if defined(KOKKOS_ENABLE_LIBDL) || defined(KOKKOS_TOOLS_INDEPENDENT_BUILD)
+#include <dlfcn.h>
+#define KOKKOS_TOOLS_ENABLE_LIBDL
+#endif
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <stack>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+#include <sstream>
+#include <iostream>
+namespace Kokkos {
+
+namespace Tools {
+
+InitArguments tool_arguments;
+
+const std::string InitArguments::unset_string_option = {
+    "kokkos_tools_impl_unset_option"};
+
+namespace Impl {
+void parse_command_line_arguments(int& narg, char* arg[],
+                                  InitArguments& arguments) {
+  int iarg = 0;
+  using Kokkos::Impl::check_arg;
+  using Kokkos::Impl::check_int_arg;
+  using Kokkos::Impl::check_str_arg;
+
+  auto& lib            = arguments.lib;
+  auto& args           = arguments.args;
+  auto& help           = arguments.help;
+  auto& tune_internals = arguments.tune_internals;
+  while (iarg < narg) {
+    if (check_arg(arg[iarg], "--kokkos-tune-internals")) {
+      tune_internals = InitArguments::PossiblyUnsetOption::on;
+      for (int k = iarg; k < narg - 1; k++) {
+        arg[k] = arg[k + 1];
+      }
+      narg--;
+    } else if (check_str_arg(arg[iarg], "--kokkos-tools-library", lib)) {
+      for (int k = iarg; k < narg - 1; k++) {
+        arg[k] = arg[k + 1];
+      }
+      narg--;
+    } else if (check_str_arg(arg[iarg], "--kokkos-tools-args", args)) {
+      for (int k = iarg; k < narg - 1; k++) {
+        arg[k] = arg[k + 1];
+      }
+      narg--;
+      // strip any leading and/or trailing quotes if they were retained in the
+      // string because this will very likely cause parsing issues for tools.
+      // If the quotes are retained (via bypassing the shell):
+      //    <EXE> --kokkos-tools-args="-c my example"
+      // would be tokenized as:
+      //    "<EXE>" "\"-c" "my" "example\""
+      // instead of:
+      //    "<EXE>" "-c" "my" "example"
+      if (!args.empty()) {
+        if (args.front() == '"') args = args.substr(1);
+        if (args.back() == '"') args = args.substr(0, args.length() - 1);
+      }
+      // add the name of the executable to the beginning
+      if (narg > 0) args = std::string(arg[0]) + " " + args;
+    } else if (check_arg(arg[iarg], "--kokkos-tools-help")) {
+      help = InitArguments::PossiblyUnsetOption::on;
+      for (int k = iarg; k < narg - 1; k++) {
+        arg[k] = arg[k + 1];
+      }
+      narg--;
+    } else {
+      iarg++;
+    }
+    if ((args == Kokkos::Tools::InitArguments::unset_string_option) && narg > 0)
+      args = arg[0];
+  }
+}
+Kokkos::Tools::Impl::InitializationStatus parse_environment_variables(
+    InitArguments& arguments) {
+  auto& tool_lib       = arguments.lib;
+  auto& tune_internals = arguments.tune_internals;
+  auto env_tool_lib    = std::getenv("KOKKOS_PROFILE_LIBRARY");
+  if (env_tool_lib != nullptr) {
+    if ((tool_lib != Kokkos::Tools::InitArguments::unset_string_option) &&
+        std::string(env_tool_lib) != tool_lib)
+      return {Kokkos::Tools::Impl::InitializationStatus::InitializationResult::
+                  environment_argument_mismatch,
+              "Error: expecting a match between --kokkos-tools-library and "
+              "KOKKOS_PROFILE_LIBRARY if both are set. Raised by "
+              "Kokkos::initialize(int narg, char* argc[])."};
+    else
+      tool_lib = env_tool_lib;
+  }
+  char* env_tuneinternals_str = std::getenv("KOKKOS_TUNE_INTERNALS");
+  if (env_tuneinternals_str != nullptr) {
+    std::string env_str(env_tuneinternals_str);  // deep-copies string
+    for (char& c : env_str) {
+      c = toupper(c);
+    }
+    if ((env_str == "TRUE") || (env_str == "ON") || (env_str == "1"))
+      tune_internals = InitArguments::PossiblyUnsetOption::on;
+    else if (tune_internals)
+      return {Kokkos::Tools::Impl::InitializationStatus::InitializationResult::
+                  environment_argument_mismatch,
+              "Error: expecting a match between --kokkos-tune-internals and "
+              "KOKKOS_TUNE_INTERNALS if both are set. Raised by "
+              "Kokkos::initialize(int narg, char* argc[])."};
+  }
+  return {
+      Kokkos::Tools::Impl::InitializationStatus::InitializationResult::success};
+}
+InitializationStatus initialize_tools_subsystem(
+    const Kokkos::Tools::InitArguments& args) {
+  Kokkos::Profiling::initialize(args.lib);
+  auto final_args =
+      (args.args != Kokkos::Tools::InitArguments::unset_string_option)
+          ? args.args
+          : "";
+
+  if (args.help) {
+    if (!Kokkos::Tools::printHelp(final_args)) {
+      std::cerr << "Tool has not provided a help message" << std::endl;
+    }
+    return {InitializationStatus::InitializationResult::help_request};
+  }
+  Kokkos::Tools::parseArgs(final_args);
+  return {InitializationStatus::InitializationResult::success};
+}
+
+}  // namespace Impl
+void initialize(const InitArguments& arguments) {
+  Impl::initialize_tools_subsystem(arguments);
+}
+void initialize(int argc, char* argv[]) {
+  InitArguments arguments;
+  Impl::parse_command_line_arguments(argc, argv, arguments);
+  Impl::parse_environment_variables(arguments);
+  initialize(arguments);
+}
+
+namespace Experimental {
+
+namespace Impl {
+void tool_invoked_fence(const uint32_t /* devID */) {
+  /**
+   * Currently the function ignores the device ID,
+   * Eventually we want to support fencing only
+   * a given stream/resource
+   */
+#ifndef KOKKOS_TOOLS_INDEPENDENT_BUILD
+  Kokkos::fence(
+      "Kokkos::Tools::Experimental::Impl::tool_invoked_fence: Tool Requested "
+      "Fence");
+#endif
+}
+}  // namespace Impl
+
+#ifdef KOKKOS_ENABLE_TUNING
+static size_t kernel_name_context_variable_id;
+static size_t kernel_type_context_variable_id;
+static std::unordered_map<size_t, std::unordered_set<size_t>>
+    features_per_context;
+static std::unordered_set<size_t> active_features;
+static std::unordered_map<size_t, VariableValue> feature_values;
+static std::unordered_map<size_t, VariableInfo> variable_metadata;
+#endif
+static EventSet current_callbacks;
+static EventSet backup_callbacks;
+static EventSet no_profiling;
+static ToolSettings tool_requirements;
+bool eventSetsEqual(const EventSet& l, const EventSet& r) {
+  return l.init == r.init && l.finalize == r.finalize &&
+         l.parse_args == r.parse_args && l.print_help == r.print_help &&
+         l.begin_parallel_for == r.begin_parallel_for &&
+         l.end_parallel_for == r.end_parallel_for &&
+         l.begin_parallel_reduce == r.begin_parallel_reduce &&
+         l.end_parallel_reduce == r.end_parallel_reduce &&
+         l.begin_parallel_scan == r.begin_parallel_scan &&
+         l.end_parallel_scan == r.end_parallel_scan &&
+         l.push_region == r.push_region && l.pop_region == r.pop_region &&
+         l.allocate_data == r.allocate_data &&
+         l.deallocate_data == r.deallocate_data &&
+         l.create_profile_section == r.create_profile_section &&
+         l.start_profile_section == r.start_profile_section &&
+         l.stop_profile_section == r.stop_profile_section &&
+         l.destroy_profile_section == r.destroy_profile_section &&
+         l.profile_event == r.profile_event &&
+         l.begin_deep_copy == r.begin_deep_copy &&
+         l.end_deep_copy == r.end_deep_copy && l.begin_fence == r.begin_fence &&
+         l.end_fence == r.end_fence && l.sync_dual_view == r.sync_dual_view &&
+         l.modify_dual_view == r.modify_dual_view &&
+         l.declare_metadata == r.declare_metadata &&
+         l.request_tool_settings == r.request_tool_settings &&
+         l.provide_tool_programming_interface ==
+             r.provide_tool_programming_interface &&
+         l.declare_input_type == r.declare_input_type &&
+         l.declare_output_type == r.declare_output_type &&
+         l.end_tuning_context == r.end_tuning_context &&
+         l.begin_tuning_context == r.begin_tuning_context &&
+         l.request_output_values == r.request_output_values &&
+         l.declare_optimization_goal == r.declare_optimization_goal;
+}
+enum class MayRequireGlobalFencing : bool { No, Yes };
+template <typename Callback, typename... Args>
+inline void invoke_kokkosp_callback(
+    MayRequireGlobalFencing may_require_global_fencing,
+    const Callback& callback, Args&&... args) {
+  if (callback != nullptr) {
+    // two clause if statement
+    // may_require_global_fencing: "if this callback ever needs a fence", AND
+    // if the tool requires global fencing (default true, but tools can
+    // overwrite)
+    if (may_require_global_fencing == MayRequireGlobalFencing::Yes &&
+        (tool_requirements.requires_global_fencing)) {
+#ifndef KOKKOS_TOOLS_INDEPENDENT_BUILD
+      Kokkos::fence(
+          "Kokkos::Tools::invoke_kokkosp_callback: Kokkos Profile Tool Fence");
+#endif
+    }
+    (*callback)(std::forward<Args>(args)...);
+  }
+}
+}  // namespace Experimental
+bool profileLibraryLoaded() {
+  return !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                       Experimental::no_profiling);
+}
+
+void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
+                      uint64_t* kernelID) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::Yes,
+      Experimental::current_callbacks.begin_parallel_for, kernelPrefix.c_str(),
+      devID, kernelID);
+#ifdef KOKKOS_ENABLE_TUNING
+  if (Kokkos::tune_internals()) {
+    auto context_id = Experimental::get_new_context_id();
+    Experimental::begin_context(context_id);
+    Experimental::VariableValue contextValues[] = {
+        Experimental::make_variable_value(
+            Experimental::kernel_name_context_variable_id, kernelPrefix),
+        Experimental::make_variable_value(
+            Experimental::kernel_type_context_variable_id, "parallel_for")};
+    Experimental::set_input_values(context_id, 2, contextValues);
+  }
+#endif
+}
+
+void endParallelFor(const uint64_t kernelID) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::Yes,
+      Experimental::current_callbacks.end_parallel_for, kernelID);
+#ifdef KOKKOS_ENABLE_TUNING
+  if (Kokkos::tune_internals()) {
+    Experimental::end_context(Experimental::get_current_context_id());
+  }
+#endif
+}
+
+void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
+                       uint64_t* kernelID) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::Yes,
+      Experimental::current_callbacks.begin_parallel_scan, kernelPrefix.c_str(),
+      devID, kernelID);
+#ifdef KOKKOS_ENABLE_TUNING
+  if (Kokkos::tune_internals()) {
+    auto context_id = Experimental::get_new_context_id();
+    Experimental::begin_context(context_id);
+    Experimental::VariableValue contextValues[] = {
+        Experimental::make_variable_value(
+            Experimental::kernel_name_context_variable_id, kernelPrefix),
+        Experimental::make_variable_value(
+            Experimental::kernel_type_context_variable_id, "parallel_for")};
+    Experimental::set_input_values(context_id, 2, contextValues);
+  }
+#endif
+}
+
+void endParallelScan(const uint64_t kernelID) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::Yes,
+      Experimental::current_callbacks.end_parallel_scan, kernelID);
+#ifdef KOKKOS_ENABLE_TUNING
+  if (Kokkos::tune_internals()) {
+    Experimental::end_context(Experimental::get_current_context_id());
+  }
+#endif
+}
+
+void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
+                         uint64_t* kernelID) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::Yes,
+      Experimental::current_callbacks.begin_parallel_reduce,
+      kernelPrefix.c_str(), devID, kernelID);
+#ifdef KOKKOS_ENABLE_TUNING
+  if (Kokkos::tune_internals()) {
+    auto context_id = Experimental::get_new_context_id();
+    Experimental::begin_context(context_id);
+    Experimental::VariableValue contextValues[] = {
+        Experimental::make_variable_value(
+            Experimental::kernel_name_context_variable_id, kernelPrefix),
+        Experimental::make_variable_value(
+            Experimental::kernel_type_context_variable_id, "parallel_for")};
+    Experimental::set_input_values(context_id, 2, contextValues);
+  }
+#endif
+}
+
+void endParallelReduce(const uint64_t kernelID) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::Yes,
+      Experimental::current_callbacks.end_parallel_reduce, kernelID);
+#ifdef KOKKOS_ENABLE_TUNING
+  if (Kokkos::tune_internals()) {
+    Experimental::end_context(Experimental::get_current_context_id());
+  }
+#endif
+}
+
+void pushRegion(const std::string& kName) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::Yes,
+      Experimental::current_callbacks.push_region, kName.c_str());
+}
+
+void popRegion() {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::Yes,
+      Experimental::current_callbacks.pop_region);
+}
+
+void allocateData(const SpaceHandle space, const std::string label,
+                  const void* ptr, const uint64_t size) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.allocate_data, space, label.c_str(), ptr,
+      size);
+}
+
+void deallocateData(const SpaceHandle space, const std::string label,
+                    const void* ptr, const uint64_t size) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.deallocate_data, space, label.c_str(),
+      ptr, size);
+}
+
+void beginDeepCopy(const SpaceHandle dst_space, const std::string dst_label,
+                   const void* dst_ptr, const SpaceHandle src_space,
+                   const std::string src_label, const void* src_ptr,
+                   const uint64_t size) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.begin_deep_copy, dst_space,
+      dst_label.c_str(), dst_ptr, src_space, src_label.c_str(), src_ptr, size);
+#ifdef KOKKOS_ENABLE_TUNING
+  if (Experimental::current_callbacks.begin_deep_copy != nullptr) {
+    if (Kokkos::tune_internals()) {
+      auto context_id = Experimental::get_new_context_id();
+      Experimental::begin_context(context_id);
+      Experimental::VariableValue contextValues[] = {
+          Experimental::make_variable_value(
+              Experimental::kernel_name_context_variable_id,
+              "deep_copy_kernel"),
+          Experimental::make_variable_value(
+              Experimental::kernel_type_context_variable_id, "deep_copy")};
+      Experimental::set_input_values(context_id, 2, contextValues);
+    }
+  }
+#endif
+}
+
+void endDeepCopy() {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.end_deep_copy);
+#ifdef KOKKOS_ENABLE_TUNING
+  if (Experimental::current_callbacks.end_deep_copy != nullptr) {
+    if (Kokkos::tune_internals()) {
+      Experimental::end_context(Experimental::get_current_context_id());
+    }
+  }
+#endif
+}
+
+void beginFence(const std::string name, const uint32_t deviceId,
+                uint64_t* handle) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.begin_fence, name.c_str(), deviceId,
+      handle);
+}
+
+void endFence(const uint64_t handle) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.end_fence, handle);
+}
+
+void createProfileSection(const std::string& sectionName, uint32_t* secID) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.create_profile_section,
+      sectionName.c_str(), secID);
+}
+
+void startSection(const uint32_t secID) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.start_profile_section, secID);
+}
+
+void stopSection(const uint32_t secID) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.stop_profile_section, secID);
+}
+
+void destroyProfileSection(const uint32_t secID) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.destroy_profile_section, secID);
+}
+
+void markEvent(const std::string& eventName) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.profile_event, eventName.c_str());
+}
+
+bool printHelp(const std::string& args) {
+  if (Experimental::current_callbacks.print_help == nullptr) {
+    return false;
+  }
+  std::string arg0  = args.substr(0, args.find_first_of(' '));
+  const char* carg0 = arg0.c_str();
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.print_help, const_cast<char*>(carg0));
+  return true;
+}
+
+void parseArgs(int _argc, char** _argv) {
+  if (Experimental::current_callbacks.parse_args != nullptr && _argc > 0) {
+    Experimental::invoke_kokkosp_callback(
+        Experimental::MayRequireGlobalFencing::No,
+        Experimental::current_callbacks.parse_args, _argc, _argv);
+  }
+}
+
+void parseArgs(const std::string& args) {
+  if (Experimental::current_callbacks.parse_args == nullptr) {
+    return;
+  }
+  using strvec_t = std::vector<std::string>;
+  auto tokenize  = [](const std::string& line, const std::string& delimiters) {
+    strvec_t _result{};
+    std::size_t _bidx = 0;  // position that is the beginning of the new string
+    std::size_t _didx = 0;  // position of the delimiter in the string
+    while (_bidx < line.length() && _didx < line.length()) {
+      // find the first character (starting at _didx) that is not a delimiter
+      _bidx = line.find_first_not_of(delimiters, _didx);
+      // if no more non-delimiter chars, done
+      if (_bidx == std::string::npos) break;
+      // starting at the position of the new string, find the next delimiter
+      _didx = line.find_first_of(delimiters, _bidx);
+      // starting at the position of the new string, get the characters
+      // between this position and the next delimiter
+      std::string _tmp = line.substr(_bidx, _didx - _bidx);
+      // don't add empty strings
+      if (!_tmp.empty()) _result.emplace_back(_tmp);
+    }
+    return _result;
+  };
+  auto vargs = tokenize(args, " \t");
+  if (vargs.size() == 0) return;
+  auto _argc          = static_cast<int>(vargs.size());
+  char** _argv        = new char*[_argc + 1];
+  _argv[vargs.size()] = nullptr;
+  for (int i = 0; i < _argc; ++i) {
+    auto& _str = vargs.at(i);
+    _argv[i]   = new char[_str.length() + 1];
+    std::memcpy(_argv[i], _str.c_str(), _str.length() * sizeof(char));
+    _argv[i][_str.length()] = '\0';
+  }
+  parseArgs(_argc, _argv);
+  for (int i = 0; i < _argc; ++i) {
+    delete[] _argv[i];
+  }
+  delete[] _argv;
+}
+
+SpaceHandle make_space_handle(const char* space_name) {
+  SpaceHandle handle;
+  strncpy(handle.name, space_name, 63);
+  return handle;
+}
+
+template <typename Callback>
+void lookup_function(void* dlopen_handle, const std::string& basename,
+                     Callback& callback) {
+#ifdef KOKKOS_TOOLS_ENABLE_LIBDL
+  // dlsym returns a pointer to an object, while we want to assign to
+  // pointer to function A direct cast will give warnings hence, we have to
+  // workaround the issue by casting pointer to pointers.
+  void* p  = dlsym(dlopen_handle, basename.c_str());
+  callback = *reinterpret_cast<Callback*>(&p);
+#else
+  (void)dlopen_handle;
+  (void)basename;
+  (void)callback;
+#endif
+}
+
+void initialize(const std::string& profileLibrary) {
+  // Make sure initialize calls happens only once
+  static int is_initialized = 0;
+  if (is_initialized) return;
+  is_initialized = 1;
+
+  auto invoke_init_callbacks = []() {
+    Experimental::invoke_kokkosp_callback(
+        Experimental::MayRequireGlobalFencing::No,
+        Experimental::current_callbacks.init, 0,
+        (uint64_t)KOKKOSP_INTERFACE_VERSION, (uint32_t)0, nullptr);
+
+    Experimental::tool_requirements.requires_global_fencing = true;
+
+    Experimental::invoke_kokkosp_callback(
+        Experimental::MayRequireGlobalFencing::No,
+        Experimental::current_callbacks.request_tool_settings, 1,
+        &Experimental::tool_requirements);
+
+    Experimental::ToolProgrammingInterface actions;
+    actions.fence = &Experimental::Impl::tool_invoked_fence;
+
+    Experimental::invoke_kokkosp_callback(
+        Experimental::MayRequireGlobalFencing::No,
+        Experimental::current_callbacks.provide_tool_programming_interface, 1,
+        actions);
+  };
+
+#ifdef KOKKOS_TOOLS_ENABLE_LIBDL
+  void* firstProfileLibrary = nullptr;
+
+  if ((profileLibrary.empty()) ||
+      (profileLibrary == InitArguments::unset_string_option)) {
+    invoke_init_callbacks();
+    return;
+  }
+
+  char* envProfileLibrary = const_cast<char*>(profileLibrary.c_str());
+
+  const auto envProfileCopy =
+      std::make_unique<char[]>(strlen(envProfileLibrary) + 1);
+  sprintf(envProfileCopy.get(), "%s", envProfileLibrary);
+
+  char* profileLibraryName = strtok(envProfileCopy.get(), ";");
+
+  if ((profileLibraryName != nullptr) &&
+      (strcmp(profileLibraryName, "") != 0)) {
+    firstProfileLibrary = dlopen(profileLibraryName, RTLD_NOW | RTLD_GLOBAL);
+
+    if (firstProfileLibrary == nullptr) {
+      std::cerr << "Error: Unable to load KokkosP library: "
+                << profileLibraryName << std::endl;
+      std::cerr << "dlopen(" << profileLibraryName
+                << ", RTLD_NOW | RTLD_GLOBAL) failed with " << dlerror()
+                << '\n';
+    } else {
+#ifdef KOKKOS_ENABLE_PROFILING_LOAD_PRINT
+      std::cout << "KokkosP: Library Loaded: " << profileLibraryName
+                << std::endl;
+#endif
+      lookup_function(firstProfileLibrary, "kokkosp_begin_parallel_scan",
+                      Experimental::current_callbacks.begin_parallel_scan);
+      lookup_function(firstProfileLibrary, "kokkosp_begin_parallel_for",
+                      Experimental::current_callbacks.begin_parallel_for);
+      lookup_function(firstProfileLibrary, "kokkosp_begin_parallel_reduce",
+                      Experimental::current_callbacks.begin_parallel_reduce);
+      lookup_function(firstProfileLibrary, "kokkosp_end_parallel_scan",
+                      Experimental::current_callbacks.end_parallel_scan);
+      lookup_function(firstProfileLibrary, "kokkosp_end_parallel_for",
+                      Experimental::current_callbacks.end_parallel_for);
+      lookup_function(firstProfileLibrary, "kokkosp_end_parallel_reduce",
+                      Experimental::current_callbacks.end_parallel_reduce);
+
+      lookup_function(firstProfileLibrary, "kokkosp_init_library",
+                      Experimental::current_callbacks.init);
+      lookup_function(firstProfileLibrary, "kokkosp_finalize_library",
+                      Experimental::current_callbacks.finalize);
+
+      lookup_function(firstProfileLibrary, "kokkosp_push_profile_region",
+                      Experimental::current_callbacks.push_region);
+      lookup_function(firstProfileLibrary, "kokkosp_pop_profile_region",
+                      Experimental::current_callbacks.pop_region);
+      lookup_function(firstProfileLibrary, "kokkosp_allocate_data",
+                      Experimental::current_callbacks.allocate_data);
+      lookup_function(firstProfileLibrary, "kokkosp_deallocate_data",
+                      Experimental::current_callbacks.deallocate_data);
+
+      lookup_function(firstProfileLibrary, "kokkosp_begin_deep_copy",
+                      Experimental::current_callbacks.begin_deep_copy);
+      lookup_function(firstProfileLibrary, "kokkosp_end_deep_copy",
+                      Experimental::current_callbacks.end_deep_copy);
+      lookup_function(firstProfileLibrary, "kokkosp_begin_fence",
+                      Experimental::current_callbacks.begin_fence);
+      lookup_function(firstProfileLibrary, "kokkosp_end_fence",
+                      Experimental::current_callbacks.end_fence);
+      lookup_function(firstProfileLibrary, "kokkosp_dual_view_sync",
+                      Experimental::current_callbacks.sync_dual_view);
+      lookup_function(firstProfileLibrary, "kokkosp_dual_view_modify",
+                      Experimental::current_callbacks.modify_dual_view);
+
+      lookup_function(firstProfileLibrary, "kokkosp_declare_metadata",
+                      Experimental::current_callbacks.declare_metadata);
+      lookup_function(firstProfileLibrary, "kokkosp_create_profile_section",
+                      Experimental::current_callbacks.create_profile_section);
+      lookup_function(firstProfileLibrary, "kokkosp_start_profile_section",
+                      Experimental::current_callbacks.start_profile_section);
+      lookup_function(firstProfileLibrary, "kokkosp_stop_profile_section",
+                      Experimental::current_callbacks.stop_profile_section);
+      lookup_function(firstProfileLibrary, "kokkosp_destroy_profile_section",
+                      Experimental::current_callbacks.destroy_profile_section);
+
+      lookup_function(firstProfileLibrary, "kokkosp_profile_event",
+                      Experimental::current_callbacks.profile_event);
+#ifdef KOKKOS_ENABLE_TUNING
+      lookup_function(firstProfileLibrary, "kokkosp_declare_output_type",
+                      Experimental::current_callbacks.declare_output_type);
+
+      lookup_function(firstProfileLibrary, "kokkosp_declare_input_type",
+                      Experimental::current_callbacks.declare_input_type);
+      lookup_function(firstProfileLibrary, "kokkosp_request_values",
+                      Experimental::current_callbacks.request_output_values);
+      lookup_function(firstProfileLibrary, "kokkosp_end_context",
+                      Experimental::current_callbacks.end_tuning_context);
+      lookup_function(firstProfileLibrary, "kokkosp_begin_context",
+                      Experimental::current_callbacks.begin_tuning_context);
+      lookup_function(
+          firstProfileLibrary, "kokkosp_declare_optimization_goal",
+          Experimental::current_callbacks.declare_optimization_goal);
+#endif  // KOKKOS_ENABLE_TUNING
+
+      lookup_function(firstProfileLibrary, "kokkosp_print_help",
+                      Experimental::current_callbacks.print_help);
+      lookup_function(firstProfileLibrary, "kokkosp_parse_args",
+                      Experimental::current_callbacks.parse_args);
+      lookup_function(
+          firstProfileLibrary, "kokkosp_provide_tool_programming_interface",
+          Experimental::current_callbacks.provide_tool_programming_interface);
+      lookup_function(firstProfileLibrary, "kokkosp_request_tool_settings",
+                      Experimental::current_callbacks.request_tool_settings);
+    }
+  }
+#else
+  (void)profileLibrary;
+#endif  // KOKKOS_ENABLE_LIBDL
+
+  invoke_init_callbacks();
+
+#ifdef KOKKOS_ENABLE_TUNING
+  Experimental::VariableInfo kernel_name;
+  kernel_name.type = Experimental::ValueType::kokkos_value_string;
+  kernel_name.category =
+      Experimental::StatisticalCategory::kokkos_value_categorical;
+  kernel_name.valueQuantity =
+      Experimental::CandidateValueType::kokkos_value_unbounded;
+
+  std::array<std::string, 4> candidate_values = {
+      "parallel_for",
+      "parallel_reduce",
+      "parallel_scan",
+      "parallel_copy",
+  };
+
+  Experimental::SetOrRange kernel_type_variable_candidates =
+      Experimental::make_candidate_set(4, candidate_values.data());
+
+  Experimental::kernel_name_context_variable_id =
+      Experimental::declare_input_type("kokkos.kernel_name", kernel_name);
+
+  Experimental::VariableInfo kernel_type;
+  kernel_type.type = Experimental::ValueType::kokkos_value_string;
+  kernel_type.category =
+      Experimental::StatisticalCategory::kokkos_value_categorical;
+  kernel_type.valueQuantity =
+      Experimental::CandidateValueType::kokkos_value_set;
+  kernel_type.candidates = kernel_type_variable_candidates;
+  Experimental::kernel_type_context_variable_id =
+      Experimental::declare_input_type("kokkos.kernel_type", kernel_type);
+
+#endif
+
+  Experimental::no_profiling.init     = nullptr;
+  Experimental::no_profiling.finalize = nullptr;
+
+  Experimental::no_profiling.begin_parallel_for    = nullptr;
+  Experimental::no_profiling.begin_parallel_scan   = nullptr;
+  Experimental::no_profiling.begin_parallel_reduce = nullptr;
+  Experimental::no_profiling.end_parallel_scan     = nullptr;
+  Experimental::no_profiling.end_parallel_for      = nullptr;
+  Experimental::no_profiling.end_parallel_reduce   = nullptr;
+
+  Experimental::no_profiling.push_region     = nullptr;
+  Experimental::no_profiling.pop_region      = nullptr;
+  Experimental::no_profiling.allocate_data   = nullptr;
+  Experimental::no_profiling.deallocate_data = nullptr;
+
+  Experimental::no_profiling.begin_deep_copy = nullptr;
+  Experimental::no_profiling.end_deep_copy   = nullptr;
+
+  Experimental::no_profiling.create_profile_section  = nullptr;
+  Experimental::no_profiling.start_profile_section   = nullptr;
+  Experimental::no_profiling.stop_profile_section    = nullptr;
+  Experimental::no_profiling.destroy_profile_section = nullptr;
+
+  Experimental::no_profiling.profile_event = nullptr;
+
+  Experimental::no_profiling.declare_input_type    = nullptr;
+  Experimental::no_profiling.declare_output_type   = nullptr;
+  Experimental::no_profiling.request_output_values = nullptr;
+  Experimental::no_profiling.end_tuning_context    = nullptr;
+}
+
+void finalize() {
+  // Make sure finalize calls happens only once
+  static int is_finalized = 0;
+  if (is_finalized) return;
+  is_finalized = 1;
+
+  if (Experimental::current_callbacks.finalize != nullptr) {
+    Experimental::invoke_kokkosp_callback(
+        Experimental::MayRequireGlobalFencing::No,
+        Experimental::current_callbacks.finalize);
+
+    Experimental::pause_tools();
+  }
+#ifdef KOKKOS_ENABLE_TUNING
+  // clean up string candidate set
+  for (auto& metadata_pair : Experimental::variable_metadata) {
+    auto metadata = metadata_pair.second;
+    if ((metadata.type == Experimental::ValueType::kokkos_value_string) &&
+        (metadata.valueQuantity ==
+         Experimental::CandidateValueType::kokkos_value_set)) {
+      auto candidate_set = metadata.candidates.set;
+      delete[] candidate_set.values.string_value;
+    }
+  }
+#endif
+}
+
+void syncDualView(const std::string& label, const void* const ptr,
+                  bool to_device) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.sync_dual_view, label.c_str(), ptr,
+      to_device);
+}
+void modifyDualView(const std::string& label, const void* const ptr,
+                    bool on_device) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.modify_dual_view, label.c_str(), ptr,
+      on_device);
+}
+
+void declareMetadata(const std::string& key, const std::string& value) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.declare_metadata, key.c_str(),
+      value.c_str());
+}
+
+}  // namespace Tools
+
+namespace Tools {
+namespace Experimental {
+void set_init_callback(initFunction callback) {
+  current_callbacks.init = callback;
+}
+void set_finalize_callback(finalizeFunction callback) {
+  current_callbacks.finalize = callback;
+}
+void set_parse_args_callback(parseArgsFunction callback) {
+  current_callbacks.parse_args = callback;
+}
+void set_print_help_callback(printHelpFunction callback) {
+  current_callbacks.print_help = callback;
+}
+void set_begin_parallel_for_callback(beginFunction callback) {
+  current_callbacks.begin_parallel_for = callback;
+}
+void set_end_parallel_for_callback(endFunction callback) {
+  current_callbacks.end_parallel_for = callback;
+}
+void set_begin_parallel_reduce_callback(beginFunction callback) {
+  current_callbacks.begin_parallel_reduce = callback;
+}
+void set_end_parallel_reduce_callback(endFunction callback) {
+  current_callbacks.end_parallel_reduce = callback;
+}
+void set_begin_parallel_scan_callback(beginFunction callback) {
+  current_callbacks.begin_parallel_scan = callback;
+}
+void set_end_parallel_scan_callback(endFunction callback) {
+  current_callbacks.end_parallel_scan = callback;
+}
+void set_push_region_callback(pushFunction callback) {
+  current_callbacks.push_region = callback;
+}
+void set_pop_region_callback(popFunction callback) {
+  current_callbacks.pop_region = callback;
+}
+void set_allocate_data_callback(allocateDataFunction callback) {
+  current_callbacks.allocate_data = callback;
+}
+void set_deallocate_data_callback(deallocateDataFunction callback) {
+  current_callbacks.deallocate_data = callback;
+}
+void set_create_profile_section_callback(
+    createProfileSectionFunction callback) {
+  current_callbacks.create_profile_section = callback;
+}
+void set_start_profile_section_callback(startProfileSectionFunction callback) {
+  current_callbacks.start_profile_section = callback;
+}
+void set_stop_profile_section_callback(stopProfileSectionFunction callback) {
+  current_callbacks.stop_profile_section = callback;
+}
+void set_destroy_profile_section_callback(
+    destroyProfileSectionFunction callback) {
+  current_callbacks.destroy_profile_section = callback;
+}
+void set_profile_event_callback(profileEventFunction callback) {
+  current_callbacks.profile_event = callback;
+}
+void set_begin_deep_copy_callback(beginDeepCopyFunction callback) {
+  current_callbacks.begin_deep_copy = callback;
+}
+void set_end_deep_copy_callback(endDeepCopyFunction callback) {
+  current_callbacks.end_deep_copy = callback;
+}
+void set_begin_fence_callback(beginFenceFunction callback) {
+  current_callbacks.begin_fence = callback;
+}
+void set_end_fence_callback(endFenceFunction callback) {
+  current_callbacks.end_fence = callback;
+}
+
+void set_dual_view_sync_callback(dualViewSyncFunction callback) {
+  current_callbacks.sync_dual_view = callback;
+}
+void set_dual_view_modify_callback(dualViewModifyFunction callback) {
+  current_callbacks.modify_dual_view = callback;
+}
+void set_declare_metadata_callback(declareMetadataFunction callback) {
+  current_callbacks.declare_metadata = callback;
+}
+void set_request_tool_settings_callback(requestToolSettingsFunction callback) {
+  current_callbacks.request_tool_settings = callback;
+}
+void set_provide_tool_programming_interface_callback(
+    provideToolProgrammingInterfaceFunction callback) {
+  current_callbacks.provide_tool_programming_interface = callback;
+}
+
+void set_declare_output_type_callback(
+    Experimental::outputTypeDeclarationFunction callback) {
+  current_callbacks.declare_output_type = callback;
+}
+void set_declare_input_type_callback(
+    Experimental::inputTypeDeclarationFunction callback) {
+  current_callbacks.declare_input_type = callback;
+}
+void set_request_output_values_callback(
+    Experimental::requestValueFunction callback) {
+  current_callbacks.request_output_values = callback;
+}
+void set_end_context_callback(Experimental::contextEndFunction callback) {
+  current_callbacks.end_tuning_context = callback;
+}
+void set_begin_context_callback(Experimental::contextBeginFunction callback) {
+  current_callbacks.begin_tuning_context = callback;
+}
+void set_declare_optimization_goal_callback(
+    Experimental::optimizationGoalDeclarationFunction callback) {
+  current_callbacks.declare_optimization_goal = callback;
+}
+
+void pause_tools() {
+  backup_callbacks  = current_callbacks;
+  current_callbacks = no_profiling;
+}
+
+void resume_tools() { current_callbacks = backup_callbacks; }
+
+Kokkos::Tools::Experimental::EventSet get_callbacks() {
+  return current_callbacks;
+}
+void set_callbacks(Kokkos::Tools::Experimental::EventSet new_events) {
+  current_callbacks = new_events;
+}
+}  // namespace Experimental
+}  // namespace Tools
+
+namespace Profiling {
+bool profileLibraryLoaded() { return Kokkos::Tools::profileLibraryLoaded(); }
+
+void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
+                      uint64_t* kernelID) {
+  Kokkos::Tools::beginParallelFor(kernelPrefix, devID, kernelID);
+}
+void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
+                         uint64_t* kernelID) {
+  Kokkos::Tools::beginParallelReduce(kernelPrefix, devID, kernelID);
+}
+void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
+                       uint64_t* kernelID) {
+  Kokkos::Tools::beginParallelScan(kernelPrefix, devID, kernelID);
+}
+void endParallelFor(const uint64_t kernelID) {
+  Kokkos::Tools::endParallelFor(kernelID);
+}
+void endParallelReduce(const uint64_t kernelID) {
+  Kokkos::Tools::endParallelReduce(kernelID);
+}
+void endParallelScan(const uint64_t kernelID) {
+  Kokkos::Tools::endParallelScan(kernelID);
+}
+
+void pushRegion(const std::string& kName) { Kokkos::Tools::pushRegion(kName); }
+void popRegion() { Kokkos::Tools::popRegion(); }
+
+void createProfileSection(const std::string& sectionName, uint32_t* secID) {
+  Kokkos::Tools::createProfileSection(sectionName, secID);
+}
+void destroyProfileSection(const uint32_t secID) {
+  Kokkos::Tools::destroyProfileSection(secID);
+}
+
+void startSection(const uint32_t secID) { Kokkos::Tools::startSection(secID); }
+
+void stopSection(const uint32_t secID) { Kokkos::Tools::stopSection(secID); }
+
+void markEvent(const std::string& eventName) {
+  Kokkos::Tools::markEvent(eventName);
+}
+void allocateData(const SpaceHandle handle, const std::string name,
+                  const void* data, const uint64_t size) {
+  Kokkos::Tools::allocateData(handle, name, data, size);
+}
+void deallocateData(const SpaceHandle space, const std::string label,
+                    const void* ptr, const uint64_t size) {
+  Kokkos::Tools::deallocateData(space, label, ptr, size);
+}
+
+void beginDeepCopy(const SpaceHandle dst_space, const std::string dst_label,
+                   const void* dst_ptr, const SpaceHandle src_space,
+                   const std::string src_label, const void* src_ptr,
+                   const uint64_t size) {
+  Kokkos::Tools::beginDeepCopy(dst_space, dst_label, dst_ptr, src_space,
+                               src_label, src_ptr, size);
+}
+void endDeepCopy() { Kokkos::Tools::endDeepCopy(); }
+
+void finalize() { Kokkos::Tools::finalize(); }
+void initialize(const std::string& profileLibrary) {
+  Kokkos::Tools::initialize(profileLibrary);
+}
+
+bool printHelp(const std::string& args) {
+  return Kokkos::Tools::printHelp(args);
+}
+void parseArgs(const std::string& args) { Kokkos::Tools::parseArgs(args); }
+void parseArgs(int _argc, char** _argv) {
+  Kokkos::Tools::parseArgs(_argc, _argv);
+}
+
+SpaceHandle make_space_handle(const char* space_name) {
+  return Kokkos::Tools::make_space_handle(space_name);
+}
+}  // namespace Profiling
+
+// Tuning
+
+namespace Tools {
+namespace Experimental {
+static size_t& get_context_counter() {
+  static size_t x;
+  return x;
+}
+static size_t& get_variable_counter() {
+  static size_t x;
+  return ++x;
+}
+
+size_t get_new_context_id() { return ++get_context_counter(); }
+size_t get_current_context_id() { return get_context_counter(); }
+void decrement_current_context_id() { --get_context_counter(); }
+size_t get_new_variable_id() { return get_variable_counter(); }
+
+size_t declare_output_type(const std::string& variableName, VariableInfo info) {
+  size_t variableId = get_new_variable_id();
+#ifdef KOKKOS_ENABLE_TUNING
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.declare_output_type, variableName.c_str(),
+      variableId, &info);
+  variable_metadata[variableId] = info;
+#else
+  (void)variableName;
+  (void)info;
+#endif
+  return variableId;
+}
+
+size_t declare_input_type(const std::string& variableName, VariableInfo info) {
+  size_t variableId = get_new_variable_id();
+#ifdef KOKKOS_ENABLE_TUNING
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.declare_input_type, variableName.c_str(),
+      variableId, &info);
+  variable_metadata[variableId] = info;
+#else
+  (void)variableName;
+  (void)info;
+#endif
+  return variableId;
+}
+
+void set_input_values(size_t contextId, size_t count, VariableValue* values) {
+#ifdef KOKKOS_ENABLE_TUNING
+  if (features_per_context.find(contextId) == features_per_context.end()) {
+    features_per_context[contextId] = std::unordered_set<size_t>();
+  }
+  for (size_t x = 0; x < count; ++x) {
+    values[x].metadata = &variable_metadata[values[x].type_id];
+    features_per_context[contextId].insert(values[x].type_id);
+    active_features.insert(values[x].type_id);
+    feature_values[values[x].type_id] = values[x];
+  }
+#else
+  (void)contextId;
+  (void)count;
+  (void)values;
+#endif
+}
+#include <iostream>
+void request_output_values(size_t contextId, size_t count,
+                           VariableValue* values) {
+#ifdef KOKKOS_ENABLE_TUNING
+  std::vector<size_t> context_ids;
+  std::vector<VariableValue> context_values;
+  for (auto id : active_features) {
+    context_values.push_back(feature_values[id]);
+  }
+  if (Experimental::current_callbacks.request_output_values != nullptr) {
+    for (size_t x = 0; x < count; ++x) {
+      values[x].metadata = &variable_metadata[values[x].type_id];
+    }
+    Experimental::invoke_kokkosp_callback(
+        Experimental::MayRequireGlobalFencing::No,
+        Experimental::current_callbacks.request_output_values, contextId,
+        context_values.size(), context_values.data(), count, values);
+  }
+#else
+  (void)contextId;
+  (void)count;
+  (void)values;
+#endif
+}
+
+#ifdef KOKKOS_ENABLE_TUNING
+static std::unordered_map<size_t, size_t> optimization_goals;
+#endif
+
+void begin_context(size_t contextId) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.begin_tuning_context, contextId);
+}
+void end_context(size_t contextId) {
+#ifdef KOKKOS_ENABLE_TUNING
+  for (auto id : features_per_context[contextId]) {
+    active_features.erase(id);
+  }
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.end_tuning_context, contextId,
+      feature_values[optimization_goals[contextId]]);
+  optimization_goals.erase(contextId);
+  decrement_current_context_id();
+#else
+  (void)contextId;
+#endif
+}
+
+bool have_tuning_tool() {
+#ifdef KOKKOS_ENABLE_TUNING
+  return (Experimental::current_callbacks.request_output_values != nullptr);
+#else
+  return false;
+#endif
+}
+
+VariableValue make_variable_value(size_t id, int64_t val) {
+  VariableValue variable_value;
+  variable_value.type_id         = id;
+  variable_value.value.int_value = val;
+  return variable_value;
+}
+VariableValue make_variable_value(size_t id, double val) {
+  VariableValue variable_value;
+  variable_value.type_id            = id;
+  variable_value.value.double_value = val;
+  return variable_value;
+}
+VariableValue make_variable_value(size_t id, const std::string& val) {
+  VariableValue variable_value;
+  variable_value.type_id = id;
+  strncpy(variable_value.value.string_value, val.c_str(),
+          KOKKOS_TOOLS_TUNING_STRING_LENGTH - 1);
+  return variable_value;
+}
+SetOrRange make_candidate_set(size_t size, std::string* data) {
+  SetOrRange value_set;
+  value_set.set.values.string_value = new TuningString[size];
+  for (size_t x = 0; x < size; ++x) {
+    strncpy(value_set.set.values.string_value[x], data[x].c_str(),
+            KOKKOS_TOOLS_TUNING_STRING_LENGTH - 1);
+  }
+  value_set.set.size = size;
+  return value_set;
+}
+SetOrRange make_candidate_set(size_t size, int64_t* data) {
+  SetOrRange value_set;
+  value_set.set.size             = size;
+  value_set.set.values.int_value = data;
+  return value_set;
+}
+SetOrRange make_candidate_set(size_t size, double* data) {
+  SetOrRange value_set;
+  value_set.set.size                = size;
+  value_set.set.values.double_value = data;
+  return value_set;
+}
+SetOrRange make_candidate_range(double lower, double upper, double step,
+                                bool openLower = false,
+                                bool openUpper = false) {
+  SetOrRange value_range;
+  value_range.range.lower.double_value = lower;
+  value_range.range.upper.double_value = upper;
+  value_range.range.step.double_value  = step;
+  value_range.range.openLower          = openLower;
+  value_range.range.openUpper          = openUpper;
+  return value_range;
+}
+
+SetOrRange make_candidate_range(int64_t lower, int64_t upper, int64_t step,
+                                bool openLower = false,
+                                bool openUpper = false) {
+  SetOrRange value_range;
+  value_range.range.lower.int_value = lower;
+  value_range.range.upper.int_value = upper;
+  value_range.range.step.int_value  = step;
+  value_range.range.openLower       = openLower;
+  value_range.range.openUpper       = openUpper;
+  return value_range;
+}
+
+size_t get_new_context_id();
+size_t get_current_context_id();
+void decrement_current_context_id();
+size_t get_new_variable_id();
+void declare_optimization_goal(const size_t context,
+                               const OptimizationGoal& goal) {
+#ifdef KOKKOS_ENABLE_TUNING
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.declare_optimization_goal, context, goal);
+  optimization_goals[context] = goal.type_id;
+#else
+  (void)context;
+  (void)goal;
+#endif
+}
+}  // end namespace Experimental
+}  // end namespace Tools
+
+}  // end namespace Kokkos


### PR DESCRIPTION
# Summary

- This PR is a  feature
- It does the following (modify list as needed):
  - Adds partial support for Kokkos Tools to RAJA
# Design review (for API changes or additions---delete if unneeded)

We have not yet done a design review.

I wanted to get this started before taking off. In Kokkos, we've managed to isolate the vast majority of the plumbing to allow Kokkos Tools to operate in other programming models, including RAJA ([this PR](https://github.com/kokkos/kokkos/pull/4365)).

What would need to be done to bring this to production would be

- [ ] Plumb however you load tools in with how we do it. If you have an environment variable you recommend people set to load a tool, populate the Kokkos::Tools::InitArguments with it (or ask people to call `RAJA::initialize(argc, argv)` and just use our arg-parsing) before calling `Kokkos::Tools::initialize`
- [ ] Possibly start using this with your named kernel facilities
- [ ] For something crazy high-impact, add autotuning. `RAJA::forall<cuda_autotuning_exec>`, which will by the way work with your Apollo tool if you implement it with Kokkos Tools
- [ ] Fix the build system weirdness. I put the header files in `impl/` in include, because I get CMake errors if I put them in `include/RAJA/tools/impl`

Anyway, this is something you could work on with the Kokkos team, if it's of interest