### PR TITLE
Fixed warnings, simd intrinsics, and unroll issues with gcc

### DIFF
--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -371,6 +371,8 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_INLINE inline  __attribute__((always_inline))
 #endif
 
+#define RAJA_UNROLL RAJA_PRAGMA(unroll)
+
 #if defined(RAJA_ENABLE_CUDA) || defined(RAJA_ENABLE_HIP)
 #define RAJA_ALIGN_DATA(d) d
 #else
@@ -535,6 +537,10 @@ T * align_hint(T * x)
 
 }  // closing brace for RAJA namespace
 
+
+#ifndef RAJA_UNROLL
+#define RAJA_UNROLL
+#endif
 
 // If we're in CUDA device code, we can use the nvcc unroll pragma
 #if defined(__CUDA_ARCH__) && defined(RAJA_CUDA_ACTIVE)

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -395,7 +395,6 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 //
 #define RAJA_FORCEINLINE_RECURSIVE
 #define RAJA_INLINE inline  __attribute__((always_inline))
-//#define RAJA_UNROLL __attribute__((optimize("unroll-loops")))
 #define RAJA_UNROLL RAJA_PRAGMA(GCC unroll 10000)
 
 

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -395,6 +395,9 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 //
 #define RAJA_FORCEINLINE_RECURSIVE
 #define RAJA_INLINE inline  __attribute__((always_inline))
+//#define RAJA_UNROLL __attribute__((optimize("unroll-loops")))
+#define RAJA_UNROLL RAJA_PRAGMA(GCC unroll 10000)
+
 
 #if defined(RAJA_ENABLE_CUDA) || defined(RAJA_ENABLE_HIP)
 #define RAJA_ALIGN_DATA(d) d
@@ -421,7 +424,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 //
 #define RAJA_FORCEINLINE_RECURSIVE
 #define RAJA_INLINE inline  __attribute__((always_inline))
-
+#define RAJA_UNROLL 
 // FIXME: alignx is breaking CUDA+xlc
 #if defined(RAJA_ENABLE_CUDA)
 #define RAJA_ALIGN_DATA(d) d
@@ -500,6 +503,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_ALIGN_DATA(d) d
 #define RAJA_SIMD
 #define RAJA_NO_SIMD
+#define RAJA_UNROLL
 
 #endif
 
@@ -529,10 +533,14 @@ T * align_hint(T * x)
 #endif
 }
 
-#ifndef RAJA_UNROLL
-#define RAJA_UNROLL RAJA_PRAGMA(unroll)
-#endif
 
 }  // closing brace for RAJA namespace
+
+
+// If we're in CUDA device code, we can use the nvcc unroll pragma
+#if defined(__CUDA_ARCH__) && defined(RAJA_CUDA_ACTIVE)
+#undef RAJA_UNROLL
+#define RAJA_UNROLL RAJA_PRAGMA(unroll)
+#endif
 
 #endif // closing endif for header file include guard

--- a/include/RAJA/pattern/tensor/internal/VectorRegisterImpl.hpp
+++ b/include/RAJA/pattern/tensor/internal/VectorRegisterImpl.hpp
@@ -74,6 +74,10 @@ namespace expt
       static constexpr camp::idx_t s_mask_per_register =
           (1<<log_base2_t::value)-1;
 
+      // Offset of last regiser in m_registers
+      static constexpr camp::idx_t s_final_register =
+          s_num_partial_lanes == 0 ?
+              s_num_full_registers-1 : s_num_full_registers;
 
       template<typename IDX>
       RAJA_INLINE
@@ -322,7 +326,7 @@ namespace expt
           m_registers[reg].load_packed(ptr+reg*s_register_num_elem);
         }
         if(s_num_partial_lanes){
-          m_registers[s_num_full_registers].load_packed_n(ptr+s_num_full_registers*s_register_num_elem, s_num_partial_lanes);
+          m_registers[s_final_register].load_packed_n(ptr+s_final_register*s_register_num_elem, s_num_partial_lanes);
         }
         return *this;
       }
@@ -338,7 +342,7 @@ namespace expt
           m_registers[reg].load_strided(ptr+reg*s_register_num_elem*stride, stride);
         }
         if(s_num_partial_lanes){
-          m_registers[s_num_full_registers].load_strided_n(ptr+s_num_full_registers*s_register_num_elem*stride, stride, s_num_partial_lanes);
+          m_registers[s_final_register].load_strided_n(ptr+s_final_register*s_register_num_elem*stride, stride, s_num_partial_lanes);
         }
         return *this;
       }
