### PR TITLE
Fix roctx cmake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,7 @@ if (RAJA_ENABLE_HIP)
   set(raja_depends
     ${raja_depends}
     hip)
-  if(ENABLE_ROCTX)
+  if(RAJA_ENABLE_ROCTX)
       set(raja_depends
       ${raja_depends}
       roctx)

--- a/cmake/SetupPackages.cmake
+++ b/cmake/SetupPackages.cmake
@@ -75,7 +75,7 @@ if (RAJA_ENABLE_HIP OR RAJA_ENABLE_EXTERNAL_ROCPRIM)
   endif()
 endif ()
 
-if (ENABLE_HIP AND ENABLE_ROCTX)
+if (RAJA_ENABLE_HIP AND RAJA_ENABLE_ROCTX)
   include(FindRoctracer)
   blt_import_library(NAME roctx
                      INCLUDES ${ROCTX_INCLUDE_DIRS}


### PR DESCRIPTION
Looks like there were some changes to cmake that were not propagated to the ROCTX configuration. 
This PR propagates those changes. 