### PR TITLE
Fix MultiLambda GPU test

### DIFF
--- a/test/functional/kernel/nested-loop/CMakeLists.txt
+++ b/test/functional/kernel/nested-loop/CMakeLists.txt
@@ -60,23 +60,10 @@ foreach( NESTED_LOOP_BACKEND ${KERNEL_BACKENDS} )
     foreach( NESTED_LOOP_TYPE ${NESTED_LOOPTYPES} )
       configure_file( test-kernel-nested-loop.cpp.in
           test-kernel${RESOURCE}nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.cpp )
+      raja_add_test( NAME test-kernel${RESOURCE}nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}
+                     SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-kernel${RESOURCE}nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.cpp )
 
-      #Some tests are known to fail for Hip, mark those tests (Will not be run in Gitlab CI)
-      if(${NESTED_LOOP_BACKEND} STREQUAL "Hip" AND ${NESTED_LOOP_TYPE} STREQUAL "MultiLambda")
-
-        raja_add_test( NAME test-kernel${RESOURCE}nested-loop-Known-Hip-Failure-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}
-                       SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-kernel${RESOURCE}nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.cpp )
-
-        target_include_directories(test-kernel${RESOURCE}nested-loop-Known-Hip-Failure-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-
-      else()
-
-        raja_add_test( NAME test-kernel${RESOURCE}nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}
-                       SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-kernel${RESOURCE}nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.cpp )
-
-        target_include_directories(test-kernel${RESOURCE}nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-
-      endif()
+      target_include_directories(test-kernel${RESOURCE}nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
 
     endforeach()
   endforeach()

--- a/test/functional/kernel/nested-loop/tests/nested-loop-MultiLambda-impl.hpp
+++ b/test/functional/kernel/nested-loop/tests/nested-loop-MultiLambda-impl.hpp
@@ -172,7 +172,9 @@ struct MultiLambdaNestedLoopExec<DEVICE_DEPTH_2, POLICY_DATA> {
           RAJA::statement::For<1, typename camp::at<POLICY_DATA, camp::num<1>>::type,
             RAJA::statement::Lambda<0>
           >
-        >,
+        >
+      >,
+      RAJA::statement::DEVICE_KERNEL<
         RAJA::statement::For<0, typename camp::at<POLICY_DATA, camp::num<0>>::type,
           RAJA::statement::For<1, typename camp::at<POLICY_DATA, camp::num<1>>::type,
             RAJA::statement::Lambda<1>


### PR DESCRIPTION
# Fix race condition in MultiLambda GPU policy

The gpu policy ran two dependent nested loops in the same kernel.
This is a race condition so it now uses two kernels so one nested loop is done before the other.

This fixes a known failure with hip.
This was passing for cuda, but it also had the same race condition.


- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes #988 