### PR TITLE
Draft: Clang OpenMP Target Problems

### DIFF
--- a/test/functional/forall/segment/tests/test-forall-RangeSegment.hpp
+++ b/test/functional/forall/segment/tests/test-forall-RangeSegment.hpp
@@ -39,6 +39,8 @@ void ForallRangeSegmentTestImpl(INDEX_TYPE first, INDEX_TYPE last)
 
     std::iota(test_array, test_array + RAJA::stripIndexType(N), rbegin);
 
+    working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * data_len);
+
     RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {
       working_array[RAJA::stripIndexType(idx - rbegin)] = idx;
     });

--- a/test/functional/kernel/CMakeLists.txt
+++ b/test/functional/kernel/CMakeLists.txt
@@ -49,7 +49,7 @@ add_subdirectory(nested-loop-view-types)
 
 add_subdirectory(reduce-loc)
 
-add_subdirectory(single-loop-tile-icount-tcount)
+#add_subdirectory(single-loop-tile-icount-tcount)
 
 add_subdirectory(tile-variants)
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix **IN PROGRESS**
- Clang + OpenMPTarget has all sorts of problems:
  - Running in to this internal clang error in `single-loop-tile-icount-tcount` https://github.com/LLNL/RAJA/issues/1274. No versions of clang (up to 14.0.5) can resolve this. May need to try newer clang.
  - With the previous set of tests removed, compilation is successful with 14.0.5, but all OpenMPTarget tests fail at runtime. It appears that mem copies are not transferring enough data. There are also some missing memcpy's, but adding them does not resolve many of the errors.
  - The alternative of using Desul atomics does not resolve https://github.com/LLNL/RAJA/issues/1274.
  - N.B. XLC can compile all tests successfully.

List of failing tests:
```
         33 - test-forall-IndexSet-OpenMPTarget.exe (Subprocess aborted)                                                                                                                                                                                                                                     [25/1657]
         34 - test-forall-IcountIndexSet-OpenMPTarget.exe (Failed)
         45 - test-forall-ListSegment-OpenMPTarget.exe (Subprocess aborted)
         46 - test-forall-RangeSegment-OpenMPTarget.exe (Failed)
         47 - test-forall-RangeStrideSegment-OpenMPTarget.exe (Failed)
         56 - test-forall-ListSegmentView-OpenMPTarget.exe (Subprocess aborted)
         57 - test-forall-RangeSegmentView-OpenMPTarget.exe (Failed)
         58 - test-forall-RangeSegment2DView-OpenMPTarget.exe (Failed)
         88 - test-forall-basic-ReduceSum-OpenMPTarget.exe (Subprocess aborted)
        119 - test-forall-resource-ListSegment-OpenMPTarget.exe (Subprocess aborted)
        120 - test-forall-resource-RangeSegment-OpenMPTarget.exe (Failed)
        121 - test-forall-resource-RangeStrideSegment-OpenMPTarget.exe (Failed)
        128 - test-forall-CombiningAdapter-1D-OpenMPTarget.exe (Failed)
        129 - test-forall-CombiningAdapter-2D-OpenMPTarget.exe (Failed)
        130 - test-forall-CombiningAdapter-3D-OpenMPTarget.exe (Failed)
        135 - test-forall-atomic-basic-OpenMPTarget.exe (Subprocess aborted)
        136 - test-forall-atomic-basic-unsigned-OpenMPTarget.exe (Subprocess aborted)
        141 - test-forall-AtomicMultiView-OpenMPTarget.exe (Subprocess aborted)
        155 - test-forall-AtomicRefAdd-OpenMPTarget.exe (Subprocess aborted)
        156 - test-forall-AtomicRefCAS-OpenMPTarget.exe (Failed)
        168 - test-kernel-resource-basic-single-loop-Segments-OpenMPTarget.exe (Failed)
        169 - test-kernel-basic-single-loop-Segments-OpenMPTarget.exe (Failed)
        172 - test-kernel-basic-single-icount-loop-OpenMPTarget.exe (Failed)
        175 - test-kernel-basic-fission-fusion-loop-OpenMPTarget.exe (Failed)
        178 - test-kernel-conditional-fission-fusion-loop-OpenMPTarget.exe (Failed)
        191 - test-kernel-nested-loop-Basic-OpenMPTarget.exe (Failed)
        218 - test-kernel-nested-loop-PermutedOffsetView2D-OpenMPTarget.exe (Failed)
        219 - test-kernel-nested-loop-PermutedOffsetView3D-OpenMPTarget.exe (Failed)
        234 - test-kernel-tile-Fixed2D-OpenMPTarget.exe (Failed)
        274 - test-workgroup-Unordered-Single-IndirectFunction-OpenMPTarget.exe (Failed)
        275 - test-workgroup-Unordered-MultipleReuse-IndirectFunction-OpenMPTarget.exe (Failed)
        276 - test-workgroup-Unordered-Single-IndirectVirtual-OpenMPTarget.exe (Failed)
        277 - test-workgroup-Unordered-MultipleReuse-IndirectVirtual-OpenMPTarget.exe (Failed)
        278 - test-workgroup-Unordered-Single-Direct-OpenMPTarget.exe (Failed)
        279 - test-workgroup-Unordered-MultipleReuse-Direct-OpenMPTarget.exe (Failed)
        486 - test-reducer-constructors-openmp-target.exe (Failed)
        498 - test-resource-Depends-OpenMPTarget.exe (Failed)
        499 - test-resource-MultiStream-OpenMPTarget.exe (Subprocess aborted)
        501 - test-resource-BasicAsyncSemantics-OpenMPTarget.exe (Subprocess aborted)
        502 - test-resource-JoinAsyncSemantics-OpenMPTarget.exe (Subprocess aborted)
        545 - test-workgroup-Enqueue-Single-Direct-OpenMPTarget.exe (Failed)
        546 - test-workgroup-Enqueue-Multiple-Direct-OpenMPTarget.exe (Failed)
        547 - test-workgroup-Enqueue-Single-IndirectFunction-OpenMPTarget.exe (Failed)
        548 - test-workgroup-Enqueue-Multiple-IndirectFunction-OpenMPTarget.exe (Failed)
        549 - test-workgroup-Enqueue-Single-IndirectVirtual-OpenMPTarget.exe (Failed)
        550 - test-workgroup-Enqueue-Multiple-IndirectVirtual-OpenMPTarget.exe (Failed)
```