### PR TITLE
Enable vectorization by default.

### DIFF
--- a/cmake/SetupRajaOptions.cmake
+++ b/cmake/SetupRajaOptions.cmake
@@ -15,7 +15,7 @@ option(RAJA_ENABLE_TBB "Build TBB support" Off)
 option(RAJA_ENABLE_TARGET_OPENMP "Build OpenMP on target device support" Off)
 option(RAJA_ENABLE_SYCL "Build SYCL support" Off)
 
-option(RAJA_ENABLE_VECTORIZATION "Build experimental vectorization support" Off)
+option(RAJA_ENABLE_VECTORIZATION "Build experimental vectorization support" On)
 
 option(RAJA_ENABLE_REPRODUCERS "Build issue reproducers" Off)
 


### PR DESCRIPTION
# Summary

- This PR reverses the logic for disabling vectorization features in a build. This makes the default 'On'. Users can still disable if they wish.