### PR TITLE
Turn off corona ci until machine is back up

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,7 +52,7 @@ stages:
   - l_build_and_test
   - b_build_and_test
 # - c_build_and_test
-# - multi_project
+  - multi_project
 
 # This is the rules that drives the activation of "advanced" jobs. All advanced
 # jobs will share this through a template mechanism.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,8 +51,8 @@ stages:
   - r_release_resources
   - l_build_and_test
   - b_build_and_test
-  - c_build_and_test
-  - multi_project
+# - c_build_and_test
+# - multi_project
 
 # This is the rules that drives the activation of "advanced" jobs. All advanced
 # jobs will share this through a template mechanism.
@@ -73,9 +73,9 @@ stages:
     reports:
       junit: junit.xml
 
-.build_toss_3_x86_64_ib_corona_script:
-  script:
-    - srun -p mi60 -t 30 -N 1 scripts/gitlab/build_and_test.sh
+#.build_toss_3_x86_64_ib_corona_script:
+#  script:
+#    - srun -p mi60 -t 30 -N 1 scripts/gitlab/build_and_test.sh
 
 # Lassen and Butte use a different job scheduler (spectrum lsf) that does not
 # allow pre-allocation the same way slurm does.
@@ -117,5 +117,5 @@ include:
   - local: .gitlab/ruby-jobs.yml
   - local: .gitlab/lassen-templates.yml
   - local: .gitlab/lassen-jobs.yml
-  - local: .gitlab/corona-templates.yml
-  - local: .gitlab/corona-jobs.yml
+# - local: .gitlab/corona-templates.yml
+# - local: .gitlab/corona-jobs.yml


### PR DESCRIPTION
# Summary

- This PR truns off gitlab ci for corona until it can be run

**Meanwhile, please run Hip tests manually on rznevada and note that you have done so in your PRs.**