### PR TITLE
Fix amdclang missing symbols

### DIFF
--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -242,11 +242,11 @@ static_assert(RAJA_HAS_SOME_CXX14,
 
 
 /* NOTE: Below we define RAJA_MAX_ALIGN for each compiler, currently it is set as 16 bytes
-for all cases. Previously this was set by alignof(std::max_align_t) which, in Clang,
+for all cases, except MSVC. Previously this was set by alignof(std::max_align_t) which, in Clang,
 is based on the sizeof(long double). This causes an in inconsistency as CUDA/HIP long doubles 
 are demoted to doubles causing alignof(std::max_align_t) to return 8 bytes on the device and
 16 bytes on the host. We therefore set a standard size and ensure validity through a 
-static_assert in pattern/WorkGroup/WorkStruct.hpp.
+static_assert.
 */
 
 namespace RAJA {

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -480,7 +480,8 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_INLINE inline  __attribute__((always_inline))
 #define RAJA_UNROLL RAJA_PRAGMA(clang loop unroll(enable))
 #define RAJA_UNROLL_COUNT(N) RAJA_PRAGMA(clang loop unroll_count(N))
-
+#define RAJA_HOST_MAX_ALIGN std::max_align_t
+#define RAJA_DEVICE_MAX_ALIGN 8
 
 // note that neither nvcc nor Apple Clang compiler currently doesn't support
 // the __builtin_assume_aligned attribute

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -425,7 +425,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 //
 #define RAJA_FORCEINLINE_RECURSIVE
 #define RAJA_INLINE inline  __attribute__((always_inline))
-#define RAJA_HOST_ALIGN 16
+#define RAJA_MAX_ALIGN 16
 #if !defined(__NVCC__)
 #define RAJA_UNROLL RAJA_PRAGMA(GCC unroll 10000)
 #define RAJA_UNROLL_COUNT(N) RAJA_PRAGMA(GCC unroll N)

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -536,7 +536,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_NO_SIMD
 #define RAJA_UNROLL
 #define RAJA_UNROLL_COUNT(N)
-#define RAJA_HOST_MAX_ALIGN 16
+#define RAJA_HOST_MAX_ALIGN alignof(std::max_align_t)
 #define RAJA_DEVICE_MAX_ALIGN 16
 #else
 

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -384,7 +384,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 //
 // Configuration options for Intel compilers
 //
-
+#define RAJA_MAX_ALIGN 16
 #if defined (RAJA_ENABLE_FORCEINLINE_RECURSIVE)
 #define RAJA_FORCEINLINE_RECURSIVE  RAJA_PRAGMA(forceinline recursive)
 #else
@@ -397,7 +397,6 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_INLINE inline  __attribute__((always_inline))
 #endif
 
-#define RAJA_MAX_ALIGN 16
 
 #define RAJA_UNROLL RAJA_PRAGMA(unroll)
 #define RAJA_UNROLL_COUNT(N) RAJA_PRAGMA(unroll(N))
@@ -424,9 +423,9 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 //
 // Configuration options for GNU compilers
 //
+#define RAJA_MAX_ALIGN 16
 #define RAJA_FORCEINLINE_RECURSIVE
 #define RAJA_INLINE inline  __attribute__((always_inline))
-#define RAJA_MAX_ALIGN 16
 #if !defined(__NVCC__)
 #define RAJA_UNROLL RAJA_PRAGMA(GCC unroll 10000)
 #define RAJA_UNROLL_COUNT(N) RAJA_PRAGMA(GCC unroll N)
@@ -458,11 +457,11 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 //
 // Configuration options for xlc compiler (i.e., bgq/sequoia).
 //
+#define RAJA_MAX_ALIGN 16
 #define RAJA_FORCEINLINE_RECURSIVE
 #define RAJA_INLINE inline  __attribute__((always_inline))
 #define RAJA_UNROLL
 #define RAJA_UNROLL_COUNT(N)
-#define RAJA_MAX_ALIGN 16
 // FIXME: alignx is breaking CUDA+xlc
 #if defined(RAJA_ENABLE_CUDA)
 #define RAJA_ALIGN_DATA(d) d
@@ -488,11 +487,11 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 //
 // Configuration options for clang compilers
 //
+#define RAJA_MAX_ALIGN 16
 #define RAJA_FORCEINLINE_RECURSIVE
 #define RAJA_INLINE inline  __attribute__((always_inline))
 #define RAJA_UNROLL RAJA_PRAGMA(clang loop unroll(enable))
 #define RAJA_UNROLL_COUNT(N) RAJA_PRAGMA(clang loop unroll_count(N))
-#define RAJA_MAX_ALIGN 16
 // note that neither nvcc nor Apple Clang compiler currently doesn't support
 // the __builtin_assume_aligned attribute
 #if defined(RAJA_ENABLE_CUDA) || defined(__APPLE__)
@@ -525,7 +524,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 
 // This is the same as undefined compiler, but squelches the warning message
 #elif defined(RAJA_COMPILER_MSVC)
-
+#define RAJA_MAX_ALIGN alignof(std::max_align_t)
 #define RAJA_FORCEINLINE_RECURSIVE
 #define RAJA_INLINE inline
 #define RAJA_ALIGN_DATA(d) d
@@ -533,7 +532,6 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_NO_SIMD
 #define RAJA_UNROLL
 #define RAJA_UNROLL_COUNT(N)
-#define RAJA_MAX_ALIGN alignof(std::max_align_t)
 
 #else
 
@@ -548,8 +546,10 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_UNROLL_COUNT(N)
 
 #endif
+
 static_assert(RAJA_MAX_ALIGN >= alignof(std::max_align_t) && (RAJA_MAX_ALIGN/alignof(std::max_align_t))*alignof(std::max_align_t) == RAJA_MAX_ALIGN, 
         "Inconsistent RAJA_MAX_ALIGN size");
+
 #cmakedefine RAJA_HAVE_POSIX_MEMALIGN
 #cmakedefine RAJA_HAVE_ALIGNED_ALLOC
 #cmakedefine RAJA_HAVE_MM_MALLOC

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -239,6 +239,15 @@ static_assert(RAJA_HAS_SOME_CXX14,
 #define RAJA_PRAGMA(x) _Pragma(RAJA_STRINGIFY(x))
 #endif
 
+
+/* NOTE: Below we define RAJA_MAX_ALIGN for each compiler, currently it is set as 16 bytes
+for all cases. Previously this was set by alignof(std::max_align_t) which, in Clang,
+is based on the sizeof(long double). This causes an in inconsistency as CUDA/HIP long doubles 
+are demoted to doubles causing alignof(std::max_align_t) to return 8 bytes on the device and
+16 bytes on the host. We therefore set a standard size and ensure validity through a 
+static_assert in pattern/WorkGroup/WorkStruct.hpp.
+*/
+
 namespace RAJA {
 
 #if defined(RAJA_ENABLE_OPENMP) && !defined(__HIP_DEVICE_COMPILE__)
@@ -387,8 +396,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_INLINE inline  __attribute__((always_inline))
 #endif
 
-#define RAJA_HOST_MAX_ALIGN 16
-#define RAJA_DEVICE_MAX_ALIGN 16
+#define RAJA_MAX_ALIGN 16
 
 #define RAJA_UNROLL RAJA_PRAGMA(unroll)
 #define RAJA_UNROLL_COUNT(N) RAJA_PRAGMA(unroll(N))
@@ -417,12 +425,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 //
 #define RAJA_FORCEINLINE_RECURSIVE
 #define RAJA_INLINE inline  __attribute__((always_inline))
-#define RAJA_HOST_MAX_ALIGN 16
-#if defined(RAJA_ENABLE_HIP)
-#define RAJA_DEVICE_MAX_ALIGN 8
-#else
-#define RAJA_HOST_MAX_ALIGN 16
-#endif
+#define RAJA_HOST_ALIGN 16
 #if !defined(__NVCC__)
 #define RAJA_UNROLL RAJA_PRAGMA(GCC unroll 10000)
 #define RAJA_UNROLL_COUNT(N) RAJA_PRAGMA(GCC unroll N)
@@ -458,8 +461,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_INLINE inline  __attribute__((always_inline))
 #define RAJA_UNROLL
 #define RAJA_UNROLL_COUNT(N)
-#define RAJA_HOST_MAX_ALIGN 16
-#define RAJA_DEVICE_MAX_ALIGN 16
+#define RAJA_MAX_ALIGN 16
 
 // FIXME: alignx is breaking CUDA+xlc
 #if defined(RAJA_ENABLE_CUDA)
@@ -490,12 +492,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_INLINE inline  __attribute__((always_inline))
 #define RAJA_UNROLL RAJA_PRAGMA(clang loop unroll(enable))
 #define RAJA_UNROLL_COUNT(N) RAJA_PRAGMA(clang loop unroll_count(N))
-#define RAJA_HOST_MAX_ALIGN 16
-#if defined(RAJA_ENABLE_HIP)
-#define RAJA_DEVICE_MAX_ALIGN 8
-#else
-#define RAJA_HOST_MAX_ALIGN 16
-#endif
+#define RAJA_MAX_ALIGN 16
 // note that neither nvcc nor Apple Clang compiler currently doesn't support
 // the __builtin_assume_aligned attribute
 #if defined(RAJA_ENABLE_CUDA) || defined(__APPLE__)
@@ -536,13 +533,11 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_NO_SIMD
 #define RAJA_UNROLL
 #define RAJA_UNROLL_COUNT(N)
-#define RAJA_HOST_MAX_ALIGN alignof(std::max_align_t)
-#define RAJA_DEVICE_MAX_ALIGN 16
+#define RAJA_MAX_ALIGN 16
 #else
 
 #pragma message("RAJA_COMPILER unknown, using default empty macros.")
-#define RAJA_HOST_MAX_ALIGN 16
-#define RAJA_DEVICE_MAX_ALIGN 16
+#define RAJA_MAX_ALIGN 16
 #define RAJA_FORCEINLINE_RECURSIVE
 #define RAJA_INLINE inline
 #define RAJA_ALIGN_DATA(d) d

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -388,6 +388,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #endif
 
 #define RAJA_HOST_MAX_ALIGN 16
+#define RAJA_DEVICE_MAX_ALIGN 16
 
 #define RAJA_UNROLL RAJA_PRAGMA(unroll)
 #define RAJA_UNROLL_COUNT(N) RAJA_PRAGMA(unroll(N))
@@ -417,7 +418,11 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_FORCEINLINE_RECURSIVE
 #define RAJA_INLINE inline  __attribute__((always_inline))
 #define RAJA_HOST_MAX_ALIGN 16
-
+#if defined(RAJA_ENABLE_HIP)
+#define RAJA_DEVICE_MAX_ALIGN 8
+#else
+#define RAJA_HOST_MAX_ALIGN 16
+#endif
 #if !defined(__NVCC__)
 #define RAJA_UNROLL RAJA_PRAGMA(GCC unroll 10000)
 #define RAJA_UNROLL_COUNT(N) RAJA_PRAGMA(GCC unroll N)
@@ -454,13 +459,12 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_UNROLL
 #define RAJA_UNROLL_COUNT(N)
 #define RAJA_HOST_MAX_ALIGN 16
+#define RAJA_DEVICE_MAX_ALIGN 16
 
 // FIXME: alignx is breaking CUDA+xlc
 #if defined(RAJA_ENABLE_CUDA)
 #define RAJA_ALIGN_DATA(d) d
-#define RAJA_DEVICE_MAX_ALIGN 16
 #else
-#define RAJA_DEVICE_MAX_ALIGN 16
 #define RAJA_ALIGN_DATA(d) __alignx(RAJA::DATA_ALIGN, d)
 #endif
 
@@ -487,14 +491,16 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_UNROLL RAJA_PRAGMA(clang loop unroll(enable))
 #define RAJA_UNROLL_COUNT(N) RAJA_PRAGMA(clang loop unroll_count(N))
 #define RAJA_HOST_MAX_ALIGN 16
-
+#if defined(RAJA_ENABLE_HIP)
+#define RAJA_DEVICE_MAX_ALIGN 8
+#else
+#define RAJA_HOST_MAX_ALIGN 16
+#endif
 // note that neither nvcc nor Apple Clang compiler currently doesn't support
 // the __builtin_assume_aligned attribute
 #if defined(RAJA_ENABLE_CUDA) || defined(__APPLE__)
 #define RAJA_ALIGN_DATA(d) d
-#define RAJA_DEVICE_MAX_ALIGN 16
 #else
-#define RAJA_DEVICE_MAX_ALIGN 8
 #define RAJA_ALIGN_DATA(d) __builtin_assume_aligned(d, RAJA::DATA_ALIGN)
 #endif
 
@@ -530,13 +536,13 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_NO_SIMD
 #define RAJA_UNROLL
 #define RAJA_UNROLL_COUNT(N)
-
 #define RAJA_HOST_MAX_ALIGN 16
+#define RAJA_DEVICE_MAX_ALIGN 16
 #else
 
 #pragma message("RAJA_COMPILER unknown, using default empty macros.")
 #define RAJA_HOST_MAX_ALIGN 16
-#define RAJA_DEVICE_MAX_ALIGN 8
+#define RAJA_DEVICE_MAX_ALIGN 16
 #define RAJA_FORCEINLINE_RECURSIVE
 #define RAJA_INLINE inline
 #define RAJA_ALIGN_DATA(d) d

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -480,7 +480,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_INLINE inline  __attribute__((always_inline))
 #define RAJA_UNROLL RAJA_PRAGMA(clang loop unroll(enable))
 #define RAJA_UNROLL_COUNT(N) RAJA_PRAGMA(clang loop unroll_count(N))
-#define RAJA_HOST_MAX_ALIGN std::max_align_t
+#define RAJA_HOST_MAX_ALIGN 16
 #define RAJA_DEVICE_MAX_ALIGN 8
 
 // note that neither nvcc nor Apple Clang compiler currently doesn't support

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -387,6 +387,8 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_INLINE inline  __attribute__((always_inline))
 #endif
 
+#define RAJA_HOST_MAX_ALIGN 16
+
 #define RAJA_UNROLL RAJA_PRAGMA(unroll)
 #define RAJA_UNROLL_COUNT(N) RAJA_PRAGMA(unroll(N))
 
@@ -414,6 +416,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 //
 #define RAJA_FORCEINLINE_RECURSIVE
 #define RAJA_INLINE inline  __attribute__((always_inline))
+#define RAJA_HOST_MAX_ALIGN 16
 
 #if !defined(__NVCC__)
 #define RAJA_UNROLL RAJA_PRAGMA(GCC unroll 10000)
@@ -450,11 +453,14 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_INLINE inline  __attribute__((always_inline))
 #define RAJA_UNROLL
 #define RAJA_UNROLL_COUNT(N)
+#define RAJA_HOST_MAX_ALIGN 16
 
 // FIXME: alignx is breaking CUDA+xlc
 #if defined(RAJA_ENABLE_CUDA)
 #define RAJA_ALIGN_DATA(d) d
+#define RAJA_DEVICE_MAX_ALIGN 16
 #else
+#define RAJA_DEVICE_MAX_ALIGN 16
 #define RAJA_ALIGN_DATA(d) __alignx(RAJA::DATA_ALIGN, d)
 #endif
 
@@ -481,13 +487,14 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_UNROLL RAJA_PRAGMA(clang loop unroll(enable))
 #define RAJA_UNROLL_COUNT(N) RAJA_PRAGMA(clang loop unroll_count(N))
 #define RAJA_HOST_MAX_ALIGN 16
-#define RAJA_DEVICE_MAX_ALIGN 8
 
 // note that neither nvcc nor Apple Clang compiler currently doesn't support
 // the __builtin_assume_aligned attribute
 #if defined(RAJA_ENABLE_CUDA) || defined(__APPLE__)
 #define RAJA_ALIGN_DATA(d) d
+#define RAJA_DEVICE_MAX_ALIGN 16
 #else
+#define RAJA_DEVICE_MAX_ALIGN 8
 #define RAJA_ALIGN_DATA(d) __builtin_assume_aligned(d, RAJA::DATA_ALIGN)
 #endif
 
@@ -524,9 +531,12 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_UNROLL
 #define RAJA_UNROLL_COUNT(N)
 
+#define RAJA_HOST_MAX_ALIGN 16
 #else
 
 #pragma message("RAJA_COMPILER unknown, using default empty macros.")
+#define RAJA_HOST_MAX_ALIGN 16
+#define RAJA_DEVICE_MAX_ALIGN 8
 #define RAJA_FORCEINLINE_RECURSIVE
 #define RAJA_INLINE inline
 #define RAJA_ALIGN_DATA(d) d

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -533,7 +533,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_NO_SIMD
 #define RAJA_UNROLL
 #define RAJA_UNROLL_COUNT(N)
-#define RAJA_MAX_ALIGN 16
+#define RAJA_MAX_ALIGN alignof(std::max_align_t)
 #else
 
 #pragma message("RAJA_COMPILER unknown, using default empty macros.")

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -32,6 +32,7 @@
 #define RAJA_config_HPP
 
 #include <utility>
+#include <cstddef>
 #include <type_traits>
 
 #if defined(_MSVC_LANG)
@@ -462,7 +463,6 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_UNROLL
 #define RAJA_UNROLL_COUNT(N)
 #define RAJA_MAX_ALIGN 16
-
 // FIXME: alignx is breaking CUDA+xlc
 #if defined(RAJA_ENABLE_CUDA)
 #define RAJA_ALIGN_DATA(d) d
@@ -534,6 +534,7 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_UNROLL
 #define RAJA_UNROLL_COUNT(N)
 #define RAJA_MAX_ALIGN alignof(std::max_align_t)
+
 #else
 
 #pragma message("RAJA_COMPILER unknown, using default empty macros.")
@@ -547,7 +548,8 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_UNROLL_COUNT(N)
 
 #endif
-
+static_assert(RAJA_MAX_ALIGN >= alignof(std::max_align_t) && (RAJA_MAX_ALIGN/alignof(std::max_align_t))*alignof(std::max_align_t) == RAJA_MAX_ALIGN, 
+        "Inconsistent RAJA_MAX_ALIGN size");
 #cmakedefine RAJA_HAVE_POSIX_MEMALIGN
 #cmakedefine RAJA_HAVE_ALIGNED_ALLOC
 #cmakedefine RAJA_HAVE_MM_MALLOC

--- a/include/RAJA/pattern/WorkGroup/WorkStruct.hpp
+++ b/include/RAJA/pattern/WorkGroup/WorkStruct.hpp
@@ -71,8 +71,6 @@ struct WorkStruct<size, Dispatcher<platform, dispatch_policy, DispatcherID, Call
         "WorkStruct and GenericWorkStruct must have obj at the same offset");
     static_assert(sizeof(value_type) <= sizeof(true_value_type),
         "WorkStruct must not be smaller than GenericWorkStruct");
-    static_assert(16 >= alignof(std::max_align_t) && (16/alignof(std::max_align_t))*alignof(std::max_align_t) == 16,
-			  "WorkStruct max align value must be 16 bytes");
     true_value_type* value_ptr = static_cast<true_value_type*>(ptr);
 
     value_ptr->dispatcher = dispatcher;

--- a/include/RAJA/pattern/WorkGroup/WorkStruct.hpp
+++ b/include/RAJA/pattern/WorkGroup/WorkStruct.hpp
@@ -45,7 +45,7 @@ struct WorkStruct;
  *   sizeof(GenericWorkStruct) <= sizeof(WorkStruct<size>)
  */
 template < typename Dispatcher_T >
-using GenericWorkStruct = WorkStruct<RAJA_HOST_MAX_ALIGN, Dispatcher_T>;
+using GenericWorkStruct = WorkStruct<RAJA_MAX_ALIGN, Dispatcher_T>;
 
 template < size_t size, Platform platform, typename dispatch_policy, typename DispatcherID, typename ... CallArgs >
 struct WorkStruct<size, Dispatcher<platform, dispatch_policy, DispatcherID, CallArgs...>>
@@ -71,7 +71,8 @@ struct WorkStruct<size, Dispatcher<platform, dispatch_policy, DispatcherID, Call
         "WorkStruct and GenericWorkStruct must have obj at the same offset");
     static_assert(sizeof(value_type) <= sizeof(true_value_type),
         "WorkStruct must not be smaller than GenericWorkStruct");
-
+    static_assert(16 >= alignof(std::max_align_t) && (16/alignof(std::max_align_t))*alignof(std::max_align_t) == 16,
+			  "WorkStruct max align value must be 16 bytes");
     true_value_type* value_ptr = static_cast<true_value_type*>(ptr);
 
     value_ptr->dispatcher = dispatcher;
@@ -112,7 +113,7 @@ struct WorkStruct<size, Dispatcher<platform, dispatch_policy, DispatcherID, Call
 
   const dispatcher_type* dispatcher;
   typename dispatcher_type::invoker_type invoke;
-  typename std::aligned_storage<size, RAJA_HOST_MAX_ALIGN>::type obj;
+  typename std::aligned_storage<size, RAJA_MAX_ALIGN>::type obj;
 };
 
 }  // namespace detail

