### PR TITLE
Adding CUDA 11 jobs to Lassen CI

### DIFF
--- a/.gitlab/lassen-jobs.yml
+++ b/.gitlab/lassen-jobs.yml
@@ -45,34 +45,34 @@ xl_16_1_1_11_gcc_8_3_1:
 # CUDA
 ##########
 
-clang_9_cuda:
+clang_9_cuda_11_0_2:
   variables:
     SPEC: "+openmp +cuda cuda_arch=70 %clang@9.0.0 ^cuda@11.0.2"
   extends: .build_and_test_on_lassen
 
-clang_11_cuda:
+clang_11_cuda_11_5_0:
   variables:
     SPEC: "+openmp +cuda cuda_arch=70 %clang@11.0.0 ^cuda@11.5.0"
   extends: .build_and_test_on_lassen
 
-gcc_8_3_1_cuda:
+gcc_8_3_1_cuda_11_0_2:
   variables:
     SPEC: "+openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@11.0.2"
   extends: .build_and_test_on_lassen
 
-gcc_8_3_1_cuda_ats_disabled:
+gcc_8_3_1_cuda_11_5_0_ats_disabled:
   variables:
     SPEC: "+openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@11.5.0"
   extends: .build_and_test_on_lassen_ats_disabled
 
-xl_16_1_1_11_cuda_10:
+xl_16_1_1_11_cuda_11_0_2:
   variables:
     SPEC: "+openmp +cuda %xl@16.1.1.11 cxxflags='-qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036' cuda_arch=70 ^cuda@11.0.2 ^cmake@3.14.5"
     DEFAULT_TIME: 60
   allow_failure: true
   extends: .build_and_test_on_lassen
 
-xl_16_1_1_11_gcc_8_3_1_cuda_11:
+xl_16_1_1_11_gcc_8_3_1_cuda_11_0_2:
   variables:
     SPEC: "+openmp +cuda %xl@16.1.1.11 cxxflags='--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 -qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036' cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 cuda_arch=70 ^cuda@11.0.2 ^cmake@3.14.5"
     DEFAULT_TIME: 60

--- a/.gitlab/lassen-jobs.yml
+++ b/.gitlab/lassen-jobs.yml
@@ -47,27 +47,27 @@ xl_16_1_1_11_gcc_8_3_1:
 
 clang_9_cuda:
   variables:
-    SPEC: "+openmp +cuda cuda_arch=70 %clang@9.0.0 ^cuda@10.1.168"
+    SPEC: "+openmp +cuda cuda_arch=70 %clang@9.0.0 ^cuda@11.0.2"
   extends: .build_and_test_on_lassen
 
 clang_11_cuda:
   variables:
-    SPEC: "+openmp +cuda cuda_arch=70 %clang@11.0.0 ^cuda@10.1.168"
+    SPEC: "+openmp +cuda cuda_arch=70 %clang@11.0.0 ^cuda@11.5.0"
   extends: .build_and_test_on_lassen
 
 gcc_8_3_1_cuda:
   variables:
-    SPEC: "+openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@10.1.168"
+    SPEC: "+openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@11.0.2"
   extends: .build_and_test_on_lassen
 
 gcc_8_3_1_cuda_ats_disabled:
   variables:
-    SPEC: "+openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@10.1.168"
+    SPEC: "+openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@11.5.0"
   extends: .build_and_test_on_lassen_ats_disabled
 
 xl_16_1_1_11_cuda_10:
   variables:
-    SPEC: "+openmp +cuda %xl@16.1.1.11 cxxflags='-qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036' cuda_arch=70 ^cuda@10.1.168 ^cmake@3.14.5"
+    SPEC: "+openmp +cuda %xl@16.1.1.11 cxxflags='-qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036' cuda_arch=70 ^cuda@11.0.2 ^cmake@3.14.5"
     DEFAULT_TIME: 60
   allow_failure: true
   extends: .build_and_test_on_lassen
@@ -96,5 +96,5 @@ clang_9_0_0_memleak (build and test on lassen):
 
 gcc_8_3_1_cuda_desul_atomics:
   variables:
-    SPEC: "+openmp +cuda +desul %gcc@8.3.1 cuda_arch=70 ^cuda@10.1.168"
+    SPEC: "+openmp +cuda +desul %gcc@8.3.1 cuda_arch=70 ^cuda@11.0.2"
   extends: .build_and_test_on_lassen


### PR DESCRIPTION
# Summary

- This PR is simply updates the version of CUDA used in Lassen Gitlab CI jobs to CUDA 11 (both 11.0.2 and 11.5.0 jobs)