### PR TITLE
Fix exclusive scan with const-iterators

### DIFF
--- a/include/RAJA/policy/loop/scan.hpp
+++ b/include/RAJA/policy/loop/scan.hpp
@@ -51,10 +51,11 @@ inclusive_inplace(
     Iter end,
     BinFn f)
 {
-  auto agg = *begin;
+  using ValueT = typename std::remove_reference<decltype(*begin)>::type;
+  ValueT agg = *begin;
 
   for (Iter i = ++begin; i != end; ++i) {
-    agg = f(*i, agg);
+    agg = f(agg, *i);
     *i = agg;
   }
 
@@ -79,10 +80,9 @@ exclusive_inplace(
 {
   using std::distance;
   const auto n = distance(begin, end);
-
   using DistanceT = typename std::remove_const<decltype(n)>::type;
-  using ValueT = decltype(*begin);
 
+  using ValueT = typename std::remove_reference<decltype(*begin)>::type;
   ValueT agg = v;
 
   for (DistanceT i = 0; i < n; ++i) {
@@ -110,7 +110,8 @@ inclusive(
     OutIter out,
     BinFn f)
 {
-  auto agg = *begin;
+  using ValueT = typename std::remove_reference<decltype(*out)>::type;
+  ValueT agg = *begin;
   *out++ = agg;
 
   for (Iter i = begin + 1; i != end; ++i) {
@@ -142,12 +143,13 @@ exclusive(
     BinFn f,
     T v)
 {
-  typename std::remove_const< decltype(*begin) >::type agg = v;
+  using ValueT = typename std::remove_reference<decltype(*out)>::type;
+  ValueT agg = v;
   OutIter o = out;
   *o++ = v;
 
   for (Iter i = begin; i != end - 1; ++i, ++o) {
-    agg = f(*i, agg);
+    agg = f(agg, *i);
     *o = agg;
   }
 

--- a/include/RAJA/policy/sequential/scan.hpp
+++ b/include/RAJA/policy/sequential/scan.hpp
@@ -114,7 +114,6 @@ inclusive(
 {
   using ValueT = typename std::remove_reference<decltype(*out)>::type;
   ValueT agg = *begin;
-
   *out++ = agg;
 
   RAJA_NO_SIMD
@@ -147,7 +146,7 @@ exclusive(
     BinFn f,
     T v)
 {
-  using ValueT = typename std::remove_const<decltype(*begin)>::type;
+  using ValueT = typename std::remove_reference<decltype(*out)>::type;
   ValueT agg = v;
   OutIter o = out;
   *o++ = v;

--- a/test/functional/scan/tests/test-scan-Exclusive.hpp
+++ b/test/functional/scan/tests/test-scan-Exclusive.hpp
@@ -54,7 +54,7 @@ void ScanExclusiveTestImpl(int N,
   res.memcpy(work_in, host_in, sizeof(T) * N);
   res.wait();
 
-  RAJA::exclusive_scan<EXEC_POLICY>(RAJA::make_span(work_in, N),
+  RAJA::exclusive_scan<EXEC_POLICY>(RAJA::make_span(static_cast<const T*>(work_in), N),
                                     RAJA::make_span(work_out, N),
                                     OP_TYPE{},
                                     offset);
@@ -68,7 +68,7 @@ void ScanExclusiveTestImpl(int N,
   res.memcpy(work_in, host_in, sizeof(T) * N);
 
   RAJA::exclusive_scan<EXEC_POLICY>(res,
-                                    RAJA::make_span(work_in, N),
+                                    RAJA::make_span(static_cast<const T*>(work_in), N),
                                     RAJA::make_span(work_out, N),
                                     OP_TYPE{},
                                     offset);

--- a/test/functional/scan/tests/test-scan-Inclusive.hpp
+++ b/test/functional/scan/tests/test-scan-Inclusive.hpp
@@ -53,7 +53,7 @@ void ScanInclusiveTestImpl(int N)
   res.memcpy(work_in, host_in, sizeof(T) * N);
   res.wait();
 
-  RAJA::inclusive_scan<EXEC_POLICY>(RAJA::make_span(work_in, N),
+  RAJA::inclusive_scan<EXEC_POLICY>(RAJA::make_span(static_cast<const T*>(work_in), N),
                                     RAJA::make_span(work_out, N),
                                     OP_TYPE{});
 
@@ -66,7 +66,7 @@ void ScanInclusiveTestImpl(int N)
   res.memcpy(work_in, host_in, sizeof(T) * N);
 
   RAJA::inclusive_scan<EXEC_POLICY>(res,
-                                    RAJA::make_span(work_in, N),
+                                    RAJA::make_span(static_cast<const T*>(work_in), N),
                                     RAJA::make_span(work_out, N),
                                     OP_TYPE{});
 


### PR DESCRIPTION
# Summary
Fix exclusive scan with const-iterators

Also make loop and sequential implementations consistent.

- This PR is a bugfix and refactoring
- It does the following (modify list as needed):
  - refactors loop scan implementation to match sequential where appropriate
  - Fixes #1191 

