### PR TITLE
Improve hip build script

### DIFF
--- a/scripts/lc-builds/toss3_hipcc.sh
+++ b/scripts/lc-builds/toss3_hipcc.sh
@@ -38,6 +38,10 @@ mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
 
 module load cmake/3.14.5
 
+# unload rocm to avoid configuration problems where the loaded rocm and COMP_VER
+# are inconsistent causing the rocprim from the module to be used unexpectedly
+module unload rocm
+
 
 cmake \
   -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
# Summary

Unload the rocm module in the hip build script to avoid some
inconsistencies that appear if using the script while having
a rocm module loaded. Namely cmake will use the rocprim from
the rocm module because it searches the CMAKE_PREFIX environment
variable set by the module first.

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes #1140 
