### PR TITLE
Change path to generated doxygen due to RTD change

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,7 +23,7 @@ sphinx:
   configuration: docs/conf.py
 
 # Optionally build docs in add'l formats such as PDF and ePub
-#formats: all
+formats: all
 
 # Optionally set the version of Python and requirements to build the docs
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,10 +23,9 @@ sphinx:
   configuration: docs/conf.py
 
 # Optionally build docs in add'l formats such as PDF and ePub
-formats: all
+#formats: all
 
 # Optionally set the version of Python and requirements to build the docs
-
 python:
 #  version: 3.7
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
-version: 2
+#version: 2
 
 # Print tree
 build:
@@ -22,12 +22,12 @@ build:
 sphinx:
   configuration: docs/conf.py
 
-# Optionally build docs in add'l formats such as PDF and ePub 
+# Optionally build docs in add'l formats such as PDF and ePub
 #formats: all
 
 # Optionally set the version of Python and requirements to build the docs
 
 python:
-  version: 3.7
+#  version: 3.7
   install:
     - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
-#version: 2
+version: 2
 
 # Print tree
 build:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,32 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Print tree
+build:
+  os: ubuntu-20.04
+  apt_packages:
+    - tree
+  tools:
+    python: "3.7"
+  jobs:
+    post_build:
+      #- tree /home/docs/checkouts/readthedocs.org/user_builds/raja/checkouts/cwtask-doxy-patch/
+      #- tree Not found? The directory or the command?
+      - tree -J
+
+# Build documentation in the docs/ directory with Sphinx 
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build docs in add'l formats such as PDF and ePub 
+#formats: all
+
+# Optionally set the version of Python and requirements to build the docs
+
 python:
   version: 3.7
   install:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ if read_the_docs_build:
     with open('./doxygen/Doxyfile.in', 'w') as f:
         f.write(fdata)
     with open('./doxygen/Doxyfile.in', 'a') as f:
-        f.write("\nOUTPUT_DIRECTORY=./_readthedocs/html/doxygen")
+        f.write("\nOUTPUT_DIRECTORY=../_readthedocs/html/doxygen")
 
     # Call doxygen
     from subprocess import call

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,20 +24,20 @@ import subprocess
 # Call doxygen in ReadtheDocs
 read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
 if read_the_docs_build:
-    # Generate an RST file for Doxygen index, this is replaced by the real
-    # index.html by hooking into the Sphinx build-finished event at the bottom of
-    # this file
-    cwd=os.getcwd()
-    fpath=os.path.join(cwd,"doxygen/html")
-    if (os.path.isdir(fpath) == 0):
-        os.makedirs(fpath)
-    with open(os.path.join(fpath,"index.rst"), 'w') as f:
-        print("Writing file {}", f)
-        f.write(".. _doxygen:\n")
-        f.write("\n")
-        f.write("*******\n")
-        f.write("Doxygen\n")
-        f.write("*******\n")
+
+    # Modify Doxyfile for ReadTheDocs compatibility
+    with open('./doxygen/Doxyfile.in', 'r') as f:
+        fdata = f.read()
+    fdata = fdata.replace('@PROJECT_SOURCE_DIR@', '.')
+    with open('./doxygen/Doxyfile.in', 'w') as f:
+        f.write(fdata)
+    with open('./doxygen/Doxyfile.in', 'a') as f:
+        f.write("\nOUTPUT_DIRECTORY=./_readthedocs/html/doxygen")
+
+    # Call doxygen
+    from subprocess import call
+    call(['doxygen', "./doxygen/Doxyfile.in"])    
+
 
 # Get current directory
 conf_directory = os.path.dirname(os.path.realpath(__file__))
