### PR TITLE
Complete implementations of GPU basic reducer constructor test

### DIFF
--- a/test/unit/reducer/test-reducer-constructors-cuda.cpp
+++ b/test/unit/reducer/test-reducer-constructors-cuda.cpp
@@ -12,11 +12,20 @@
 #include "tests/test-reducer-constructors.hpp"
 
 #if defined(RAJA_ENABLE_CUDA)
+using CudaBasicReducerConstructorTypes = 
+  Test< camp::cartesian_product< CudaReducerPolicyList,
+                                 DataTypeList,
+                                 CudaResourceList > >::Types;
+
 using CudaInitReducerConstructorTypes = 
   Test< camp::cartesian_product< CudaReducerPolicyList,
                                  DataTypeList,
                                  CudaResourceList,
                                  CudaForoneList > >::Types;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(CudaBasicTest,
+                               ReducerBasicConstructorUnitTest,
+                               CudaBasicReducerConstructorTypes);
 
 INSTANTIATE_TYPED_TEST_SUITE_P(CudaInitTest,
                                ReducerInitConstructorUnitTest,

--- a/test/unit/reducer/test-reducer-constructors-hip.cpp
+++ b/test/unit/reducer/test-reducer-constructors-hip.cpp
@@ -12,11 +12,20 @@
 #include "tests/test-reducer-constructors.hpp"
 
 #if defined(RAJA_ENABLE_HIP)
+using HipBasicReducerConstructorTypes = 
+  Test< camp::cartesian_product< HipReducerPolicyList,
+                                 DataTypeList,
+                                 HipResourceList > >::Types;
+
 using HipInitReducerConstructorTypes = 
   Test< camp::cartesian_product< HipReducerPolicyList,
                                  DataTypeList,
                                  HipResourceList,
                                  HipForoneList > >::Types;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(HipBasicTest,
+                               ReducerBasicConstructorUnitTest,
+                               HipBasicReducerConstructorTypes);
 
 INSTANTIATE_TYPED_TEST_SUITE_P(HipInitTest,
                                ReducerInitConstructorUnitTest,

--- a/test/unit/reducer/tests/test-reducer-constructors.hpp
+++ b/test/unit/reducer/tests/test-reducer-constructors.hpp
@@ -32,17 +32,15 @@ TYPED_TEST_SUITE_P(ReducerInitConstructorUnitTest);
 #if defined(RAJA_ENABLE_CUDA) || defined(RAJA_ENABLE_HIP)
 template <typename ReducePolicy,
           typename NumericType>
-#if defined(RAJA_ENABLE_CUDA)
-typename  std::enable_if< // CUDA policy does nothing.
+typename  std::enable_if<
+#if defined(RAJA_ENABLE_CUDA) // CUDA policy does nothing.
             std::is_same<ReducePolicy, RAJA::cuda_reduce>::value
-          >::type
-#elif defined(RAJA_ENABLE_HIP)
-typename  std::enable_if< // HIP policy does nothing.
+#elif defined(RAJA_ENABLE_HIP) // HIP policy does nothing.
             std::is_same<ReducePolicy, RAJA::hip_reduce>::value
-          >::type
 #else
 #error Please enable a supported GPU platform, e.g. CUDA or HIP.
 #endif
+          >::type
 testReducerConstructor()
 {
   // do nothing

--- a/test/unit/reducer/tests/test-reducer-constructors.hpp
+++ b/test/unit/reducer/tests/test-reducer-constructors.hpp
@@ -204,9 +204,6 @@ TYPED_TEST_P(ReducerInitConstructorUnitTest, InitReducerConstructor)
   testInitReducerConstructor< ReduceType, NumericType, ResourceType, ForOneType >();
 }
 
-#if defined(RAJA_ENABLE_HIP)
-GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(ReducerBasicConstructorUnitTest);
-#endif
 
 REGISTER_TYPED_TEST_SUITE_P(ReducerBasicConstructorUnitTest,
                             BasicReducerConstructor);

--- a/test/unit/reducer/tests/test-reducer-constructors.hpp
+++ b/test/unit/reducer/tests/test-reducer-constructors.hpp
@@ -204,6 +204,9 @@ TYPED_TEST_P(ReducerInitConstructorUnitTest, InitReducerConstructor)
   testInitReducerConstructor< ReduceType, NumericType, ResourceType, ForOneType >();
 }
 
+#if defined(RAJA_ENABLE_HIP)
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(ReducerBasicConstructorUnitTest);
+#endif
 
 REGISTER_TYPED_TEST_SUITE_P(ReducerBasicConstructorUnitTest,
                             BasicReducerConstructor);

--- a/test/unit/reducer/tests/test-reducer-constructors.hpp
+++ b/test/unit/reducer/tests/test-reducer-constructors.hpp
@@ -29,9 +29,40 @@ class ReducerInitConstructorUnitTest : public ::testing::Test
 TYPED_TEST_SUITE_P(ReducerBasicConstructorUnitTest);
 TYPED_TEST_SUITE_P(ReducerInitConstructorUnitTest);
 
+#if defined(RAJA_ENABLE_CUDA) || defined(RAJA_ENABLE_HIP)
 template <typename ReducePolicy,
           typename NumericType>
-void testReducerConstructor()
+#if defined(RAJA_ENABLE_CUDA)
+typename  std::enable_if< // CUDA policy does nothing.
+            std::is_same<ReducePolicy, RAJA::cuda_reduce>::value
+          >::type
+#elif defined(RAJA_ENABLE_HIP)
+typename  std::enable_if< // HIP policy does nothing.
+            std::is_same<ReducePolicy, RAJA::hip_reduce>::value
+          >::type
+#else
+#error Please enable a supported GPU platform, e.g. CUDA or HIP.
+#endif
+testReducerConstructor()
+{
+  // do nothing
+}
+#endif
+
+// Basic constructor tests are only expected to be verified on the host.
+// Should not run this on a GPU.
+template <typename ReducePolicy,
+          typename NumericType>
+typename  std::enable_if< // CPU policy.
+#if defined(RAJA_ENABLE_CUDA)
+            !std::is_same<ReducePolicy, RAJA::cuda_reduce>::value
+#elif defined(RAJA_ENABLE_HIP)
+            !std::is_same<ReducePolicy, RAJA::hip_reduce>::value
+#else
+            true  // Always run for non-GPU policies.
+#endif
+          >::type
+testReducerConstructor()
 {
   RAJA::ReduceSum<ReducePolicy, NumericType> reduce_sum;
   RAJA::ReduceMin<ReducePolicy, NumericType> reduce_min;


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - The basic reducer constructor test was not being compiled for the GPU due to lack of an instantiation of the test. This particular test should not be runnable on the GPU, but Gtest requires an implementation anyway. Hence, the implementation is empty.
  - Should help resolve CI pipeline failures in https://github.com/LLNL/RAJA/pull/1434 and https://github.com/LLNL/RAJA/pull/1289.