### PR TITLE
Change openmp default mechanism, so we can turn it off when needed

### DIFF
--- a/.gitlab/lassen-jobs.yml
+++ b/.gitlab/lassen-jobs.yml
@@ -9,14 +9,14 @@
 # CPU ONLY
 ##########
 
-ibm_clang_9:
+clang_9:
   variables:
-    SPEC: "%clang@ibm.9.0.0"
+    SPEC: "%clang@9.0.0"
   extends: .build_and_test_on_lassen
 
-ibm_clang_9_gcc_8:
+clang_9_gcc_8:
   variables:
-    SPEC: "%clang@ibm.9.0.0 cxxflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1"
+    SPEC: "%clang@9.0.0 cxxflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1"
   extends: .build_and_test_on_lassen
 
 gcc_8_3_1:
@@ -40,14 +40,14 @@ xl_16_1_1_11_gcc_8_3_1:
 # CUDA
 ##########
 
-ibm_clang_9_cuda:
+clang_9_cuda:
   variables:
-    SPEC: "+cuda cuda_arch=70 %clang@ibm.9.0.0 ^cuda@10.1.168"
+    SPEC: "+cuda cuda_arch=70 %clang@9.0.0 ^cuda@10.1.168"
   extends: .build_and_test_on_lassen
 
-ibm_clang_10_cuda:
+clang_11_cuda:
   variables:
-    SPEC: "+cuda cuda_arch=70 %clang@ibm.10.0.1 ^cuda@10.1.168"
+    SPEC: "+cuda cuda_arch=70 %clang@11.0.0 ^cuda@10.1.168"
   extends: .build_and_test_on_lassen
 
 gcc_8_3_1_cuda:

--- a/.gitlab/lassen-jobs.yml
+++ b/.gitlab/lassen-jobs.yml
@@ -11,28 +11,28 @@
 
 clang_9:
   variables:
-    SPEC: "%clang@9.0.0"
+    SPEC: "+openmp %clang@9.0.0"
   extends: .build_and_test_on_lassen
 
 clang_9_gcc_8:
   variables:
-    SPEC: "%clang@9.0.0 cxxflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1"
+    SPEC: "+openmp %clang@9.0.0 cxxflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1"
   extends: .build_and_test_on_lassen
 
 gcc_8_3_1:
   variables:
-    SPEC: "%gcc@8.3.1 cxxflags='-finline-functions -finline-limit=20000' cflags='-finline-functions -finline-limit=20000'"
+    SPEC: "+openmp %gcc@8.3.1 cxxflags='-finline-functions -finline-limit=20000' cflags='-finline-functions -finline-limit=20000'"
   extends: .build_and_test_on_lassen
 
 xl_16_1_1_11:
   variables:
-    SPEC: "%xl@16.1.1.11 cxxflags='-qthreaded -std=c++14 -O3 -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036'"
+    SPEC: "+openmp %xl@16.1.1.11 cxxflags='-qthreaded -std=c++14 -O3 -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036'"
     DEFAULT_TIME: 50
   extends: .build_and_test_on_lassen
 
 xl_16_1_1_11_gcc_8_3_1:
   variables:
-    SPEC: "%xl@16.1.1.11 cxxflags='--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 -qthreaded -std=c++14 -O3 -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036' cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1"
+    SPEC: "+openmp %xl@16.1.1.11 cxxflags='--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 -qthreaded -std=c++14 -O3 -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036' cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1"
     DEFAULT_TIME: 50
   extends: .build_and_test_on_lassen
 
@@ -42,34 +42,34 @@ xl_16_1_1_11_gcc_8_3_1:
 
 clang_9_cuda:
   variables:
-    SPEC: "+cuda cuda_arch=70 %clang@9.0.0 ^cuda@10.1.168"
+    SPEC: "+openmp +cuda cuda_arch=70 %clang@9.0.0 ^cuda@10.1.168"
   extends: .build_and_test_on_lassen
 
 clang_11_cuda:
   variables:
-    SPEC: "+cuda cuda_arch=70 %clang@11.0.0 ^cuda@10.1.168"
+    SPEC: "+openmp +cuda cuda_arch=70 %clang@11.0.0 ^cuda@10.1.168"
   extends: .build_and_test_on_lassen
 
 gcc_8_3_1_cuda:
   variables:
-    SPEC: "+cuda %gcc@8.3.1 cuda_arch=70 ^cuda@10.1.168"
+    SPEC: "+openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@10.1.168"
   extends: .build_and_test_on_lassen
 
 gcc_8_3_1_cuda_ats_disabled:
   variables:
