### PR TITLE
Squash RAJA_UNROLL warnings (nvcc/gcc)

### DIFF
--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -397,8 +397,12 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 //
 #define RAJA_FORCEINLINE_RECURSIVE
 #define RAJA_INLINE inline  __attribute__((always_inline))
-#define RAJA_UNROLL RAJA_PRAGMA(GCC unroll 10000)
 
+#if !defined(__NVCC__)
+#define RAJA_UNROLL RAJA_PRAGMA(GCC unroll 10000)
+#else
+#define RAJA_UNROLL RAJA_PRAGMA(unroll)
+#endif
 
 #if defined(RAJA_ENABLE_CUDA) || defined(RAJA_ENABLE_HIP)
 #define RAJA_ALIGN_DATA(d) d


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Fixes pragma warnings that appear when compiling with nvcc/gcc in RAJA_UNROLL
