### PR TITLE
Fix OffsetLayout Constructor

### DIFF
--- a/examples/tut_offset-layout.cpp
+++ b/examples/tut_offset-layout.cpp
@@ -176,8 +176,8 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 // object to simplify multidimensional indexing.
 // An offset layout is constructed by using the make_offset_layout method.
 // The first argument of the layout is an array object with the coordinates of
-// the bottom left corner of the lattice, and the second argument is an array 
-// object of the coordinates of the top right corner.
+// the bottom left corner of the lattice, and the second argument is an array
+// object of the coordinates of the top right corner plus 1.
 // The example uses double braces to initiate the array object and its
 // subobjects.
 //
@@ -185,7 +185,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   const int DIM = 2;
 
   RAJA::OffsetLayout<DIM> layout =
-      RAJA::make_offset_layout<DIM>({{-1, -1}}, {{N_r, N_c}});
+      RAJA::make_offset_layout<DIM>({{-1, -1}}, {{N_r+1, N_c+1}});
 
   RAJA::View<int, RAJA::OffsetLayout<DIM>> inputView(input, layout);
   RAJA::View<int, RAJA::OffsetLayout<DIM>> outputView(output, layout);

--- a/exercises/tutorial_halfday/ex6_stencil-offset-layout.cpp
+++ b/exercises/tutorial_halfday/ex6_stencil-offset-layout.cpp
@@ -22,8 +22,8 @@
  *  The exercise demonstrates the relative ease with which array data access
  *  can be done using multi-dimensional RAJA Views as compared to C-style
  *  pointer offset arithmetic.
- * 
- *  The five-cell stencil accumulates values in a cell from itself and and 
+ *
+ *  The five-cell stencil accumulates values in a cell from itself and
  *  its four neighbors. Assuming the cells are indexed using (i,j) pairs on
  *  the two dimensional mesh, the stencil computation looks like:
  * 

--- a/exercises/tutorial_halfday/ex6_stencil-offset-layout_solution.cpp
+++ b/exercises/tutorial_halfday/ex6_stencil-offset-layout_solution.cpp
@@ -22,8 +22,8 @@
  *  The exercise demonstrates the relative ease with which array data access
  *  can be done using multi-dimensional RAJA Views as compared to C-style
  *  pointer offset arithmetic.
- * 
- *  The five-cell stencil accumulates values in a cell from itself and and 
+ *
+ *  The five-cell stencil accumulates values in a cell from itself and
  *  its four neighbors. Assuming the cells are indexed using (i,j) pairs on
  *  the two dimensional mesh, the stencil computation looks like:
  * 
@@ -209,7 +209,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   //
 
   RAJA::OffsetLayout<DIM> B_layout =
-      RAJA::make_offset_layout<DIM>({{-1, -1}}, {{Nc_tot-2, Nr_tot-2}});
+      RAJA::make_offset_layout<DIM>({{-1, -1}}, {{Nc_tot-1, Nr_tot-1}});
 
   RAJA::View<int, RAJA::OffsetLayout<DIM>> Bview(B, B_layout);
   RAJA::View<int, RAJA::Layout<DIM>> Aview(A, Nc_int, Nr_int);
@@ -293,7 +293,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
                                                // is stride-1 
 
   RAJA::OffsetLayout<DIM> pB_layout =
