### PR TITLE
StaticLayout Warning

### DIFF
--- a/include/RAJA/util/StaticLayout.hpp
+++ b/include/RAJA/util/StaticLayout.hpp
@@ -59,7 +59,7 @@ struct StaticLayoutBase_impl<IdxLin,
 
   static constexpr camp::idx_t stride_one_dim =
       RAJA::max<camp::idx_t>(
-          (camp::seq_at<RangeInts, strides>::value == 1 ? RangeInts : 0)...);
+          (camp::seq_at<RangeInts, strides>::value == 1 ? camp::idx_t(RangeInts) : -1)...);
 
   static constexpr size_t n_dims = sizeof...(Sizes);
 

--- a/include/RAJA/util/StaticLayout.hpp
+++ b/include/RAJA/util/StaticLayout.hpp
@@ -59,7 +59,7 @@ struct StaticLayoutBase_impl<IdxLin,
 
   static constexpr camp::idx_t stride_one_dim =
       RAJA::max<camp::idx_t>(
-          (camp::seq_at<RangeInts, strides>::value == 1 ? RangeInts : -1)...);
+          (camp::seq_at<RangeInts, strides>::value == 1 ? RangeInts : 0)...);
 
   static constexpr size_t n_dims = sizeof...(Sizes);
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix to #1033 
- It does the following (modify list as needed):
  - Changes the false return to a 0 to avoid signed/unsigned type warnings.
