### PR TITLE
Woptim/update to xl 16 1 1 11

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,7 +48,7 @@ stages:
     include:
       - local: '.gitlab/custom-jobs.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: v2022.08.1
+        ref: woptim/update-to-xl_16_1_1_11
         file: '${CI_MACHINE}-build-and-test.yml'
       - local: '.gitlab/${CI_MACHINE}-build-and-test-extra.yml'
     strategy: depend

--- a/.gitlab/lassen-build-and-test-extra.yml
+++ b/.gitlab/lassen-build-and-test-extra.yml
@@ -14,23 +14,26 @@ clang_11_0_0:
     SPEC: "+openmp %clang@11.0.0"
   extends: .build_and_test_on_lassen
 
-# Overriding shared spec
+# Overriding shared spec: Extra flags
 gcc_8_3_1:
   variables:
     SPEC: "+openmp %gcc@8.3.1 cxxflags='-finline-functions -finline-limit=20000' cflags='-finline-functions -finline-limit=20000'"
   extends: .build_and_test_on_lassen
 
+# Overriding shared spec: Longer allocation
 pgi_20_4_gcc_8_3_1:
   variables:
     SPEC: "${PROJECT_LASSEN_VARIANTS} %pgi@20.4 cxxflags=\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" cflags=\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" ${PROJECT_LASSEN_DEPS}"
     LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 120"
   extends: .build_and_test_on_lassen
 
+# Overriding shared spec: Extra flags
 xl_16_1_1_11:
   variables:
     SPEC: "+openmp %xl@16.1.1.11 cxxflags='-qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036'"
   extends: .build_and_test_on_lassen
 
+# Overriding shared spec: Extra flags
 xl_16_1_1_11_gcc_8_3_1:
   variables:
     SPEC: "+openmp %xl@16.1.1.11 cxxflags='--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 -qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036' cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1"
@@ -45,7 +48,8 @@ clang_9_cuda_11_0_2:
     SPEC: "+openmp +cuda cuda_arch=70 %clang@9.0.0 ^cuda@11.0.2"
   extends: .build_and_test_on_lassen
 
-ibm_clang_9_gcc_8_cuda:
+# Overriding shared spec: Longer allocation
+ibm_clang_9_gcc_8_3_1_cuda_10_1_168:
   variables:
     SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %clang@ibm.9.0.0 cxxflags=\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" cflags=\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" ^cuda@10.1.168 ${PROJECT_LASSEN_DEPS}"
     LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 120"
@@ -67,12 +71,14 @@ gcc_8_3_1_cuda_11_5_0_ats_disabled:
     LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 --atsdisable -W 60"
   extends: .build_and_test_on_lassen
 
+# Overriding shared spec: Extra flags
 xl_16_1_1_11_cuda_11_0_2:
   variables:
     SPEC: "+openmp +cuda %xl@16.1.1.11 cxxflags='-qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036' cuda_arch=70 ^cuda@11.0.2 ^cmake@3.14.5"
   allow_failure: true
   extends: .build_and_test_on_lassen
 
+# Overriding shared spec: Extra flags
 xl_16_1_1_11_gcc_8_3_1_cuda_11_0_2:
   variables:
     SPEC: "+openmp +cuda %xl@16.1.1.11 cxxflags='--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 -qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036' cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 cuda_arch=70 ^cuda@11.0.2 ^cmake@3.14.5"


### PR DESCRIPTION
Relates to #1308 

# Summary

- This PR is an attempt to reduce the number of xl targets in CI
- It does the following:
  - Update radiuss-shared-ci to use the sister PR in that project.
  - Use only xl-16-1-1-11