### PR TITLE
Fix cuda and hip reduceloc reset and make interface consistent

### DIFF
--- a/include/RAJA/pattern/detail/reduce.hpp
+++ b/include/RAJA/pattern/detail/reduce.hpp
@@ -355,9 +355,18 @@ public:
   constexpr BaseReduceMinLoc() : Base(value_type(T(), IndexType())) {}
 
   constexpr BaseReduceMinLoc(T init_val, IndexType init_idx,
-                             T identity_ = reduce_type::identity())
-    : Base(value_type(init_val, init_idx), identity_)
+                             T identity_val_ = reduce_type::identity(),
+                             IndexType identity_loc_ = DefaultLoc<IndexType>().value())
+    : Base(value_type(init_val, init_idx), value_type(identity_val_, identity_loc_))
   {
+  }
+
+  void reset(T init_val, IndexType init_idx = DefaultLoc<IndexType>().value(),
+             T identity_val_ = reduce_type::identity(),
+             IndexType identity_loc_ = DefaultLoc<IndexType>().value())
+  {
+    operator T(); // automatic get() before reset
+    Base::reset(value_type(init_val, init_idx), value_type(identity_val_, identity_loc_));
   }
 
   /// \brief reducer function; updates the current instance's state
@@ -366,13 +375,6 @@ public:
   {
     this->combine(value_type(rhs, loc));
     return *this;
-  }
-
-  void reset(T init_val, IndexType init_idx=DefaultLoc<IndexType>().value(),
-             T identity_ = reduce_type::identity())
-  {
-    operator T(); // automatic get() before reset
-    Base::reset(value_type(init_val, init_idx), identity_);
   }
 
   //! Get the calculated reduced value
@@ -498,9 +500,18 @@ public:
   constexpr BaseReduceMaxLoc() : Base(value_type(T(), IndexType())) {}
 
   constexpr BaseReduceMaxLoc(T init_val, IndexType init_idx,
-                             T identity_ = reduce_type::identity())
-    : Base(value_type(init_val, init_idx), identity_)
+                             T identity_val_ = reduce_type::identity(),
+                             IndexType identity_loc_ = DefaultLoc<IndexType>().value())
+    : Base(value_type(init_val, init_idx), value_type(identity_val_, identity_loc_))
   {
+  }
+
+  void reset(T init_val, IndexType init_idx = DefaultLoc<IndexType>().value(),
+             T identity_val_ = reduce_type::identity(),
+             IndexType identity_loc_ = DefaultLoc<IndexType>().value())
+  {
+    operator T(); // automatic get() before reset
+    Base::reset(value_type(init_val, init_idx), value_type(identity_val_, identity_loc_));
   }
 
   //! reducer function; updates the current instance's state
@@ -509,13 +520,6 @@ public:
   {
     this->combine(value_type(rhs, loc));
     return *this;
-  }
-
-  void reset(T init_val, IndexType init_idx=DefaultLoc<IndexType>().value(),
-             T identity_ = reduce_type::identity())
-  {
-    operator T(); // automatic get() before reset
-    Base::reset(value_type(init_val, init_idx), identity_);
   }
 
   //! Get the calculated reduced value

