### PR TITLE
Guard tensor hip and cuda policy includes when not running on device

### DIFF
--- a/include/RAJA/policy/tensor/arch_impl.hpp
+++ b/include/RAJA/policy/tensor/arch_impl.hpp
@@ -45,11 +45,11 @@
 #include<RAJA/policy/tensor/arch/avx.hpp>
 #endif
 
-#ifdef RAJA_ENABLE_CUDA
+#ifdef RAJA_CUDA_ACTIVE
 #include<RAJA/policy/tensor/arch/cuda.hpp>
 #endif
 
-#ifdef RAJA_ENABLE_HIP
+#ifdef RAJA_HIP_ACTIVE
 #include<RAJA/policy/tensor/arch/hip.hpp>
 #endif
 


### PR DESCRIPTION
This PR guards tensor hip and cuda policy includes when not running on device.

Compilation errors were encountered when compiling code that depended on raja but were not on device.

Related to LLNL/axom#817 and LLNL/axom#812