### PR TITLE
[Woptim] External python in Spack configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ RAJA is a library of C++ software abstractions, primarily developed at
 Lawrence Livermore National Laboratory (LLNL), that enables architecture
 and programming model portability for HPC applications. RAJA has two main goals:
 
-  * To enable application portability with manageable disruption to existing 
+  * To enable application portability with manageable disruption to existing
     algorithms and programming styles
-  * To achieve performance comparable to using common programming models, 
+  * To achieve performance comparable to using common programming models,
     such as OpenMP, CUDA, etc. directly.
 
 RAJA offers portable, parallel loop execution by providing building blocks 


### PR DESCRIPTION
Speed up Caliper installation by setting up external python installation in Radiuss Spack Configs.