--- a/include/RAJA/pattern/WorkGroup/WorkStruct.hpp
+++ b/include/RAJA/pattern/WorkGroup/WorkStruct.hpp
@@ -45,7 +45,7 @@ struct WorkStruct;
  *   sizeof(GenericWorkStruct) <= sizeof(WorkStruct<size>)
  */
 template < typename Dispatcher_T >
-using GenericWorkStruct = WorkStruct<alignof(RAJA_HOST_MAX_ALIGN), Dispatcher_T>;
+using GenericWorkStruct = WorkStruct<RAJA_HOST_MAX_ALIGN, Dispatcher_T>;
 
 template < size_t size, Platform platform, typename dispatch_policy, typename DispatcherID, typename ... CallArgs >
 struct WorkStruct<size, Dispatcher<platform, dispatch_policy, DispatcherID, CallArgs...>>
@@ -112,7 +112,7 @@ struct WorkStruct<size, Dispatcher<platform, dispatch_policy, DispatcherID, Call
 
   const dispatcher_type* dispatcher;
   typename dispatcher_type::invoker_type invoke;
-  typename std::aligned_storage<size, alignof(RAJA_HOST_MAX_ALIGN)>::type obj;
+  typename std::aligned_storage<size, RAJA_HOST_MAX_ALIGN>::type obj;
 };
 
 }  // namespace detail

