### PR TITLE
Fix tbb scan

### DIFF
--- a/include/RAJA/policy/tbb/scan.hpp
+++ b/include/RAJA/policy/tbb/scan.hpp
@@ -172,7 +172,7 @@ inclusive(
     BinFn f)
 {
   auto adapter = detail::scan_adapter_inclusive<
-      typename std::remove_reference<decltype(*begin)>::type,
+      typename std::remove_reference<decltype(*out)>::type,
       Iter,
       OutIter,
       BinFn>{begin, out, f, BinFn::identity()};
@@ -205,7 +205,7 @@ exclusive(
     T v)
 {
   auto adapter = detail::scan_adapter_exclusive<
-      typename std::remove_reference<decltype(*begin)>::type,
+      typename std::remove_reference<decltype(*out)>::type,
       Iter,
       OutIter,
       BinFn>{begin, out, f, v};


### PR DESCRIPTION
# Fix tbb non-inplace scan implementation

Use type of *out instead of *begin to avoid using const types in the implementation.

- This PR is a bugfix
- It does the following:
  - Fixes tbb scan