### PR TITLE
Sycl: Remove nontrivial forall/kernel interface

### DIFF
--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -468,20 +468,6 @@ GPU Policies for SYCL
 
  ======================================== ============= ========================
 
-There is a notable constraint to using the sycl policies.
-
-.. note:: SYCL kernels impose the restriction that kernel parameters must
-          be trivially copyable.  The sycl_exec_nontrivial and
-          SyclKernelNonTrivial policies provide a workaround to this
-          constraint given the non trivially copyable data is safe to 
-          memcpy to the device. 
-
-          The non trivial policies incur some additional overhead, but 
-          will function whether data is trivially copyable or not.  
-          Beginning with non trivial polices will help accerate development
-          of a working RAJA SYCL application.
-
-
 OpenMP Target Offload Policies 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -839,8 +825,6 @@ Statement types that lauch SYCL kernels are listed next.
 * ``SyclKernel<EnclosedStatements>`` launches ``EnclosedStatements`` as a SYCL kernel.  This kernel launch is synchronous.
 
 * ``SyclKernelAsync<EnclosedStatements>`` asynchronous version of SyclKernel.
-
-* ``SyclKernelNonTrivial<EnclosedStatements>`` Same as SyclKernel, but allows for non-trivially copyable kernels by preforming an allocation on the device followed by a memcpy.  If the non-trivially data type in the kernel cannot be safely memcpy'd to the device the kernel the execution may be incorrect.
 
 RAJA provides statements to define loop tiling which can improve performance; 
 e.g., by allowing CPU cache blocking or use of GPU shared memory. 

--- a/examples/memoryManager.hpp
+++ b/examples/memoryManager.hpp
@@ -41,7 +41,7 @@ T *allocate(RAJA::Index_type size)
 #elif defined(RAJA_ENABLE_HIP)
       hipErrchk(hipMalloc((void **)&ptr, sizeof(T) * size));
 #elif defined(RAJA_ENABLE_SYCL)
-      ptr = sycl_res->allocate<T>(size);
+      ptr = sycl_res->allocate<T>(size, camp::resources::MemoryAccess::Managed);
 #else
   ptr = new T[size];
 #endif

--- a/examples/tut_dot-product.cpp
+++ b/examples/tut_dot-product.cpp
@@ -194,7 +194,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // _rajasycl_dotprod_start
   RAJA::ReduceSum<RAJA::sycl_reduce, double> hpdot(0.0);
 
