### PR TITLE
Tasks/gpu macro changes

### DIFF
--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -293,7 +293,7 @@ namespace RAJA {
 #if defined(RAJA_CUDA_ACTIVE) || \
     defined(RAJA_HIP_ACTIVE) || \
     defined(RAJA_SYCL_ACTIVE)
-#define RAJA_DEVICE_ACTIVE
+#define RAJA_GPU_ACTIVE
 #endif
 
 /*!
@@ -589,7 +589,7 @@ T * align_hint(T * x)
 #endif
 
 // If we're in CUDA or HIP device code, we can use the unroll pragma
-#if (defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)) && defined(RAJA_DEVICE_ACTIVE)
+#if (defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)) && defined(RAJA_GPU_ACTIVE)
 #undef RAJA_UNROLL
 #undef RAJA_UNROLL_COUNT
 #define RAJA_UNROLL RAJA_PRAGMA(unroll)

--- a/include/RAJA/index/ListSegment.hpp
+++ b/include/RAJA/index/ListSegment.hpp
@@ -230,7 +230,7 @@ public:
   RAJA_HOST_DEVICE void clear()
   {
 
-#if !defined(RAJA_DEVICE_CODE)
+#if !defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
     if (m_data != nullptr && m_owned == Owned) {
       m_resource->deallocate(m_data);
       delete m_resource;

--- a/include/RAJA/pattern/detail/algorithm.hpp
+++ b/include/RAJA/pattern/detail/algorithm.hpp
@@ -74,7 +74,7 @@ RAJA_HOST_DEVICE RAJA_INLINE
 void
 safe_iter_swap(Iter lhs, Iter rhs)
 {
-#ifdef RAJA_DEVICE_CODE
+#ifdef RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE
   using camp::safe_swap;
   safe_swap(*lhs, *rhs);
 #else

--- a/include/RAJA/pattern/launch/launch_core.hpp
+++ b/include/RAJA/pattern/launch/launch_core.hpp
@@ -31,7 +31,7 @@
 //Odd dependecy with atomics is breaking CI builds
 //#include "RAJA/util/View.hpp"
 
-#if defined(RAJA_DEVICE_CODE) && !defined(RAJA_ENABLE_SYCL)
+#if defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE) && !defined(RAJA_ENABLE_SYCL)
 #define RAJA_TEAM_SHARED __shared__
 #else
 #define RAJA_TEAM_SHARED
@@ -201,11 +201,11 @@ public:
   RAJA_HOST_DEVICE
   void teamSync()
   {
-#if defined(RAJA_DEVICE_CODE) && defined(RAJA_ENABLE_SYCL)
+#if defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE) && defined(RAJA_ENABLE_SYCL)
     itm->barrier(sycl::access::fence_space::local_space);
 #endif
 
-#if defined(RAJA_DEVICE_CODE) && !defined(RAJA_ENABLE_SYCL)
+#if defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE) && !defined(RAJA_ENABLE_SYCL)
     __syncthreads();
 #endif
   }
@@ -362,7 +362,7 @@ launch(RAJA::resources::Resource res, LaunchParams const &params, const char *ke
 }
 
 template<typename POLICY_LIST>
-#if defined(RAJA_DEVICE_CODE)
+#if defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
 using loop_policy = typename POLICY_LIST::device_policy_t;
 #else
 using loop_policy = typename POLICY_LIST::host_policy_t;

--- a/include/RAJA/pattern/launch/launch_core.hpp
+++ b/include/RAJA/pattern/launch/launch_core.hpp
@@ -49,7 +49,7 @@ struct null_launch_t {
 
 // Support for host, and device
 template <typename HOST_POLICY
-#if defined(RAJA_DEVICE_ACTIVE)
+#if defined(RAJA_GPU_ACTIVE)
           ,
           typename DEVICE_POLICY = HOST_POLICY
 #endif
@@ -57,20 +57,20 @@ template <typename HOST_POLICY
 
 struct LoopPolicy {
   using host_policy_t = HOST_POLICY;
-#if defined(RAJA_DEVICE_ACTIVE)
+#if defined(RAJA_GPU_ACTIVE)
   using device_policy_t = DEVICE_POLICY;
 #endif
 };
 
 template <typename HOST_POLICY
-#if defined(RAJA_DEVICE_ACTIVE)
+#if defined(RAJA_GPU_ACTIVE)
           ,
           typename DEVICE_POLICY = HOST_POLICY
 #endif
           >
 struct LaunchPolicy {
   using host_policy_t = HOST_POLICY;
-#if defined(RAJA_DEVICE_ACTIVE)
+#if defined(RAJA_GPU_ACTIVE)
   using device_policy_t = DEVICE_POLICY;
 #endif
 };
@@ -265,7 +265,7 @@ void launch(ExecPlace place, const LaunchParams &params, const char *kernel_name
       launch<LaunchPolicy<typename POLICY_LIST::host_policy_t>>(Res::get_default(), params, kernel_name, body);
       break;
     }
-#ifdef RAJA_DEVICE_ACTIVE
+#if defined(RAJA_GPU_ACTIVE)
   case ExecPlace::DEVICE: {
       using Res = typename resources::get_resource<typename POLICY_LIST::device_policy_t>::type;
       launch<LaunchPolicy<typename POLICY_LIST::device_policy_t>>(Res::get_default(), params, kernel_name, body);
@@ -318,7 +318,7 @@ launch(RAJA::resources::Resource res, LaunchParams const &params, const char *ke
   //
   //Configure plugins
   //
-#ifdef RAJA_DEVICE_ACTIVE
+#if defined(RAJA_GPU_ACTIVE)
   util::PluginContext context{place == ExecPlace::HOST ?
       util::make_context<typename POLICY_LIST::host_policy_t>()
       : util::make_context<typename POLICY_LIST::device_policy_t>()};
@@ -342,7 +342,7 @@ launch(RAJA::resources::Resource res, LaunchParams const &params, const char *ke
       util::callPostLaunchPlugins(context);
       return e_proxy;
     }
-#ifdef RAJA_DEVICE_ACTIVE
+#if defined(RAJA_GPU_ACTIVE)
     case ExecPlace::DEVICE: {
       using launch_t = LaunchExecute<typename POLICY_LIST::device_policy_t>;
       resources::EventProxy<resources::Resource> e_proxy = launch_t::exec(res, params, kernel_name, p_body);

--- a/include/RAJA/policy/cuda/reduce.hpp
+++ b/include/RAJA/policy/cuda/reduce.hpp
@@ -1080,7 +1080,7 @@ public:
   //  reducer in host device lambda not being used on device.
   RAJA_HOST_DEVICE
   Reduce(const Reduce& other)
-#if !defined(RAJA_DEVICE_CODE)
+#if !defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
       : parent{other.parent},
 #else
       : parent{&other},
@@ -1088,7 +1088,7 @@ public:
         tally_or_val_ptr{other.tally_or_val_ptr},
         val(other.val)
   {
-#if !defined(RAJA_DEVICE_CODE)
+#if !defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
     if (parent) {
       if (val.setupForDevice()) {
         tally_or_val_ptr.val_ptr =
@@ -1105,7 +1105,7 @@ public:
   RAJA_HOST_DEVICE
   ~Reduce()
   {
-#if !defined(RAJA_DEVICE_CODE)
+#if !defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
     if (parent == this) {
       delete tally_or_val_ptr.list;
       tally_or_val_ptr.list = nullptr;

--- a/include/RAJA/policy/hip/reduce.hpp
+++ b/include/RAJA/policy/hip/reduce.hpp
@@ -955,7 +955,7 @@ public:
   //  reducer in host device lambda not being used on device.
   RAJA_HOST_DEVICE
   Reduce(const Reduce& other)
-#if !defined(RAJA_DEVICE_CODE)
+#if !defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
       : parent{other.parent},
 #else
       : parent{&other},
@@ -963,7 +963,7 @@ public:
         tally_or_val_ptr{other.tally_or_val_ptr},
         val(other.val)
   {
-#if !defined(RAJA_DEVICE_CODE)
+#if !defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
     if (parent) {
       if (val.setupForDevice()) {
         tally_or_val_ptr.val_ptr =
@@ -980,7 +980,7 @@ public:
   RAJA_HOST_DEVICE
   ~Reduce()
   {
-#if !defined(RAJA_DEVICE_CODE)
+#if !defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
     if (parent == this) {
       delete tally_or_val_ptr.list;
       tally_or_val_ptr.list = nullptr;

--- a/include/RAJA/util/macros.hpp
+++ b/include/RAJA/util/macros.hpp
@@ -36,7 +36,7 @@
 #if (defined(RAJA_ENABLE_CUDA) && defined(__CUDA_ARCH__)) \
   || (defined(RAJA_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)) \
   || (defined(RAJA_ENABLE_SYCL) && defined(__SYCL_DEVICE_ONLY__))
-#define RAJA_DEVICE_CODE
+#define RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE
 #endif
 
 #if defined(RAJA_ENABLE_CUDA) && defined(__CUDACC__)

--- a/test/functional/dynamic_forall/resource-segment/tests/test-dynamic-forall-resource-RangeSegment.hpp
+++ b/test/functional/dynamic_forall/resource-segment/tests/test-dynamic-forall-resource-RangeSegment.hpp
@@ -66,7 +66,7 @@ TYPED_TEST_P(DynamicForallResourceRangeSegmentTest, RangeSegmentForallResource)
   using POLICY_LIST = typename camp::at<TypeParam, camp::num<2>>::type;
 
 
-#if defined(RAJA_DEVICE_ACTIVE)
+#if defined(RAJA_GPU_ACTIVE)
   constexpr int N = camp::size<POLICY_LIST>::value;
 #endif
 
@@ -90,7 +90,7 @@ TYPED_TEST_P(DynamicForallResourceRangeSegmentTest, RangeSegmentForallResource)
             (INDEX_TYPE(0), INDEX_TYPE(27), pol);
         }
   }
-#if defined(RAJA_DEVICE_ACTIVE)
+#if defined(RAJA_GPU_ACTIVE)
   else
   {
     int device_start = 2;

--- a/test/functional/dynamic_forall/segment/tests/test-dynamic-forall-RangeSegment.hpp
+++ b/test/functional/dynamic_forall/segment/tests/test-dynamic-forall-RangeSegment.hpp
@@ -105,7 +105,7 @@ TYPED_TEST_P(DynamicForallRangeSegmentTest, RangeSegmentForall)
             (INDEX_TYPE(0), INDEX_TYPE(27), pol);
         }
   }
-#if defined(RAJA_DEVICE_ACTIVE)
+#if defined(RAJA_GPU_ACTIVE)
   else
   {
     int device_start = 2;

--- a/test/integration/plugin/tests/test-plugin.hpp
+++ b/test/integration/plugin/tests/test-plugin.hpp
@@ -79,7 +79,7 @@ struct PluginTestCallable
     , m_data_iptr(rhs.m_data_iptr)
     , m_data(rhs.m_data)
   {
-#if !defined(RAJA_DEVICE_CODE)
+#if !defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
     if (omp_is_initial_device())
 #endif


### PR DESCRIPTION
# Summary

- This PR changes easily confuseable device macro names https://github.com/LLNL/RAJA/issues/1395

- RAJA_DEVICE_CODE changed to RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE meaning when defined, this is the device compile pass
- RAJA_DEVICE_ACTIVE changed to to RAJA_GPU_ACTIVE meaning when defined cuda, hip, or sycl back-end is enabled and active