@@ -366,9 +370,9 @@ namespace expt
 
         }
         if(s_num_partial_lanes){
-          m_registers[s_num_full_registers].load_packed_n(
-              ptr+s_num_full_registers*s_register_num_elem,
-              N-s_num_full_registers*s_register_num_elem);
+          m_registers[s_final_register].load_packed_n(
+              ptr+s_final_register*s_register_num_elem,
+              N-s_final_register*s_register_num_elem);
         }
         return *this;
       }
@@ -397,10 +401,10 @@ namespace expt
 
         }
         if(s_num_partial_lanes){
-          m_registers[s_num_full_registers].load_strided_n(
-              ptr+s_num_full_registers*s_register_num_elem*stride,
+          m_registers[s_final_register].load_strided_n(
+              ptr+s_final_register*s_register_num_elem*stride,
               stride,
-              N-s_num_full_registers*s_register_num_elem);
+              N-s_final_register*s_register_num_elem);
         }
         return *this;
       }
@@ -421,7 +425,7 @@ namespace expt
           m_registers[reg].gather(ptr, offsets.vec(reg));
         }
         if(s_num_partial_lanes){
-          m_registers[s_num_full_registers].gather_n(ptr, offsets.vec(s_num_full_registers), s_num_partial_lanes);
+          m_registers[s_final_register].gather_n(ptr, offsets.vec(s_final_register), s_num_partial_lanes);
         }
         return *this;
       }
@@ -451,10 +455,10 @@ namespace expt
 
         }
         if(s_num_partial_lanes){
-          m_registers[s_num_full_registers].gather_n(
+          m_registers[s_final_register].gather_n(
               ptr,
-              offsets.vec(s_num_full_registers),
-              N-s_num_full_registers*s_register_num_elem);
+              offsets.vec(s_final_register),
+              N-s_final_register*s_register_num_elem);
         }
         return *this;
       }
@@ -471,7 +475,7 @@ namespace expt
           m_registers[reg].store_packed(ptr+reg*s_register_num_elem);
         }
         if(s_num_partial_lanes){
-          m_registers[s_num_full_registers].store_packed_n(ptr+s_num_full_registers*s_register_num_elem, s_num_partial_lanes);
+          m_registers[s_final_register].store_packed_n(ptr+s_final_register*s_register_num_elem, s_num_partial_lanes);
         }
         return *this;
       }
@@ -487,7 +491,7 @@ namespace expt
           m_registers[reg].store_strided(ptr+reg*s_register_num_elem*stride, stride);
         }
         if(s_num_partial_lanes){
-          m_registers[s_num_full_registers].store_strided_n(ptr+s_num_full_registers*s_register_num_elem*stride, stride, s_num_partial_lanes);
+          m_registers[s_final_register].store_strided_n(ptr+s_final_register*s_register_num_elem*stride, stride, s_num_partial_lanes);
         }
         return *this;
       }
@@ -511,9 +515,9 @@ namespace expt
 
         }
         if(s_num_partial_lanes){
-          m_registers[s_num_full_registers].store_packed_n(
-              ptr+s_num_full_registers*s_register_num_elem,
-              N-s_num_full_registers*s_register_num_elem);
+          m_registers[s_final_register].store_packed_n(
+              ptr+s_final_register*s_register_num_elem,
+              N-s_final_register*s_register_num_elem);
         }
         return *this;
       }
@@ -539,10 +543,10 @@ namespace expt
 
         }
         if(s_num_partial_lanes){
-          m_registers[s_num_full_registers].store_strided_n(
-              ptr+s_num_full_registers*s_register_num_elem*stride,
+          m_registers[s_final_register].store_strided_n(
+              ptr+s_final_register*s_register_num_elem*stride,
               stride,
-              N-s_num_full_registers*s_register_num_elem);
+              N-s_final_register*s_register_num_elem);
         }
         return *this;
       }
@@ -565,7 +569,7 @@ namespace expt
           m_registers[reg].scatter(ptr, offsets.vec(reg));
         }
         if(s_num_partial_lanes){
-          m_registers[s_num_full_registers].scatter_n(ptr, offsets.vec(s_num_full_registers), s_num_partial_lanes);
+          m_registers[s_final_register].scatter_n(ptr, offsets.vec(s_final_register), s_num_partial_lanes);
         }
         return *this;
       }