--- a/include/RAJA/policy/cuda/reduce.hpp
+++ b/include/RAJA/policy/cuda/reduce.hpp
@@ -915,14 +915,6 @@ struct Reduce_Data {
   {
   }
 
-  void reset(T initValue, T identity_ = T())
-  {
-    value = initValue;
-    identity = identity_;
-    device_count = nullptr;
-    own_device_ptr = false;
-  }
-
   RAJA_HOST_DEVICE
   Reduce_Data(const Reduce_Data& other)
       : value{other.identity},
@@ -1001,15 +993,6 @@ struct ReduceAtomic_Data {
         device{nullptr},
         own_device_ptr{false}
   {
-  }
-
-  void reset(T initValue, T identity_ = Combiner::identity())
-  {
-    value = initValue;
-    identity = identity_;
-    device_count = nullptr;
-    device = nullptr;
-    own_device_ptr = false;
   }
 
   RAJA_HOST_DEVICE

--- a/include/RAJA/policy/cuda/reduce.hpp
+++ b/include/RAJA/policy/cuda/reduce.hpp
@@ -1284,15 +1284,29 @@ class ReduceMinLoc<cuda_reduce_base<maybe_atomic>, T, IndexType>
 
 public:
   using value_type = RAJA::reduce::detail::ValueLoc<T, IndexType>;
-  using Base = cuda::
-      Reduce<RAJA::reduce::min<value_type>, value_type, maybe_atomic>;
+  using Combiner = RAJA::reduce::min<value_type>;
+  using NonLocCombiner = RAJA::reduce::min<T>;
+  using Base = cuda::Reduce<Combiner, value_type, maybe_atomic>;
   using Base::Base;
 
   //! constructor requires a default value for the reducer
-  ReduceMinLoc(T init_val, IndexType init_idx)
-      : Base(value_type(init_val, init_idx))
+  ReduceMinLoc(T init_val, IndexType init_idx,
+               T identity_val = NonLocCombiner::identity(),
+               IndexType identity_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value())
+      : Base(value_type(init_val, init_idx), value_type(identity_val, identity_idx))
   {
   }
+
+  //! reset requires a default value for the reducer
+  // this must be here to hide Base::reset
+  void reset(T init_val,
+             IndexType init_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value(),
+             T identity_val = NonLocCombiner::identity(),
+             IndexType identity_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value())
+  {
+    Base::reset(value_type(init_val, init_idx), value_type(identity_val, identity_idx));
+  }
+
   //! reducer function; updates the current instance's state
   RAJA_HOST_DEVICE
   const ReduceMinLoc& minloc(T rhs, IndexType loc) const
@@ -1321,15 +1335,29 @@ class ReduceMaxLoc<cuda_reduce_base<maybe_atomic>, T, IndexType>
 {
 public:
   using value_type = RAJA::reduce::detail::ValueLoc<T, IndexType, false>;
-  using Base = cuda::
-      Reduce<RAJA::reduce::max<value_type>, value_type, maybe_atomic>;
+  using Combiner = RAJA::reduce::max<value_type>;
+  using NonLocCombiner = RAJA::reduce::max<T>;
+  using Base = cuda::Reduce<Combiner, value_type, maybe_atomic>;
   using Base::Base;
 
   //! constructor requires a default value for the reducer
-  ReduceMaxLoc(T init_val, IndexType init_idx)
-      : Base(value_type(init_val, init_idx))
+  ReduceMaxLoc(T init_val, IndexType init_idx,
+               T identity_val = NonLocCombiner::identity(),
+               IndexType identity_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value())
+      : Base(value_type(init_val, init_idx), value_type(identity_val, identity_idx))
   {
   }
+
+  //! reset requires a default value for the reducer
+  // this must be here to hide Base::reset
+  void reset(T init_val,
+             IndexType init_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value(),
+             T identity_val = NonLocCombiner::identity(),
+             IndexType identity_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value())
+  {
+    Base::reset(value_type(init_val, init_idx), value_type(identity_val, identity_idx));
+  }
+
   //! reducer function; updates the current instance's state
   RAJA_HOST_DEVICE
   const ReduceMaxLoc& maxloc(T rhs, IndexType loc) const

--- a/include/RAJA/policy/hip/reduce.hpp
+++ b/include/RAJA/policy/hip/reduce.hpp
@@ -1159,15 +1159,29 @@ class ReduceMinLoc<hip_reduce_base<maybe_atomic>, T, IndexType>
 
 public:
   using value_type = RAJA::reduce::detail::ValueLoc<T, IndexType>;
-  using Base = hip::
-      Reduce<RAJA::reduce::min<value_type>, value_type, maybe_atomic>;
+  using Combiner = RAJA::reduce::min<value_type>;
+  using NonLocCombiner = RAJA::reduce::min<T>;
+  using Base = hip::Reduce<Combiner, value_type, maybe_atomic>;
   using Base::Base;
 
   //! constructor requires a default value for the reducer
-  ReduceMinLoc(T init_val, IndexType init_idx)
-      : Base(value_type(init_val, init_idx))
+  ReduceMinLoc(T init_val, IndexType init_idx,
+               T identity_val = NonLocCombiner::identity(),
+               IndexType identity_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value())
+      : Base(value_type(init_val, init_idx), value_type(identity_val, identity_idx))
   {
   }
+
+  //! reset requires a default value for the reducer
+  // this must be here to hide Base::reset
+  void reset(T init_val,
+             IndexType init_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value(),
+             T identity_val = NonLocCombiner::identity(),
+             IndexType identity_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value())
+  {
+    Base::reset(value_type(init_val, init_idx), value_type(identity_val, identity_idx));
+  }
+
   //! reducer function; updates the current instance's state
   RAJA_HOST_DEVICE
   const ReduceMinLoc& minloc(T rhs, IndexType loc) const
@@ -1196,15 +1210,29 @@ class ReduceMaxLoc<hip_reduce_base<maybe_atomic>, T, IndexType>
 {
 public:
   using value_type = RAJA::reduce::detail::ValueLoc<T, IndexType, false>;
-  using Base = hip::
-      Reduce<RAJA::reduce::max<value_type>, value_type, maybe_atomic>;
+  using Combiner = RAJA::reduce::max<value_type>;
+  using NonLocCombiner = RAJA::reduce::max<T>;
+  using Base = hip::Reduce<Combiner, value_type, maybe_atomic>;
   using Base::Base;
 
   //! constructor requires a default value for the reducer
-  ReduceMaxLoc(T init_val, IndexType init_idx)
-      : Base(value_type(init_val, init_idx))
+  ReduceMaxLoc(T init_val, IndexType init_idx,
+               T identity_val = NonLocCombiner::identity(),
+               IndexType identity_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value())
+      : Base(value_type(init_val, init_idx), value_type(identity_val, identity_idx))
   {
   }
+
+  //! reset requires a default value for the reducer
+  // this must be here to hide Base::reset
+  void reset(T init_val,
+             IndexType init_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value(),
+             T identity_val = NonLocCombiner::identity(),
+             IndexType identity_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value())
+  {
+    Base::reset(value_type(init_val, init_idx), value_type(identity_val, identity_idx));
+  }
+
   //! reducer function; updates the current instance's state
   RAJA_HOST_DEVICE
   const ReduceMaxLoc& maxloc(T rhs, IndexType loc) const

--- a/include/RAJA/policy/hip/reduce.hpp
+++ b/include/RAJA/policy/hip/reduce.hpp
@@ -790,14 +790,6 @@ struct Reduce_Data {
   {
   }
 
-  void reset(T initValue, T identity_ = T())
-  {
-    value = initValue;
-    identity = identity_;
-    device_count = nullptr;
-    own_device_ptr = false;
-  }
-
   RAJA_HOST_DEVICE
   Reduce_Data(const Reduce_Data& other)
       : value{other.identity},
@@ -876,15 +868,6 @@ struct ReduceAtomic_Data {
         device{nullptr},
         own_device_ptr{false}
   {
-  }
-
-  void reset(T initValue, T identity_ = Combiner::identity())
-  {
-    value = initValue;
-    identity = identity_;
-    device_count = nullptr;
-    device = nullptr;
-    own_device_ptr = false;
   }
 
   RAJA_HOST_DEVICE

--- a/include/RAJA/policy/openmp_target/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/reduce.hpp
@@ -269,29 +269,30 @@ struct TargetReduceLoc
   TargetReduceLoc() = delete;
   TargetReduceLoc(const TargetReduceLoc &) = default;
   explicit TargetReduceLoc(T init_val_, IndexType init_loc,
-                           T identity_ = Reducer::identity)
+                           T identity_val_ = Reducer::identity,
+                           IndexType identity_loc_ = RAJA::reduce::detail::DefaultLoc<IndexType>().value())
       : info(),
-        val(identity_, identity_, info),
-        loc(init_loc, IndexType(RAJA::reduce::detail::DefaultLoc<IndexType>().value()), info),
+        val(identity_val_, identity_val_, info),
+        loc(identity_loc_, identity_loc_, info),
         initVal(init_val_),
-        finalVal(identity_),
+        finalVal(identity_val_),
         initLoc(init_loc),
-        finalLoc(IndexType(RAJA::reduce::detail::DefaultLoc<IndexType>().value()))
+        finalLoc(identity_loc_)
   {
   }
 
   void reset(T init_val_,
-             IndexType init_local_ =
-             IndexType(RAJA::reduce::detail::DefaultLoc<IndexType>().value()),
-             T identity_ = Reducer::identity)
+             IndexType init_loc_ = RAJA::reduce::detail::DefaultLoc<IndexType>().value(),
+             T identity_val_ = Reducer::identity,
+             IndexType identity_loc_ = RAJA::reduce::detail::DefaultLoc<IndexType>().value())
   {
     operator T();
-    val.reset(identity_);
-    loc.reset(init_local_);
+    val.reset(identity_val_);
+    loc.reset(identity_loc_);
     initVal = init_val_;
-    finalVal = identity_;
-    initLoc = reduce::detail::DefaultLoc<IndexType>().value();
-    finalLoc = IndexType(RAJA::reduce::detail::DefaultLoc<IndexType>().value());
+    finalVal = identity_val_;
+    initLoc = init_loc_;
+    finalLoc = identity_loc_;
   }
 
   //! apply reduction on device upon destruction

--- a/test/functional/forall/reduce-multiple-segment/tests/test-forall-segment-multiple-ReduceMax.hpp
+++ b/test/functional/forall/reduce-multiple-segment/tests/test-forall-segment-multiple-ReduceMax.hpp
@@ -22,8 +22,6 @@ void ForallReduceMaxMultipleTestImpl(IDX_TYPE first,
 {
   RAJA::TypedRangeSegment<IDX_TYPE> r1(first, last);
 
-  IDX_TYPE index_len = last - first;
-
   camp::resources::Resource working_res{WORKING_RES::get_default()};
   DATA_TYPE* working_array;
   DATA_TYPE* check_array;
@@ -37,18 +35,11 @@ void ForallReduceMaxMultipleTestImpl(IDX_TYPE first,
 
   const DATA_TYPE default_val = static_cast<DATA_TYPE>(-SHRT_MAX);
   const DATA_TYPE big_val = 500;
-
-  for (IDX_TYPE i = 0; i < last; ++i) {
-    test_array[i] = default_val;
-  }
-
   
   static std::random_device rd;
   static std::mt19937 mt(rd());
   static std::uniform_real_distribution<double> dist(-100, 100);
-  static std::uniform_real_distribution<double> dist2(0, index_len - 1);
-
-  DATA_TYPE current_max = default_val;
+  static std::uniform_int_distribution<int> dist2(static_cast<int>(first), static_cast<int>(last) - 1);
 
   // Workaround for broken omp-target reduction interface.
   // This should be `max0;` not `max0(0);`
@@ -57,59 +48,59 @@ void ForallReduceMaxMultipleTestImpl(IDX_TYPE first,
   RAJA::ReduceMax<REDUCE_POLICY, DATA_TYPE> max1(default_val);
   RAJA::ReduceMax<REDUCE_POLICY, DATA_TYPE> max2(big_val);
 
-  const int nloops = 8;
-  for (int j = 0; j < nloops; ++j) {
+  const int nOuterLoops = 2;
+  for (int l = 0; l < nOuterLoops; ++l) {
 
-    DATA_TYPE roll = static_cast<DATA_TYPE>( dist(mt) );
-    IDX_TYPE max_index = static_cast<IDX_TYPE>(dist2(mt));
+    ASSERT_EQ(default_val, static_cast<DATA_TYPE>(max0.get()));
+    ASSERT_EQ(default_val, static_cast<DATA_TYPE>(max1.get()));
+    ASSERT_EQ(big_val, static_cast<DATA_TYPE>(max2.get()));
 
-    if ( test_array[max_index] < roll ) {
-      test_array[max_index] = roll;
-      current_max = RAJA_MAX( current_max, roll );
+    DATA_TYPE current_max = default_val;
 
+    const int nMiddleLoops = 2;
+    for (int k = 0; k < nMiddleLoops; ++k) {
+
+      for (IDX_TYPE i = 0; i < last; ++i) {
+        test_array[i] = default_val;
+      }
       working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
+
+      const int nloops = 6;
+      for (int j = 0; j < nloops; ++j) {
+
+        DATA_TYPE roll = static_cast<DATA_TYPE>( dist(mt) );
+        IDX_TYPE max_index = static_cast<IDX_TYPE>(dist2(mt));
+
+        test_array[max_index] = roll;
+        working_res.memcpy(&working_array[max_index], &test_array[max_index], sizeof(DATA_TYPE));
+
+        if ( current_max < roll ) {
+          current_max = roll ;
+        }
+
+        RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+          max0.max(working_array[idx]);
+          max1.max(2 * working_array[idx]);
+          max2.max(working_array[idx]);
+        });
+
+        ASSERT_EQ(current_max, static_cast<DATA_TYPE>(max0.get()));
+        ASSERT_EQ(current_max * 2, static_cast<DATA_TYPE>(max1.get()));
+        ASSERT_EQ(big_val, static_cast<DATA_TYPE>(max2.get()));
+
+      }
+
     }
 
-    RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
-      max0.max(working_array[idx]);
-      max1.max(2 * working_array[idx]);
-      max2.max(working_array[idx]);
-    });
-
-    ASSERT_EQ(current_max, static_cast<DATA_TYPE>(max0.get()));
-    ASSERT_EQ(current_max * 2, static_cast<DATA_TYPE>(max1.get()));
-    ASSERT_EQ(big_val, static_cast<DATA_TYPE>(max2.get()));
+    max0.reset(default_val);
+    max1.reset(default_val);
+    max2.reset(big_val);
 
   }
 
-  max0.reset(default_val); 
-  max1.reset(default_val); 
-  max2.reset(big_val); 
-
-  const int nloops_b = 4;
-  for (int j = 0; j < nloops_b; ++j) {
-
-    DATA_TYPE roll = dist(mt);
-    IDX_TYPE max_index = static_cast<IDX_TYPE>(dist2(mt));
-
-    if ( test_array[max_index] < roll ) {
-      test_array[max_index] = roll;
-      current_max = RAJA_MAX(current_max, roll );
-
-      working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
-    }
-
-    RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
-      max0.max(working_array[idx]);
-      max1.max(2 * working_array[idx]);
-      max2.max(working_array[idx]);    
-    });
-
-    ASSERT_EQ(current_max, static_cast<DATA_TYPE>(max0.get()));
-    ASSERT_EQ(current_max * 2, static_cast<DATA_TYPE>(max1.get()));
-    ASSERT_EQ(big_val, static_cast<DATA_TYPE>(max2.get()));
-
-  }
+  ASSERT_EQ(default_val, static_cast<DATA_TYPE>(max0.get()));
+  ASSERT_EQ(default_val, static_cast<DATA_TYPE>(max1.get()));
+  ASSERT_EQ(big_val, static_cast<DATA_TYPE>(max2.get()));
 
   deallocateForallTestData<DATA_TYPE>(working_res,
                                       working_array,

--- a/test/functional/forall/reduce-multiple-segment/tests/test-forall-segment-multiple-ReduceMaxLoc.hpp
+++ b/test/functional/forall/reduce-multiple-segment/tests/test-forall-segment-multiple-ReduceMaxLoc.hpp
@@ -22,8 +22,6 @@ void ForallReduceMaxLocMultipleTestImpl(IDX_TYPE first,
 {
   RAJA::TypedRangeSegment<IDX_TYPE> r1(first, last);
 
-  IDX_TYPE index_len = last - first;
-
   camp::resources::Resource working_res{WORKING_RES::get_default()};
   DATA_TYPE* working_array;
   DATA_TYPE* check_array;
@@ -38,91 +36,88 @@ void ForallReduceMaxLocMultipleTestImpl(IDX_TYPE first,
   const DATA_TYPE default_val = static_cast<DATA_TYPE>(-SHRT_MAX);
   const IDX_TYPE default_loc = -1;
   const DATA_TYPE big_val = 500;
-
-  for (IDX_TYPE i = 0; i < last; ++i) {
-    test_array[i] = default_val;
-  }
-
   
   static std::random_device rd;
   static std::mt19937 mt(rd());
   static std::uniform_real_distribution<double> dist(-100, 100);
-  static std::uniform_real_distribution<double> dist2(0, index_len - 1);
+  static std::uniform_int_distribution<int> dist2(static_cast<int>(first), static_cast<int>(last) - 1);
 
-  DATA_TYPE current_max        = default_val;
-  IDX_TYPE current_loc = default_loc;
-
-  RAJA::ReduceMaxLoc<REDUCE_POLICY, DATA_TYPE, IDX_TYPE> max0(default_val, default_loc);;
+  RAJA::ReduceMaxLoc<REDUCE_POLICY, DATA_TYPE, IDX_TYPE> max0(default_val, default_loc);
   RAJA::ReduceMaxLoc<REDUCE_POLICY, DATA_TYPE, IDX_TYPE> max1(default_val, default_loc);
   RAJA::ReduceMaxLoc<REDUCE_POLICY, DATA_TYPE, IDX_TYPE> max2(big_val, default_loc);
 
-  const int nloops = 8;
-  for (int j = 0; j < nloops; ++j) {
+  const int nOuterLoops = 2;
+  for (int l = 0; l < nOuterLoops; ++l) {
 
-    DATA_TYPE roll = static_cast<DATA_TYPE>( dist(mt) );
-    IDX_TYPE max_index = static_cast<IDX_TYPE>(dist2(mt));
+    ASSERT_EQ(default_val, static_cast<DATA_TYPE>(max0.get()));
+    ASSERT_EQ(default_loc, static_cast<IDX_TYPE>(max0.getLoc()));
 
-    if ( current_max < roll && test_array[max_index] < roll ) {
-      test_array[max_index] = roll;
-      current_max = RAJA_MAX( current_max, roll );
-      current_loc = max_index;
-
-      working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
-    }
-
-    working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
-
-    RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
-      max0.maxloc(working_array[idx], idx);
-      max1.maxloc(2 * working_array[idx], idx);
-      max2.maxloc(working_array[idx], idx);
-    });
-
-    ASSERT_EQ(current_max, static_cast<DATA_TYPE>(max0.get()));
-    ASSERT_EQ(current_loc, static_cast<IDX_TYPE>(max0.getLoc()));
-
-    ASSERT_EQ(current_max * 2, static_cast<DATA_TYPE>(max1.get()));
-    ASSERT_EQ(current_loc, static_cast<IDX_TYPE>(max1.getLoc()));
+    ASSERT_EQ(default_val, static_cast<DATA_TYPE>(max1.get()));
+    ASSERT_EQ(default_loc, static_cast<IDX_TYPE>(max1.getLoc()));
 
     ASSERT_EQ(big_val, static_cast<DATA_TYPE>(max2.get()));
     ASSERT_EQ(default_loc, static_cast<IDX_TYPE>(max2.getLoc()));
 
-  }
+    DATA_TYPE current_max = default_val;
+    IDX_TYPE  current_loc = default_loc;
 
-  max0.reset(default_val, default_loc); 
-  max1.reset(default_val, default_loc); 
-  max2.reset(big_val, default_loc); 
+    const int nMiddleLoops = 2;
+    for (int k = 0; k < nMiddleLoops; ++k) {
 
-  const int nloops_b = 4;
-  for (int j = 0; j < nloops_b; ++j) {
-
-    DATA_TYPE roll = static_cast<DATA_TYPE>( dist(mt) );
-    IDX_TYPE max_index = static_cast<IDX_TYPE>(dist2(mt));
-
-    if ( current_max < roll && test_array[max_index] < roll ) {
-      test_array[max_index] = roll;
-      current_max = RAJA_MAX( current_max, roll );
-      current_loc = max_index;
-
+      for (IDX_TYPE i = first; i < last; ++i) {
+        test_array[i] = default_val;
+      }
       working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
+
+      const int nloops = 6;
+      for (int j = 0; j < nloops; ++j) {
+
+        DATA_TYPE roll = static_cast<DATA_TYPE>( dist(mt) );
+        IDX_TYPE max_index = static_cast<IDX_TYPE>(dist2(mt));
+
+        if ( current_max != roll ) { // avoid two indices getting the same value
+          test_array[max_index] = roll;
+          working_res.memcpy(&working_array[max_index], &test_array[max_index], sizeof(DATA_TYPE));
+
+          if ( current_max < roll ) {
+            current_max = roll;
+            current_loc = max_index;
+          }
+        }
+
+        RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+          max0.maxloc(working_array[idx], idx);
+          max1.maxloc(2 * working_array[idx], idx);
+          max2.maxloc(working_array[idx], idx);
+        });
+
+        ASSERT_EQ(current_max, static_cast<DATA_TYPE>(max0.get()));
+        ASSERT_EQ(current_loc, static_cast<IDX_TYPE>(max0.getLoc()));
+
+        ASSERT_EQ(current_max * 2, static_cast<DATA_TYPE>(max1.get()));
+        ASSERT_EQ(current_loc, static_cast<IDX_TYPE>(max1.getLoc()));
+
+        ASSERT_EQ(big_val, static_cast<DATA_TYPE>(max2.get()));
+        ASSERT_EQ(default_loc, static_cast<IDX_TYPE>(max2.getLoc()));
+
+      }
+
     }
 
-    RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
-      max0.maxloc(working_array[idx], idx);
-      max1.maxloc(2 * working_array[idx], idx);
-      max2.maxloc(working_array[idx], idx);    
-    });
-
-    ASSERT_EQ(current_max, static_cast<DATA_TYPE>(max0.get()));
-    ASSERT_EQ(current_loc, static_cast<IDX_TYPE>(max0.getLoc()));
-
-    ASSERT_EQ(current_max * 2, static_cast<DATA_TYPE>(max1.get()));
-    ASSERT_EQ(current_loc, static_cast<IDX_TYPE>(max1.getLoc()));
-
-    ASSERT_EQ(big_val, static_cast<DATA_TYPE>(max2.get()));
-    ASSERT_EQ(default_loc, static_cast<IDX_TYPE>(max2.getLoc()));
+    max0.reset(default_val, default_loc);
+    max1.reset(default_val, default_loc);
+    max2.reset(big_val, default_loc);
 
   }
+
+  ASSERT_EQ(default_val, static_cast<DATA_TYPE>(max0.get()));
+  ASSERT_EQ(default_loc, static_cast<IDX_TYPE>(max0.getLoc()));
+
+  ASSERT_EQ(default_val, static_cast<DATA_TYPE>(max1.get()));
+  ASSERT_EQ(default_loc, static_cast<IDX_TYPE>(max1.getLoc()));
+
+  ASSERT_EQ(big_val, static_cast<DATA_TYPE>(max2.get()));
+  ASSERT_EQ(default_loc, static_cast<IDX_TYPE>(max2.getLoc()));
 
   deallocateForallTestData<DATA_TYPE>(working_res,
                                       working_array,

--- a/test/functional/forall/reduce-multiple-segment/tests/test-forall-segment-multiple-ReduceMin.hpp
+++ b/test/functional/forall/reduce-multiple-segment/tests/test-forall-segment-multiple-ReduceMin.hpp
@@ -22,8 +22,6 @@ void ForallReduceMinMultipleTestImpl(IDX_TYPE first,
 {
   RAJA::TypedRangeSegment<IDX_TYPE> r1(first, last);
 
-  IDX_TYPE index_len = last - first;
-
   camp::resources::Resource working_res{WORKING_RES::get_default()};
   DATA_TYPE* working_array;
   DATA_TYPE* check_array;
@@ -37,18 +35,11 @@ void ForallReduceMinMultipleTestImpl(IDX_TYPE first,
 
   const DATA_TYPE default_val = static_cast<DATA_TYPE>(SHRT_MAX);
   const DATA_TYPE big_val = -500;
-
-  for (IDX_TYPE i = 0; i < last; ++i) {
-    test_array[i] = default_val;
-  }
-
   
   static std::random_device rd;
   static std::mt19937 mt(rd());
   static std::uniform_real_distribution<double> dist(-100, 100);
-  static std::uniform_real_distribution<double> dist2(0, index_len - 1);
-
-  DATA_TYPE current_min = default_val;
+  static std::uniform_int_distribution<int> dist2(static_cast<int>(first), static_cast<int>(last) - 1);
 
   // Workaround for broken omp-target reduction interface.
   // This should be `min0;` not `min0(0);`
@@ -57,59 +48,59 @@ void ForallReduceMinMultipleTestImpl(IDX_TYPE first,
   RAJA::ReduceMin<REDUCE_POLICY, DATA_TYPE> min1(default_val);
   RAJA::ReduceMin<REDUCE_POLICY, DATA_TYPE> min2(big_val);
 
-  const int nloops = 8;
-  for (int j = 0; j < nloops; ++j) {
+  const int nOuterLoops = 2;
+  for (int l = 0; l < nOuterLoops; ++l) {
 
-    DATA_TYPE roll = static_cast<DATA_TYPE>( dist(mt) );
-    IDX_TYPE min_index = static_cast<IDX_TYPE>(dist2(mt));
+    ASSERT_EQ(default_val, static_cast<DATA_TYPE>(min0.get()));
+    ASSERT_EQ(default_val, static_cast<DATA_TYPE>(min1.get()));
+    ASSERT_EQ(big_val, static_cast<DATA_TYPE>(min2.get()));
 
-    if ( test_array[min_index] > roll ) {
-      test_array[min_index] = roll;
-      current_min = RAJA_MIN( current_min, roll );
+    DATA_TYPE current_min = default_val;
 
+    const int nMiddleLoops = 2;
+    for (int k = 0; k < nMiddleLoops; ++k) {
+
+      for (IDX_TYPE i = 0; i < last; ++i) {
+        test_array[i] = default_val;
+      }
       working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
+
+      const int nloops = 6;
+      for (int j = 0; j < nloops; ++j) {
+
+        DATA_TYPE roll = static_cast<DATA_TYPE>( dist(mt) );
+        IDX_TYPE min_index = static_cast<IDX_TYPE>(dist2(mt));
+
+        test_array[min_index] = roll;
+        working_res.memcpy(&working_array[min_index], &test_array[min_index], sizeof(DATA_TYPE));
+
+        if ( current_min > roll ) {
+          current_min = roll ;
+        }
+
+        RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+          min0.min(working_array[idx]);
+          min1.min(2 * working_array[idx]);
+          min2.min(working_array[idx]);
+        });
+
+        ASSERT_EQ(current_min, static_cast<DATA_TYPE>(min0.get()));
+        ASSERT_EQ(current_min * 2, static_cast<DATA_TYPE>(min1.get()));
+        ASSERT_EQ(big_val, static_cast<DATA_TYPE>(min2.get()));
+
+      }
+
     }
 
-    RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
-      min0.min(working_array[idx]);
-      min1.min(2 * working_array[idx]);
-      min2.min(working_array[idx]);
-    });
-
-    ASSERT_EQ(current_min, static_cast<DATA_TYPE>(min0.get()));
-    ASSERT_EQ(current_min * 2, static_cast<DATA_TYPE>(min1.get()));
-    ASSERT_EQ(big_val, static_cast<DATA_TYPE>(min2.get()));
+    min0.reset(default_val);
+    min1.reset(default_val);
+    min2.reset(big_val);
 
   }
 
-  min0.reset(default_val); 
-  min1.reset(default_val); 
-  min2.reset(big_val); 
-
-  const int nloops_b = 4;
-  for (int j = 0; j < nloops_b; ++j) {
-
-    DATA_TYPE roll = static_cast<DATA_TYPE>( dist(mt) );
-    IDX_TYPE min_index = static_cast<IDX_TYPE>(dist2(mt));
-
-    if ( test_array[min_index] > roll ) {
-      test_array[min_index] = roll;
-      current_min = RAJA_MIN(current_min, roll );
-
-      working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
-    }
-
-    RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
-      min0.min(working_array[idx]);
-      min1.min(2 * working_array[idx]);
-      min2.min(working_array[idx]);    
-    });
-
-    ASSERT_EQ(current_min, static_cast<DATA_TYPE>(min0.get()));
-    ASSERT_EQ(current_min * 2, static_cast<DATA_TYPE>(min1.get()));
-    ASSERT_EQ(big_val, static_cast<DATA_TYPE>(min2.get()));
-
-  }
+  ASSERT_EQ(default_val, static_cast<DATA_TYPE>(min0.get()));
+  ASSERT_EQ(default_val, static_cast<DATA_TYPE>(min1.get()));
+  ASSERT_EQ(big_val, static_cast<DATA_TYPE>(min2.get()));
 
   deallocateForallTestData<DATA_TYPE>(working_res,
                                       working_array,

--- a/test/functional/forall/reduce-multiple-segment/tests/test-forall-segment-multiple-ReduceMinLoc.hpp
+++ b/test/functional/forall/reduce-multiple-segment/tests/test-forall-segment-multiple-ReduceMinLoc.hpp
@@ -22,8 +22,6 @@ void ForallReduceMinLocMultipleTestImpl(IDX_TYPE first,
 {
   RAJA::TypedRangeSegment<IDX_TYPE> r1(first, last);
 
-  IDX_TYPE index_len = last - first;
-
   camp::resources::Resource working_res{WORKING_RES::get_default()};
   DATA_TYPE* working_array;
   DATA_TYPE* check_array;
@@ -39,90 +37,95 @@ void ForallReduceMinLocMultipleTestImpl(IDX_TYPE first,
   const IDX_TYPE default_loc = -1;
   const DATA_TYPE big_val = -500;
 
-  for (IDX_TYPE i = 0; i < last; ++i) {
-    test_array[i] = default_val;
-  }
-
-  
   static std::random_device rd;
   static std::mt19937 mt(rd());
   static std::uniform_real_distribution<double> dist(-100, 100);
-  static std::uniform_real_distribution<double> dist2(0, index_len - 1);
+  static std::uniform_int_distribution<int> dist2(static_cast<int>(first), static_cast<int>(last) - 1);
 
-  DATA_TYPE current_min    = default_val;
-  IDX_TYPE current_loc = default_loc;
-
-  RAJA::ReduceMinLoc<REDUCE_POLICY, DATA_TYPE, IDX_TYPE> min0(default_val, default_loc);;
+  printf("min0 init { %f, %f }\n", (double)default_val, (double)default_loc);
+  RAJA::ReduceMinLoc<REDUCE_POLICY, DATA_TYPE, IDX_TYPE> min0(default_val, default_loc);
   RAJA::ReduceMinLoc<REDUCE_POLICY, DATA_TYPE, IDX_TYPE> min1(default_val, default_loc);
   RAJA::ReduceMinLoc<REDUCE_POLICY, DATA_TYPE, IDX_TYPE> min2(big_val, default_loc);
 
-  const int nloops = 8;
-  for (int j = 0; j < nloops; ++j) {
+  const int nOuterLoops = 2;
+  for (int l = 0; l < nOuterLoops; ++l) {
 
-    DATA_TYPE roll = static_cast<DATA_TYPE>( dist(mt) );
-    IDX_TYPE min_index = static_cast<IDX_TYPE>(dist2(mt));
+    printf("min0 { %f, %f }\n", (double)min0.get(), (double)min0.getLoc());
+    ASSERT_EQ(default_val, static_cast<DATA_TYPE>(min0.get()));
+    ASSERT_EQ(default_loc, static_cast<IDX_TYPE>(min0.getLoc()));
 
-    if ( current_min > roll && test_array[min_index] > roll ) {
-      test_array[min_index] = roll;
-      current_min = RAJA_MIN( current_min, roll );
-      current_loc = min_index;
-
-      working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
-    }
-
-    working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
-
-    RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
-      min0.minloc(working_array[idx], idx);
-      min1.minloc(2 * working_array[idx], idx);
-      min2.minloc(working_array[idx], idx);
-    });
-
-    ASSERT_EQ(current_min, static_cast<DATA_TYPE>(min0.get()));
-    ASSERT_EQ(current_loc, static_cast<IDX_TYPE>(min0.getLoc()));
-
-    ASSERT_EQ(current_min * 2, static_cast<DATA_TYPE>(min1.get()));
-    ASSERT_EQ(current_loc, static_cast<IDX_TYPE>(min1.getLoc()));
+    ASSERT_EQ(default_val, static_cast<DATA_TYPE>(min1.get()));
+    ASSERT_EQ(default_loc, static_cast<IDX_TYPE>(min1.getLoc()));
 
     ASSERT_EQ(big_val, static_cast<DATA_TYPE>(min2.get()));
     ASSERT_EQ(default_loc, static_cast<IDX_TYPE>(min2.getLoc()));
 
-  }
+    DATA_TYPE current_min = default_val;
+    IDX_TYPE  current_loc = default_loc;
 
-  min0.reset(default_val, default_loc); 
-  min1.reset(default_val, default_loc); 
-  min2.reset(big_val, default_loc); 
+    const int nMiddleLoops = 2;
+    for (int k = 0; k < nMiddleLoops; ++k) {
 
-  const int nloops_b = 4;
-  for (int j = 0; j < nloops_b; ++j) {
-
-    DATA_TYPE roll = static_cast<DATA_TYPE>( dist(mt) );
-    IDX_TYPE min_index = static_cast<IDX_TYPE>(dist2(mt));
-
-    if ( current_min > roll && test_array[min_index] > roll ) {
-      test_array[min_index] = roll;
-      current_min = RAJA_MIN( current_min, roll );
-      current_loc = min_index;
-
+      printf("reset data { %f }\n", (double)default_val);
+      for (IDX_TYPE i = first; i < last; ++i) {
+        test_array[i] = default_val;
+      }
       working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * last);
+
+      const int nloops = 6;
+      for (int j = 0; j < nloops; ++j) {
+
+        DATA_TYPE roll = static_cast<DATA_TYPE>( dist(mt) );
+        IDX_TYPE min_index = static_cast<IDX_TYPE>(dist2(mt));
+
+        printf("rolling { %f, %f }\n", (double)roll, (double)min_index);
+        if ( current_min != roll ) { // avoid two indices getting the same value
+          test_array[min_index] = roll;
+          working_res.memcpy(&working_array[min_index], &test_array[min_index], sizeof(DATA_TYPE));
+
+          if ( current_min > roll ) {
+            current_min = roll;
+            current_loc = min_index;
+          }
+        }
+        printf("current { %f, %f }\n", (double)current_min, (double)current_loc);
+
+        RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+          min0.minloc(working_array[idx], idx);
+          min1.minloc(2 * working_array[idx], idx);
+          min2.minloc(working_array[idx], idx);
+        });
+
+        printf("min0 { %f, %f }\n", (double)min0.get(), (double)min0.getLoc());
+        ASSERT_EQ(current_min, static_cast<DATA_TYPE>(min0.get()));
+        ASSERT_EQ(current_loc, static_cast<IDX_TYPE>(min0.getLoc()));
+
+        ASSERT_EQ(current_min * 2, static_cast<DATA_TYPE>(min1.get()));
+        ASSERT_EQ(current_loc, static_cast<IDX_TYPE>(min1.getLoc()));
+
+        ASSERT_EQ(big_val, static_cast<DATA_TYPE>(min2.get()));
+        ASSERT_EQ(default_loc, static_cast<IDX_TYPE>(min2.getLoc()));
+
+      }
+
     }
 
-    RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
-      min0.minloc(working_array[idx], idx);
-      min1.minloc(2 * working_array[idx], idx);
-      min2.minloc(working_array[idx], idx);    
-    });
-
-    ASSERT_EQ(current_min, static_cast<DATA_TYPE>(min0.get()));
-    ASSERT_EQ(current_loc, static_cast<IDX_TYPE>(min0.getLoc()));
-
-    ASSERT_EQ(current_min * 2, static_cast<DATA_TYPE>(min1.get()));
-    ASSERT_EQ(current_loc, static_cast<IDX_TYPE>(min1.getLoc()));
-
-    ASSERT_EQ(big_val, static_cast<DATA_TYPE>(min2.get()));
-    ASSERT_EQ(default_loc, static_cast<IDX_TYPE>(min2.getLoc()));
+    printf("min0 reset { %f, %f }\n", (double)default_val, (double)default_loc);
+    min0.reset(default_val, (DATA_TYPE)default_loc);
+    min1.reset(default_val, default_loc);
+    min2.reset(big_val, default_loc);
 
   }
+
+  printf("min0 { %f, %f }\n", (double)min0.get(), (double)min0.getLoc());
+  ASSERT_EQ(default_val, static_cast<DATA_TYPE>(min0.get()));
+  ASSERT_EQ(default_loc, static_cast<IDX_TYPE>(min0.getLoc()));
+
+  ASSERT_EQ(default_val, static_cast<DATA_TYPE>(min1.get()));
+  ASSERT_EQ(default_loc, static_cast<IDX_TYPE>(min1.getLoc()));
+
+  ASSERT_EQ(big_val, static_cast<DATA_TYPE>(min2.get()));
+  ASSERT_EQ(default_loc, static_cast<IDX_TYPE>(min2.getLoc()));
 
   deallocateForallTestData<DATA_TYPE>(working_res,
                                       working_array,

--- a/test/functional/forall/reduce-multiple-segment/tests/test-forall-segment-multiple-ReduceSum.hpp
+++ b/test/functional/forall/reduce-multiple-segment/tests/test-forall-segment-multiple-ReduceSum.hpp
@@ -32,7 +32,7 @@ void ForallReduceSumMultipleStaggeredTestImpl(IDX_TYPE first,
 
   const DATA_TYPE initval = 2;
 
-  for (IDX_TYPE i = 0; i < last; ++i) {
+  for (IDX_TYPE i = first; i < last; ++i) {
     test_array[i] = initval;
   }
 
@@ -104,7 +104,7 @@ void ForallReduceSumMultipleStaggered2TestImpl(IDX_TYPE first,
 
   const DATA_TYPE initval = 2;
 
-  for (IDX_TYPE i = 0; i < last; ++i) {
+  for (IDX_TYPE i = first; i < last; ++i) {
     test_array[i] = initval;
   }
 


### PR DESCRIPTION
# Fix cuda and hip reduceloc reset and make interface consistent

There was a problem with the cuda and hip minloc and maxloc reducers. If you called reset you would change the identity value leading to incorrect results in some cases. This was caused by accidentally calling a base class reset method that treated the initial location argument as the identity. This PR adds a reset method in the derived class that hides the base class method.

In addition the arguments to all reduce loc constructors and resets were inconsistent. They now all take an initial value and location and an identity value and location.

The forall segment multiple reduce tests had some duplication and some potential for error in places so I refactored those to reduce duplication and fixed some potential for errors like the test assumed that first would always be 0.

- This PR is a refactoring, bugfix
- It does the following (modify list as needed):
  - Modifies/refactors
    - reduce loc constructors and reset methods 
    - the forall segment multiple reduce tests
  - Fixes cuda and hip loc reducer reset
