### PR TITLE
[WOPTIM] Udpate spack-configs and shared-ci for raja-perf and other improvements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,7 +58,7 @@ stages:
     include:
       - local: '.gitlab/custom-jobs-and-variables.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: main
+        ref: v2023.03.0rc
         file: '${CI_MACHINE}-build-and-test.yml'
       - local: '.gitlab/${CI_MACHINE}-build-and-test-extra.yml'
     strategy: depend
@@ -84,7 +84,7 @@ trigger-rajaperf:
 include:
   # checks preliminary to running the actual CI test (optional)
   - project: 'radiuss/radiuss-shared-ci'
-    ref: main
+    ref: v2023.03.0rc
     file: 'preliminary-ignore-draft-pr.yml'
   # pipelines subscribed by the project
   - local: '.gitlab/subscribed-pipelines.yml'

--- a/.gitlab/corona-build-and-test-extra.yml
+++ b/.gitlab/corona-build-and-test-extra.yml
@@ -21,8 +21,8 @@
 # ${PROJECT_<MACHINE>_DEPS} in the extra jobs. There is no reason not to fully
 # describe the spec here.
 
-rocm_5_1_1_clang_13_0_0_desul_atomics:
+rocmcc_5_1_1_hip_desul_atomics:
   variables:
-    SPEC: " ~shared +rocm ~openmp +tests +desul amdgpu_target=gfx906 %clang@13.0.0 ^hip@5.1.1 ^blt@develop"
+    SPEC: " ~shared +rocm ~openmp +tests +desul amdgpu_target=gfx906 %rocmcc@5.1.1 ^hip@5.1.1 ^blt@develop"
   extends: .build_and_test_on_corona
 

--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -24,7 +24,7 @@ variables:
 
 # Corona
 # Arguments for top level allocation
-  CORONA_BUILD_AND_TEST_SHARED_ALLOC: "--time-limit=60m --nodes=1"
+  CORONA_BUILD_AND_TEST_SHARED_ALLOC: "--exclusive --time-limit=60m --nodes=1"
 # Arguments for job level allocation
   CORONA_BUILD_AND_TEST_JOB_ALLOC: "--time-limit=45m --nodes=1"
 # Project specific variants for corona
@@ -34,7 +34,7 @@ variables:
 
 # Tioga
 # Arguments for top level allocation
-  TIOGA_BUILD_AND_TEST_SHARED_ALLOC: "--time-limit=60m --nodes=1"
+  TIOGA_BUILD_AND_TEST_SHARED_ALLOC: "--exclusive --time-limit=60m --nodes=1"
 # Arguments for job level allocation
   TIOGA_BUILD_AND_TEST_JOB_ALLOC: "--time-limit=45m --nodes=1"
 # Project specific variants for corona

--- a/.gitlab/tioga-build-and-test-extra.yml
+++ b/.gitlab/tioga-build-and-test-extra.yml
@@ -21,12 +21,12 @@
 # ${PROJECT_<MACHINE>_DEPS} in the extra jobs. There is no reason not to fully
 # describe the spec here.
 
-rocm_5_2_3_clang_13_0_0_desul_atomics:
+rocmcc_5_2_3_hip_desul_atomics:
   variables:
-    SPEC: "~shared +rocm ~openmp +desul +tests amdgpu_target=gfx90a %clang@13.0.0 ^blt@develop ^hip@5.2.3"
+    SPEC: "~shared +rocm ~openmp +desul +tests amdgpu_target=gfx90a %rocmcc@5.2.3 ^blt@develop ^hip@5.2.3"
   extends: .build_and_test_on_tioga
 
-rocm_5_2_3_clang_13_0_0_openmp:
+rocmcc_5_2_3_hip_openmp:
   variables:
-    SPEC: "~shared +rocm +openmp +tests amdgpu_target=gfx90a %clang@13.0.0 ^blt@develop ^hip@5.2.3"
+    SPEC: "~shared +rocm +openmp +tests amdgpu_target=gfx90a %rocmcc@5.2.3 ^blt@develop ^hip@5.2.3"
   extends: .build_and_test_on_tioga

--- a/.gitlab/tioga-build-and-test-extra.yml
+++ b/.gitlab/tioga-build-and-test-extra.yml
@@ -23,10 +23,10 @@
 
 rocmcc_5_2_3_hip_desul_atomics:
   variables:
-    SPEC: "~shared +rocm ~openmp +desul +tests amdgpu_target=gfx90a %rocmcc@5.2.3 ^blt@develop ^hip@5.2.3"
+    SPEC: "~shared +rocm ~openmp +desul +tests amdgpu_target=gfx90a %rocmcc@5.2.3 ^hip@5.2.3 ^blt@develop"
   extends: .build_and_test_on_tioga
 
 rocmcc_5_2_3_hip_openmp:
   variables:
-    SPEC: "~shared +rocm +openmp +tests amdgpu_target=gfx90a %rocmcc@5.2.3 ^blt@develop ^hip@5.2.3"
+    SPEC: "~shared +rocm +openmp +tests amdgpu_target=gfx90a %rocmcc@5.2.3 ^hip@5.2.3 ^blt@develop"
   extends: .build_and_test_on_tioga


### PR DESCRIPTION
## Summary

Working on moving RAJAPerf to RADIUSS Spack Config (RAD_SConf)

Here is the process, with the merge sequence:

- I created a PR in RAD_SConf with new RAJA_Perf package,
- I used @main as a base branch, which has new rocmcc, which will force us to update Radiuss Shared CI (RAD_SCI) to v2023.03.0rc
- I created a PR in RAJA with new RAD_SConf (with raja_perf package) and update [RAD_SCI@v2023.03.0rc] as well as CI local config
- I created a PR in RAJAPerf with new RAJA (with new RAD_SConf (with raja_perf package) an RAD_SCI) and removed local RAJA_Perf package and pointed uberenv at RAD_SConf/packages in RAJA tpl.
- I also update RAD_SCI and local CI config.

Once test pass:

- [DONE] Merge PR in RAD_SCI@main
- [DONE] Update PR in RAJA to point to new [RAD_SCI@main]
- [THIS] Merge PR in RAJA@develop
- Update PR in RAJA_Perf to point to new [RAJA@develop]
- Merge PR in RAJA_Perf

## More information

This PR updates radiuss-spack-configs (to add raja-perf package) to the main branch which also required an update of radiuss-shared-ci to the new release-candidate-branch v2023.03.0rc.

New radiuss-shared-ci required some changes, like merging #1441, closed in favor of this.

@rhornung67 a reminder of the remark in #1441 regarding updated allocation logic with flux: 

> I think doing so is good practice: we allocate resource only once and run all the jobs in it. Basically, I would argue that it improves the throughput by only allocating once.
> 
> We do that on ruby (with slurm), but I didn’t know how to do the same with flux (tried but failed) until I used the slurm-like wrappers to figure it out.
> 
> Reminder:
> Once the ressource is allocated, there are 2 strategies: "overload" the node with parallel builds, or run the builds sequentially. You always preferred running builds one after the other in RAJA, and the same happens here. In order to speed-up the build, we car increase the number on nodes in the top-level allocation.