-    SPEC: "+cuda %gcc@8.3.1 cuda_arch=70 ^cuda@10.1.168"
+    SPEC: "+openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@10.1.168"
   extends: .build_and_test_on_lassen_ats_disabled
 
 xl_16_1_1_7_cuda:
   variables:
-    SPEC: "+cuda %xl@16.1.1.7 cuda_arch=70 ^cuda@10.1.168 ^cmake@3.14.5"
+    SPEC: "+openmp +cuda %xl@16.1.1.7 cuda_arch=70 ^cuda@10.1.168 ^cmake@3.14.5"
     DEFAULT_TIME: 60
   allow_failure: true
   extends: .build_and_test_on_lassen
 
 xl_16_1_1_7_gcc_8_3_1_cuda_11:
   variables:
-    SPEC: "+cuda %xl@16.1.1.7 cuda_arch=70 cxxflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 ^cuda@11.0.2 ^cmake@3.14.5"
+    SPEC: "+openmp +cuda %xl@16.1.1.7 cuda_arch=70 cxxflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 ^cuda@11.0.2 ^cmake@3.14.5"
     DEFAULT_TIME: 60
   allow_failure: true
   extends: .build_and_test_on_lassen
@@ -80,16 +80,16 @@ xl_16_1_1_7_gcc_8_3_1_cuda_11:
 
 clang_9_0_0_libcpp (build and test on lassen):
   variables:
-    SPEC: "%clang@9.0.0+libcpp"
+    SPEC: "+openmp %clang@9.0.0+libcpp"
   extends: .build_and_test_on_lassen
 
 clang_9_0_0_memleak (build and test on lassen):
   variables:
-    SPEC: "%clang@9.0.0 cxxflags=-fsanitize=address"
+    SPEC: "+openmp %clang@9.0.0 cxxflags=-fsanitize=address"
     ASAN_OPTIONS: "detect_leaks=1"
   extends: .build_and_test_on_lassen
 
 gcc_8_3_1_cuda_desul_atomics:
   variables:
-    SPEC: "+cuda +desul %gcc@8.3.1 cuda_arch=70 ^cuda@10.1.168"
+    SPEC: "+openmp +cuda +desul %gcc@8.3.1 cuda_arch=70 ^cuda@10.1.168"
   extends: .build_and_test_on_lassen

--- a/.gitlab/ruby-jobs.yml
+++ b/.gitlab/ruby-jobs.yml
@@ -7,15 +7,26 @@
 
 clang_10:
   variables:
-    SPEC: "%clang@10.0.1"
+    SPEC: "+openmp %clang@10.0.1"
   extends: .build_and_test_on_ruby
 
 clang_9:
   variables:
-    SPEC: "%clang@9.0.0"
+    SPEC: "+openmp %clang@9.0.0"
+  extends: .build_and_test_on_ruby
+
+clang_9_openmp_off:
+  variables:
+    SPEC: "~openmp %clang@9.0.0"
   extends: .build_and_test_on_ruby
 
 gcc_8_1_0:
+  variables:
+    SPEC: "+openmp %gcc@8.1.0"
+    DEFAULT_TIME: 60
+  extends: .build_and_test_on_ruby
+
+gcc_8_1_0_openmp_default:
   variables:
     SPEC: "%gcc@8.1.0"
     DEFAULT_TIME: 60
@@ -35,7 +46,7 @@ icpc_18_0_2:
 
 icpc_19_1_0:
   variables:
-    SPEC: "%intel@19.1.0"
+    SPEC: "+openmp %intel@19.1.0"
     DEFAULT_TIME: 40
   extends: .build_and_test_on_ruby
 

--- a/cmake/SetupRajaOptions.cmake
+++ b/cmake/SetupRajaOptions.cmake
@@ -5,9 +5,6 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ################################################################################
 
-# Enable OpenMP by by default (ENABLE_OPENMP is a BLT option)
-#set(ENABLE_OPENMP On CACHE BOOL "Build OpenMP support")
-
 set(RAJA_ENABLE_WARNINGS_AS_ERRORS Off CACHE BOOL "")
 set(ENABLE_GTEST_DEATH_TESTS On CACHE BOOL "Enable tests asserting failure.")
 

--- a/cmake/SetupRajaOptions.cmake
+++ b/cmake/SetupRajaOptions.cmake
@@ -6,7 +6,7 @@
 ################################################################################
 
 # Enable OpenMP by by default (ENABLE_OPENMP is a BLT option)
-set(ENABLE_OPENMP On CACHE BOOL "Build OpenMP support")
+#set(ENABLE_OPENMP On CACHE BOOL "Build OpenMP support")
 
 set(RAJA_ENABLE_WARNINGS_AS_ERRORS Off CACHE BOOL "")
 set(ENABLE_GTEST_DEATH_TESTS On CACHE BOOL "Enable tests asserting failure.")

