### PR TITLE
Pull in correct header file

### DIFF
--- a/benchmark/host-device-lambda-benchmark.cpp
+++ b/benchmark/host-device-lambda-benchmark.cpp
@@ -6,7 +6,7 @@
 
 #include <iostream>
 
-#include "benchmark/benchmark_api.h"
+#include "benchmark/benchmark.h"
 
 #include "RAJA/RAJA.hpp"
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix.
- It pulls in the correct google benchmark header so our benchmark code compiles. The issue may be due to a change in version of google benchmark since the code was originally written.