-  RAJA::forall<RAJA::sycl_exec_nontrivial<SYCL_BLOCK_SIZE, false>>(RAJA::RangeSegment(0, N),
+  RAJA::forall<RAJA::sycl_exec<SYCL_BLOCK_SIZE, false>>(RAJA::RangeSegment(0, N),
     [=] RAJA_DEVICE (int i) {
     hpdot += a[i] * b[i];
   });

--- a/include/RAJA/policy/sycl/forall.hpp
+++ b/include/RAJA/policy/sycl/forall.hpp
@@ -82,7 +82,8 @@ cl::sycl::range<1> getGridDim(size_t len, size_t block_size)
 ////////////////////////////////////////////////////////////////////////
 //
 
-template <typename Iterable, typename LoopBody, size_t BlockSize, bool Async>
+template <typename Iterable, typename LoopBody, size_t BlockSize, bool Async,
+          typename std::enable_if<std::is_trivially_copyable<LoopBody>{},bool>::type = true>
 RAJA_INLINE resources::EventProxy<resources::Sycl>  forall_impl(resources::Sycl &sycl_res,
                                                                 sycl_exec<BlockSize, Async>,
                                                                 Iterable&& iter,
@@ -137,9 +138,10 @@ RAJA_INLINE resources::EventProxy<resources::Sycl>  forall_impl(resources::Sycl 
   return resources::EventProxy<resources::Sycl>(sycl_res);
 }
 
-template <typename Iterable, typename LoopBody, size_t BlockSize, bool Async>
+template <typename Iterable, typename LoopBody, size_t BlockSize, bool Async,
+          typename std::enable_if<!std::is_trivially_copyable<LoopBody>{},bool>::type = true>
 RAJA_INLINE resources::EventProxy<resources::Sycl> forall_impl(resources::Sycl &sycl_res,
-                                                    sycl_exec_nontrivial<BlockSize, Async>,
+                                                    sycl_exec<BlockSize, Async>,
                                                     Iterable&& iter,
                                                     LoopBody&& loop_body)
 {

--- a/include/RAJA/policy/sycl/forall.hpp
+++ b/include/RAJA/policy/sycl/forall.hpp
@@ -83,7 +83,7 @@ cl::sycl::range<1> getGridDim(size_t len, size_t block_size)
 //
 
 template <typename Iterable, typename LoopBody, size_t BlockSize, bool Async,
-          typename std::enable_if<std::is_trivially_copyable<LoopBody>{},bool>::type = true>
+          typename std::enable_if<std::is_trivially_copyable_v<LoopBody>,bool>::type = true>
 RAJA_INLINE resources::EventProxy<resources::Sycl>  forall_impl(resources::Sycl &sycl_res,
                                                                 sycl_exec<BlockSize, Async>,
                                                                 Iterable&& iter,
@@ -139,7 +139,7 @@ RAJA_INLINE resources::EventProxy<resources::Sycl>  forall_impl(resources::Sycl 
 }
 
 template <typename Iterable, typename LoopBody, size_t BlockSize, bool Async,
-          typename std::enable_if<!std::is_trivially_copyable<LoopBody>{},bool>::type = true>
+          typename std::enable_if<!std::is_trivially_copyable_v<LoopBody>,bool>::type = true>
 RAJA_INLINE resources::EventProxy<resources::Sycl> forall_impl(resources::Sycl &sycl_res,
                                                     sycl_exec<BlockSize, Async>,
                                                     Iterable&& iter,

--- a/include/RAJA/policy/sycl/policy.hpp
+++ b/include/RAJA/policy/sycl/policy.hpp
@@ -72,15 +72,6 @@ struct sycl_exec : public RAJA::make_policy_pattern_launch_platform_t<
                        RAJA::Platform::sycl> {
 };
 
-template <size_t BLOCK_SIZE, bool Async = false>
-struct sycl_exec_nontrivial : public RAJA::make_policy_pattern_launch_platform_t<
-                       RAJA::Policy::sycl,
-                       RAJA::Pattern::forall,
-                       detail::get_launch<Async>::value,
-                       RAJA::Platform::sycl> {
-};
-
-
 struct sycl_reduce
     : make_policy_pattern_t<RAJA::Policy::sycl, RAJA::Pattern::reduce> {
 };
@@ -89,7 +80,6 @@ struct sycl_reduce
 }  // namespace policy
 
 using policy::sycl::sycl_exec;
-using policy::sycl::sycl_exec_nontrivial;
 using policy::sycl::sycl_reduce;
 
 /*!

--- a/include/RAJA/policy/sycl/reduce.hpp
+++ b/include/RAJA/policy/sycl/reduce.hpp
@@ -204,7 +204,7 @@ struct TargetReduce
   {
 #ifdef __SYCL_DEVICE_ONLY__
     auto i = 0; //__spirv::initLocalInvocationId<1, cl::sycl::id<1>>()[0];
-    auto atm = cl::sycl::ONEAPI::atomic_ref<T, cl::sycl::ONEAPI::memory_order::relaxed, cl::sycl::ONEAPI::memory_scope::device, cl::sycl::access::address_space::global_space>(val.device[i]);
+    auto atm = cl::sycl::ext::oneapi::atomic_ref<T, cl::sycl::ext::oneapi::memory_order::relaxed, cl::sycl::ext::oneapi::memory_scope::device, cl::sycl::access::address_space::global_space>(val.device[i]);
     Reducer{}(atm, rhsVal);
     return *this;
 #else
@@ -219,7 +219,7 @@ struct TargetReduce
   {
 #ifdef __SYCL_DEVICE_ONLY__
     auto i = 0; //__spirv::initLocalInvocationId<1, cl::sycl::id<1>>()[0];
-    auto atm = cl::sycl::ONEAPI::atomic_ref<T, cl::sycl::ONEAPI::memory_order::relaxed, cl::sycl::ONEAPI::memory_scope::device, cl::sycl::access::address_space::global_space>(val.device[i]);
+    auto atm = cl::sycl::ext::oneapi::atomic_ref<T, cl::sycl::ext::oneapi::memory_order::relaxed, cl::sycl::ext::oneapi::memory_scope::device, cl::sycl::access::address_space::global_space>(val.device[i]);
     atm.fetch_add(rhsVal);  
     return *this;
 #else
@@ -356,7 +356,7 @@ public:
   {
 #ifdef __SYCL_DEVICE_ONLY__
     auto i = __spirv::initLocalInvocationId<1, cl::sycl::id<1>>()[0];
-    auto atm = cl::sycl::ONEAPI::atomic_ref<T, cl::sycl::ONEAPI::memory_order::relaxed, cl::sycl::ONEAPI::memory_scope::device, cl::sycl::access::address_space::global_space>(parent::val.device[i]);
+    auto atm = cl::sycl::ext::oneapi::atomic_ref<T, cl::sycl::ext::oneapi::memory_order::relaxed, cl::sycl::ext::oneapi::memory_scope::device, cl::sycl::access::address_space::global_space>(parent::val.device[i]);
     atm.fetch_add(rhsVal);
     return *this;
 #else
@@ -383,7 +383,7 @@ public:
   {
 #ifdef __SYCL_DEVICE_ONLY__
     auto i = __spirv::initLocalInvocationId<1, cl::sycl::id<1>>()[0];
-    auto atm = cl::sycl::ONEAPI::atomic_ref<T, cl::sycl::ONEAPI::memory_order::relaxed, cl::sycl::ONEAPI::memory_scope::device, cl::sycl::access::address_space::global_space>(parent::val.device[i]);
+    auto atm = cl::sycl::ext::oneapi::atomic_ref<T, cl::sycl::ext::oneapi::memory_order::relaxed, cl::sycl::ext::oneapi::memory_scope::device, cl::sycl::access::address_space::global_space>(parent::val.device[i]);
     atm.fetch_min(rhsVal);
     return *this;
 #else
@@ -397,7 +397,7 @@ public:
   {
 #ifdef __SYCL_DEVICE_ONLY__
     auto i = __spirv::initLocalInvocationId<1, cl::sycl::id<1>>()[0];
-    auto atm = cl::sycl::ONEAPI::atomic_ref<T, cl::sycl::ONEAPI::memory_order::relaxed, cl::sycl::ONEAPI::memory_scope::device, cl::sycl::access::address_space::global_space>(parent::val.device[i]);
+    auto atm = cl::sycl::ext::oneapi::atomic_ref<T, cl::sycl::ext::oneapi::memory_order::relaxed, cl::sycl::ext::oneapi::memory_scope::device, cl::sycl::access::address_space::global_space>(parent::val.device[i]);
     atm.fetch_min(rhsVal);
     return *this;
 #else
@@ -424,7 +424,7 @@ public:
   {
 #ifdef __SYCL_DEVICE_ONLY__
     auto i = 0;//__spirv::initLocalInvocationId<1, cl::sycl::id<1>>()[0];
-    auto atm = cl::sycl::ONEAPI::atomic_ref<T, cl::sycl::ONEAPI::memory_order::relaxed, cl::sycl::ONEAPI::memory_scope::device, cl::sycl::access::address_space::global_space>(parent::val.device[i]);
+    auto atm = cl::sycl::ext::oneapi::atomic_ref<T, cl::sycl::ext::oneapi::memory_order::relaxed, cl::sycl::ext::oneapi::memory_scope::device, cl::sycl::access::address_space::global_space>(parent::val.device[i]);
     atm.fetch_max(rhsVal);
     return *this;
 #else
@@ -438,7 +438,7 @@ public:
   {
 #ifdef __SYCL_DEVICE_ONLY__
     auto i = 0;//__spirv::initLocalInvocationId<1, cl::sycl::id<1>>()[0];
-    auto atm = cl::sycl::ONEAPI::atomic_ref<T, cl::sycl::ONEAPI::memory_order::relaxed, cl::sycl::ONEAPI::memory_scope::device, cl::sycl::access::address_space::global_space>(parent::val.device[i]);
+    auto atm = cl::sycl::ext::oneapi::atomic_ref<T, cl::sycl::ext::oneapi::memory_order::relaxed, cl::sycl::ext::oneapi::memory_scope::device, cl::sycl::access::address_space::global_space>(parent::val.device[i]);
     atm.fetch_max(rhsVal);
     return *this;
 #else

--- a/include/RAJA/util/resource.hpp
+++ b/include/RAJA/util/resource.hpp
@@ -97,11 +97,6 @@ namespace RAJA
     using type = camp::resources::Sycl;
   };
 
-  template<size_t BlockSize, bool Async>
-  struct get_resource<sycl_exec_nontrivial<BlockSize, Async>>{
-    using type = camp::resources::Sycl;
-  };
-
   template<typename ISetIter, size_t BlockSize, bool Async>
   struct get_resource<ExecPolicy<ISetIter, sycl_exec<BlockSize, Async>>>{
     using type = camp::resources::Sycl;


### PR DESCRIPTION
# Summary

- This PR is a refactoring of the SYCL backend `nontrivial` policies and includes minor fixes for the SYCL backend
- It does the following (modify list as needed):
  - Removes the user facing nontrivial SYCL policies
  - Dispatches execution to use nontrivial launch based on `is_trivially_copyable` type trait 
  - Cleans up SYCL atomic oneapi extension namespace
  - Updates usage of nontrivial SYCL policies
  - Updates the SYCL examples memory space

**NOTE: The fork has been pulled into the RAJA repo. Please review and approve the PR: https://github.com/LLNL/RAJA/pull/1185**