### PR TITLE
Fix spack package.

### DIFF
--- a/.gitlab/lassen-jobs.yml
+++ b/.gitlab/lassen-jobs.yml
@@ -45,9 +45,9 @@ ibm_clang_9_cuda:
     SPEC: "+cuda cuda_arch=70 %clang@9.0.0ibm ^cuda@10.1.168"
   extends: .build_and_test_on_lassen
 
-ibm_clang_9_gcc_8_cuda:
+ibm_clang_10_cuda:
   variables:
-    SPEC: "+cuda %clang@9.0.0ibm cuda_arch=70 cxxflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 ^cuda@10.1.168"
+    SPEC: "+cuda cuda_arch=70 %clang@10.0.1ibm ^cuda@10.1.168"
   extends: .build_and_test_on_lassen
 
 gcc_8_3_1_cuda:

--- a/scripts/spack_packages/raja/package.py
+++ b/scripts/spack_packages/raja/package.py
@@ -54,7 +54,7 @@ def get_spec_path(spec, package_name, path_replacements = {}, use_bin = False) :
 class Raja(CMakePackage, CudaPackage, ROCmPackage):
     """RAJA Performance Portability Abstractions for C++ HPC Applications."""
 
-    homepage = "https://github.llnl.gov/RAJA/"
+    homepage = "https://github.com/LLNL/RAJA"
     git      = "https://github.com/LLNL/RAJA.git"
 
     version('develop', branch='develop', submodules='True')

--- a/scripts/spack_packages/raja/package.py
+++ b/scripts/spack_packages/raja/package.py
@@ -52,13 +52,16 @@ def get_spec_path(spec, package_name, path_replacements = {}, use_bin = False) :
 
 
 class Raja(CMakePackage, CudaPackage, ROCmPackage):
-    """RAJA Parallel Framework."""
+    """RAJA Performance Portability Abstractions for C++ HPC Applications."""
 
-    homepage = "http://software.llnl.gov/RAJA/"
+    homepage = "https://github.llnl.gov/RAJA/"
     git      = "https://github.com/LLNL/RAJA.git"
 
     version('develop', branch='develop', submodules='True')
     version('main',  branch='main',  submodules='True')
+    version('0.14.1', tag='v0.14.1', submodules="True")
+    version('0.14.0', tag='v0.14.0', submodules="True")
+    version('0.13.0', tag='v0.13.0', submodules="True")
     version('0.12.1', tag='v0.12.1', submodules="True")
     version('0.12.0', tag='v0.12.0', submodules="True")
     version('0.11.0', tag='v0.11.0', submodules="True")
@@ -345,18 +348,8 @@ class Raja(CMakePackage, CudaPackage, ROCmPackage):
             if "+cuda" in spec:
                 cfg.write(cmake_cache_string("CMAKE_CUDA_STANDARD", "14"))
 
-        # Note 1: Work around spack adding -march=ppc64le to SPACK_TARGET_ARGS
-        # which is used by the spack compiler wrapper.  This can go away when
-        # BLT removes -Werror from GTest flags
-        # Note 2: Tests are either built if variant is set, or if run-tests
-        # option is passed.
-        if self.spec.satisfies('%clang target=ppc64le:'):
-            cfg.write(cmake_cache_option("ENABLE_TESTS",False))
-            if 'tests=benchmarks' in spec or not 'tests=none' in spec:
-                print("MSG: no testing supported on %clang target=ppc64le:")
-        else:
-            cfg.write(cmake_cache_option("ENABLE_BENCHMARKS", 'tests=benchmarks' in spec))
-            cfg.write(cmake_cache_option("ENABLE_TESTS", not 'tests=none' in spec or self.run_tests))
+        cfg.write(cmake_cache_option("ENABLE_BENCHMARKS", 'tests=benchmarks' in spec))
+        cfg.write(cmake_cache_option("ENABLE_TESTS", not 'tests=none' in spec or self.run_tests))
 
         cfg.write(cmake_cache_path("BLT_SOURCE_DIR", spec['blt'].prefix))
         cfg.write(cmake_cache_path("camp_DIR", spec['camp'].prefix))


### PR DESCRIPTION
# Summary

- This PR is a bugfix.
- It removes some old code from our spack package that prevented our clang tests from building on Gitlab CI for lassen (you read that correctly...our tests were not building with clang on GItlab CI for lassen).
- It also updates versioned release info and fixes an issue with the project homepage URL