### PR TITLE
Change type declarations in vectorization to avoid macro overload.

### DIFF
--- a/include/RAJA/pattern/tensor/TensorIndex.hpp
+++ b/include/RAJA/pattern/tensor/TensorIndex.hpp
@@ -68,13 +68,13 @@ namespace expt
         return self_type(begin, value_type(stripIndexType(end-begin)));
       }
 
-      template<value_type BEGIN, value_type END>
+      template<value_type TBEGIN, value_type TEND>
       RAJA_INLINE
       RAJA_HOST_DEVICE
       static
       constexpr
-      StaticTensorIndex<StaticTensorIndexInner<IDX,TENSOR_TYPE,DIM,BEGIN,END-BEGIN>> static_range(){
-        return StaticTensorIndex<StaticTensorIndexInner<IDX,TENSOR_TYPE,DIM,BEGIN,END-BEGIN>>();
+      StaticTensorIndex<StaticTensorIndexInner<IDX,TENSOR_TYPE,DIM,TBEGIN,TEND-TBEGIN>> static_range(){
+        return StaticTensorIndex<StaticTensorIndexInner<IDX,TENSOR_TYPE,DIM,TBEGIN,TEND-TBEGIN>>();
       }
 
 

--- a/include/RAJA/pattern/tensor/internal/TensorRef.hpp
+++ b/include/RAJA/pattern/tensor/internal/TensorRef.hpp
@@ -248,7 +248,7 @@ namespace expt
 
 
 
-    template< typename INDEX_TYPE, TensorTileSize TENSOR_SIZE, typename BEGIN, typename SIZE>
+    template< typename INDEX_TYPE, TensorTileSize TENSOR_SIZE, typename TBEGIN, typename TSIZE>
     struct StaticTensorTile;
 
     template< typename INDEX_TYPE,
@@ -318,35 +318,35 @@ namespace expt
         template< typename TILE, typename VALUE, size_t IDX>
         struct SetStaticTensorTileBegin;
 
-        template< typename INDEX_TYPE, TensorTileSize TENSOR_SIZE, typename BEGIN, typename SIZE, INDEX_TYPE VALUE, size_t IDX > 
+        template< typename INDEX_TYPE, TensorTileSize TENSOR_SIZE, typename TBEGIN, typename TSIZE, INDEX_TYPE VALUE, size_t IDX > 
         struct SetStaticTensorTileBegin<
-              StaticTensorTile<INDEX_TYPE, TENSOR_SIZE, BEGIN, SIZE >,
+              StaticTensorTile<INDEX_TYPE, TENSOR_SIZE, TBEGIN, TSIZE >,
               camp::integral_constant<INDEX_TYPE,VALUE>,
               IDX
         > {
-            using BeginType = StaticIndexArray<BEGIN>;
+            using BeginType = StaticIndexArray<TBEGIN>;
             using Type = StaticTensorTile<
                 INDEX_TYPE,
                 TENSOR_SIZE,
                 typename SetStaticIndexArray<INDEX_TYPE,IDX,VALUE,BeginType>::Seq,
-                SIZE
+                TSIZE
             >;
         };
 
         template< typename TILE, typename VALUE, size_t IDX>
         struct SetStaticTensorTileSize;
 
-        template< typename INDEX_TYPE, TensorTileSize TENSOR_SIZE, typename BEGIN, typename SIZE, INDEX_TYPE VALUE, size_t IDX > 
+        template< typename INDEX_TYPE, TensorTileSize TENSOR_SIZE, typename TBEGIN, typename TSIZE, INDEX_TYPE VALUE, size_t IDX > 
         struct SetStaticTensorTileSize<
-              StaticTensorTile<INDEX_TYPE, TENSOR_SIZE, BEGIN, SIZE >,
+              StaticTensorTile<INDEX_TYPE, TENSOR_SIZE, TBEGIN, TSIZE >,
               camp::integral_constant<INDEX_TYPE,VALUE>,
               IDX
         > {
-            using SizeType = StaticIndexArray<SIZE>;
+            using SizeType = StaticIndexArray<TSIZE>;
             using Type = StaticTensorTile<
                 INDEX_TYPE,
                 TENSOR_SIZE,
-                BEGIN,
+                TBEGIN,
                 typename SetStaticIndexArray<INDEX_TYPE,IDX,VALUE,SizeType>::Seq
             >;
         };
@@ -655,25 +655,25 @@ namespace expt
     /*!
      * Changes StaticTensorTile size type to FULL
      */
-    template< typename INDEX_TYPE, TensorTileSize RTENSOR_SIZE, typename BEGIN, typename SIZE>
+    template< typename INDEX_TYPE, TensorTileSize RTENSOR_SIZE, typename TBEGIN, typename TSIZE>
     RAJA_INLINE
     RAJA_HOST_DEVICE
     constexpr
-    StaticTensorTile<INDEX_TYPE, TENSOR_FULL, BEGIN, SIZE> &
-    make_tensor_tile_full(StaticTensorTile<INDEX_TYPE, RTENSOR_SIZE, BEGIN, SIZE> &tile){
-      return reinterpret_cast<StaticTensorTile<INDEX_TYPE, TENSOR_FULL, BEGIN, SIZE> &>(tile);
+    StaticTensorTile<INDEX_TYPE, TENSOR_FULL, TBEGIN, TSIZE> &
+    make_tensor_tile_full(StaticTensorTile<INDEX_TYPE, RTENSOR_SIZE, TBEGIN, TSIZE> &tile){
+      return reinterpret_cast<StaticTensorTile<INDEX_TYPE, TENSOR_FULL, TBEGIN, TSIZE> &>(tile);
     }
 
     /*!
      * Changes StaticTensorTile size type to PARTIAL
      */
-    template< typename INDEX_TYPE, TensorTileSize RTENSOR_SIZE, typename BEGIN, typename SIZE>
+    template< typename INDEX_TYPE, TensorTileSize RTENSOR_SIZE, typename TBEGIN, typename TSIZE>
     RAJA_INLINE
     RAJA_HOST_DEVICE
     constexpr
-    StaticTensorTile<INDEX_TYPE, TENSOR_PARTIAL, BEGIN, SIZE> &
-    make_tensor_tile_partial(StaticTensorTile<INDEX_TYPE, RTENSOR_SIZE, BEGIN, SIZE> &tile){
-      return reinterpret_cast<StaticTensorTile<INDEX_TYPE, TENSOR_PARTIAL, BEGIN, SIZE> &>(tile);
+    StaticTensorTile<INDEX_TYPE, TENSOR_PARTIAL, TBEGIN, TSIZE> &
+    make_tensor_tile_partial(StaticTensorTile<INDEX_TYPE, RTENSOR_SIZE, TBEGIN, TSIZE> &tile){
+      return reinterpret_cast<StaticTensorTile<INDEX_TYPE, TENSOR_PARTIAL, TBEGIN, TSIZE> &>(tile);
     }
 
 

--- a/include/RAJA/pattern/tensor/internal/TensorTileExec.hpp
+++ b/include/RAJA/pattern/tensor/internal/TensorTileExec.hpp
@@ -324,17 +324,17 @@ namespace expt
 
 
 
-    template<typename STORAGE, typename INDEX_TYPE, TensorTileSize TENSOR_SIZE, typename BEGIN, typename SIZE, typename BODY, camp::idx_t ... IDX_SEQ, camp::idx_t ... DIM_SEQ>
+    template<typename STORAGE, typename INDEX_TYPE, TensorTileSize TENSOR_SIZE, typename TBEGIN, typename TSIZE, typename BODY, camp::idx_t ... IDX_SEQ, camp::idx_t ... DIM_SEQ>
     RAJA_INLINE
     RAJA_HOST_DEVICE
-    void tensorTileExec_expanded( StaticTensorTile<INDEX_TYPE,TENSOR_SIZE, BEGIN, SIZE> const &orig_tile, BODY && body, camp::idx_seq<IDX_SEQ...> const &, camp::idx_seq<DIM_SEQ...> const &)
+    void tensorTileExec_expanded( StaticTensorTile<INDEX_TYPE,TENSOR_SIZE, TBEGIN, TSIZE> const &orig_tile, BODY && body, camp::idx_seq<IDX_SEQ...> const &, camp::idx_seq<DIM_SEQ...> const &)
     {
 
       using InputType = StaticTensorTile<
           INDEX_TYPE,
           TENSOR_SIZE,
-          BEGIN,
-          SIZE
+          TBEGIN,
+          TSIZE
       >;
 
       using InputBegin = typename InputType::begin_type;


### PR DESCRIPTION
# Summary

- This PR is a pre-emptive bugfix
- It does the following:
  - In here https://rzlc.llnl.gov/gitlab/deterministic-transport/NG/Ardra/-/merge_requests/354, a lexer is used to generate some code, while using RAJA. There is a `BEGIN` macro defined in the lexer's header file which incurs replacement within the RAJA headers as well, leading to strange compilation errors. While this error is not necessarily due to any inherent RAJA bug, I'm replacing some of the type declarations with commonly used names to avoid this sort of problem in the vectorization API in the future.