--- a/include/RAJA/pattern/WorkGroup/WorkStruct.hpp
+++ b/include/RAJA/pattern/WorkGroup/WorkStruct.hpp
@@ -45,7 +45,7 @@ struct WorkStruct;
  *   sizeof(GenericWorkStruct) <= sizeof(WorkStruct<size>)
  */
 template < typename Dispatcher_T >
-using GenericWorkStruct = WorkStruct<alignof(std::max_align_t), Dispatcher_T>;
+using GenericWorkStruct = WorkStruct<alignof(RAJA_HOST_MAX_ALIGN), Dispatcher_T>;
 
 template < size_t size, Platform platform, typename dispatch_policy, typename DispatcherID, typename ... CallArgs >
 struct WorkStruct<size, Dispatcher<platform, dispatch_policy, DispatcherID, CallArgs...>>
@@ -112,7 +112,7 @@ struct WorkStruct<size, Dispatcher<platform, dispatch_policy, DispatcherID, Call
 
   const dispatcher_type* dispatcher;
   typename dispatcher_type::invoker_type invoke;
-  typename std::aligned_storage<size, alignof(std::max_align_t)>::type obj;
+  typename std::aligned_storage<size, alignof(RAJA_HOST_MAX_ALIGN)>::type obj;
 };
 
 }  // namespace detail


### PR DESCRIPTION
This PR fixes missing symbol errors when using amdclang:

In pattern/WorkGroup/WorkStruct.hpp
```
template < typename Dispatcher_T >
using GenericWorkStruct = WorkStruct<alignof(std::max_align_t), Dispatcher_T>;

``` 
std::max_align_t assumes alignof(std::max_align_t) evaluates to identical constants on both the host and device however a recent change in the AMDGPU backend (https://reviews.llvm.org/D127771) updated the long double size to be 8 bytes on the device (previously 16 bytes on both host and device) causing a template mismatch during deduction/instantiation which only manifests when std::max_align_t is evaluated at runtime.

Would like some input from @MrBurmark @rhornung67 @artv3 on implementation. Options I see are:
1. Add alignment as an overload and create a HostGenericWorkStruct and DeviceGenericWorkStruct
2. Have a compile time #ifdef to set the alignment if compiling for device code
3. Just set the value to be the larger of the two (16) and remove std::max_align_t entirely
4. Other options welcome
