### PR TITLE
Consistent Loc Reducer Reset Args

### DIFF
--- a/include/RAJA/pattern/detail/reduce.hpp
+++ b/include/RAJA/pattern/detail/reduce.hpp
@@ -361,7 +361,7 @@ public:
   {
   }
 
-  void reset(T init_val, IndexType init_idx = DefaultLoc<IndexType>().value(),
+  void reset(T init_val, IndexType init_idx,
              T identity_val_ = reduce_type::identity(),
              IndexType identity_loc_ = DefaultLoc<IndexType>().value())
   {
@@ -506,7 +506,7 @@ public:
   {
   }
 
-  void reset(T init_val, IndexType init_idx = DefaultLoc<IndexType>().value(),
+  void reset(T init_val, IndexType init_idx,
              T identity_val_ = reduce_type::identity(),
              IndexType identity_loc_ = DefaultLoc<IndexType>().value())
   {

--- a/include/RAJA/policy/cuda/reduce.hpp
+++ b/include/RAJA/policy/cuda/reduce.hpp
@@ -1299,8 +1299,7 @@ public:
 
   //! reset requires a default value for the reducer
   // this must be here to hide Base::reset
-  void reset(T init_val,
-             IndexType init_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value(),
+  void reset(T init_val, IndexType init_idx,
              T identity_val = NonLocCombiner::identity(),
              IndexType identity_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value())
   {
@@ -1350,8 +1349,7 @@ public:
 
   //! reset requires a default value for the reducer
   // this must be here to hide Base::reset
-  void reset(T init_val,
-             IndexType init_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value(),
+  void reset(T init_val, IndexType init_idx,
              T identity_val = NonLocCombiner::identity(),
              IndexType identity_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value())
   {

--- a/include/RAJA/policy/hip/reduce.hpp
+++ b/include/RAJA/policy/hip/reduce.hpp
@@ -1174,8 +1174,7 @@ public:
 
   //! reset requires a default value for the reducer
   // this must be here to hide Base::reset
-  void reset(T init_val,
-             IndexType init_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value(),
+  void reset(T init_val, IndexType init_idx,
              T identity_val = NonLocCombiner::identity(),
              IndexType identity_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value())
   {
@@ -1225,8 +1224,7 @@ public:
 
   //! reset requires a default value for the reducer
   // this must be here to hide Base::reset
-  void reset(T init_val,
-             IndexType init_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value(),
+  void reset(T init_val, IndexType init_idx,
              T identity_val = NonLocCombiner::identity(),
              IndexType identity_idx = RAJA::reduce::detail::DefaultLoc<IndexType>().value())
   {

--- a/include/RAJA/policy/openmp_target/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/reduce.hpp
@@ -281,8 +281,7 @@ struct TargetReduceLoc
   {
   }
 
-  void reset(T init_val_,
-             IndexType init_loc_ = RAJA::reduce::detail::DefaultLoc<IndexType>().value(),
+  void reset(T init_val_, IndexType init_loc_,
              T identity_val_ = Reducer::identity,
              IndexType identity_loc_ = RAJA::reduce::detail::DefaultLoc<IndexType>().value())
   {

--- a/include/RAJA/policy/sycl/reduce.hpp
+++ b/include/RAJA/policy/sycl/reduce.hpp
@@ -305,8 +305,7 @@ struct TargetReduceLoc
   {
   }
 
-  void reset(T init_val_,
-             IndexType init_loc_ = RAJA::reduce::detail::DefaultLoc<IndexType>().value(),
+  void reset(T init_val_, IndexType init_loc_,
              T identity_val_ = Reducer::identity,
              IndexType identity_loc_ = RAJA::reduce::detail::DefaultLoc<IndexType>().value())
   {

--- a/test/unit/reducer/tests/test-reducer-reset.hpp
+++ b/test/unit/reducer/tests/test-reducer-reset.hpp
@@ -139,10 +139,12 @@ void testReducerReset()
   reduce_sum.reset(resetVal[0]);
   reduce_min.reset(resetVal[0]);
   reduce_max.reset(resetVal[0]);
-  reduce_minloc.reset(resetVal[0]);
-  reduce_maxloc.reset(resetVal[0]);
-  reduce_maxloctup.reset(resetVal[0]);
-  reduce_minloctup.reset(resetVal[0]);
+  reduce_minloc.reset(resetVal[0], -1);
+  reduce_maxloc.reset(resetVal[0], -1);
+
+  RAJA::tuple<RAJA::Index_type, RAJA::Index_type> resetLocTup(0, 0);
+  reduce_maxloctup.reset(resetVal[0], resetLocTup);
+  reduce_minloctup.reset(resetVal[0], resetLocTup);
 
   ASSERT_EQ((NumericType)reduce_sum.get(), (NumericType)(resetVal[0]));
   ASSERT_EQ((NumericType)reduce_min.get(), (NumericType)(resetVal[0]));


### PR DESCRIPTION
# Make Loc Reducer reset args consistent

Always require both a value and loc. Previously the loc was optional as it had a default value.

- This PR is a refactoring/bugfix
- It does the following (modify list as needed):
  - Fixes #1424