### PR TITLE
Fix not seg faulting in abort_or_throw in OpenMP Target

### DIFF
--- a/include/RAJA/util/macros.hpp
+++ b/include/RAJA/util/macros.hpp
@@ -137,8 +137,7 @@ inline void RAJA_ABORT_OR_THROW(const char *str)
   printf ( "%s\n", str );
 #if defined(RAJA_ENABLE_TARGET_OPENMP) && (_OPENMP >= 201511)
   // seg faulting here instead of calling std::abort for omp target
-  const char * errtemp = nullptr;
-  errtemp = str;
+  *((volatile char *)0) = 0;  // write to address 0
 #elif defined(__CUDA_ARCH__)
   asm ("trap;");
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - The ABORT_OR_THROW function was not properly seg faulting in OpenMP Target regions. Now, it writes to address 0 to generate a seg fault on TOSS and BlueOS platforms.
  - Unused arg warnings from previous code have been eliminated.