### PR TITLE
Point to new shared-ci branch to test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,7 +53,7 @@ stages:
     include:
       - local: '.gitlab/custom-jobs-and-variables.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: v2022.12.0
+        ref: woptim/fix-draft-detection-develop
         file: '${CI_MACHINE}-build-and-test.yml'
       - local: '.gitlab/${CI_MACHINE}-build-and-test-extra.yml'
     strategy: depend
@@ -79,7 +79,7 @@ trigger-rajaperf:
 include:
   # checks preliminary to running the actual CI test (optional)
   - project: 'radiuss/radiuss-shared-ci'
-    ref: v2022.12.0
+    ref: woptim/fix-draft-detection-develop
     file: 'preliminary-ignore-draft-pr.yml'
   # pipelines subscribed by the project
   - local: '.gitlab/subscribed-pipelines.yml'


### PR DESCRIPTION
## Fix CI not running on develop in GitLab

Branches like develop are considered "draft" on GitHub because they don’t have an associated PR.
A fix in RADIUSS Shared CI allows to define branches that will skip the "draft test" and run anyway.

It is possible to override the list of branches always running, with the variable ALWAYS_RUN_LIST.
This will be used to validate that the fix works, without waiting to run on develop.