### PR TITLE
Fixing RAJA RDC build

### DIFF
--- a/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
+++ b/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
@@ -118,7 +118,7 @@ namespace detail
 struct cudaInfo {
   cuda_dim_t gridDim{0, 0, 0};
   cuda_dim_t blockDim{0, 0, 0};
-  ::RAJA::resources::Cuda res;
+  ::RAJA::resources::Cuda res{::RAJA::resources::Cuda::CudaFromStream(0,0)};
   bool setup_reducers = false;
 #if defined(RAJA_ENABLE_OPENMP)
   cudaInfo* thread_states = nullptr;

--- a/include/RAJA/policy/hip/MemUtils_HIP.hpp
+++ b/include/RAJA/policy/hip/MemUtils_HIP.hpp
@@ -121,7 +121,7 @@ namespace detail
 struct hipInfo {
   hip_dim_t gridDim = 0;
   hip_dim_t blockDim = 0;
-  ::RAJA::resources::Hip res;
+  ::RAJA::resources::Hip res{::RAJA::resources::Hip::HipFromStream(0,0)};
   bool setup_reducers = false;
 #if defined(RAJA_ENABLE_OPENMP)
   hipInfo* thread_states = nullptr;


### PR DESCRIPTION
# Summary

- This PR is a bugfix related to #1447 
- It does the following (modify list as needed):
  - Stops `cudaInfo` and `hipInfo` from initializing `res` members with constructors that call out to CUDA/HIP APIs before the runtime is initialized.

