### PR TITLE
Use compile time blocksize in forall

### DIFF
--- a/include/RAJA/policy/cuda/forall.hpp
+++ b/include/RAJA/policy/cuda/forall.hpp
@@ -81,15 +81,17 @@ cuda_dim_t getGridDim(cuda_dim_member_t len, cuda_dim_t blockDim)
  *
  ******************************************************************************
  */
+template <size_t BlockSize>
 __device__ __forceinline__ unsigned int getGlobalIdx_1D_1D()
 {
   unsigned int blockId = blockIdx.x;
-  unsigned int threadId = blockId * blockDim.x + threadIdx.x;
+  unsigned int threadId = blockId * BlockSize + threadIdx.x;
   return threadId;
 }
+template <size_t BlockSize>
 __device__ __forceinline__ unsigned int getGlobalNumThreads_1D_1D()
 {
-  unsigned int numThreads = blockDim.x * gridDim.x;
+  unsigned int numThreads = BlockSize * gridDim.x;
   return numThreads;
 }
 
@@ -144,7 +146,7 @@ __launch_bounds__(BlockSize, BlocksPerSM) __global__
   using RAJA::internal::thread_privatize;
   auto privatizer = thread_privatize(loop_body);
   auto& body = privatizer.get_priv();
-  auto ii = static_cast<IndexType>(getGlobalIdx_1D_1D());
+  auto ii = static_cast<IndexType>(getGlobalIdx_1D_1D<BlockSize>());
   if (ii < length) {
     body(idx[ii]);
   }
@@ -167,7 +169,7 @@ __launch_bounds__(BlockSize, 1) __global__
   using RAJA::internal::thread_privatize;
   auto privatizer = thread_privatize(loop_body);
   auto& body = privatizer.get_priv();
-  auto ii = static_cast<IndexType>(getGlobalIdx_1D_1D());
+  auto ii = static_cast<IndexType>(getGlobalIdx_1D_1D<BlockSize>());
   if ( ii < length )
   {
     RAJA::expt::invoke_body( f_params, body, idx[ii] );

--- a/include/RAJA/policy/hip/forall.hpp
+++ b/include/RAJA/policy/hip/forall.hpp
@@ -77,15 +77,17 @@ hip_dim_t getGridDim(hip_dim_member_t len, hip_dim_t blockDim)
  *
  ******************************************************************************
  */
+template <size_t BlockSize>
 __device__ __forceinline__ unsigned int getGlobalIdx_1D_1D()
 {
   unsigned int blockId = blockIdx.x;
-  unsigned int threadId = blockId * blockDim.x + threadIdx.x;
+  unsigned int threadId = blockId * BlockSize + threadIdx.x;
   return threadId;
 }
+template <size_t BlockSize>
 __device__ __forceinline__ unsigned int getGlobalNumThreads_1D_1D()
 {
-  unsigned int numThreads = blockDim.x * gridDim.x;
+  unsigned int numThreads = BlockSize * gridDim.x;
   return numThreads;
 }
 
@@ -139,7 +141,7 @@ __launch_bounds__(BlockSize, 1) __global__
   using RAJA::internal::thread_privatize;
   auto privatizer = thread_privatize(loop_body);
   auto& body = privatizer.get_priv();
-  auto ii = static_cast<IndexType>(getGlobalIdx_1D_1D());
+  auto ii = static_cast<IndexType>(getGlobalIdx_1D_1D<BlockSize>());
   if (ii < length) {
     body(idx[ii]);
   }
@@ -161,7 +163,7 @@ __launch_bounds__(BlockSize, 1) __global__
   using RAJA::internal::thread_privatize;
   auto privatizer = thread_privatize(loop_body);
   auto& body = privatizer.get_priv();
-  auto ii = static_cast<IndexType>(getGlobalIdx_1D_1D());
+  auto ii = static_cast<IndexType>(getGlobalIdx_1D_1D<BlockSize>());
   if ( ii < length )
   {
     RAJA::expt::invoke_body( f_params, body, idx[ii] );


### PR DESCRIPTION
# Use compile time blocksize in forall
This improves performance of hip forall kernels.

- This PR is a feature
- It does the following:
  - Adds better hip forall performance at the request of me
