### PR TITLE
Update build scripts to work with newer cmake version

### DIFF
--- a/docs/sphinx/user_guide/getting_started.rst
+++ b/docs/sphinx/user_guide/getting_started.rst
@@ -323,15 +323,18 @@ OpenMP
 ^^^^^^^
 
 To use OpenMP target offload GPU execution, additional options may need to be
-passed to the compiler. The variable ``OpenMP_CXX_FLAGS`` is used for this.
-Option syntax follows the CMake *list* pattern. For example, to specify OpenMP 
-target options for NVIDIA GPUs using a clang-based compiler, one may do
-something like::
+passed to the compiler. BLT variables are used for this. Option syntax follows 
+the CMake *list* pattern. For example, to specify OpenMP target options for 
+NVIDIA GPUs using a clang-based compiler, one may do something like::
 
    cmake \
      ... \
-     -DOpenMP_CXX_FLAGS="-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda" \
+     -DBLT_OPENMP_COMPILE_FLAGS="-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda" \
+     -DBLT_OPENMP_LINK_FLAGS="-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda" \
      ...
+
+Compiler flags are passed to other compilers similarly, using flags specific to
+the compiler. Typically, the compile and link flags are the same as shown here.
 
 ----------------------------------------
 RAJA Example Build Configuration Files

--- a/scripts/lc-builds/blueos_clang_omptarget.sh
+++ b/scripts/lc-builds/blueos_clang_omptarget.sh
@@ -40,7 +40,8 @@ cmake \
   -DENABLE_OPENMP=On \
   -DENABLE_CUDA=Off \
   -DRAJA_ENABLE_TARGET_OPENMP=On \
-  -DOpenMP_CXX_FLAGS="-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda" \
+  -DBLT_OPENMP_COMPILE_FLAGS="-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda" \
+  -DBLT_OPENMP_LINK_FLAGS="-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda" \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
   "$@" \
   ..

--- a/scripts/lc-builds/blueos_xl_omptarget.sh
+++ b/scripts/lc-builds/blueos_xl_omptarget.sh
@@ -37,7 +37,8 @@ cmake \
   -C ../host-configs/lc-builds/blueos/xl_X.cmake \
   -DENABLE_OPENMP=On \
   -DRAJA_ENABLE_TARGET_OPENMP=On \
-  -DOpenMP_CXX_FLAGS="-qoffload;-qsmp=omp;-qalias=noansi" \
+  -DBLT_OPENMP_COMPILE_FLAGS="-qoffload;-qsmp=omp;-qalias=noansi" \
+  -DBLT_OPENMP_LINK_FLAGS="-qoffload;-qsmp=omp;-qalias=noansi" \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
   "$@" \
   ..


### PR DESCRIPTION
# Summary

- This PR changes the way we pass openmp flags to the compiler for openmp target offload builds so they work with new cmake min required version.

@MrBurmark feel free to push other script changes to this PR/branch