@@ -105,7 +105,7 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_readthedocs']
+exclude_patterns = ['_build']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -123,7 +123,7 @@ exclude_patterns = ['_readthedocs']
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = 'default'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
@@ -332,20 +332,20 @@ texinfo_documents = [
 
 # Generate Doxygen, and overwrite the index.rst in doxygen/html
 # Only do this on readthedocs
-def gendoxy(app, exception):
-    if read_the_docs_build:
-        buildpath=os.path.join(conf_directory,"_readthedocs/html/doxygen/html")
-        if (os.path.isdir(buildpath) == 0):
-            os.makedirs(buildpath)
-
-        if (os.path.exists(os.path.join(buildpath, 'index.html"'))):
-            print("Removing existing index.html")
-            os.remove(os.path.join(buildpath, "index.html"))
-
-        # Call doxygen
-        from subprocess import call
-        call(['doxygen', "./doxygen/Doxyfile"])
-
-
-def setup(app):
-    app.connect('build-finished', gendoxy)
+#def gendoxy(app, exception):
+#    if read_the_docs_build:
+#        buildpath=os.path.join(conf_directory,"_readthedocs/html/doxygen/html")
+#        if (os.path.isdir(buildpath) == 0):
+#            os.makedirs(buildpath)
+#
+#        if (os.path.exists(os.path.join(buildpath, 'index.html"'))):
+#            print("Removing existing index.html")
+#            os.remove(os.path.join(buildpath, "index.html"))
+#
+#        # Call doxygen
+#        from subprocess import call
+#        call(['doxygen', "./doxygen/Doxyfile"])
+#
+#
+#def setup(app):
+#    app.connect('build-finished', gendoxy)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,17 +26,17 @@ read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
 if read_the_docs_build:
 
     # Modify Doxyfile for ReadTheDocs compatibility
-    with open('./doxygen/Doxyfile.in', 'r') as f:
-        fdata = f.read()
-    fdata = fdata.replace('@PROJECT_SOURCE_DIR@', '.')
-    with open('./doxygen/Doxyfile.in', 'w') as f:
-        f.write(fdata)
-    with open('./doxygen/Doxyfile.in', 'a') as f:
-        f.write("\nOUTPUT_DIRECTORY=../_readthedocs/html/doxygen")
+#    with open('./doxygen/Doxyfile', 'r') as f:
+#        fdata = f.read()
+#    fdata = fdata.replace('@PROJECT_SOURCE_DIR@', '.')
+#    with open('./doxygen/Doxyfile', 'w') as f:
+#        f.write(fdata)
+#    with open('./doxygen/Doxyfile', 'a') as f:
+#        f.write("\nOUTPUT_DIRECTORY=../_readthedocs/html/doxygen")
 
     # Call doxygen
     from subprocess import call
-    call(['doxygen', "./doxygen/Doxyfile.in"])    
+    call(['doxygen', "./doxygen/Doxyfile"])
 
 
 # Get current directory

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,7 +105,7 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_readthedocs']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -334,7 +334,7 @@ texinfo_documents = [
 # Only do this on readthedocs
 def gendoxy(app, exception):
     if read_the_docs_build:
-        buildpath=os.path.join(conf_directory,"_build/html/doxygen/html")
+        buildpath=os.path.join(conf_directory,"_readthedocs/html/doxygen/html")
         if (os.path.isdir(buildpath) == 0):
             os.makedirs(buildpath)
 

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -22,7 +22,7 @@ PROJECT_NAME           = RAJA
 PROJECT_NUMBER         = 
 PROJECT_BRIEF          = "RAJA provides a collection of platform portability abstractions for C++ HPC applications."
 PROJECT_LOGO           =
-OUTPUT_DIRECTORY       = ./_build/html/doxygen
+OUTPUT_DIRECTORY       = ./_readthedocs/html/doxygen
 CREATE_SUBDIRS         = NO
 ALLOW_UNICODE_NAMES    = NO
 

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -22,7 +22,7 @@ PROJECT_NAME           = RAJA
 PROJECT_NUMBER         = 
 PROJECT_BRIEF          = "RAJA provides a collection of platform portability abstractions for C++ HPC applications."
 PROJECT_LOGO           =
-OUTPUT_DIRECTORY       = ./_readthedocs/html/doxygen
+OUTPUT_DIRECTORY       = ../_readthedocs/html/doxygen
 CREATE_SUBDIRS         = NO
 ALLOW_UNICODE_NAMES    = NO
 


### PR DESCRIPTION
# Summary

- This PR is a change to address a change made recently in readthedocs to where hosted doxygen content is located: https://github.com/readthedocs/readthedocs.org/pull/9888