### PR TITLE
Ambiguous camp::get<>

### DIFF
--- a/include/RAJA/pattern/WorkGroup/WorkRunner.hpp
+++ b/include/RAJA/pattern/WorkGroup/WorkRunner.hpp
@@ -76,7 +76,7 @@ struct HoldBodyArgs_host : HoldBodyArgs_base<LoopBody, Args...>
   template < camp::idx_t ... Is >
   RAJA_INLINE void invoke(index_type i, camp::idx_seq<Is...>) const
   {
-    this->m_body(i, get<Is>(this->m_arg_tuple)...);
+    this->m_body(i, camp::get<Is>(this->m_arg_tuple)...);
   }
 };
 
@@ -98,7 +98,7 @@ struct HoldBodyArgs_device : HoldBodyArgs_base<LoopBody, Args...>
   template < camp::idx_t ... Is >
   RAJA_DEVICE RAJA_INLINE void invoke(index_type i, camp::idx_seq<Is...>) const
   {
-    this->m_body(i, get<Is>(this->m_arg_tuple)...);
+    this->m_body(i, camp::get<Is>(this->m_arg_tuple)...);
   }
 };
 

--- a/include/RAJA/policy/simd/kernel/For.hpp
+++ b/include/RAJA/policy/simd/kernel/For.hpp
@@ -107,7 +107,7 @@ struct StatementExecutor<
     // Set the argument type for this loop
     using NewTypes = setSegmentTypeFromData<Types, ArgumentId, Data>;
 
-    auto iter = get<ArgumentId>(data.segment_tuple);
+    auto iter = camp::get<ArgumentId>(data.segment_tuple);
     auto begin = std::begin(iter);
     auto end = std::end(iter);
     auto distance = std::distance(begin, end);

--- a/include/RAJA/policy/simd/kernel/ForICount.hpp
+++ b/include/RAJA/policy/simd/kernel/ForICount.hpp
@@ -55,7 +55,7 @@ struct StatementExecutor<
     // Set the argument type for this loop
     using NewTypes = setSegmentTypeFromData<Types, ArgumentId, Data>;
 
-    auto iter = get<ArgumentId>(data.segment_tuple);
+    auto iter = camp::get<ArgumentId>(data.segment_tuple);
     auto begin = std::begin(iter);
     auto end = std::end(iter);
     auto distance = std::distance(begin, end);


### PR DESCRIPTION
# Summary

- This PR is a bugfix
  - It corrects some ambiguous calls to `camp::get<>`