@@ -594,9 +598,9 @@ namespace expt
 
         }
         if(s_num_partial_lanes){
-          m_registers[s_num_full_registers].scatter_n(
+          m_registers[s_final_register].scatter_n(
               ptr,
-              offsets.vec(s_num_full_registers),
+              offsets.vec(s_final_register),
               N-s_num_full_registers*s_register_num_elem);
         }
         return *this;
@@ -611,7 +615,7 @@ namespace expt
           result.vec(reg) = m_registers[reg].divide(den.vec(reg));
         }
         if(s_num_partial_lanes){
-          result.vec(s_num_full_registers) = m_registers[s_num_full_registers].divide_n(den.vec(s_num_full_registers), s_num_partial_lanes);
+          result.vec(s_final_register) = m_registers[s_final_register].divide_n(den.vec(s_final_register), s_num_partial_lanes);
         }
         return result;
       }
@@ -668,7 +672,7 @@ namespace expt
           result = RAJA::min<element_type>(result, m_registers[i].min());
         }
         if(s_num_partial_lanes){
-          result = RAJA::min<element_type>(result, m_registers[s_num_full_registers].min_n(s_num_partial_lanes));
+          result = RAJA::min<element_type>(result, m_registers[s_final_register].min_n(s_num_partial_lanes));
         }
         return result;
       }
@@ -694,7 +698,7 @@ namespace expt
           }
         }
         if(N-s_num_full_registers*s_register_num_elem > 0){
-          result = RAJA::min<element_type>(result, m_registers[s_num_full_registers].min_n(N-s_num_full_registers*s_register_num_elem));
+          result = RAJA::min<element_type>(result, m_registers[s_final_register].min_n(N-s_final_register*s_register_num_elem));
         }
         return result;
       }
@@ -716,7 +720,7 @@ namespace expt
           result = RAJA::max<element_type>(result, m_registers[i].max());
         }
         if(s_num_partial_lanes){
-          result = RAJA::max<element_type>(result, m_registers[s_num_full_registers].max_n(s_num_partial_lanes));
+          result = RAJA::max<element_type>(result, m_registers[s_final_register].max_n(s_num_partial_lanes));
         }
         return result;
       }
@@ -742,7 +746,7 @@ namespace expt
           }
         }
         if(N-s_num_full_registers*s_register_num_elem > 0){
-          result = RAJA::max<element_type>(result, m_registers[s_num_full_registers].max_n(N-s_num_full_registers*s_register_num_elem));
+          result = RAJA::max<element_type>(result, m_registers[s_final_register].max_n(N-s_final_register*s_register_num_elem));
         }
         return result;
       }

--- a/include/RAJA/policy/tensor/arch/avx/avx_int32.hpp
+++ b/include/RAJA/policy/tensor/arch/avx/avx_int32.hpp
@@ -229,7 +229,7 @@ namespace expt
        */
       RAJA_INLINE
       self_type const &store_packed_n(element_type *ptr, camp::idx_t N) const{
-        _mm256_maskstore_ps(reinterpret_cast<float*>(ptr), createMask(N), m_value);
+        _mm256_maskstore_ps(reinterpret_cast<float*>(ptr), createMask(N), reinterpret_cast<__m256>(m_value));
         return *this;
       }
 

--- a/include/RAJA/policy/tensor/arch/avx/avx_int64.hpp
+++ b/include/RAJA/policy/tensor/arch/avx/avx_int64.hpp
@@ -203,7 +203,7 @@ namespace expt
        */
       RAJA_INLINE
       self_type const &store_packed_n(element_type *ptr, camp::idx_t N) const{
-        _mm256_maskstore_pd(reinterpret_cast<double*>(ptr), createMask(N), m_value);
+        _mm256_maskstore_pd(reinterpret_cast<double*>(ptr), createMask(N), reinterpret_cast<__m256d>(m_value));
         return *this;
       }
 

--- a/test/include/RAJA_gtest.hpp
+++ b/test/include/RAJA_gtest.hpp
@@ -117,7 +117,6 @@
       asm("trap;"); \
   } \
 }
-      //printf("Assertion failed: " #X " (%ld) != " #Y " (%ld)\n", (long)x, (long)y); \
 
 #define RAJA_ASSERT_FLOAT_EQ(X,Y) {RAJA_ASSERT_EQ(X,Y);}
 #define RAJA_ASSERT_DOUBLE_EQ(X,Y) {RAJA_ASSERT_EQ(X,Y);}


### PR DESCRIPTION
# Summary

- This PR is a bugfix for gcc
- It does the following:
  - Fixes RAJA_UNROLL to not break on gcc, and also work correctly with CUDA
  - Fixes SIMD intrinsics to properly work for in32 and in64 with GCC
  - Removed a warning being emitted from the RAJA_gtest.hpp file

