### PR TITLE
Remove OpenMPTarget tests for WorkGroup Dispatcher.

### DIFF
--- a/test/unit/workgroup/CMakeLists.txt
+++ b/test/unit/workgroup/CMakeLists.txt
@@ -74,6 +74,10 @@ if(RAJA_TEST_EXHAUSTIVE OR NOT RAJA_COMPILER MATCHES "RAJA_COMPILER_Intel")
 endif()
 
 set(Dispatcher_SUBTESTS Single)
+if(RAJA_ENABLE_TARGET_OPENMP)
+  # WorkGroup dispatcher for OpenMPTarget not implemented yet
+  list(REMOVE_ITEM BACKENDS OpenMPTarget)
+endif()
 buildunitworkgrouptest(Dispatcher    "${Dispatcher_SUBTESTS}"  "${DISPATCHERS}" "${BACKENDS}")
 
 set(WorkStorage_SUBTESTS Constructor Iterator InsertCall Multiple)


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - After consulting with @MrBurmark, these tests should be removed because the functionality for OpenMPTarget dispatching in WorkGroups is not yet implemented, and cause a compilation error due to lack of policies for them.