-    RAJA::make_permuted_offset_layout( {{-1, -1}}, {{Nc_tot-2, Nr_tot-2}},
+    RAJA::make_permuted_offset_layout( {{-1, -1}}, {{Nc_tot-1, Nr_tot-1}},
                                        perm );
 
   RAJA::Layout<DIM> pA_layout = 

--- a/include/RAJA/util/OffsetLayout.hpp
+++ b/include/RAJA/util/OffsetLayout.hpp
@@ -54,10 +54,10 @@ struct OffsetLayout_impl<camp::idx_seq<RangeInts...>, IdxLin> {
   IdxLin offsets[n_dims]={0}; //If not specified set to zero
 
   constexpr RAJA_INLINE OffsetLayout_impl(
-      std::array<IdxLin, sizeof...(RangeInts)> lower,
-      std::array<IdxLin, sizeof...(RangeInts)> upper)
-      : base_{(upper[RangeInts] - lower[RangeInts] + 1)...},
-        offsets{lower[RangeInts]...}
+      std::array<IdxLin, sizeof...(RangeInts)> begin,
+      std::array<IdxLin, sizeof...(RangeInts)> end)
+      : base_{(end[RangeInts] - begin[RangeInts])...},
+        offsets{begin[RangeInts]...}
   {
   }
 
@@ -180,25 +180,25 @@ struct TypedOffsetLayout<IdxLin, camp::tuple<DimTypes...>>
 
 
 template <size_t n_dims, typename IdxLin = Index_type>
-auto make_offset_layout(const std::array<IdxLin, n_dims>& lower,
-                        const std::array<IdxLin, n_dims>& upper)
+auto make_offset_layout(const std::array<IdxLin, n_dims>& begin,
+                        const std::array<IdxLin, n_dims>& end)
     -> OffsetLayout<n_dims, IdxLin>
 {
-  return OffsetLayout<n_dims, IdxLin>{lower, upper};
+  return OffsetLayout<n_dims, IdxLin>{begin, end};
 }
 
 template <size_t Rank, typename IdxLin = Index_type>
-auto make_permuted_offset_layout(const std::array<IdxLin, Rank>& lower,
-                                 const std::array<IdxLin, Rank>& upper,
+auto make_permuted_offset_layout(const std::array<IdxLin, Rank>& begin,
+                                 const std::array<IdxLin, Rank>& end,
                                  const std::array<IdxLin, Rank>& permutation)
-    -> decltype(make_offset_layout<Rank, IdxLin>(lower, upper))
+    -> decltype(make_offset_layout<Rank, IdxLin>(begin, end))
 {
   std::array<IdxLin, Rank> sizes;
   for (size_t i = 0; i < Rank; ++i) {
-    sizes[i] = upper[i] - lower[i] + 1;
+    sizes[i] = end[i] - begin[i];
   }
   return internal::OffsetLayout_impl<camp::make_idx_seq_t<Rank>, IdxLin>::
-      from_layout_and_offsets(lower, make_permuted_layout(sizes, permutation));
+      from_layout_and_offsets(begin, make_permuted_layout(sizes, permutation));
 }
 
 }  // namespace RAJA

--- a/test/functional/forall/segment-view/tests/test-forall-RangeSegment2DView.hpp
+++ b/test/functional/forall/segment-view/tests/test-forall-RangeSegment2DView.hpp
@@ -88,8 +88,8 @@ void ForallRangeSegment2DOffsetViewTestImpl(INDEX_TYPE N)
 
   using view_type = RAJA::View< INDEX_TYPE, RAJA::OffsetLayout<NDIMS> >;
   RAJA::OffsetLayout<NDIMS> layout =
-    RAJA::make_offset_layout<NDIMS>( {{-1, -1}} , {{N, N}} ); 
-  
+    RAJA::make_offset_layout<NDIMS>( {{-1, -1}} , {{N+1, N+1}} );
+
   view_type work_view(working_array, layout);
 
   RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {

--- a/test/functional/kernel/nested-loop-view-types/tests/test-kernel-nested-loop-OffsetView2D.hpp
+++ b/test/functional/kernel/nested-loop-view-types/tests/test-kernel-nested-loop-OffsetView2D.hpp
@@ -21,8 +21,8 @@ void KernelOffsetView2DTestImpl(std::array<RAJA::idx_t, 2> dim,
 
   RAJA::idx_t N = dim.at(0) * dim.at(1);
 
-  RAJA::idx_t off_dim0 = offset_hi.at(0) + 1 - offset_lo.at(0);
-  RAJA::idx_t off_dim1 = offset_hi.at(1) + 1 - offset_lo.at(1); 
+  RAJA::idx_t off_dim0 = offset_hi.at(0) - offset_lo.at(0);
+  RAJA::idx_t off_dim1 = offset_hi.at(1) - offset_lo.at(1);
   EXPECT_LT( off_dim0, dim.at(0) );
   EXPECT_LT( off_dim1, dim.at(1) );
 
@@ -43,14 +43,14 @@ void KernelOffsetView2DTestImpl(std::array<RAJA::idx_t, 2> dim,
   }
 
 
-  RAJA::OffsetLayout<2> layout = 
-    RAJA::make_offset_layout<2>( {{offset_lo.at(0), offset_lo.at(1)}}, 
-                                 {{offset_lo.at(0) + dim.at(0) - 1, 
-                                   offset_lo.at(1) + dim.at(1) - 1}} );
+  RAJA::OffsetLayout<2> layout =
+    RAJA::make_offset_layout<2>( {{offset_lo.at(0), offset_lo.at(1)}},
+                                 {{offset_lo.at(0) + dim.at(0),
+                                   offset_lo.at(1) + dim.at(1)}} );
   RAJA::View< IDX_TYPE, RAJA::OffsetLayout<2> > view(working_array, layout);
 
-  RAJA::TypedRangeSegment<IDX_TYPE> iseg( offset_lo.at(0), offset_hi.at(0) + 1);
-  RAJA::TypedRangeSegment<IDX_TYPE> jseg( offset_lo.at(1), offset_hi.at(1) + 1);
+  RAJA::TypedRangeSegment<IDX_TYPE> iseg( offset_lo.at(0), offset_hi.at(0));
+  RAJA::TypedRangeSegment<IDX_TYPE> jseg( offset_lo.at(1), offset_hi.at(1));
 
   RAJA::kernel<EXEC_POLICY>( 
     RAJA::make_tuple( iseg, jseg ),

--- a/test/functional/kernel/nested-loop-view-types/tests/test-kernel-nested-loop-OffsetView3D.hpp
+++ b/test/functional/kernel/nested-loop-view-types/tests/test-kernel-nested-loop-OffsetView3D.hpp
@@ -21,9 +21,9 @@ void KernelOffsetView3DTestImpl(std::array<RAJA::idx_t, 3> dim,
 
   RAJA::idx_t N = dim.at(0) * dim.at(1) * dim.at(2);
 
-  RAJA::idx_t off_dim0 = offset_hi.at(0) + 1 - offset_lo.at(0);
-  RAJA::idx_t off_dim1 = offset_hi.at(1) + 1 - offset_lo.at(1); 
-  RAJA::idx_t off_dim2 = offset_hi.at(2) + 1 - offset_lo.at(2); 
+  RAJA::idx_t off_dim0 = offset_hi.at(0) - offset_lo.at(0);
+  RAJA::idx_t off_dim1 = offset_hi.at(1) - offset_lo.at(1);
+  RAJA::idx_t off_dim2 = offset_hi.at(2) - offset_lo.at(2);
   EXPECT_LT( off_dim0, dim.at(0) );
   EXPECT_LT( off_dim1, dim.at(1) );
   EXPECT_LT( off_dim2, dim.at(2) );
@@ -48,19 +48,19 @@ void KernelOffsetView3DTestImpl(std::array<RAJA::idx_t, 3> dim,
   }
 
 
-  RAJA::OffsetLayout<3> layout = 
-    RAJA::make_offset_layout<3>( {{offset_lo.at(0), 
-                                   offset_lo.at(1), 
-                                   offset_lo.at(2)}}, 
-                                 {{offset_lo.at(0) + dim.at(0) - 1, 
-                                   offset_lo.at(1) + dim.at(1) - 1,
-                                   offset_lo.at(2) + dim.at(2) - 1}} );
+  RAJA::OffsetLayout<3> layout =
+    RAJA::make_offset_layout<3>( {{offset_lo.at(0),
+                                   offset_lo.at(1),
+                                   offset_lo.at(2)}},
+                                 {{offset_lo.at(0) + dim.at(0),
+                                   offset_lo.at(1) + dim.at(1),
+                                   offset_lo.at(2) + dim.at(2)}} );
 
   RAJA::View< IDX_TYPE, RAJA::OffsetLayout<3> > view(working_array, layout);
 
-  RAJA::TypedRangeSegment<IDX_TYPE> iseg( offset_lo.at(0), offset_hi.at(0) + 1);
-  RAJA::TypedRangeSegment<IDX_TYPE> jseg( offset_lo.at(1), offset_hi.at(1) + 1);
-  RAJA::TypedRangeSegment<IDX_TYPE> kseg( offset_lo.at(2), offset_hi.at(2) + 1);
+  RAJA::TypedRangeSegment<IDX_TYPE> iseg( offset_lo.at(0), offset_hi.at(0));
+  RAJA::TypedRangeSegment<IDX_TYPE> jseg( offset_lo.at(1), offset_hi.at(1));
+  RAJA::TypedRangeSegment<IDX_TYPE> kseg( offset_lo.at(2), offset_hi.at(2));
 
   RAJA::kernel<EXEC_POLICY>( 
     RAJA::make_tuple( iseg, jseg, kseg ),

--- a/test/functional/kernel/nested-loop-view-types/tests/test-kernel-nested-loop-PermutedOffsetView2D.hpp
+++ b/test/functional/kernel/nested-loop-view-types/tests/test-kernel-nested-loop-PermutedOffsetView2D.hpp
@@ -30,7 +30,7 @@ void KernelPermutedOffsetView2DTestImpl(std::array<RAJA::idx_t, 2> dim,
 
   //
   // These are used in data initialization and setting reference solution.
-  // We set loop bounds baed on permutation, so inner loop is always stride-1, 
+  // We set loop bounds based on permutation, so inner loop is always stride-1,
   // etc.
   // 
   // Also, we assume a finite difference stencil width of one.
@@ -91,7 +91,7 @@ void KernelPermutedOffsetView2DTestImpl(std::array<RAJA::idx_t, 2> dim,
 
   RAJA::OffsetLayout<2> B_layout =
     RAJA::make_permuted_offset_layout<2>( {{-1, -1}},
-                                          {{Ntot_len.at(0)-2, Ntot_len.at(1)-2}},
+                                          {{Ntot_len.at(0)-1, Ntot_len.at(1)-1}},
                                           perm );
   RAJA::Layout<2> A_layout =
     RAJA::make_permuted_layout( {{Nint_len.at(0), Nint_len.at(1)}}, perm );

--- a/test/functional/kernel/nested-loop-view-types/tests/test-kernel-nested-loop-PermutedOffsetView3D.hpp
+++ b/test/functional/kernel/nested-loop-view-types/tests/test-kernel-nested-loop-PermutedOffsetView3D.hpp
@@ -104,9 +104,9 @@ void KernelPermutedOffsetView3DTestImpl(std::array<RAJA::idx_t, 3> dim,
 
   RAJA::OffsetLayout<3> B_layout =
     RAJA::make_permuted_offset_layout<3>( {{-1, -1, -1}},
-                                          {{Ntot_len.at(0)-2, 
-                                            Ntot_len.at(1)-2,
-                                            Ntot_len.at(2)-2}},
+                                          {{Ntot_len.at(0)-1,
+                                            Ntot_len.at(1)-1,
+                                            Ntot_len.at(2)-1}},
                                           perm );
   RAJA::Layout<3> A_layout =
     RAJA::make_permuted_layout( {{Nint_len.at(0), 

--- a/test/unit/view-layout/test-makelayout.cpp
+++ b/test/unit/view-layout/test-makelayout.cpp
@@ -14,7 +14,7 @@ TEST(LayoutUnitTest, OffsetVsRegular)
                                  RAJA::as_array<RAJA::Perm<1, 0>>::get());
   const auto offset =
       RAJA::make_permuted_offset_layout({{0, 0}},
-                                        {{5, 5}},
+                                        {{6, 6}},
                                         RAJA::as_array<RAJA::PERM_JI>::get());
 
   /*
@@ -37,7 +37,7 @@ TEST(OffsetLayoutUnitTest, 2D_IJ)
    * (-1, -1), (0, -1), (1, -1)
    * (-1, -2), (0, -2), (1, -2)
    */
-  const auto layout = RAJA::make_offset_layout<2>({{-1, -2}}, {{1, 0}});
+  const auto layout = RAJA::make_offset_layout<2>({{-1, -2}}, {{2, 1}});
 
   /*
    * First element, (-1, -2), should have index 0.
@@ -69,7 +69,7 @@ TEST(OffsetLayoutUnitTest, 2D_JI)
    */
   const my_layout layout =
       RAJA::make_permuted_offset_layout({{-1, -2}},
-                                        {{1, 0}},
+                                        {{2, 1}},
                                         RAJA::as_array<RAJA::PERM_JI>::get());
 
   /*

--- a/test/unit/view-layout/test-multiview.cpp
+++ b/test/unit/view-layout/test-multiview.cpp
@@ -186,7 +186,7 @@ TYPED_TEST(OffsetLayoutMultiViewUnitTest, View)
    * MultiView is constructed by passing in the layout.
    */
   std::array<RAJA::Index_type, 1> lower{{1}};
-  std::array<RAJA::Index_type, 1> upper{{10}};
+  std::array<RAJA::Index_type, 1> upper{{11}};
   RAJA::MultiView<TypeParam, layout> view(data, RAJA::make_offset_layout<1>(lower, upper));
   RAJA::MultiView<TypeParam, layout,1> view1p(data, RAJA::make_offset_layout<1>(lower, upper));
 
@@ -216,7 +216,7 @@ TYPED_TEST(MultiViewUnitTest, Shift1D)
 
   //Create a view from a base view
   const int DIM = 1;
-  RAJA::OffsetLayout<DIM> layout = RAJA::make_offset_layout<DIM>({{0}},{{N-1}});
+  RAJA::OffsetLayout<DIM> layout = RAJA::make_offset_layout<DIM>({{0}},{{N}});
   RAJA::MultiView<TypeParam, RAJA::OffsetLayout<DIM>> A(a,layout);
   RAJA::MultiView<TypeParam, RAJA::Layout<DIM>> B(a,N);
 
@@ -276,7 +276,7 @@ TYPED_TEST(MultiViewUnitTest, Shift2D)
   a[1] = b0;
 
   const int DIM = 2;
-  RAJA::OffsetLayout<DIM> layout = RAJA::make_offset_layout<DIM>({{0,0}},{{N-1,N-1}});
+  RAJA::OffsetLayout<DIM> layout = RAJA::make_offset_layout<DIM>({{0,0}},{{N,N}});
   RAJA::MultiView<TypeParam, RAJA::OffsetLayout<DIM>> A(a,layout);
   RAJA::MultiView<TypeParam, RAJA::Layout<DIM>> B(a,N,N);
 
@@ -301,7 +301,7 @@ TYPED_TEST(MultiViewUnitTest, Shift2D)
   //Create a view from a base view with permuted layout
   std::array< RAJA::idx_t, 2> perm {{1, 0}};
   RAJA::OffsetLayout<2> playout =
-    RAJA::make_permuted_offset_layout<2>( {{0, 0}}, {{N-1, N-1}}, perm );
+    RAJA::make_permuted_offset_layout<2>( {{0, 0}}, {{N, N}}, perm );
 
   RAJA::MultiView<TypeParam, RAJA::OffsetLayout<DIM>> C(a, playout);
   RAJA::MultiView<TypeParam, RAJA::OffsetLayout<DIM>> Cshift = C.shift({{N,N}});

--- a/test/unit/view-layout/test-standard-layout.cpp
+++ b/test/unit/view-layout/test-standard-layout.cpp
@@ -20,7 +20,7 @@ TEST(OffsetLayoutUnitTest, Constructors)
    *
    * 10, 11, 12, 13, 14
    */
-  const layout l({{10}}, {{14}});
+  const layout l({{10}}, {{15}});
 
   /*
    * First element, 10, should have index 0.

--- a/test/unit/view-layout/test-typedview.cpp
+++ b/test/unit/view-layout/test-typedview.cpp
@@ -176,7 +176,7 @@ TYPED_TEST(OffsetLayoutViewUnitTest, View)
    * View is constructed by passing in the layout.
    */
   std::array<RAJA::Index_type, 1> lower{{1}};
-  std::array<RAJA::Index_type, 1> upper{{10}};
+  std::array<RAJA::Index_type, 1> upper{{11}};
   RAJA::View<TypeParam, layout> view(data, RAJA::make_offset_layout<1>(lower, upper));
 
   for (int i = 0; i < 10; i++) {
@@ -200,7 +200,7 @@ TYPED_TEST(TypedViewUnitTest, Shift1D)
    * Create a view from a base view
    */
   const int DIM = 1;
-  RAJA::OffsetLayout<DIM> layout = RAJA::make_offset_layout<DIM>({{0}},{{N-1}});
+  RAJA::OffsetLayout<DIM> layout = RAJA::make_offset_layout<DIM>({{0}},{{N}});
   RAJA::View<TypeParam, RAJA::OffsetLayout<DIM>> A(a,layout);
   RAJA::View<TypeParam, RAJA::Layout<DIM>> B(a,N);
   RAJA::TypedView<TypeParam, RAJA::Layout<DIM>,TX> C(a,N);
@@ -258,7 +258,7 @@ TYPED_TEST(TypedViewUnitTest, Shift2D)
   TypeParam *b = new TypeParam[N*N];
 
   const int DIM = 2;
-  RAJA::OffsetLayout<DIM> layout = RAJA::make_offset_layout<DIM>({{0,0}},{{N-1,N-1}});
+  RAJA::OffsetLayout<DIM> layout = RAJA::make_offset_layout<DIM>({{0,0}},{{N,N}});
   RAJA::View<TypeParam, RAJA::OffsetLayout<DIM>> A(a,layout);
   RAJA::View<TypeParam, RAJA::Layout<DIM>> B(a,N,N);
 
@@ -286,7 +286,7 @@ TYPED_TEST(TypedViewUnitTest, Shift2D)
    */
   std::array< RAJA::idx_t, 2> perm {{1, 0}};
   RAJA::OffsetLayout<2> playout =
-    RAJA::make_permuted_offset_layout<2>( {{0, 0}}, {{N-1, N-1}}, perm );
+    RAJA::make_permuted_offset_layout<2>( {{0, 0}}, {{N, N}}, perm );
 
   RAJA::View<TypeParam, RAJA::OffsetLayout<DIM>> C(a, playout);
   RAJA::View<TypeParam, RAJA::OffsetLayout<DIM>> Cshift = C.shift({{N,N}});


### PR DESCRIPTION
# Summary
Change OffsetLayout constructor and maker functions to take begin, end where end is excluded instead of first, last where last is included.

This also fixes the tests, examples, and exercies. Note that some tests were not changed because were previously wrong and assumed the [begin, end) behavior and the out of bounds accesses didn't happen to cause failures.

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes #1173 