### PR TITLE
The real fix for the recent RTD change....

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,18 +5,20 @@
 # Required
 version: 2
 
+##
+## Code for debugging directory structure in readthedocs 
+## to fix broken links, etc.
+##
 # Print tree
-build:
-  os: ubuntu-20.04
-  apt_packages:
-    - tree
-  tools:
-    python: "3.7"
-  jobs:
-    post_build:
-      #- tree /home/docs/checkouts/readthedocs.org/user_builds/raja/checkouts/cwtask-doxy-patch/
-      #- tree Not found? The directory or the command?
-      - tree -J
+#build:
+#  os: ubuntu-20.04
+#  apt_packages:
+#    - tree
+#  tools:
+#    python: "3.7"
+#  jobs:
+#    post_build:
+#      - tree -J
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -27,6 +29,6 @@ sphinx:
 
 # Optionally set the version of Python and requirements to build the docs
 python:
-#  version: 3.7
+  version: 3.7
   install:
     - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,32 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Print tree
+build:
+  os: ubuntu-20.04
+  apt_packages:
+    - tree
+  tools:
+    python: "3.7"
+  jobs:
+    post_build:
+      #- tree /home/docs/checkouts/readthedocs.org/user_builds/raja/checkouts/cwtask-doxy-patch/
+      #- tree Not found? The directory or the command?
+      - tree -J
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build docs in add'l formats such as PDF and ePub
+#formats: all
+
+# Optionally set the version of Python and requirements to build the docs
 python:
-  version: 3.7
+#  version: 3.7
   install:
     - requirements: docs/requirements.txt

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -22,7 +22,7 @@ PROJECT_NAME           = RAJA
 PROJECT_NUMBER         = 
 PROJECT_BRIEF          = "RAJA provides a collection of platform portability abstractions for C++ HPC applications."
 PROJECT_LOGO           =
-OUTPUT_DIRECTORY       = ./_build/html/doxygen
+OUTPUT_DIRECTORY       = ./_readthedocs/html/doxygen
 CREATE_SUBDIRS         = NO
 ALLOW_UNICODE_NAMES    = NO
 

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -22,7 +22,7 @@ PROJECT_NAME           = RAJA
 PROJECT_NUMBER         = 
 PROJECT_BRIEF          = "RAJA provides a collection of platform portability abstractions for C++ HPC applications."
 PROJECT_LOGO           =
-OUTPUT_DIRECTORY       = ./_readthedocs/html/doxygen
+OUTPUT_DIRECTORY       = ../_readthedocs/html/doxygen
 CREATE_SUBDIRS         = NO
 ALLOW_UNICODE_NAMES    = NO
 


### PR DESCRIPTION
# Summary

- This PR is a change to address a change made recently in readthedocs to where hosted doxygen content is located: https://github.com/readthedocs/readthedocs.org/pull/9888
- Note that I've also left in some code (commented out) to debug the directory tree structure on read the docs in case we need it in the future. Thanks @bmhan12 for the recipe for this!

@davidbeckingsale you will likely need to make a similar change in Umpire to preserve your doxygen content.