### PR TITLE
adding openmp_target specs to lassen jobs

### DIFF
--- a/.gitlab/lassen-jobs.yml
+++ b/.gitlab/lassen-jobs.yml
@@ -21,7 +21,7 @@ clang_9_gcc_8:
 
 clang_11_0_0:
   variables:
-    SPEC: "+openmp %clang@11.0.0"
+    SPEC: "+openmp+openmp_target cxxflags=-std=c++14 %clang@11.0.0"
   extends: .build_and_test_on_lassen
 
 gcc_8_3_1:


### PR DESCRIPTION
# Summary

- This PR is a bugfix and feature add for Gitlab CI
- It does the following:
  - Fixes a problem where `ENABLE_OPENMP` never actually got turned on and thus openmp was never actually tested in CI before this fix
  - Adds openmp_target job on Lassen CI

Things to check:
- [ ] Are conflicts true?
- [ ] Need both `RAJA_ENABLE_OPENMP` and `ENABLE_OPENMP` or just the latter?
- [ ] Should it be named "openmp_target" or "target_openmp" - would like consistency