### PR TITLE
Fix usage of amdgpu_target/CMAKE_HIP_ARCHITECTURES

### DIFF
--- a/.gitlab/corona-jobs.yml
+++ b/.gitlab/corona-jobs.yml
@@ -7,10 +7,10 @@
 
 hip_4_5_2_clang_13_0_0 (build and test on corona):
   variables:
-    SPEC: "+rocm~openmp amdgpu_target=gfx906 %clang@13.0.0 cxxflags=--offload-arch=gfx906 ^blt@develop ^hip@4.5.2"
+    SPEC: "+rocm~openmp amdgpu_target=gfx906 %clang@13.0.0 ^blt@develop ^hip@4.5.2"
   extends: .build_and_test_on_corona
 
 hip_4_5_2_clang_13_0_0_desul_atomics (build and test on corona):
   variables:
-    SPEC: "+rocm~openmp +desul amdgpu_target=gfx906 %clang@13.0.0 cxxflags=--offload-arch=gfx906 ^blt@develop ^hip@4.5.2"
+    SPEC: "+rocm~openmp +desul amdgpu_target=gfx906 %clang@13.0.0 ^blt@develop ^hip@4.5.2"
   extends: .build_and_test_on_corona

--- a/scripts/spack_packages/raja/package.py
+++ b/scripts/spack_packages/raja/package.py
@@ -305,23 +305,15 @@ class Raja(CMakePackage, CudaPackage, ROCmPackage):
 
             hip_root = spec['hip'].prefix
             rocm_root = hip_root + "/.."
+            hip_arch = spec.variants['amdgpu_target'].value
             cfg.write(cmake_cache_entry("HIP_ROOT_DIR",
                                         hip_root))
             cfg.write(cmake_cache_entry("ROCM_ROOT_DIR",
                                         rocm_root))
             cfg.write(cmake_cache_entry("HIP_PATH",
                                         rocm_root + '/llvm/bin'))
-            cfg.write(cmake_cache_entry("CMAKE_HIP_ARCHITECTURES", 'fx906'))
+            cfg.write(cmake_cache_entry("CMAKE_HIP_ARCHITECTURES", hip_arch[0]))
 
-            hipcc_flags = ['--amdgpu-target=gfx906']
-            if "+desul" in spec:
-                hipcc_flags.append('-std=c++14')
-            
-            cfg.write(cmake_cache_entry("HIP_HIPCC_FLAGS", ';'.join(hipcc_flags)))
-
-            #cfg.write(cmake_cache_entry("HIP_RUNTIME_INCLUDE_DIRS",
-            #                            "{0}/include;{0}/../hsa/include".format(hip_root)))
-            #hip_link_flags = "-Wl,--disable-new-dtags -L{0}/lib -L{0}/../lib64 -L{0}/../lib -Wl,-rpath,{0}/lib:{0}/../lib:{0}/../lib64 -lamdhip64 -lhsakmt -lhsa-runtime64".format(hip_root)
             if ('%gcc' in spec) or (using_toolchain):
                 if ('%gcc' in spec):
                     gcc_bin = os.path.dirname(self.compiler.cxx)
@@ -332,8 +324,6 @@ class Raja(CMakePackage, CudaPackage, ROCmPackage):
                 "--gcc-toolchain={0}".format(gcc_prefix))) 
                 cfg.write(cmake_cache_entry("CMAKE_EXE_LINKER_FLAGS",
                 " -Wl,-rpath {}/lib64".format(gcc_prefix)))
-            #else:
-            #    cfg.write(cmake_cache_entry("CMAKE_EXE_LINKER_FLAGS", hip_link_flags))
 
         else:
             cfg.write(cmake_cache_option("ENABLE_HIP", False))


### PR DESCRIPTION
This cleans up the HIP builds by correctly using the `CMAKE_HIP_ARCHITECTURES` variable.