### PR TITLE
Replace DEVICE macro with using alias

### DIFF
--- a/include/RAJA/pattern/params/reducer.hpp
+++ b/include/RAJA/pattern/params/reducer.hpp
@@ -5,11 +5,11 @@
 #include "RAJA/util/SoAPtr.hpp"
 
 #if defined(RAJA_CUDA_ACTIVE)
-#define RAJA_DEVICE_BACKEND cuda
 #include "RAJA/policy/cuda/MemUtils_CUDA.hpp"
+using device_mem_pool_t = RAJA::cuda::device_mempool_type;
 #elif defined(RAJA_HIP_ACTIVE)
-#define RAJA_DEVICE_BACKEND hip
 #include "RAJA/policy/hip/MemUtils_HIP.hpp"
+using device_mem_pool_t = RAJA::hip::device_mempool_type;
 #endif
 
 namespace RAJA
@@ -91,11 +91,11 @@ namespace detail
 #if defined(RAJA_CUDA_ACTIVE) || defined(RAJA_HIP_ACTIVE)
     // Device related attributes.
     value_type * devicetarget = nullptr;
-    RAJA::detail::SoAPtr<value_type, RAJA::RAJA_DEVICE_BACKEND::device_mempool_type> device_mem;
+    RAJA::detail::SoAPtr<value_type, device_mem_pool_t> device_mem;
     unsigned int * device_count = nullptr;
 #endif
 
-    using ARG_TUP_T = camp::tuple<value_type*>; 
+    using ARG_TUP_T = camp::tuple<value_type*>;
     RAJA_HOST_DEVICE ARG_TUP_T get_lambda_arg_tup() { return camp::make_tuple(&val); }
 
     using ARG_LIST_T = typename ARG_TUP_T::TList;

--- a/include/RAJA/pattern/params/reducer.hpp
+++ b/include/RAJA/pattern/params/reducer.hpp
@@ -5,10 +5,10 @@
 #include "RAJA/util/SoAPtr.hpp"
 
 #if defined(RAJA_CUDA_ACTIVE)
-#define DEVICE cuda
+#define RAJA_DEVICE_BACKEND cuda
 #include "RAJA/policy/cuda/MemUtils_CUDA.hpp"
 #elif defined(RAJA_HIP_ACTIVE)
-#define DEVICE hip
+#define RAJA_DEVICE_BACKEND hip
 #include "RAJA/policy/hip/MemUtils_HIP.hpp"
 #endif
 
@@ -91,7 +91,7 @@ namespace detail
 #if defined(RAJA_CUDA_ACTIVE) || defined(RAJA_HIP_ACTIVE)
     // Device related attributes.
     value_type * devicetarget = nullptr;
-    RAJA::detail::SoAPtr<value_type, RAJA::DEVICE::device_mempool_type> device_mem;
+    RAJA::detail::SoAPtr<value_type, RAJA::RAJA_DEVICE_BACKEND::device_mempool_type> device_mem;
     unsigned int * device_count = nullptr;
 #endif
 


### PR DESCRIPTION
Fixes name conflicts reported with MFEM in: https://github.com/mfem/mfem/pull/3293 