--- a/cmake/SetupRajaOptions.cmake
+++ b/cmake/SetupRajaOptions.cmake
@@ -5,8 +5,8 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ################################################################################
 
-# Enable OpenMP by by default
-set(RAJA_ENABLE_OPENMP On CACHE BOOL "Build OpenMP support")
+# Enable OpenMP by by default (ENABLE_OPENMP is a BLT option)
+set(ENABLE_OPENMP On CACHE BOOL "Build OpenMP support")
 
 set(RAJA_ENABLE_WARNINGS_AS_ERRORS Off CACHE BOOL "")
 set(ENABLE_GTEST_DEATH_TESTS On CACHE BOOL "Enable tests asserting failure.")

--- a/docs/sphinx/user_guide/config_options.rst
+++ b/docs/sphinx/user_guide/config_options.rst
@@ -74,17 +74,26 @@ need to do that using appropriate CMake variables.
 All RAJA options are set like regular CMake variables. RAJA settings for 
 default options, compilers, flags for optimization, etc. can be found in files 
 in the ``RAJA/cmake`` directory and top-level ``CMakeLists.txt`` file. 
-Configuration variables can be set by passing
-arguments to CMake on the command line when CMake is called, or by setting
-options in a CMake *cache file* and passing that file to CMake using the 
-CMake ``-C`` options. For example, to enable RAJA OpenMP functionality, 
-pass the following argument to CMake::
+Configuration variables can be set by passing arguments to CMake on the 
+command line when calling CMake. For example, to enable RAJA OpenMP 
+functionality, pass the following argument to CMake::
 
+    cmake ... \
     -DENABLE_OPENMP=On
+    ...
 
-The RAJA repository contains a collection of CMake cache files 
-(we call them *host-config* files) that may be used as a guide for users trying
-to set their own options. See :ref:`configopt-raja-hostconfig-label`.
+Alternatively, CMake options may be set in a CMake *cache file* and passing 
+that file to CMake using the CMake ``-C`` option; for example::
+
+    cmake ... \
+    -C my_cache_file.cmake
+    ...
+
+The directories ``RAJA/scripts/*-builds`` contain scripts that run CMake for
+various build configurations. These contain cmake invocations that use CMake 
+cache files (we call them *host-config* files) and may be used as a guide for 
+users trying to set their own options. 
+See :ref:`configopt-raja-hostconfig-label`.
 
 Next, we summarize RAJA options and their defaults.
 
@@ -159,7 +168,7 @@ are as follows (names are descriptive of what they enable):
       ==========================   ============================================
       Variable                     Default
       ==========================   ============================================
-      (RAJA_)ENABLE_OPENMP         On
+      (RAJA_)ENABLE_OPENMP         Off
       (RAJA_)ENABLE_CUDA           Off
       (RAJA_)ENABLE_HIP            Off
       RAJA_ENABLE_TARGET_OPENMP    Off (when on, (RAJA_)ENABLE_OPENMP must 

--- a/docs/sphinx/user_guide/getting_started.rst
+++ b/docs/sphinx/user_guide/getting_started.rst
@@ -89,10 +89,8 @@ RAJA uses CMake to configure a build. A "bare bones" configuration looks like::
             run CMake in it.
 
 When you run CMake, it will generate output about the build environment 
-(compiler and version, options, etc.). Some RAJA features, 
-like OpenMP support are enabled by default if, for example, the compiler 
-supports OpenMP. These can be disabled if desired. For a summary of 
-RAJA configuration options, please see :ref:`configopt-label`.
+(compiler and version, options, etc.). For a summary of RAJA configuration 
+options, please see :ref:`configopt-label`.
 
 After CMake successfully completes, you compile RAJA by executing the ``make``
 command in the build directory; i.e.,::


### PR DESCRIPTION
# Summary

- This PR is a bugfix.
- Prior to this we were setting RAJA_ENABLE_OPENMP as a cached variable and also as a dependent option.
- The changes made here change the default for OpenMP to off. It must be enabled using a CMake option (i.e., -DENABLE_OPENMP=On). This is consistent with how we handle other back-ends and also allow folks to turn OpenMP off, if desired, which was broken before.
- User guide is also updated to relflect this change.
- Also, changed blueos clang builds to use regular clang and not clang-ibm. We have intermittent test failures with clang-ibm that I think are due to runtime issue(s).

Note: the test configurations all also changed to include multiple OpenMP enable/disable scenarios; described in this issue https://github.com/LLNL/RAJA/issues/1252