### PR TITLE
Switch to HIP 5.1.0 in CI

### DIFF
--- a/.gitlab/corona-jobs.yml
+++ b/.gitlab/corona-jobs.yml
@@ -5,12 +5,12 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 #############################################################################
 
-hip_4_5_2_clang_13_0_0 (build and test on corona):
+hip_5.1.0_clang_13_0_0 (build and test on corona):
   variables:
-    SPEC: "+rocm~openmp amdgpu_target=gfx906 %clang@13.0.0 ^blt@develop ^hip@4.5.2"
+    SPEC: "+rocm~openmp amdgpu_target=gfx906 %clang@13.0.0 ^blt@develop ^hip@5.1.0"
   extends: .build_and_test_on_corona
 
-hip_4_5_2_clang_13_0_0_desul_atomics (build and test on corona):
+hip_5.1.0_clang_13_0_0_desul_atomics (build and test on corona):
   variables:
-    SPEC: "+rocm~openmp +desul amdgpu_target=gfx906 %clang@13.0.0 ^blt@develop ^hip@4.5.2"
+    SPEC: "+rocm~openmp +desul amdgpu_target=gfx906 %clang@13.0.0 ^blt@develop ^hip@5.1.0"
   extends: .build_and_test_on_corona


### PR DESCRIPTION
This PR switches the CI jobs running on corona to use HIP 5.1.0
