### PR TITLE
resolve merge conflicts with v2022.10.5 mergeback from main

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,16 @@ Notable changes include:
 
   * Bug fixes/improvements:
 
+Version 2022.10.5 -- Release date 2023-02-28
+============================================
+
+This release fixes an issue that was found after the v2022.10.4 release.
+
+  * Fixes CUDA and HIP separable compilation option that was broken before the 
+    v2022.10.0 release. For the curious reader, the issue was that resources
+    were constructed and calling CUDA/HIP API routines before either runtime
+    was initialized.
+
 Version 2022.10.4 -- Release date 2022-12-14
 ============================================
 

--- a/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
+++ b/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
@@ -118,7 +118,7 @@ namespace detail
 struct cudaInfo {
   cuda_dim_t gridDim{0, 0, 0};
   cuda_dim_t blockDim{0, 0, 0};
-  ::RAJA::resources::Cuda res{::RAJA::resources::Cuda::CudaFromStream(0,0)};
+  ::RAJA::resources::Cuda res{::RAJA::resources::Cuda::CudaFromStream(0,0)}; 
   bool setup_reducers = false;
 #if defined(RAJA_ENABLE_OPENMP)
   cudaInfo* thread_states = nullptr;


### PR DESCRIPTION
# Summary

- This PR resolves merge conflicts with mergeback from main after v2022.10.5 patch release.
- This must be merged into develop before https://github.com/LLNL/RAJA/pull/1453 can be merged