### PR TITLE
Update radiuss-space-configs submodule and Gitlab CI for lassen

### DIFF
--- a/.gitlab/lassen-jobs.yml
+++ b/.gitlab/lassen-jobs.yml
@@ -19,6 +19,11 @@ clang_9_gcc_8:
     SPEC: "+openmp %clang@9.0.0 cxxflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1"
   extends: .build_and_test_on_lassen
 
+clang_11_0_0:
+  variables:
+    SPEC: "+openmp %clang@11.0.0"
+  extends: .build_and_test_on_lassen
+
 gcc_8_3_1:
   variables:
     SPEC: "+openmp %gcc@8.3.1 cxxflags='-finline-functions -finline-limit=20000' cflags='-finline-functions -finline-limit=20000'"
@@ -26,13 +31,13 @@ gcc_8_3_1:
 
 xl_16_1_1_11:
   variables:
-    SPEC: "+openmp %xl@16.1.1.11 cxxflags='-qthreaded -std=c++14 -O3 -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036'"
+    SPEC: "+openmp %xl@16.1.1.11 cxxflags='-qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036'"
     DEFAULT_TIME: 50
   extends: .build_and_test_on_lassen
 
 xl_16_1_1_11_gcc_8_3_1:
   variables:
-    SPEC: "+openmp %xl@16.1.1.11 cxxflags='--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 -qthreaded -std=c++14 -O3 -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036' cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1"
+    SPEC: "+openmp %xl@16.1.1.11 cxxflags='--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 -qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036' cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1"
     DEFAULT_TIME: 50
   extends: .build_and_test_on_lassen
 
@@ -60,16 +65,16 @@ gcc_8_3_1_cuda_ats_disabled:
     SPEC: "+openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@10.1.168"
   extends: .build_and_test_on_lassen_ats_disabled
 
-xl_16_1_1_7_cuda:
+xl_16_1_1_11_cuda_10:
   variables:
-    SPEC: "+openmp +cuda %xl@16.1.1.7 cuda_arch=70 ^cuda@10.1.168 ^cmake@3.14.5"
+    SPEC: "+openmp +cuda %xl@16.1.1.11 cxxflags='-qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036' cuda_arch=70 ^cuda@10.1.168 ^cmake@3.14.5"
     DEFAULT_TIME: 60
   allow_failure: true
   extends: .build_and_test_on_lassen
 
-xl_16_1_1_7_gcc_8_3_1_cuda_11:
+xl_16_1_1_11_gcc_8_3_1_cuda_11:
   variables:
-    SPEC: "+openmp +cuda %xl@16.1.1.7 cuda_arch=70 cxxflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 ^cuda@11.0.2 ^cmake@3.14.5"
+    SPEC: "+openmp +cuda %xl@16.1.1.11 cxxflags='--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 -qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036' cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 cuda_arch=70 ^cuda@11.0.2 ^cmake@3.14.5"
     DEFAULT_TIME: 60
   allow_failure: true
   extends: .build_and_test_on_lassen


### PR DESCRIPTION

# Summary

- This PR pulls in the latest radiuss-spack-configs version of the submodule
- It also updates some of the GItlab CI builds on lassen

Note: the compiler specs in the radiuss-spack-configs repo require further updates. When that is done, we can update the compiler for Gitlab CI again in a new PR.