### PR TITLE
Reduce number of exec methods in launch backends

### DIFF
--- a/include/RAJA/pattern/launch/launch_core.hpp
+++ b/include/RAJA/pattern/launch/launch_core.hpp
@@ -238,7 +238,10 @@ void launch(LaunchParams const &params, const char *kernel_name, BODY const &bod
   util::callPreLaunchPlugins(context);
 
   using launch_t = LaunchExecute<typename LAUNCH_POLICY::host_policy_t>;
-  launch_t::exec(params, kernel_name, p_body);
+
+  using Res = typename resources::get_resource<typename LAUNCH_POLICY::host_policy_t>::type;
+
+  launch_t::exec(Res::get_default(), params, kernel_name, p_body);
 
   util::callPostLaunchPlugins(context);
 }
@@ -258,12 +261,14 @@ void launch(ExecPlace place, const LaunchParams &params, const char *kernel_name
   //Forward to single policy launch API - simplifies testing of plugins
   switch (place) {
     case ExecPlace::HOST: {
-      launch<LaunchPolicy<typename POLICY_LIST::host_policy_t>>(params, kernel_name, body);
+      using Res = typename resources::get_resource<typename POLICY_LIST::host_policy_t>::type;
+      launch<LaunchPolicy<typename POLICY_LIST::host_policy_t>>(Res::get_default(), params, kernel_name, body);
       break;
     }
 #ifdef RAJA_DEVICE_ACTIVE
   case ExecPlace::DEVICE: {
-      launch<LaunchPolicy<typename POLICY_LIST::device_policy_t>>(params, kernel_name, body);
+      using Res = typename resources::get_resource<typename POLICY_LIST::device_policy_t>::type;
+      launch<LaunchPolicy<typename POLICY_LIST::device_policy_t>>(Res::get_default(), params, kernel_name, body);
       break;
     }
 #endif

--- a/include/RAJA/policy/cuda/launch.hpp
+++ b/include/RAJA/policy/cuda/launch.hpp
@@ -50,50 +50,6 @@ struct LaunchExecute<RAJA::cuda_launch_t<async, 1>> {
 // cuda_launch_t num_threads set to 1, but not used in launch of kernel
 
   template <typename BODY_IN>
-  static void exec(const LaunchParams &params, const char *kernel_name, BODY_IN &&body_in)
-  {
-
-    using BODY = camp::decay<BODY_IN>;
-
-    auto func = launch_global_fcn<BODY>;
-
-    resources::Cuda cuda_res = resources::Cuda::get_default();
-    //
-    // Compute the number of blocks and threads
-    //
-    cuda_dim_t gridSize{ static_cast<cuda_dim_member_t>(params.teams.value[0]),
-                         static_cast<cuda_dim_member_t>(params.teams.value[1]),
-                         static_cast<cuda_dim_member_t>(params.teams.value[2]) };
-
-    cuda_dim_t blockSize{ static_cast<cuda_dim_member_t>(params.threads.value[0]),
-                          static_cast<cuda_dim_member_t>(params.threads.value[1]),
-                          static_cast<cuda_dim_member_t>(params.threads.value[2]) };
-
-    // Only launch kernel if we have something to iterate over
-    constexpr cuda_dim_member_t zero = 0;
-    if ( gridSize.x  > zero && gridSize.y  > zero && gridSize.z  > zero &&
-         blockSize.x > zero && blockSize.y > zero && blockSize.z > zero ) {
-
-      RAJA_FT_BEGIN;
-      {
-        //
-        // Privatize the loop_body, using make_launch_body to setup reductions
-        //
-        BODY body = RAJA::cuda::make_launch_body(gridSize, blockSize, params.shared_mem_size, cuda_res, std::forward<BODY_IN>(body_in));
-
-        //
-        // Launch the kernel
-        //
-        void *args[] = {(void*)&body};
-        RAJA::cuda::launch((const void*)func, gridSize, blockSize, args, params.shared_mem_size, cuda_res, async, kernel_name);
-      }
-
-      RAJA_FT_END;
-    }
-
-  };
-
-  template <typename BODY_IN>
   static resources::EventProxy<resources::Resource>
   exec(RAJA::resources::Resource res, const LaunchParams &params, const char *kernel_name, BODY_IN &&body_in)
   {
@@ -169,53 +125,6 @@ __launch_bounds__(num_threads, BLOCKS_PER_SM) __global__
 
 template <bool async, int nthreads, size_t BLOCKS_PER_SM>
 struct LaunchExecute<RAJA::policy::cuda::cuda_launch_explicit_t<async, nthreads, BLOCKS_PER_SM>> {
-
-  template <typename BODY_IN>
-  static void exec(const LaunchParams &params, const char *kernel_name, BODY_IN &&body_in)
-  {
-
-    using BODY = camp::decay<BODY_IN>;
-
-    auto func = launch_global_fcn_fixed<BODY, nthreads, BLOCKS_PER_SM>;
-
-    resources::Cuda cuda_res = resources::Cuda::get_default();
-
-    //
-    // Compute the number of blocks and threads
-    //
-
-    cuda_dim_t gridSize{ static_cast<cuda_dim_member_t>(params.teams.value[0]),
-                         static_cast<cuda_dim_member_t>(params.teams.value[1]),
-                         static_cast<cuda_dim_member_t>(params.teams.value[2]) };
-
-    cuda_dim_t blockSize{ static_cast<cuda_dim_member_t>(params.threads.value[0]),
-                          static_cast<cuda_dim_member_t>(params.threads.value[1]),
-                          static_cast<cuda_dim_member_t>(params.threads.value[2]) };
-
-    // Only launch kernel if we have something to iterate over
-    constexpr cuda_dim_member_t zero = 0;
-    if ( gridSize.x  > zero && gridSize.y  > zero && gridSize.z  > zero &&
-         blockSize.x > zero && blockSize.y > zero && blockSize.z > zero ) {
-
-      RAJA_FT_BEGIN;
-
-      {
-        //
-        // Privatize the loop_body, using make_launch_body to setup reductions
-        //
-        BODY body = RAJA::cuda::make_launch_body(
-            gridSize, blockSize, params.shared_mem_size, cuda_res, std::forward<BODY_IN>(body_in));
-
-        //
-        // Launch the kernel
-        //
-        void *args[] = {(void*)&body};
-        RAJA::cuda::launch((const void*)func, gridSize, blockSize, args, params.shared_mem_size, cuda_res, async, kernel_name);
-      }
-
-      RAJA_FT_END;
-      }
-  }
 
   template <typename BODY_IN>
   static resources::EventProxy<resources::Resource>

--- a/include/RAJA/policy/hip/launch.hpp
+++ b/include/RAJA/policy/hip/launch.hpp
@@ -48,53 +48,6 @@ template <bool async>
 struct LaunchExecute<RAJA::hip_launch_t<async, 0>> {
 
   template <typename BODY_IN>
-  static void exec(const LaunchParams &params, const char *kernel_name, BODY_IN &&body_in)
-  {
-    using BODY = camp::decay<BODY_IN>;
-
-    auto func = launch_global_fcn<BODY>;
-
-    resources::Hip hip_res = resources::Hip::get_default();
-
-    //
-    // Compute the number of blocks and threads
-    //
-
-    hip_dim_t gridSize{ static_cast<hip_dim_member_t>(params.teams.value[0]),
-                        static_cast<hip_dim_member_t>(params.teams.value[1]),
-                        static_cast<hip_dim_member_t>(params.teams.value[2]) };
-
-    hip_dim_t blockSize{ static_cast<hip_dim_member_t>(params.threads.value[0]),
-                         static_cast<hip_dim_member_t>(params.threads.value[1]),
-                         static_cast<hip_dim_member_t>(params.threads.value[2]) };
-
-    // Only launch kernel if we have something to iterate over
-    constexpr hip_dim_member_t zero = 0;
-    if ( gridSize.x  > zero && gridSize.y  > zero && gridSize.z  > zero &&
-         blockSize.x > zero && blockSize.y > zero && blockSize.z > zero ) {
-
-      RAJA_FT_BEGIN;
-
-      {
-        //
-        // Privatize the loop_body, using make_launch_body to setup reductions
-        //
-        BODY body = RAJA::hip::make_launch_body(
-            gridSize, blockSize, params.shared_mem_size, hip_res, std::forward<BODY_IN>(body_in));
-
-        //
-        // Launch the kernel
-        //
-        void *args[] = {(void*)&body};
-        RAJA::hip::launch((const void*)func, gridSize, blockSize, args, params.shared_mem_size, hip_res, async, kernel_name);
-      }
-
-      RAJA_FT_END;
-    }
-
-  }
-
-  template <typename BODY_IN>
   static resources::EventProxy<resources::Resource>
   exec(RAJA::resources::Resource res, const LaunchParams &params, const char *kernel_name, BODY_IN &&body_in)
   {
@@ -164,53 +117,6 @@ static void launch_global_fcn_fixed(BODY body_in)
 
 template <bool async, int nthreads>
 struct LaunchExecute<RAJA::hip_launch_t<async, nthreads>> {
-
-  template <typename BODY_IN>
-  static void exec(const LaunchParams &params, const char *kernel_name, BODY_IN &&body_in)
-  {
-    using BODY = camp::decay<BODY_IN>;
-
-    auto func = launch_global_fcn_fixed<BODY, nthreads>;
-
-    resources::Hip hip_res = resources::Hip::get_default();
-
-    //
-    // Compute the number of blocks and threads
-    //
-
-    hip_dim_t gridSize{ static_cast<hip_dim_member_t>(params.teams.value[0]),
-                        static_cast<hip_dim_member_t>(params.teams.value[1]),
-                        static_cast<hip_dim_member_t>(params.teams.value[2]) };
-
-    hip_dim_t blockSize{ static_cast<hip_dim_member_t>(params.threads.value[0]),
-                         static_cast<hip_dim_member_t>(params.threads.value[1]),
-                         static_cast<hip_dim_member_t>(params.threads.value[2]) };
-
-    // Only launch kernel if we have something to iterate over
-    constexpr hip_dim_member_t zero = 0;
-    if ( gridSize.x  > zero && gridSize.y  > zero && gridSize.z  > zero &&
-         blockSize.x > zero && blockSize.y > zero && blockSize.z > zero ) {
-
-      RAJA_FT_BEGIN;
-
-      {
-        //
-        // Privatize the loop_body, using make_launch_body to setup reductions
-        //
-        BODY body = RAJA::hip::make_launch_body(
-            gridSize, blockSize, params.shared_mem_size, hip_res, std::forward<BODY_IN>(body_in));
-
-        //
-        // Launch the kernel
-        //
-        void *args[] = {(void*)&body};
-        RAJA::hip::launch((const void*)func, gridSize, blockSize, args, params.shared_mem_size, hip_res, async, kernel_name);
-      }
-
-      RAJA_FT_END;
-    }
-
-  }
 
   template <typename BODY_IN>
   static resources::EventProxy<resources::Resource>

--- a/include/RAJA/policy/loop/launch.hpp
+++ b/include/RAJA/policy/loop/launch.hpp
@@ -41,19 +41,6 @@ template <>
 struct LaunchExecute<RAJA::seq_launch_t> {
 
   template <typename BODY>
-  static void exec(LaunchParams const &params, const char *RAJA_UNUSED_ARG(kernel_name), BODY const &body)
-  {
-    LaunchContext ctx;
-
-    ctx.shared_mem_ptr = (char*) malloc(params.shared_mem_size);
-
-    body(ctx);
-
-    free(ctx.shared_mem_ptr);
-    ctx.shared_mem_ptr = nullptr;
-  }
-
-  template <typename BODY>
   static resources::EventProxy<resources::Resource>
   exec(RAJA::resources::Resource res, LaunchParams const &params, const char *RAJA_UNUSED_ARG(kernel_name), BODY const &body)
   {

--- a/include/RAJA/policy/openmp/launch.hpp
+++ b/include/RAJA/policy/openmp/launch.hpp
@@ -28,26 +28,6 @@ namespace RAJA
 template <>
 struct LaunchExecute<RAJA::omp_launch_t> {
 
-
-  template <typename BODY>
-  static void exec(LaunchParams const &params, const char *, BODY const &body)
-  {
-    RAJA::region<RAJA::omp_parallel_region>([&]() {
-
-        LaunchContext ctx;
-
-        using RAJA::internal::thread_privatize;
-        auto loop_body = thread_privatize(body);
-
-        ctx.shared_mem_ptr = (char*) malloc(params.shared_mem_size);
-
-        loop_body.get_priv()(ctx);
-
-        free(ctx.shared_mem_ptr);
-        ctx.shared_mem_ptr = nullptr;
-    });
-  }
-
   template <typename BODY>
   static resources::EventProxy<resources::Resource>
   exec(RAJA::resources::Resource res, LaunchParams const &params, const char *, BODY const &body)

--- a/include/RAJA/policy/sycl/launch.hpp
+++ b/include/RAJA/policy/sycl/launch.hpp
@@ -31,133 +31,6 @@ namespace RAJA
 template <bool async>
 struct LaunchExecute<RAJA::sycl_launch_t<async, 0>> {
 
-  //If the launch lambda is trivially copyable
-  template <typename BODY_IN,
-	    typename std::enable_if<std::is_trivially_copyable<BODY_IN>{},bool>::type = true>
-  static void exec(const LaunchParams &params, const char *kernel_name, BODY_IN &&body_in)	      
-  {
-
-    cl::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
-
-    resources::Sycl sycl_res = resources::Sycl::get_default();
-
-    // Global resource was not set, use the resource that was passed to forall
-    // Determine if the default SYCL res is being used
-    if (!q) {
-      q = sycl_res.get_queue();
-    }
-
-    const ::sycl::range<3> blockSize(params.threads.value[0],
-				     params.threads.value[1],
-				     params.threads.value[2]);
-
-    const ::sycl::range<3> gridSize(params.threads.value[0] * params.teams.value[0],
-				    params.threads.value[1] * params.teams.value[1],
-				    params.threads.value[2] * params.teams.value[2]);
-
-    // Only launch kernel if we have something to iterate over
-    constexpr size_t zero = 0;
-    if ( params.threads.value[0]  > zero && params.threads.value[1]  > zero && params.threads.value[2] > zero &&
-         params.teams.value[0] > zero && params.teams.value[1] > zero && params.teams.value[2]> zero ) {
-
-      RAJA_FT_BEGIN
-
-      q->submit([&](cl::sycl::handler& h) {
-
-        auto s_vec = cl::sycl::accessor<char, 1, cl::sycl::access::mode::read_write,
-                                        cl::sycl::access::target::local> (params.shared_mem_size, h);
-
-        h.parallel_for
-          (cl::sycl::nd_range<3>(gridSize, blockSize),
-           [=] (cl::sycl::nd_item<3> itm) {
-
-	     LaunchContext ctx;	     
-             ctx.itm = &itm;
-
-             //Point to shared memory
-             ctx.shared_mem_ptr = s_vec.get_pointer().get();
-
-             body_in(ctx);
-
-           });
-
-      });
-
-      RAJA_FT_END;
-    }
-
-    if (!async) { q->wait(); }
-  }
-
-  //If the launch lambda is not trivially copyable
-  template <typename BODY_IN,
-	    typename std::enable_if<!std::is_trivially_copyable<BODY_IN>{},bool>::type = true>
-  static void exec(const LaunchParams &params, const char *kernel_name, BODY_IN &&body_in)
-  {
-
-    cl::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
-
-    resources::Sycl sycl_res = resources::Sycl::get_default();
-
-    // Global resource was not set, use the resource that was passed to forall
-    // Determine if the default SYCL res is being used
-    if (!q) {
-      q = sycl_res.get_queue();
-    }
-
-    const ::sycl::range<3> blockSize(params.threads.value[0],
-				     params.threads.value[1],
-				     params.threads.value[2]);
-
-    const ::sycl::range<3> gridSize(params.threads.value[0] * params.teams.value[0],
-				    params.threads.value[1] * params.teams.value[1],
-				    params.threads.value[2] * params.teams.value[2]);
-
-    // Only launch kernel if we have something to iterate over
-    constexpr size_t zero = 0;
-    if ( params.threads.value[0]  > zero && params.threads.value[1]  > zero && params.threads.value[2] > zero &&
-         params.teams.value[0] > zero && params.teams.value[1] > zero && params.teams.value[2]> zero ) {
-
-      RAJA_FT_BEGIN
-
-      //
-      // Kernel body is nontrivially copyable, create space on device and copy to
-      // Workaround until "is_device_copyable" is supported
-      //
-      using LOOP_BODY = camp::decay<BODY_IN>;
-      LOOP_BODY* lbody;
-      lbody = (LOOP_BODY*) cl::sycl::malloc_device(sizeof(LOOP_BODY), *q);
-      q->memcpy(lbody, &body_in, sizeof(LOOP_BODY)).wait();
-
-      q->submit([&](cl::sycl::handler& h) {
-
-	  auto s_vec = cl::sycl::accessor<char, 1, cl::sycl::access::mode::read_write,
-					  cl::sycl::access::target::local> (params.shared_mem_size, h);
-
-        h.parallel_for
-          (cl::sycl::nd_range<3>(gridSize, blockSize),
-           [=] (cl::sycl::nd_item<3> itm) {
-
-   	    LaunchContext ctx;
-	    ctx.itm = &itm;
-
-	    //Point to shared memory
-	    ctx.shared_mem_ptr = s_vec.get_pointer().get();
-
-	    (*lbody)(ctx);
-
-	  });
-
-	}).wait();
-
-       cl::sycl::free(lbody, *q);
-
-      RAJA_FT_END;
-    }
-
-    if (!async) { q->wait(); }
-  }
-
  //If the launch lambda is trivially copyable
   template <typename BODY_IN,
 	    typename std::enable_if<std::is_trivially_copyable<BODY_IN>{},bool>::type = true>
@@ -204,13 +77,13 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>> {
           (cl::sycl::nd_range<3>(gridSize, blockSize),
            [=] (cl::sycl::nd_item<3> itm) {
 
- 	     LaunchContext ctx;
-             ctx.itm = &itm;
+            LaunchContext ctx;
+            ctx.itm = &itm;
 
-             //Point to shared memory
-             ctx.shared_mem_ptr = s_vec.get_pointer().get();
+            //Point to shared memory
+            ctx.shared_mem_ptr = s_vec.get_pointer().get();
 
-             body_in(ctx);
+            body_in(ctx);
 
            });
 
@@ -278,13 +151,13 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>> {
           (cl::sycl::nd_range<3>(gridSize, blockSize),
            [=] (cl::sycl::nd_item<3> itm) {
 
-	     LaunchContext ctx;
-             ctx.itm = &itm;
+            LaunchContext ctx;
+            ctx.itm = &itm;
 
-             //Point to shared memory
-             ctx.shared_mem_ptr = s_vec.get_pointer().get();
+            //Point to shared memory
+            ctx.shared_mem_ptr = s_vec.get_pointer().get();
 
-	     (*lbody)(ctx);
+            (*lbody)(ctx);
 
            });
 

--- a/include/RAJA/util/resource.hpp
+++ b/include/RAJA/util/resource.hpp
@@ -130,7 +130,7 @@ namespace RAJA
   };
 
   template <bool Async, int num_threads>
-  struct get_resource<cuda_launch_t<Async, num_threads>>{
+  struct get_resource<sycl_launch_t<Async, num_threads>>{
     using type = camp::resources::Sycl;
   };
 

--- a/include/RAJA/util/resource.hpp
+++ b/include/RAJA/util/resource.hpp
@@ -70,6 +70,16 @@ namespace RAJA
     using type = camp::resources::Cuda;
   };
 
+  template <bool Async, int num_threads>
+  struct get_resource<cuda_launch_t<Async, num_threads>>{
+    using type = camp::resources::Cuda;
+  };
+
+  template <bool Async, int num_threads, size_t BLOCKS_PER_SM>
+  struct get_resource<RAJA::policy::cuda::cuda_launch_explicit_t<Async, num_threads, BLOCKS_PER_SM>>{
+    using type = camp::resources::Cuda;
+  };
+
   template<typename ISetIter, size_t BlockSize, bool Async>
   struct get_resource<ExecPolicy<ISetIter, cuda_exec<BlockSize, Async>>>{
     using type = camp::resources::Cuda;
@@ -97,6 +107,11 @@ namespace RAJA
     using type = camp::resources::Hip;
   };
 
+  template <bool Async, int num_threads>
+  struct get_resource<hip_launch_t<Async, num_threads>>{
+    using type = camp::resources::Hip;
+  };
+
   template<typename ISetIter, size_t BlockSize, bool Async>
   struct get_resource<ExecPolicy<ISetIter, hip_exec<BlockSize, Async>>>{
     using type = camp::resources::Hip;
@@ -111,6 +126,11 @@ namespace RAJA
 
   template<size_t BlockSize, bool Async>
   struct get_resource<sycl_exec<BlockSize, Async>>{
+    using type = camp::resources::Sycl;
+  };
+
+  template <bool Async, int num_threads>
+  struct get_resource<cuda_launch_t<Async, num_threads>>{
     using type = camp::resources::Sycl;
   };
 


### PR DESCRIPTION
This is a first attempt at reducing the number of exec methods in the launch backend framework. Thought is we can keep the exec method that takes a resource and simply pass in a default when users do not specify one. 

- [x] Double check the sycl backend. 