### PR TITLE
Add cmake dependencies if none were specified in raja_add_executable.

### DIFF
--- a/cmake/RAJAMacros.cmake
+++ b/cmake/RAJAMacros.cmake
@@ -12,28 +12,29 @@ macro(raja_add_executable)
 
   cmake_parse_arguments(arg
     "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN})
+  if (NOT arg_DEPENDS_ON)
+    list (APPEND arg_DEPENDS_ON RAJA)
 
-  list (APPEND arg_DEPENDS_ON RAJA)
+    if (RAJA_ENABLE_OPENMP)
+      list (APPEND arg_DEPENDS_ON openmp)
+    endif ()
 
-  if (RAJA_ENABLE_OPENMP)
-    list (APPEND arg_DEPENDS_ON openmp)
-  endif ()
+    if (RAJA_ENABLE_CUDA)
+      list (APPEND arg_DEPENDS_ON cuda)
+    endif ()
 
-  if (RAJA_ENABLE_CUDA)
-    list (APPEND arg_DEPENDS_ON cuda)
-  endif ()
+    if (RAJA_ENABLE_HIP)
+      list (APPEND arg_DEPENDS_ON blt::hip)
+      list (APPEND arg_DEPENDS_ON blt::hip_runtime)
+    endif ()
 
-  if (RAJA_ENABLE_HIP)
-    list (APPEND arg_DEPENDS_ON blt::hip)
-    list (APPEND arg_DEPENDS_ON blt::hip_runtime)
-  endif ()
+    if (RAJA_ENABLE_SYCL)
+      list (APPEND arg_DEPENDS_ON sycl)
+    endif ()
 
-  if (RAJA_ENABLE_SYCL)
-    list (APPEND arg_DEPENDS_ON sycl)
-  endif ()
-
-  if (RAJA_ENABLE_TBB)
-    list (APPEND arg_DEPENDS_ON tbb)
+    if (RAJA_ENABLE_TBB)
+      list (APPEND arg_DEPENDS_ON tbb)
+    endif ()
   endif ()
 
   if (${arg_TEST})


### PR DESCRIPTION
# Summary

- This PR is a bugfix
  - While building CoMD in the RAJAProxies repo with HIP, RAJA attempts to add an extraneous `-lopenmp` link flag if RAJA was already installed with OpenMP enabled. HIP does not recognize this flag, and if the HIP build does not require OpenMP, this flag causes an error. Furthermore, the CoMD use of `raja_add_executable()` already passes in the necessary dependencies it requires.
- It does the following:
  - Changes RAJA's cmake setup to only add library dependencies if none are passed to `raja_add_executable()`.
  - NOTE: This would need to be patched into the v2022.03.x release.