### PR TITLE
Fix RTD build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 ##
 ## Code for debugging directory structure in readthedocs 
 ## to fix broken links, etc.
@@ -27,8 +33,7 @@ sphinx:
 # Optionally build docs in add'l formats such as PDF and ePub
 #formats: all
 
-# Optionally set the version of Python and requirements to build the docs
+# Set requirements needed to build the docs
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
# Summary

- This PR fixes the RTD build failing [urllib3 error](https://readthedocs.org/projects/axom/builds/20566025/)

- Relevant stackoverflow: [link](https://stackoverflow.com/questions/76185542/trying-to-run-jupyter-notebook-on-macos-13-3-1-a-with-python-3-9-importerror)

Passing build here: https://raja.readthedocs.io/en/bugfix-rtd_urllib/