### PR TITLE
Fix path to RTD hosted output directory for doxygen content

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -334,7 +334,7 @@ texinfo_documents = [
 # Only do this on readthedocs
 def gendoxy(app, exception):
     if read_the_docs_build:
-        buildpath=os.path.join(conf_directory,"_build/html/doxygen/html")
+        buildpath=os.path.join(conf_directory,"_readthedocs/html/doxygen/html")
         if (os.path.isdir(buildpath) == 0):
             os.makedirs(buildpath)
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix to address a change made recently in readthedocs to where hosted doxygen content is located: https://github.com/readthedocs/readthedocs.org/pull/9888