### PR TITLE
OpenMP + HIP build

### DIFF
--- a/cmake/SetupPackages.cmake
+++ b/cmake/SetupPackages.cmake
@@ -82,7 +82,7 @@ if (RAJA_ENABLE_HIP)
   endif()
 
   if (RAJA_ENABLE_EXTERNAL_ROCPRIM)
-    find_package(RocPRIM)
+    include(cmake/thirdparty/FindRocPRIM.cmake)
     if (ROCPRIM_FOUND)
       blt_import_library(
         NAME rocPRIM

--- a/examples/resource-forall.cpp
+++ b/examples/resource-forall.cpp
@@ -127,7 +127,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   std::cout << "\n Running RAJA omp_parallel_for_exec vector addition...\n";
 
-  RAJA::forall<RAJA::omp_parallel_for_exec>(host, RAJA::RangeSegment(0, N), [=] RAJA_DEVICE (int i) { 
+  RAJA::forall<RAJA::omp_parallel_for_exec>(host, RAJA::RangeSegment(0, N),
+  [=] (int i) {
     c[i] = a[i] + b[i]; 
   });
 
@@ -139,7 +140,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   std::cout << "\n Running RAJA omp_parallel_for_static_exec (default chunksize) vector addition...\n";
 
-  RAJA::forall<RAJA::omp_parallel_for_static_exec< >>(host, RAJA::RangeSegment(0, N), [=] (int i) { 
+  RAJA::forall<RAJA::omp_parallel_for_static_exec< >>(host, RAJA::RangeSegment(0, N),
+  [=] (int i) {
     c[i] = a[i] + b[i]; 
   });
 
@@ -151,7 +153,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   std::cout << "\n Running RAJA omp_for_dynamic_exec (chunksize = 16) vector addition...\n";
 
-  RAJA::forall<RAJA::omp_parallel_for_dynamic_exec<16>>(host, RAJA::RangeSegment(0, N), [=] (int i) { 
+  RAJA::forall<RAJA::omp_parallel_for_dynamic_exec<16>>(host, RAJA::RangeSegment(0, N),
+  [=] (int i) {
     c[i] = a[i] + b[i]; 
   });
 
@@ -165,7 +168,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   std::cout << "\n Running RAJA tbb_for_dynamic vector addition...\n";
 
-  RAJA::forall<RAJA::tbb_for_dynamic>(host, RAJA::RangeSegment(0, N), [=] (int i) { 
+  RAJA::forall<RAJA::tbb_for_dynamic>(host, RAJA::RangeSegment(0, N),
+  [=] (int i) {
     c[i] = a[i] + b[i]; 
   });
 
@@ -177,7 +181,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   std::cout << "\n Running RAJA tbb_for_static<8> vector addition...\n";
 
-  RAJA::forall<RAJA::tbb_for_static<8>>(host, RAJA::RangeSegment(0, N), [=] (int i) { 
+  RAJA::forall<RAJA::tbb_for_static<8>>(host, RAJA::RangeSegment(0, N),
+  [=] (int i) {
     c[i] = a[i] + b[i]; 
   });
 
@@ -383,4 +388,3 @@ void printResult(int* res, int len)
   }
   std::cout << std::endl;
 }
-

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -241,11 +241,15 @@ static_assert(RAJA_HAS_SOME_CXX14,
 
 namespace RAJA {
 
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP) && !defined(__HIP_DEVICE_COMPILE__)
+#if defined(_OPENMP)
 #if (_OPENMP >= 200805)
 #define RAJA_ENABLE_OPENMP_TASK
 #endif
-#endif // RAJA_ENABLE_OPENMP && _OPENMP
+#else
+#error RAJA configured with RAJA_ENABLE_OPENMP, but _OPENMP is not defined in this code section
+#endif // _OPENMP
+#endif // RAJA_ENABLE_OPENMP && __HIP_DEVICE_COMPILE__
 
 #if defined(RAJA_ENABLE_CUDA) && defined(__CUDACC__)
 #define RAJA_CUDA_ACTIVE

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -241,7 +241,7 @@ static_assert(RAJA_HAS_SOME_CXX14,
 
 namespace RAJA {
 
-#if defined(RAJA_ENABLE_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP) && !defined(__HIP_DEVICE_COMPILE__)
 #if defined(_OPENMP)
 #if _OPENMP >= 200805
 #define RAJA_ENABLE_OPENMP_TASK

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -241,15 +241,11 @@ static_assert(RAJA_HAS_SOME_CXX14,
 
 namespace RAJA {
 
-#if defined(RAJA_ENABLE_OPENMP) && !defined(__HIP_DEVICE_COMPILE__)
-#if defined(_OPENMP)
-#if _OPENMP >= 200805
+#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if (_OPENMP >= 200805)
 #define RAJA_ENABLE_OPENMP_TASK
 #endif
-#else
-#error RAJA configured with RAJA_ENABLE_OPENMP, but OpenMP not supported by current compiler
-#endif // _OPENMP
-#endif // RAJA_ENABLE_OPENMP
+#endif // RAJA_ENABLE_OPENMP && _OPENMP
 
 #if defined(RAJA_ENABLE_CUDA) && defined(__CUDACC__)
 #define RAJA_CUDA_ACTIVE

--- a/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
+++ b/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
@@ -120,7 +120,7 @@ struct cudaInfo {
   cuda_dim_t blockDim{0, 0, 0};
   ::RAJA::resources::Cuda* res = nullptr;
   bool setup_reducers = false;
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
   cudaInfo* thread_states = nullptr;
   omp::mutex lock;
 #endif
@@ -146,7 +146,7 @@ private:
 extern cudaInfo g_status;
 
 extern cudaInfo tl_status;
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
 #pragma omp threadprivate(tl_status)
 #endif
 
@@ -165,7 +165,7 @@ void synchronize_impl(::RAJA::resources::Cuda res)
 RAJA_INLINE
 void synchronize()
 {
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
   lock_guard<omp::mutex> lock(detail::g_status.lock);
 #endif
   bool synchronize = false;
@@ -184,7 +184,7 @@ void synchronize()
 RAJA_INLINE
 void synchronize(::RAJA::resources::Cuda res)
 {
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
   lock_guard<omp::mutex> lock(detail::g_status.lock);
 #endif
   auto iter = detail::g_stream_info_map.find(res.get_stream());
@@ -202,7 +202,7 @@ void synchronize(::RAJA::resources::Cuda res)
 RAJA_INLINE
 void launch(::RAJA::resources::Cuda res, bool async = true)
 {
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
   lock_guard<omp::mutex> lock(detail::g_status.lock);
 #endif
   auto iter = detail::g_stream_info_map.find(res.get_stream());

--- a/include/RAJA/policy/cuda/reduce.hpp
+++ b/include/RAJA/policy/cuda/reduce.hpp
@@ -701,7 +701,7 @@ public:
   //! get new value for use in resource
   T* new_value(::RAJA::resources::Cuda res)
   {
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
     lock_guard<omp::mutex> lock(m_mutex);
 #endif
     ResourceNode* rn = resource_list;
@@ -748,7 +748,7 @@ public:
 
   ~PinnedTally() { free_list(); }
 
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
   omp::mutex m_mutex;
 #endif
 
@@ -1004,7 +1004,7 @@ public:
       tally_or_val_ptr.list = nullptr;
     } else if (parent) {
       if (val.value != val.identity) {
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
         lock_guard<omp::mutex> lock(tally_or_val_ptr.list->m_mutex);
 #endif
         parent->combine(val.value);

--- a/include/RAJA/policy/hip.hpp
+++ b/include/RAJA/policy/hip.hpp
@@ -27,8 +27,9 @@
 #include <hip/hip_runtime.h>
 
 #if !defined(RAJA_ENABLE_DESUL_ATOMICS)
-    #include "RAJA/policy/hip/atomic.hpp"
+#include "RAJA/policy/hip/atomic.hpp"
 #endif
+
 #include "RAJA/policy/hip/forall.hpp"
 #include "RAJA/policy/hip/policy.hpp"
 #include "RAJA/policy/hip/reduce.hpp"

--- a/include/RAJA/policy/hip/MemUtils_HIP.hpp
+++ b/include/RAJA/policy/hip/MemUtils_HIP.hpp
@@ -123,7 +123,7 @@ struct hipInfo {
   hip_dim_t blockDim = 0;
   ::RAJA::resources::Hip* res = nullptr;
   bool setup_reducers = false;
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
   hipInfo* thread_states = nullptr;
   omp::mutex lock;
 #endif
@@ -149,7 +149,7 @@ private:
 extern hipInfo g_status;
 
 extern hipInfo tl_status;
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
 #pragma omp threadprivate(tl_status)
 #endif
 
@@ -168,7 +168,7 @@ void synchronize_impl(::RAJA::resources::Hip res)
 RAJA_INLINE
 void synchronize()
 {
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
   lock_guard<omp::mutex> lock(detail::g_status.lock);
 #endif
   bool synchronize = false;
@@ -187,7 +187,7 @@ void synchronize()
 RAJA_INLINE
 void synchronize(::RAJA::resources::Hip res)
 {
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
   lock_guard<omp::mutex> lock(detail::g_status.lock);
 #endif
   auto iter = detail::g_stream_info_map.find(res.get_stream());
@@ -205,7 +205,7 @@ void synchronize(::RAJA::resources::Hip res)
 RAJA_INLINE
 void launch(::RAJA::resources::Hip res, bool async = true)
 {
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
   lock_guard<omp::mutex> lock(detail::g_status.lock);
 #endif
   auto iter = detail::g_stream_info_map.find(res.get_stream());

--- a/include/RAJA/policy/hip/reduce.hpp
+++ b/include/RAJA/policy/hip/reduce.hpp
@@ -572,7 +572,7 @@ public:
   //! get new value for use in resource
   T* new_value(::RAJA::resources::Hip res)
   {
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
     lock_guard<omp::mutex> lock(m_mutex);
 #endif
     ResourceNode* rn = resource_list;
@@ -619,7 +619,7 @@ public:
 
   ~PinnedTally() { free_list(); }
 
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
   omp::mutex m_mutex;
 #endif
 
@@ -875,7 +875,7 @@ public:
       tally_or_val_ptr.list = nullptr;
     } else if (parent) {
       if (val.value != val.identity) {
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
         lock_guard<omp::mutex> lock(tally_or_val_ptr.list->m_mutex);
 #endif
         parent->combine(val.value);

--- a/include/RAJA/policy/openmp/sort.hpp
+++ b/include/RAJA/policy/openmp/sort.hpp
@@ -164,6 +164,7 @@ void sort(Sorter sorter,
     const diff_type iterates_per_task = std::max(n/(2*max_threads), min_iterates_per_task);
 
     const diff_type requested_num_threads = std::min((n+iterates_per_task-1)/iterates_per_task, max_threads);
+    RAJA_UNUSED_VAR(requested_num_threads); // avoid warning in hip device code
 
 #pragma omp parallel num_threads(static_cast<int>(requested_num_threads))
 #pragma omp master
@@ -174,6 +175,7 @@ void sort(Sorter sorter,
 #else
 
     const diff_type requested_num_threads = std::min((n+min_iterates_per_task-1)/min_iterates_per_task, max_threads);
+    RAJA_UNUSED_VAR(requested_num_threads); // avoid warning in hip device code
 
 #pragma omp parallel num_threads(static_cast<int>(requested_num_threads))
     {

--- a/include/RAJA/policy/sycl/MemUtils_SYCL.hpp
+++ b/include/RAJA/policy/sycl/MemUtils_SYCL.hpp
@@ -52,7 +52,7 @@ struct syclInfo {
   sycl_dim_t blockDim{0};
   cl::sycl::queue qu = cl::sycl::queue();
   bool setup_reducers = false;
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
   syclInfo* thread_states = nullptr;
   omp::mutex lock;
 #endif

--- a/scripts/lc-builds/toss3_hipcc.sh
+++ b/scripts/lc-builds/toss3_hipcc.sh
@@ -70,7 +70,7 @@ cmake \
   -DHIP_CLANG_FLAGS="${HIP_CLANG_FLAGS}" \
   -C "../host-configs/lc-builds/toss3/${HOSTCONFIG}.cmake" \
   -DENABLE_HIP=ON \
-  -DENABLE_OPENMP=OFF \
+  -DENABLE_OPENMP=ON \
   -DENABLE_CUDA=OFF \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
   "$@" \

--- a/scripts/lc-builds/toss4_amdclang.sh
+++ b/scripts/lc-builds/toss4_amdclang.sh
@@ -66,7 +66,7 @@ cmake \
   -DCMAKE_HIP_ARCHITECTURES="${MY_HIP_ARCH_FLAGS}" \
   -C "../host-configs/lc-builds/toss4/${HOSTCONFIG}.cmake" \
   -DENABLE_HIP=ON \
-  -DENABLE_OPENMP=OFF \
+  -DENABLE_OPENMP=ON \
   -DENABLE_CUDA=OFF \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
   "$@" \

--- a/scripts/lc-builds/toss4_cce_hip.sh
+++ b/scripts/lc-builds/toss4_cce_hip.sh
@@ -52,7 +52,7 @@ cmake \
   -DAMDGPU_TARGETS=${HIP_ARCH} \
   -C "../host-configs/lc-builds/toss4/${HOSTCONFIG}.cmake" \
   -DENABLE_HIP=ON \
-  -DENABLE_OPENMP=OFF \
+  -DENABLE_OPENMP=ON \
   -DENABLE_CUDA=OFF \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
   "$@" \

--- a/src/MemUtils_CUDA.cpp
+++ b/src/MemUtils_CUDA.cpp
@@ -46,7 +46,7 @@ cudaInfo g_status;
 
 //! State of the host code in this thread
 cudaInfo tl_status;
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
 #pragma omp threadprivate(tl_status)
 #endif
 

--- a/src/MemUtils_HIP.cpp
+++ b/src/MemUtils_HIP.cpp
@@ -46,7 +46,7 @@ hipInfo g_status;
 
 //! State of the host code in this thread
 hipInfo tl_status;
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
 #pragma omp threadprivate(tl_status)
 #endif
 

--- a/src/MemUtils_SYCL.cpp
+++ b/src/MemUtils_SYCL.cpp
@@ -44,7 +44,7 @@ syclInfo g_status;
 
 //! State of the host code in this thread
 syclInfo tl_status;
-#if defined(RAJA_ENABLE_OPENMP) && defined(_OPENMP)
+#if defined(RAJA_ENABLE_OPENMP)
 #pragma omp threadprivate(tl_status)
 #endif
 


### PR DESCRIPTION
# Summary

- This PR fixes issue with _OPENMP not defined in rocm device compiler pass.
- It also fixes example so it builds when openmp and hip are both enabled.