### PR TITLE
Guard tensor hip and cuda policy includes when not running on device

### DIFF
--- a/include/RAJA/policy/tensor/arch_impl.hpp
+++ b/include/RAJA/policy/tensor/arch_impl.hpp
@@ -45,11 +45,11 @@
 #include<RAJA/policy/tensor/arch/avx.hpp>
 #endif
 
-#ifdef RAJA_ENABLE_CUDA
+#ifdef RAJA_CUDA_ACTIVE
 #include<RAJA/policy/tensor/arch/cuda.hpp>
 #endif
 
-#ifdef RAJA_ENABLE_HIP
+#ifdef RAJA_HIP_ACTIVE
 #include<RAJA/policy/tensor/arch/hip.hpp>
 #endif
 


### PR DESCRIPTION
# Summary

- This PR pulls a branch from a forked repo into the RAJA repo for review. The original PR is https://github.com/LLNL/RAJA/pull/1261
