### PR TITLE
Add missing header

### DIFF
--- a/include/RAJA/internal/RAJAVec.hpp
+++ b/include/RAJA/internal/RAJAVec.hpp
@@ -21,6 +21,7 @@
 
 #include "RAJA/config.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <memory>
 #include <utility>


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Includes `<algorithm>` for std::max

**This PR is from a fork. Please approve the one from a branch in our repo: https://github.com/LLNL/RAJA/pull/1285**