### PR TITLE
Deprecate loop exec

### DIFF
--- a/docs/sphinx/user_guide/tutorial/halo-exchange.rst
+++ b/docs/sphinx/user_guide/tutorial/halo-exchange.rst
@@ -127,22 +127,22 @@ RAJA Variants using forall
 A sequential RAJA example uses this execution policy type:
 
 .. literalinclude:: ../../../../examples/tut_halo-exchange.cpp
-   :start-after: _halo_exchange_loop_forall_policies_start
-   :end-before: _halo_exchange_loop_forall_policies_end
+   :start-after: _halo_exchange_seq_forall_policies_start
+   :end-before: _halo_exchange_seq_forall_policies_end
    :language: C++
 
 to pack the grid variable data into a buffer:
 
 .. literalinclude:: ../../../../examples/tut_halo-exchange.cpp
-   :start-after: _halo_exchange_loop_forall_packing_start
-   :end-before: _halo_exchange_loop_forall_packing_end
+   :start-after: _halo_exchange_seq_forall_packing_start
+   :end-before: _halo_exchange_seq_forall_packing_end
    :language: C++
 
 and unpack the buffer data into the grid variable array:
 
 .. literalinclude:: ../../../../examples/tut_halo-exchange.cpp
-   :start-after: _halo_exchange_loop_forall_unpacking_start
-   :end-before: _halo_exchange_loop_forall_unpacking_end
+   :start-after: _halo_exchange_seq_forall_unpacking_start
+   :end-before: _halo_exchange_seq_forall_unpacking_end
    :language: C++
 
 
@@ -174,8 +174,8 @@ Using the workgroup constructs in the example requires defining a few more
 policies and types:
 
 .. literalinclude:: ../../../../examples/tut_halo-exchange.cpp
-   :start-after: _halo_exchange_loop_workgroup_policies_start
-   :end-before: _halo_exchange_loop_workgroup_policies_end
+   :start-after: _halo_exchange_seq_workgroup_policies_start
+   :end-before: _halo_exchange_seq_workgroup_policies_end
    :language: C++
 
 which are used in a slightly rearranged version of packing. See how the comment
@@ -183,16 +183,16 @@ indicating where messages are sent has been moved down after the call to
 run the operations enqueued on the workgroup:
 
 .. literalinclude:: ../../../../examples/tut_halo-exchange.cpp
-   :start-after: _halo_exchange_loop_workgroup_packing_start
-   :end-before: _halo_exchange_loop_workgroup_packing_end
+   :start-after: _halo_exchange_seq_workgroup_packing_start
+   :end-before: _halo_exchange_seq_workgroup_packing_end
    :language: C++
 
 Similarly, in the unpacking we wait to receive all of the messages before
 unpacking the data:
 
 .. literalinclude:: ../../../../examples/tut_halo-exchange.cpp
-   :start-after: _halo_exchange_loop_workgroup_unpacking_start
-   :end-before: _halo_exchange_loop_workgroup_unpacking_end
+   :start-after: _halo_exchange_seq_workgroup_unpacking_start
+   :end-before: _halo_exchange_seq_workgroup_unpacking_end
    :language: C++
 
 This reorganization has the downside of not overlapping the message sends with

--- a/examples/dynamic-forall.cpp
+++ b/examples/dynamic-forall.cpp
@@ -28,7 +28,7 @@
 void checkResult(int* res, int len);
 void printResult(int* res, int len);
 
-using policy_list = camp::list<RAJA::loop_exec
+using policy_list = camp::list<RAJA::seq_exec
                                ,RAJA::simd_exec
 #if defined(RAJA_ENABLE_OPENMP)
                                ,RAJA::omp_parallel_for_exec

--- a/examples/dynamic_mat_transpose.cpp
+++ b/examples/dynamic_mat_transpose.cpp
@@ -85,7 +85,7 @@ using launch_policy = RAJA::LaunchPolicy<
  * Up to 3 dimension are supported: x,y,z
  */
 using outer0 = RAJA::LoopPolicy<
-                                       RAJA::loop_exec
+                                       RAJA::seq_exec
 #if defined(RAJA_ENABLE_CUDA)
                                        ,
                                        RAJA::cuda_block_x_direct
@@ -104,7 +104,7 @@ using outer1 = RAJA::LoopPolicy<
 #if defined(RAJA_ENABLE_OPENMP)
                                       RAJA::omp_for_exec
 #else
-                                       RAJA::loop_exec
+                                       RAJA::seq_exec
 #endif
 #if defined(RAJA_ENABLE_CUDA)
                                        ,
@@ -124,7 +124,7 @@ using outer1 = RAJA::LoopPolicy<
  * Up to 3 dimension are supported: x,y,z
  */
 using inner0 = RAJA::LoopPolicy<
-                                         RAJA::loop_exec
+                                         RAJA::seq_exec
 #if defined(RAJA_ENABLE_CUDA)
                                          ,
                                          RAJA::cuda_thread_x_direct
@@ -139,7 +139,7 @@ using inner0 = RAJA::LoopPolicy<
 #endif
                                          >;
 
-using inner1 = RAJA::LoopPolicy<RAJA::loop_exec
+using inner1 = RAJA::LoopPolicy<RAJA::seq_exec
 #if defined(RAJA_ENABLE_CUDA)
                                          ,
                                          RAJA::cuda_thread_y_direct

--- a/examples/launch_flatten.cpp
+++ b/examples/launch_flatten.cpp
@@ -52,7 +52,7 @@ using reduce_policy = RAJA::hip_reduce;
  */
 
 using host_launch = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
-using host_loop = RAJA::LoopPolicy<RAJA::loop_exec>;
+using host_loop = RAJA::LoopPolicy<RAJA::seq_exec>;
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -138,7 +138,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
        ctx.teamSync();
 
        //As loops are dispatched as standard C loops we can revert to using
-       //a regular loop_exec policy
+       //a regular seq_exec policy
        RAJA::loop<host_loop>(ctx, RAJA::RangeSegment(0, NN), [&] (int i) {
            host_kernel_sum += h_A_1DView(i);
        });

--- a/examples/launch_matrix-multiply.cpp
+++ b/examples/launch_matrix-multiply.cpp
@@ -49,7 +49,7 @@ using launch_policy = RAJA::LaunchPolicy<
 #endif
     >;
 
-using loop_policy = RAJA::seq_exec;
+using loop_policy = RAJA::loop_exec;
 
 #if defined(RAJA_ENABLE_CUDA)
 using gpu_block_x_policy = RAJA::cuda_block_x_direct;
@@ -598,7 +598,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   std::memset(C, 0, N*N * sizeof(double));
 
-  using seq_loop =  RAJA::LoopPolicy<RAJA::seq_exec, RAJA::seq_exec>;
+  using seq_loop =  RAJA::LoopPolicy<RAJA::loop_exec, RAJA::loop_exec>;
 
   //
   // This example builds on the RAJA tiling capabilies presented earlier

--- a/examples/launch_matrix-multiply.cpp
+++ b/examples/launch_matrix-multiply.cpp
@@ -49,7 +49,7 @@ using launch_policy = RAJA::LaunchPolicy<
 #endif
     >;
 
-using loop_policy = RAJA::loop_exec;
+using loop_policy = RAJA::seq_exec;
 
 #if defined(RAJA_ENABLE_CUDA)
 using gpu_block_x_policy = RAJA::cuda_block_x_direct;
@@ -598,7 +598,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   std::memset(C, 0, N*N * sizeof(double));
 
-  using seq_loop =  RAJA::LoopPolicy<RAJA::loop_exec, RAJA::loop_exec>;
+  using seq_loop =  RAJA::LoopPolicy<RAJA::seq_exec, RAJA::seq_exec>;
 
   //
   // This example builds on the RAJA tiling capabilies presented earlier

--- a/examples/launch_reductions.cpp
+++ b/examples/launch_reductions.cpp
@@ -32,7 +32,7 @@ using host_launch = RAJA::omp_launch_t;
 using host_loop = RAJA::omp_for_exec;
 #else
 using host_launch = RAJA::seq_launch_t;
-using host_loop = RAJA::loop_exec;
+using host_loop = RAJA::seq_exec;
 #endif
 
 #if defined(RAJA_ENABLE_CUDA)

--- a/examples/omp-target-kernel.cpp
+++ b/examples/omp-target-kernel.cpp
@@ -13,7 +13,7 @@ using namespace RAJA::statement;
 int main(int /*argc*/, char** /*argv[]*/) {
 
   // using Pol = KernelPolicy<
-  //               For<1, RAJA::loop_exec>,
+  //               For<1, RAJA::seq_exec>,
   //               For<0, RAJA::omp_target_parallel_for_exec<1>, Lambda<0> >
   //             >;
   using Pol = KernelPolicy<

--- a/examples/raja-launch.cpp
+++ b/examples/raja-launch.cpp
@@ -58,7 +58,7 @@ using teams_x = RAJA::LoopPolicy<
 #if defined(RAJA_ENABLE_OPENMP)
                                        RAJA::omp_parallel_for_exec
 #else
-                                       RAJA::loop_exec
+                                       RAJA::seq_exec
 #endif
 #if defined(RAJA_ENABLE_CUDA)
                                        ,
@@ -73,7 +73,7 @@ using teams_x = RAJA::LoopPolicy<
  * Define thread policies.
  * Up to 3 dimension are supported: x,y,z
  */
-using threads_x = RAJA::LoopPolicy<RAJA::loop_exec
+using threads_x = RAJA::LoopPolicy<RAJA::seq_exec
 #if defined(RAJA_ENABLE_CUDA)
                                          ,
                                          RAJA::cuda_thread_x_loop

--- a/examples/red-black-gauss-seidel.cpp
+++ b/examples/red-black-gauss-seidel.cpp
@@ -234,8 +234,8 @@ void computeErr(double *I, grid_s grid)
   RAJA::ReduceMax<RAJA::seq_reduce, double> tMax(-1.0);
 
   using errPolicy = RAJA::KernelPolicy<
-    RAJA::statement::For<1, RAJA::loop_exec,
-    RAJA::statement::For<0, RAJA::loop_exec, RAJA::statement::Lambda<0>> > >;
+    RAJA::statement::For<1, RAJA::seq_exec,
+    RAJA::statement::For<0, RAJA::seq_exec, RAJA::statement::Lambda<0>> > >;
 
   RAJA::kernel<errPolicy>(RAJA::make_tuple(fdBounds,fdBounds),
                        [=] (RAJA::Index_type tx, RAJA::Index_type ty) {

--- a/examples/resource-dynamic-forall.cpp
+++ b/examples/resource-dynamic-forall.cpp
@@ -28,7 +28,7 @@
 void checkResult(int* res, int len);
 void printResult(int* res, int len);
 
-using policy_list = camp::list<RAJA::loop_exec
+using policy_list = camp::list<RAJA::seq_exec
                                ,RAJA::simd_exec
 #if defined(RAJA_ENABLE_CUDA)
                                ,RAJA::cuda_exec<256>

--- a/examples/resource-forall.cpp
+++ b/examples/resource-forall.cpp
@@ -84,25 +84,13 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 
 //----------------------------------------------------------------------------//
-// RAJA::seq_exec policy enforces strictly sequential execution.... 
+// RAJA::seq_exec policy enforces sequential execution.... 
 //----------------------------------------------------------------------------//
 
   std::cout << "\n Running RAJA sequential vector addition...\n";
 
 
   RAJA::forall<RAJA::seq_exec>(host, RAJA::RangeSegment(0, N), [=] (int i) { 
-    c[i] = a[i] + b[i]; 
-  });
-
-  checkResult(c, N);
-
-//----------------------------------------------------------------------------//
-// RAJA::loop_exec policy enforces loop execution.... 
-//----------------------------------------------------------------------------//
-
-  std::cout << "\n Running RAJA loop vector addition...\n";
-
-  RAJA::forall<RAJA::loop_exec>(host, RAJA::RangeSegment(0, N), [=] (int i) { 
     c[i] = a[i] + b[i]; 
   });
 

--- a/examples/resource-kernel.cpp
+++ b/examples/resource-kernel.cpp
@@ -39,7 +39,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
-  RAJA::forall<RAJA::loop_exec>(def_host_res, n_range,
+  RAJA::forall<RAJA::seq_exec>(def_host_res, n_range,
     [=, &def_cuda_res](int i){
       RAJA::resources::Cuda res_cuda; 
 
@@ -61,7 +61,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   def_cuda_res.memcpy(h_array, d_array, sizeof(int) * N * M);
 
   int ec_count = 0;
-  RAJA::forall<RAJA::loop_exec>( RAJA::RangeSegment(0, N*M),
+  RAJA::forall<RAJA::seq_exec>( RAJA::RangeSegment(0, N*M),
     [=, &ec_count](int i){
       if (h_array[i] != i) ec_count++;
     }

--- a/examples/resource-launch.cpp
+++ b/examples/resource-launch.cpp
@@ -34,7 +34,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   using threads_x = RAJA::LoopPolicy<RAJA::cuda_thread_x_loop>;
 
-  RAJA::forall<RAJA::loop_exec>(def_host_res, n_range,
+  RAJA::forall<RAJA::seq_exec>(def_host_res, n_range,
     [=, &def_cuda_res](int i){
 
       RAJA::resources::Cuda res_cuda;
@@ -62,7 +62,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   def_cuda_res.memcpy(h_array, d_array, sizeof(int) * N * M);
 
   int ec_count = 0;
-  RAJA::forall<RAJA::loop_exec>( RAJA::RangeSegment(0, N*M),
+  RAJA::forall<RAJA::seq_exec>( RAJA::RangeSegment(0, N*M),
     [=, &ec_count](int i){
       if (h_array[i] != i) ec_count++;
     }

--- a/examples/resource-runtime-launch.cpp
+++ b/examples/resource-runtime-launch.cpp
@@ -30,7 +30,7 @@
  */
 
 using host_launch = RAJA::seq_launch_t;
-using host_loop = RAJA::loop_exec;
+using host_loop = RAJA::seq_exec;
 
 #if defined(RAJA_ENABLE_CUDA)
 using device_launch = RAJA::cuda_launch_t<true>;

--- a/examples/tut_halo-exchange.cpp
+++ b/examples/tut_halo-exchange.cpp
@@ -377,9 +377,9 @@ int main(int argc, char **argv)
 
     double minCycle = std::numeric_limits<double>::max();
 
-    // _halo_exchange_loop_forall_policies_start
-    using forall_policy = RAJA::loop_exec;
-    // _halo_exchange_loop_forall_policies_end
+    // _halo_exchange_seq_forall_policies_start
+    using forall_policy = RAJA::seq_exec;
+    // _halo_exchange_seq_forall_policies_end
 
     std::vector<double*> buffers(num_neighbors, nullptr);
 
@@ -405,7 +405,7 @@ int main(int argc, char **argv)
         });
       }
 
-      // _halo_exchange_loop_forall_packing_start
+      // _halo_exchange_seq_forall_packing_start
       for (int l = 0; l < num_neighbors; ++l) {
 
         double* buffer = buffers[l];
@@ -426,9 +426,9 @@ int main(int argc, char **argv)
 
         // send single message
       }
-      // _halo_exchange_loop_forall_packing_end
+      // _halo_exchange_seq_forall_packing_end
 
-      // _halo_exchange_loop_forall_unpacking_start
+      // _halo_exchange_seq_forall_unpacking_start
       for (int l = 0; l < num_neighbors; ++l) {
 
         // recv single message
@@ -449,7 +449,7 @@ int main(int argc, char **argv)
           buffer += len;
         }
       }
-      // _halo_exchange_loop_forall_unpacking_end
+      // _halo_exchange_seq_forall_unpacking_end
 
       }
       timer.stop();
@@ -483,11 +483,11 @@ int main(int argc, char **argv)
 
     double minCycle = std::numeric_limits<double>::max();
 
-    // _halo_exchange_loop_workgroup_policies_start
-    using forall_policy = RAJA::loop_exec;
+    // _halo_exchange_seq_workgroup_policies_start
+    using forall_policy = RAJA::seq_exec;
 
     using workgroup_policy = RAJA::WorkGroupPolicy <
-                                 RAJA::loop_work,
+                                 RAJA::seq_work,
                                  RAJA::ordered,
                                  RAJA::ragged_array_of_objects,
                                  RAJA::indirect_function_call_dispatch >;
@@ -506,7 +506,7 @@ int main(int argc, char **argv)
                                      int,
                                      RAJA::xargs<>,
                                      memory_manager_allocator<char> >;
-    // _halo_exchange_loop_workgroup_policies_end
+    // _halo_exchange_seq_workgroup_policies_end
 
     std::vector<double*> buffers(num_neighbors, nullptr);
 
@@ -535,7 +535,7 @@ int main(int argc, char **argv)
         });
       }
 
-      // _halo_exchange_loop_workgroup_packing_start
+      // _halo_exchange_seq_workgroup_packing_start
       for (int l = 0; l < num_neighbors; ++l) {
 
         double* buffer = buffers[l];
@@ -560,9 +560,9 @@ int main(int argc, char **argv)
       worksite site_pack = group_pack.run();
 
       // send all messages
-      // _halo_exchange_loop_workgroup_packing_end
+      // _halo_exchange_seq_workgroup_packing_end
 
-      // _halo_exchange_loop_workgroup_unpacking_start
+      // _halo_exchange_seq_workgroup_unpacking_start
       // recv all messages
 
       for (int l = 0; l < num_neighbors; ++l) {
@@ -587,7 +587,7 @@ int main(int argc, char **argv)
       workgroup group_unpack = pool_unpack.instantiate();
 
       worksite site_unpack = group_unpack.run();
-      // _halo_exchange_loop_workgroup_unpacking_end
+      // _halo_exchange_seq_workgroup_unpacking_end
 
       }
       timer.stop();

--- a/examples/tut_launch_basic.cpp
+++ b/examples/tut_launch_basic.cpp
@@ -65,7 +65,7 @@ using launch_policy = RAJA::LaunchPolicy<
  */
 
 using teams_x = RAJA::LoopPolicy<
-                                       RAJA::loop_exec
+                                       RAJA::seq_exec
 #if defined(RAJA_ENABLE_CUDA)
                                        ,
                                        RAJA::cuda_block_x_direct
@@ -77,7 +77,7 @@ using teams_x = RAJA::LoopPolicy<
                                        >;
 
 using teams_y = RAJA::LoopPolicy<
-                                       RAJA::loop_exec
+                                       RAJA::seq_exec
 #if defined(RAJA_ENABLE_CUDA)
                                        ,
                                        RAJA::cuda_block_y_direct
@@ -88,7 +88,7 @@ using teams_y = RAJA::LoopPolicy<
 #endif
                                        >;
 
-using threads_x = RAJA::LoopPolicy<RAJA::loop_exec
+using threads_x = RAJA::LoopPolicy<RAJA::seq_exec
 #if defined(RAJA_ENABLE_CUDA)
                                          ,
                                          RAJA::cuda_thread_x_direct
@@ -99,7 +99,7 @@ using threads_x = RAJA::LoopPolicy<RAJA::loop_exec
 #endif
                                          >;
 
-using threads_y = RAJA::LoopPolicy<RAJA::loop_exec
+using threads_y = RAJA::LoopPolicy<RAJA::seq_exec
 #if defined(RAJA_ENABLE_CUDA)
                                          ,
                                          RAJA::cuda_thread_y_direct

--- a/examples/tut_matrix-multiply.cpp
+++ b/examples/tut_matrix-multiply.cpp
@@ -193,7 +193,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(C, 0, N*N * sizeof(double));
 
   // _matmult_outerforall_start
-  RAJA::forall<RAJA::loop_exec>( row_range, [=](int row) {
+  RAJA::forall<RAJA::seq_exec>( row_range, [=](int row) {
 
     for (int col = 0; col < N; ++col) {
 
@@ -230,9 +230,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(C, 0, N*N * sizeof(double));
 
   // _matmult_nestedforall_start
-  RAJA::forall<RAJA::loop_exec>( row_range, [=](int row) {
+  RAJA::forall<RAJA::seq_exec>( row_range, [=](int row) {
 
-    RAJA::forall<RAJA::loop_exec>( col_range, [=](int col) {
+    RAJA::forall<RAJA::seq_exec>( col_range, [=](int col) {
 
       double dot = 0.0;
       for (int k = 0; k < N; ++k) {
@@ -284,8 +284,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // _matmult_basickernel_start
   using EXEC_POL =
     RAJA::KernelPolicy<
-      RAJA::statement::For<1, RAJA::loop_exec,    // row
-        RAJA::statement::For<0, RAJA::loop_exec,  // col
+      RAJA::statement::For<1, RAJA::seq_exec,    // row
+        RAJA::statement::For<0, RAJA::seq_exec,  // col
           RAJA::statement::Lambda<0>
         >
       >
@@ -318,7 +318,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using EXEC_POL1 =
     RAJA::KernelPolicy<
       RAJA::statement::For<1, RAJA::omp_parallel_for_exec,  // row
-        RAJA::statement::For<0, RAJA::loop_exec,            // col
+        RAJA::statement::For<0, RAJA::seq_exec,            // col
           RAJA::statement::Lambda<0>
         >
       >
@@ -355,7 +355,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // _matmult_ompkernel_swap_start
   using EXEC_POL2 =
     RAJA::KernelPolicy<
-      RAJA::statement::For<0, RAJA::loop_exec,                  // col
+      RAJA::statement::For<0, RAJA::seq_exec,                  // col
         RAJA::statement::For<1, RAJA::omp_parallel_for_exec,    // row
           RAJA::statement::Lambda<0>
         >
@@ -634,10 +634,10 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // _matmult_3lambdakernel_seq_start
   using EXEC_POL6a =
     RAJA::KernelPolicy<
-      RAJA::statement::For<1, RAJA::loop_exec,
-        RAJA::statement::For<0, RAJA::loop_exec,
+      RAJA::statement::For<1, RAJA::seq_exec,
+        RAJA::statement::For<0, RAJA::seq_exec,
           RAJA::statement::Lambda<0, RAJA::Params<0>>,  // dot = 0.0
-          RAJA::statement::For<2, RAJA::loop_exec,
+          RAJA::statement::For<2, RAJA::seq_exec,
             RAJA::statement::Lambda<1> // inner loop: dot += ...
           >,
           RAJA::statement::Lambda<2, RAJA::Segs<0, 1>, RAJA::Params<0>>   // set C(row, col) = dot
@@ -690,10 +690,10 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   using EXEC_POL6b =
     RAJA::KernelPolicy<
-      RAJA::statement::For<1, RAJA::loop_exec,
-        RAJA::statement::For<0, RAJA::loop_exec,
+      RAJA::statement::For<1, RAJA::seq_exec,
+        RAJA::statement::For<0, RAJA::seq_exec,
           RAJA::statement::Lambda<0, Params<0>>,  // dot = 0.0
-          RAJA::statement::For<2, RAJA::loop_exec,
+          RAJA::statement::For<2, RAJA::seq_exec,
             RAJA::statement::Lambda<1, Segs<0,1,2>, Params<0>> // dot += ...
           >,
           RAJA::statement::Lambda<2, Segs<0,1>, Params<0>>  // C(row, col) = dot
@@ -741,7 +741,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       RAJA::statement::Collapse<RAJA::omp_parallel_collapse_exec,
                                 RAJA::ArgList<1, 0>,   // row, col
         RAJA::statement::Lambda<0, RAJA::Params<0>>,  // dot = 0.0
-        RAJA::statement::For<2, RAJA::loop_exec,
+        RAJA::statement::For<2, RAJA::seq_exec,
           RAJA::statement::Lambda<1> // inner loop: dot += ...
         >,
         RAJA::statement::Lambda<2, RAJA::Segs<0, 1>, RAJA::Params<0>>   // set C(row, col) = dot
@@ -970,7 +970,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
                 // Slide window across matrix: Load tiles of global matrices A, B and compute
                 // local dot products
-                RAJA::statement::Tile<1, RAJA::tile_fixed<CUDA_BLOCK_SIZE>, RAJA::loop_exec,
+                RAJA::statement::Tile<1, RAJA::tile_fixed<CUDA_BLOCK_SIZE>, RAJA::seq_exec,
 
                   // Load tile of A into shmem
                   RAJA::statement::For<1, RAJA::cuda_thread_y_loop,
@@ -990,7 +990,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
                   //Partial multiplication
                   RAJA::statement::For<2, RAJA::cuda_thread_y_loop,
-                    RAJA::statement::For<1, RAJA::loop_exec,
+                    RAJA::statement::For<1, RAJA::seq_exec,
                       RAJA::statement::For<0, RAJA::cuda_thread_x_loop,
                         shmem_Lambda3
                       >

--- a/examples/wave-eqn.cpp
+++ b/examples/wave-eqn.cpp
@@ -130,7 +130,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // OpenMP policy
   //using fdPolicy = RAJA::KernelPolicy<
   //RAJA::statement::For<1, RAJA::omp_parallel_for_exec,
-  //  RAJA::statement::For<0, RAJA::loop_exec, RAJA::statement::Lambda<0> > > >;
+  //  RAJA::statement::For<0, RAJA::seq_exec, RAJA::statement::Lambda<0> > > >;
 
   // CUDA policy
   //using fdPolicy =
@@ -192,8 +192,8 @@ void computeErr(double *P, double tf, grid_s grid)
   RAJA::ReduceMax<RAJA::seq_reduce, double> tMax(-1.0);
 
   using initialPolicy = RAJA::KernelPolicy<
-  RAJA::statement::For<1, RAJA::loop_exec ,
-    RAJA::statement::For<0, RAJA::loop_exec, RAJA::statement::Lambda<0> > > >;
+  RAJA::statement::For<1, RAJA::seq_exec ,
+    RAJA::statement::For<0, RAJA::seq_exec, RAJA::statement::Lambda<0> > > >;
 
   RAJA::kernel<initialPolicy>(RAJA::make_tuple(fdBounds,fdBounds),
                        [=] (RAJA::Index_type tx, RAJA::Index_type ty) {
@@ -223,8 +223,8 @@ void setIC(double *P1, double *P2, double t0, double t1, grid_s grid)
   RAJA::RangeSegment fdBounds(0, grid.nx);
 
   using initialPolicy = RAJA::KernelPolicy<
-  RAJA::statement::For<1, RAJA::loop_exec,
-    RAJA::statement::For<0, RAJA::loop_exec, RAJA::statement::Lambda<0>> > >;
+  RAJA::statement::For<1, RAJA::seq_exec,
+    RAJA::statement::For<0, RAJA::seq_exec, RAJA::statement::Lambda<0>> > >;
   
   RAJA::kernel<initialPolicy>(RAJA::make_tuple(fdBounds,fdBounds),
                        [=] (RAJA::Index_type tx, RAJA::Index_type ty) {

--- a/exercises/kernel-matrix-transpose-local-array.cpp
+++ b/exercises/kernel-matrix-transpose-local-array.cpp
@@ -208,8 +208,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   /*
   using SEQ_EXEC_POL_I =
     RAJA::KernelPolicy<
-      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
-        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
+      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
+        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
 
           ///
           /// TODO...
@@ -218,14 +218,14 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
           ///           in the paramater list.
           ///
 
-          RAJA::statement::ForICount<1, RAJA::statement::Param<0>, RAJA::loop_exec,
-            RAJA::statement::ForICount<0, RAJA::statement::Param<1>, RAJA::loop_exec,
+          RAJA::statement::ForICount<1, RAJA::statement::Param<0>, RAJA::seq_exec,
+            RAJA::statement::ForICount<0, RAJA::statement::Param<1>, RAJA::seq_exec,
               RAJA::statement::Lambda<0>
             >
           >,
 
-          RAJA::statement::ForICount<0, RAJA::statement::Param<1>, RAJA::loop_exec,
-            RAJA::statement::ForICount<1, RAJA::statement::Param<0>, RAJA::loop_exec,
+          RAJA::statement::ForICount<0, RAJA::statement::Param<1>, RAJA::seq_exec,
+            RAJA::statement::ForICount<1, RAJA::statement::Param<0>, RAJA::seq_exec,
               RAJA::statement::Lambda<1>
             >
           >
@@ -278,7 +278,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     //      tiles needed to carry out the transpose
     //
     RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::omp_parallel_for_exec,
-      RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
+      RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
         // This statement will initalize local array memory inside a
         // kernel. The cpu_tile_mem policy specifies that memory should be
         // allocated on the stack. The entries in the RAJA::ParamList
@@ -293,7 +293,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
           ///
           /// TODO...
           ///
-          /// EXERCISE: Use two ForICount statements with loop_exec to call the first lambda.
+          /// EXERCISE: Use two ForICount statements with seq_exec to call the first lambda.
           ///
 
           //
@@ -308,7 +308,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
           ///
           /// TODO...
           ///
-          /// EXERCISE: Use two ForICount statements with loop_exec to call the second lambda.
+          /// EXERCISE: Use two ForICount statements with seq_exec to call the second lambda.
           ///
         >
       >
@@ -350,8 +350,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     //      These loops iterate over the number of
     //      tiles needed to carry out the transpose
     //
-    RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
-      RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
+    RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
+      RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
       // This statement will initalize local array memory inside a
       // kernel. The cpu_tile_mem policy specifies that memory should be
       // allocated on the stack. The entries in the RAJA::ParamList
@@ -363,7 +363,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
           // to the local tile.
           //
           RAJA::statement::ForICount<1, RAJA::statement::Param<1>, RAJA::omp_parallel_for_exec,
-            RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::loop_exec,
+            RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::seq_exec,
                                        RAJA::statement::Lambda<0>
              >
           >,
@@ -375,8 +375,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
           //     swapped! This enables us to swap which
           //     index has unit stride.
           //
-          RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::loop_exec,
-            RAJA::statement::ForICount<1, RAJA::statement::Param<1>, RAJA::loop_exec,
+          RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::seq_exec,
+            RAJA::statement::ForICount<1, RAJA::statement::Param<1>, RAJA::seq_exec,
               RAJA::statement::Lambda<1>
             >
           >
@@ -602,19 +602,19 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   /*
   using SEQ_EXEC_POL_II =
     RAJA::KernelPolicy<
-      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
-        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
+      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
+        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
 
           RAJA::statement::InitLocalMem<RAJA::cpu_tile_mem, RAJA::ParamList<0>,
 
-          RAJA::statement::For<1, RAJA::loop_exec,
-            RAJA::statement::For<0, RAJA::loop_exec,
+          RAJA::statement::For<1, RAJA::seq_exec,
+            RAJA::statement::For<0, RAJA::seq_exec,
               RAJA::statement::Lambda<0, Segs<0>, Segs<1>, Offsets<0>, Offsets<1>, Params<0> >
             >
           >,
 
-          RAJA::statement::For<0, RAJA::loop_exec,
-            RAJA::statement::For<1, RAJA::loop_exec,
+          RAJA::statement::For<0, RAJA::seq_exec,
+            RAJA::statement::For<1, RAJA::seq_exec,
               RAJA::statement::Lambda<1, Segs<0, 1>, Offsets<0, 1>, Params<0> >
             >
           >

--- a/exercises/kernel-matrix-transpose-local-array_solution.cpp
+++ b/exercises/kernel-matrix-transpose-local-array_solution.cpp
@@ -202,19 +202,19 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // _mattranspose_localarray_raja_start
   using SEQ_EXEC_POL_I =
     RAJA::KernelPolicy<
-      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
-        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
+      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
+        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
 
           RAJA::statement::InitLocalMem<RAJA::cpu_tile_mem, RAJA::ParamList<2>,
 
-          RAJA::statement::ForICount<1, RAJA::statement::Param<0>, RAJA::loop_exec,
-            RAJA::statement::ForICount<0, RAJA::statement::Param<1>, RAJA::loop_exec,
+          RAJA::statement::ForICount<1, RAJA::statement::Param<0>, RAJA::seq_exec,
+            RAJA::statement::ForICount<0, RAJA::statement::Param<1>, RAJA::seq_exec,
               RAJA::statement::Lambda<0>
             >
           >,
 
-          RAJA::statement::ForICount<0, RAJA::statement::Param<1>, RAJA::loop_exec,
-            RAJA::statement::ForICount<1, RAJA::statement::Param<0>, RAJA::loop_exec,
+          RAJA::statement::ForICount<0, RAJA::statement::Param<1>, RAJA::seq_exec,
+            RAJA::statement::ForICount<1, RAJA::statement::Param<0>, RAJA::seq_exec,
               RAJA::statement::Lambda<1>
             >
           >
@@ -260,7 +260,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     //      tiles needed to carry out the transpose
     //
     RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::omp_parallel_for_exec,
-      RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
+      RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
         // This statement will initalize local array memory inside a
         // kernel. The cpu_tile_mem policy specifies that memory should be
         // allocated on the stack. The entries in the RAJA::ParamList
@@ -271,8 +271,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
           // loops. These loops copy data from the global matrices
           // to the local tile.
           //
-          RAJA::statement::ForICount<1, RAJA::statement::Param<0>, RAJA::loop_exec,
-            RAJA::statement::ForICount<0, RAJA::statement::Param<1>, RAJA::loop_exec,
+          RAJA::statement::ForICount<1, RAJA::statement::Param<0>, RAJA::seq_exec,
+            RAJA::statement::ForICount<0, RAJA::statement::Param<1>, RAJA::seq_exec,
                                        RAJA::statement::Lambda<0>
             >
           >,
@@ -284,8 +284,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
           //     swapped! This enables us to swap which
           //     index has unit stride.
           //
-          RAJA::statement::ForICount<0, RAJA::statement::Param<1>, RAJA::loop_exec,
-            RAJA::statement::ForICount<1, RAJA::statement::Param<0>, RAJA::loop_exec,
+          RAJA::statement::ForICount<0, RAJA::statement::Param<1>, RAJA::seq_exec,
+            RAJA::statement::ForICount<1, RAJA::statement::Param<0>, RAJA::seq_exec,
                                        RAJA::statement::Lambda<1>
             >
           >
@@ -328,8 +328,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     //      These loops iterate over the number of
     //      tiles needed to carry out the transpose
     //
-    RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
-      RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
+    RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
+      RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
       // This statement will initalize local array memory inside a
       // kernel. The cpu_tile_mem policy specifies that memory should be
       // allocated on the stack. The entries in the RAJA::ParamList
@@ -341,7 +341,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
           // to the local tile.
           //
           RAJA::statement::ForICount<1, RAJA::statement::Param<1>, RAJA::omp_parallel_for_exec,
-            RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::loop_exec,
+            RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::seq_exec,
                                        RAJA::statement::Lambda<0>
              >
           >,
@@ -353,8 +353,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
           //     swapped! This enables us to swap which
           //     index has unit stride.
           //
-          RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::loop_exec,
-            RAJA::statement::ForICount<1, RAJA::statement::Param<1>, RAJA::loop_exec,
+          RAJA::statement::ForICount<0, RAJA::statement::Param<0>, RAJA::seq_exec,
+            RAJA::statement::ForICount<1, RAJA::statement::Param<1>, RAJA::seq_exec,
               RAJA::statement::Lambda<1>
             >
           >
@@ -574,19 +574,19 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // _raja_mattranspose_lambdaargs_start
   using SEQ_EXEC_POL_II =
     RAJA::KernelPolicy<
-      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
-        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
+      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
+        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
 
           RAJA::statement::InitLocalMem<RAJA::cpu_tile_mem, RAJA::ParamList<0>,
 
-          RAJA::statement::For<1, RAJA::loop_exec,
-            RAJA::statement::For<0, RAJA::loop_exec,
+          RAJA::statement::For<1, RAJA::seq_exec,
+            RAJA::statement::For<0, RAJA::seq_exec,
               RAJA::statement::Lambda<0, Segs<0>, Segs<1>, Offsets<0>, Offsets<1>, Params<0> >
             >
           >,
 
-          RAJA::statement::For<0, RAJA::loop_exec,
-            RAJA::statement::For<1, RAJA::loop_exec,
+          RAJA::statement::For<0, RAJA::seq_exec,
+            RAJA::statement::For<1, RAJA::seq_exec,
               RAJA::statement::Lambda<1, Segs<0, 1>, Offsets<0, 1>, Params<0> >
             >
           >

--- a/exercises/kernel-matrix-transpose-tiled.cpp
+++ b/exercises/kernel-matrix-transpose-tiled.cpp
@@ -170,10 +170,10 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   using TILED_KERNEL_EXEC_POL = 
     RAJA::KernelPolicy<
-      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
-        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
-          RAJA::statement::For<1, RAJA::loop_exec, 
-            RAJA::statement::For<0, RAJA::loop_exec,
+      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
+        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
+          RAJA::statement::For<1, RAJA::seq_exec, 
+            RAJA::statement::For<0, RAJA::seq_exec,
               RAJA::statement::Lambda<0>
             >
           >
@@ -235,8 +235,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //
   using TILED_KERNEL_EXEC_POL_OMP2 = 
     RAJA::KernelPolicy<
-      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
-        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
+      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
+        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
           RAJA::statement::Collapse<RAJA::omp_parallel_collapse_exec,
                                     RAJA::ArgList<0, 1>,
                                     RAJA::statement::Lambda<0>

--- a/exercises/kernel-matrix-transpose-tiled_solution.cpp
+++ b/exercises/kernel-matrix-transpose-tiled_solution.cpp
@@ -160,10 +160,10 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // _raja_tiled_mattranspose_start
   using TILED_KERNEL_EXEC_POL = 
     RAJA::KernelPolicy<
-      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
-        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
-          RAJA::statement::For<1, RAJA::loop_exec, 
-            RAJA::statement::For<0, RAJA::loop_exec,
+      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
+        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
+          RAJA::statement::For<1, RAJA::seq_exec, 
+            RAJA::statement::For<0, RAJA::seq_exec,
               RAJA::statement::Lambda<0>
             >
           >
@@ -193,9 +193,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using TILED_KERNEL_EXEC_POL_OMP = 
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::omp_parallel_for_exec,
-        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
+        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
           RAJA::statement::For<1, RAJA::omp_parallel_for_exec, 
-            RAJA::statement::For<0, RAJA::loop_exec,
+            RAJA::statement::For<0, RAJA::seq_exec,
               RAJA::statement::Lambda<0>
             >
           > 
@@ -223,8 +223,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //
   using TILED_KERNEL_EXEC_POL_OMP2 = 
     RAJA::KernelPolicy<
-      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
-        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::loop_exec,
+      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
+        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
           RAJA::statement::Collapse<RAJA::omp_parallel_collapse_exec,
                                     RAJA::ArgList<0, 1>,
                                     RAJA::statement::Lambda<0>

--- a/exercises/kernel-matrix-transpose_solution.cpp
+++ b/exercises/kernel-matrix-transpose_solution.cpp
@@ -123,8 +123,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // _raja_mattranspose_start
   using KERNEL_EXEC_POL = 
     RAJA::KernelPolicy<
-      RAJA::statement::For<1, RAJA::loop_exec, 
-        RAJA::statement::For<0, RAJA::loop_exec,
+      RAJA::statement::For<1, RAJA::seq_exec, 
+        RAJA::statement::For<0, RAJA::seq_exec,
           RAJA::statement::Lambda<0>
          >
       >
@@ -151,7 +151,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using KERNEL_EXEC_POL_OMP = 
     RAJA::KernelPolicy<
       RAJA::statement::For<1, RAJA::omp_parallel_for_exec, 
-        RAJA::statement::For<0, RAJA::loop_exec,
+        RAJA::statement::For<0, RAJA::seq_exec,
           RAJA::statement::Lambda<0>
         >
       > 

--- a/exercises/kernelintro-execpols.cpp
+++ b/exercises/kernelintro-execpols.cpp
@@ -168,8 +168,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using EXEC_POL2 =
     RAJA::KernelPolicy<
       RAJA::statement::For<2, RAJA::omp_parallel_for_exec,    // k
-        RAJA::statement::For<1, RAJA::loop_exec,              // j
-          RAJA::statement::For<0, RAJA::loop_exec,            // i
+        RAJA::statement::For<1, RAJA::seq_exec,              // j
+          RAJA::statement::For<0, RAJA::seq_exec,            // i
             RAJA::statement::Lambda<0>
           >
         >

--- a/exercises/kernelintro-execpols_solution.cpp
+++ b/exercises/kernelintro-execpols_solution.cpp
@@ -125,9 +125,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 // _raja_tensorinit_seq_start
   using EXEC_POL1 =
     RAJA::KernelPolicy<
-      RAJA::statement::For<2, RAJA::loop_exec,    // k
-        RAJA::statement::For<1, RAJA::loop_exec,  // j
-          RAJA::statement::For<0, RAJA::loop_exec,// i
+      RAJA::statement::For<2, RAJA::seq_exec,    // k
+        RAJA::statement::For<1, RAJA::seq_exec,  // j
+          RAJA::statement::For<0, RAJA::seq_exec,// i
             RAJA::statement::Lambda<0>
           >
         >
@@ -182,8 +182,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using EXEC_POL2 =
     RAJA::KernelPolicy<
       RAJA::statement::For<2, RAJA::omp_parallel_for_exec,    // k
-        RAJA::statement::For<1, RAJA::loop_exec,              // j
-          RAJA::statement::For<0, RAJA::loop_exec,            // i
+        RAJA::statement::For<1, RAJA::seq_exec,              // j
+          RAJA::statement::For<0, RAJA::seq_exec,            // i
             RAJA::statement::Lambda<0>
           >
         >
@@ -264,7 +264,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     RAJA::KernelPolicy<
       RAJA::statement::Collapse<RAJA::omp_parallel_collapse_exec,
                                 RAJA::ArgList<2, 1>,    // k, j
-        RAJA::statement::For<0, RAJA::loop_exec,        // i
+        RAJA::statement::For<0, RAJA::seq_exec,        // i
           RAJA::statement::Lambda<0>
         >
       >

--- a/exercises/launch-matrix-transpose-local-array.cpp
+++ b/exercises/launch-matrix-transpose-local-array.cpp
@@ -175,7 +175,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(At, 0, N_r * N_c * sizeof(int));
 
   // _mattranspose_localarray_raja_start
-  using loop_pol_1 = RAJA::LoopPolicy<RAJA::loop_exec>;
+  using loop_pol_1 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_1 = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
 
   RAJA::launch<launch_policy_1>(
@@ -231,7 +231,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   ///           within the omp parallel region.
   ///
 
-  //using loop_pol_2 = RAJA::LoopPolicy<RAJA::loop_exec>;
+  //using loop_pol_2 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_2 = RAJA::LaunchPolicy<RAJA::omp_launch_t>;
 
   RAJA::launch<launch_policy_2>(

--- a/exercises/launch-matrix-transpose-local-array_solution.cpp
+++ b/exercises/launch-matrix-transpose-local-array_solution.cpp
@@ -175,7 +175,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(At, 0, N_r * N_c * sizeof(int));
 
   // _mattranspose_localarray_raja_start
-  using loop_pol_1 = RAJA::LoopPolicy<RAJA::loop_exec>;
+  using loop_pol_1 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_1 = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
 
   RAJA::launch<launch_policy_1>(
@@ -225,7 +225,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // one of the inner loops.
   //
   using omp_pol_2 = RAJA::LoopPolicy<RAJA::omp_for_exec>;
-  using loop_pol_2 = RAJA::LoopPolicy<RAJA::loop_exec>;
+  using loop_pol_2 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_2 = RAJA::LaunchPolicy<RAJA::omp_launch_t>;
 
   RAJA::launch<launch_policy_2>(

--- a/exercises/launch-matrix-transpose-tiled.cpp
+++ b/exercises/launch-matrix-transpose-tiled.cpp
@@ -165,7 +165,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // tile_fixed corresponds to the dimension size of the tile.
   //
   // _raja_tiled_mattranspose_start
-  //using loop_pol_1 = RAJA::LoopPolicy<RAJA::loop_exec>;
+  //using loop_pol_1 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_1 = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
 
   RAJA::launch<launch_policy_1>(
@@ -213,7 +213,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // one of the inner loops.
   //
   //using omp_for_pol_2 = RAJA::LoopPolicy<RAJA::omp_for_exec>;
-  //using loop_pol_2 = RAJA::LoopPolicy<RAJA::loop_exec>;
+  //using loop_pol_2 = RAJA::LoopPolicy<RAJA::seq_exec>;
 
   ///
   /// TODO...

--- a/exercises/launch-matrix-transpose-tiled_solution.cpp
+++ b/exercises/launch-matrix-transpose-tiled_solution.cpp
@@ -159,7 +159,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // tile_fixed corresponds to the dimension size of the tile.
   //
   // _raja_tiled_mattranspose_start
-  using loop_pol_1 = RAJA::LoopPolicy<RAJA::loop_exec>;
+  using loop_pol_1 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_1 = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
 
   RAJA::launch<launch_policy_1>(RAJA::LaunchParams(), //LaunchParams may be empty when running on the cpu
@@ -197,7 +197,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // one of the inner loops.
   //
   using omp_for_pol_2 = RAJA::LoopPolicy<RAJA::omp_for_exec>;
-  using loop_pol_2 = RAJA::LoopPolicy<RAJA::loop_exec>;
+  using loop_pol_2 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_2 = RAJA::LaunchPolicy<RAJA::omp_launch_t>;
 
   RAJA::launch<launch_policy_2>(

--- a/exercises/launch-matrix-transpose.cpp
+++ b/exercises/launch-matrix-transpose.cpp
@@ -121,7 +121,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // using sequential loops. 
   //
   // _raja_mattranspose_start
-  using loop_policy_seq = RAJA::LoopPolicy<RAJA::loop_exec>;
+  using loop_policy_seq = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_seq = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
 
   RAJA::launch<launch_policy_seq>

--- a/exercises/launch-matrix-transpose_solution.cpp
+++ b/exercises/launch-matrix-transpose_solution.cpp
@@ -121,7 +121,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // using sequential loops. 
   //
   // _raja_mattranspose_start
-  using loop_policy_seq = RAJA::LoopPolicy<RAJA::loop_exec>;
+  using loop_policy_seq = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_seq = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
 
   RAJA::launch<launch_policy_seq>(

--- a/exercises/launchintro-execpols.cpp
+++ b/exercises/launchintro-execpols.cpp
@@ -130,7 +130,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   ///
 
 // _raja_tensorinit_seq_start
-  //using loop_policy_1 = RAJA::LoopPolicy<RAJA::loop_exec>;
+  //using loop_policy_1 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_1 = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
 
   RAJA::launch<launch_policy_1>
@@ -189,7 +189,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 // _raja_tensorinit_omp_outer_start
   /*
   using omp_policy_2 = RAJA::LoopPolicy<RAJA::omp_for_exec>;
-  using loop_policy_2 = RAJA::LoopPolicy<RAJA::loop_exec>;
+  using loop_policy_2 = RAJA::LoopPolicy<RAJA::seq_exec>;
   */
   using launch_policy_2 = RAJA::LaunchPolicy<RAJA::omp_launch_t>;
 

--- a/exercises/launchintro-execpols_solution.cpp
+++ b/exercises/launchintro-execpols_solution.cpp
@@ -123,7 +123,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(a, 0, N_tot * sizeof(double));
 
 // _raja_tensorinit_seq_start
-  using loop_policy_1 = RAJA::LoopPolicy<RAJA::loop_exec>;
+  using loop_policy_1 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_1 = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
 
   RAJA::launch<launch_policy_1>
@@ -177,7 +177,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 // _raja_tensorinit_omp_outer_start
   using omp_policy_2 = RAJA::LoopPolicy<RAJA::omp_for_exec>;
-  using loop_policy_2 = RAJA::LoopPolicy<RAJA::loop_exec>;
+  using loop_policy_2 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_2 = RAJA::LaunchPolicy<RAJA::omp_launch_t>;
 
   RAJA::launch<launch_policy_2>

--- a/exercises/offset-layout-stencil.cpp
+++ b/exercises/offset-layout-stencil.cpp
@@ -214,8 +214,8 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   // _offsetlayout_rajaseq_start
   using NESTED_EXEC_POL1 =
     RAJA::KernelPolicy<
-      RAJA::statement::For<1, RAJA::loop_exec,    // row
-        RAJA::statement::For<0, RAJA::loop_exec,  // col
+      RAJA::statement::For<1, RAJA::seq_exec,    // row
+        RAJA::statement::For<0, RAJA::seq_exec,  // col
           RAJA::statement::Lambda<0>
         >
       >  

--- a/exercises/offset-layout-stencil_solution.cpp
+++ b/exercises/offset-layout-stencil_solution.cpp
@@ -215,8 +215,8 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   // _offsetlayout_rajaseq_start
   using NESTED_EXEC_POL1 =
     RAJA::KernelPolicy<
-      RAJA::statement::For<1, RAJA::loop_exec,    // row
-        RAJA::statement::For<0, RAJA::loop_exec,  // col
+      RAJA::statement::For<1, RAJA::seq_exec,    // row
+        RAJA::statement::For<0, RAJA::seq_exec,  // col
           RAJA::statement::Lambda<0>
         >
       >  

--- a/exercises/permuted-layout-batch-matrix-multiply.cpp
+++ b/exercises/permuted-layout-batch-matrix-multiply.cpp
@@ -176,7 +176,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 #if defined(RAJA_ENABLE_OPENMP)
   using INIT_POL = RAJA::omp_parallel_for_exec;
 #else
-  using INIT_POL = RAJA::loop_exec;
+  using INIT_POL = RAJA::seq_exec;
 #endif
 
   RAJA::forall<INIT_POL>(RAJA::TypedRangeSegment<int>(0, N), [=](int e) {
@@ -204,7 +204,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
     timer.start();
     // _permutedlayout_batchedmatmult_loop_start
-    RAJA::forall<RAJA::loop_exec>(RAJA::TypedRangeSegment<int>(0, N),
+    RAJA::forall<RAJA::seq_exec>(RAJA::TypedRangeSegment<int>(0, N),
       [=](int e) {
 
         Cview(e, 0, 0) = Aview(e, 0, 0) * Bview(e, 0, 0)
@@ -260,7 +260,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   for (int i = 0; i < NITER; ++i) {
 
     // _permutedlayout2_batchedmatmult_loop_start
-    RAJA::forall<RAJA::loop_exec>(RAJA::TypedRangeSegment<int>(0, N), 
+    RAJA::forall<RAJA::seq_exec>(RAJA::TypedRangeSegment<int>(0, N), 
       [=](int e) {
 
         Cview2(e, 0, 0) = Aview2(e, 0, 0) * Bview2(e, 0, 0)

--- a/exercises/permuted-layout-batch-matrix-multiply_solution.cpp
+++ b/exercises/permuted-layout-batch-matrix-multiply_solution.cpp
@@ -166,7 +166,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 #if defined(RAJA_ENABLE_OPENMP)
   using INIT_POL = RAJA::omp_parallel_for_exec;
 #else
-  using INIT_POL = RAJA::loop_exec;
+  using INIT_POL = RAJA::seq_exec;
 #endif
 
   RAJA::forall<INIT_POL>(RAJA::TypedRangeSegment<int>(0, N), [=](int e) {
@@ -194,7 +194,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
     timer.start();
     // _permutedlayout_batchedmatmult_loop_start
-    RAJA::forall<RAJA::loop_exec>(RAJA::TypedRangeSegment<int>(0, N),
+    RAJA::forall<RAJA::seq_exec>(RAJA::TypedRangeSegment<int>(0, N),
       [=](int e) {
 
         Cview(e, 0, 0) = Aview(e, 0, 0) * Bview(e, 0, 0)
@@ -249,7 +249,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
     timer.start();
     // _permutedlayout2_batchedmatmult_loop_start
-    RAJA::forall<RAJA::loop_exec>(RAJA::TypedRangeSegment<int>(0, N), 
+    RAJA::forall<RAJA::seq_exec>(RAJA::TypedRangeSegment<int>(0, N), 
       [=](int e) {
 
         Cview2(e, 0, 0) = Aview2(e, 0, 0) * Bview2(e, 0, 0)

--- a/exercises/tutorial_halfday/ex9_matrix-transpose-local-array.cpp
+++ b/exercises/tutorial_halfday/ex9_matrix-transpose-local-array.cpp
@@ -212,17 +212,17 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
           RAJA::statement::InitLocalMem<RAJA::cpu_tile_mem, RAJA::ParamList<2>,
 
           RAJA::statement::ForICount<1, RAJA::statement::Param<1>, 
-                                        RAJA::loop_exec,
+                                        RAJA::seq_exec,
             RAJA::statement::ForICount<0, RAJA::statement::Param<0>, 
-                                        RAJA::loop_exec,
+                                        RAJA::seq_exec,
               RAJA::statement::Lambda<0>
             >
           >,
 
           RAJA::statement::ForICount<0, RAJA::statement::Param<0>, 
-                                        RAJA::loop_exec,
+                                        RAJA::seq_exec,
             RAJA::statement::ForICount<1, RAJA::statement::Param<1>, 
-                                          RAJA::loop_exec,
+                                          RAJA::seq_exec,
               RAJA::statement::Lambda<1>
             >
           >
@@ -279,17 +279,17 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
         RAJA::statement::InitLocalMem<RAJA::cpu_tile_mem, RAJA::ParamList<2>,
 
           RAJA::statement::ForICount<1, RAJA::statement::Param<1>, 
-                                        RAJA::loop_exec,
+                                        RAJA::seq_exec,
             RAJA::statement::ForICount<0, RAJA::statement::Param<0>, 
-                                          RAJA::loop_exec,
+                                          RAJA::seq_exec,
                RAJA::statement::Lambda<0>
             >
           >,
 
           RAJA::statement::ForICount<0, RAJA::statement::Param<0>, 
-                                        RAJA::loop_exec,
+                                        RAJA::seq_exec,
             RAJA::statement::ForICount<1, RAJA::statement::Param<1>, 
-                                          RAJA::loop_exec,
+                                          RAJA::seq_exec,
               RAJA::statement::Lambda<1>
             >
           >

--- a/exercises/tutorial_halfday/ex9_matrix-transpose-local-array_solution.cpp
+++ b/exercises/tutorial_halfday/ex9_matrix-transpose-local-array_solution.cpp
@@ -204,24 +204,24 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using SEQ_EXEC_POL =
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_SZ>,
-                               RAJA::loop_exec,
+                               RAJA::seq_exec,
         RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_SZ>,
-                                 RAJA::loop_exec,
+                                 RAJA::seq_exec,
 
           RAJA::statement::InitLocalMem<RAJA::cpu_tile_mem, RAJA::ParamList<2>,
 
           RAJA::statement::ForICount<1, RAJA::statement::Param<1>, 
-                                        RAJA::loop_exec,
+                                        RAJA::seq_exec,
             RAJA::statement::ForICount<0, RAJA::statement::Param<0>, 
-                                        RAJA::loop_exec,
+                                        RAJA::seq_exec,
               RAJA::statement::Lambda<0>
             >
           >,
 
           RAJA::statement::ForICount<0, RAJA::statement::Param<0>, 
-                                        RAJA::loop_exec,
+                                        RAJA::seq_exec,
             RAJA::statement::ForICount<1, RAJA::statement::Param<1>, 
-                                          RAJA::loop_exec,
+                                          RAJA::seq_exec,
               RAJA::statement::Lambda<1>
             >
           >
@@ -262,22 +262,22 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_SZ>,
                              RAJA::omp_parallel_for_exec,
       RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_SZ>,
-                               RAJA::loop_exec,
+                               RAJA::seq_exec,
 
         RAJA::statement::InitLocalMem<RAJA::cpu_tile_mem, RAJA::ParamList<2>,
 
           RAJA::statement::ForICount<1, RAJA::statement::Param<1>, 
-                                        RAJA::loop_exec,
+                                        RAJA::seq_exec,
             RAJA::statement::ForICount<0, RAJA::statement::Param<0>, 
-                                          RAJA::loop_exec,
+                                          RAJA::seq_exec,
                RAJA::statement::Lambda<0>
             >
           >,
 
           RAJA::statement::ForICount<0, RAJA::statement::Param<0>, 
-                                        RAJA::loop_exec,
+                                        RAJA::seq_exec,
             RAJA::statement::ForICount<1, RAJA::statement::Param<1>, 
-                                          RAJA::loop_exec,
+                                          RAJA::seq_exec,
               RAJA::statement::Lambda<1>
             >
           >

--- a/exercises/vector-addition.cpp
+++ b/exercises/vector-addition.cpp
@@ -151,26 +151,6 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 
 //----------------------------------------------------------------------------//
-// RAJA::loop_exec policy allows the compiler to generate optimizations 
-// (e.g., SIMD) if it thinks it is safe to do so.
-//----------------------------------------------------------------------------//
-
-  std::memset(c, 0, N * sizeof(int));
-
-  std::cout << "\n Running RAJA loop-exec vector addition...\n";
-
-  ///
-  /// TODO...
-  ///
-  /// EXERCISE: Implement the vector addition kernel using a RAJA::forall
-  ///           method and RAJA::loop_exec execution policy type.
-  ///
-
-  checkResult(c, c_ref, N);
-//printArray(c, N);
-
-
-//----------------------------------------------------------------------------//
 // C-style OpenMP multithreading variant.
 //----------------------------------------------------------------------------//
 

--- a/exercises/vector-addition_solution.cpp
+++ b/exercises/vector-addition_solution.cpp
@@ -143,25 +143,6 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 
 //----------------------------------------------------------------------------//
-// RAJA::loop_exec policy allows the compiler to generate optimizations 
-// (e.g., SIMD) if it thinks it is safe to do so.
-//----------------------------------------------------------------------------//
-
-  std::memset(c, 0, N * sizeof(int));
-
-  std::cout << "\n Running RAJA loop-exec vector addition...\n";
-
-  RAJA::forall< RAJA::loop_exec >(
-    RAJA::TypedRangeSegment<int>(0, N), [=] (int i) { 
-      c[i] = a[i] + b[i];
-    }
-  );
-
-  checkResult(c, c_ref, N);
-//printArray(c, N);
-
-
-//----------------------------------------------------------------------------//
 // C-style OpenMP multithreading variant.
 //----------------------------------------------------------------------------//
 

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -409,13 +409,10 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 
 #if defined(_OPENMP) && (_OPENMP >= 201307) && (__INTEL_COMPILER >= 1700)
 #define RAJA_SIMD  RAJA_PRAGMA(omp simd)
-#define RAJA_NO_SIMD RAJA_PRAGMA(novector)
 #elif defined(_OPENMP) && (_OPENMP >= 201307) && (__INTEL_COMPILER < 1700)
 #define RAJA_SIMD
-#define RAJA_NO_SIMD RAJA_PRAGMA(novector)
 #else
 #define RAJA_SIMD RAJA_PRAGMA(simd)
-#define RAJA_NO_SIMD RAJA_PRAGMA(novector)
 #endif
 
 
@@ -442,14 +439,11 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 
 #if defined(_OPENMP) && (_OPENMP >= 201307)
 #define RAJA_SIMD  RAJA_PRAGMA(omp simd)
-#define RAJA_NO_SIMD
 #elif defined(__GNUC__) && defined(__GNUC_MINOR__) && \
       ( ( (__GNUC__ == 4) && (__GNUC_MINOR__ == 9) ) || (__GNUC__ >= 5) )
 #define RAJA_SIMD    RAJA_PRAGMA(GCC ivdep)
-#define RAJA_NO_SIMD
 #else
 #define RAJA_SIMD
-#define RAJA_NO_SIMD
 #endif
 
 
@@ -471,10 +465,8 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 
 #if defined(_OPENMP) && (_OPENMP >= 201307)
 #define RAJA_SIMD  RAJA_PRAGMA(omp simd)
-#define RAJA_NO_SIMD RAJA_PRAGMA(simd_level(0))
 #else
 #define RAJA_SIMD  RAJA_PRAGMA(simd_level(10))
-#define RAJA_NO_SIMD RAJA_PRAGMA(simd_level(0))
 #endif
 
 // Detect altivec, but disable if NVCC is being used due to some bad interactions
@@ -502,7 +494,6 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 
 #if defined(_OPENMP) && (_OPENMP >= 201307) && (__clang_major__ >= 4 )
 #define RAJA_SIMD  RAJA_PRAGMA(omp simd)
-#define RAJA_NO_SIMD RAJA_PRAGMA(clang loop vectorize(disable))
 #else
 
 // Clang 3.7 and later changed the "pragma clang loop vectorize" options
@@ -513,7 +504,6 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_SIMD    RAJA_PRAGMA(clang loop vectorize(enable))
 #endif
 
-#define RAJA_NO_SIMD  RAJA_PRAGMA(clang loop vectorize(disable))
 #endif
 
 // Detect altivec, but only seems to work since Clang 9
@@ -529,7 +519,6 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_INLINE inline
 #define RAJA_ALIGN_DATA(d) d
 #define RAJA_SIMD
-#define RAJA_NO_SIMD
 #define RAJA_UNROLL
 #define RAJA_UNROLL_COUNT(N)
 
@@ -541,7 +530,6 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_INLINE inline
 #define RAJA_ALIGN_DATA(d) d
 #define RAJA_SIMD
-#define RAJA_NO_SIMD
 #define RAJA_UNROLL
 #define RAJA_UNROLL_COUNT(N)
 

--- a/include/RAJA/pattern/kernel/For.hpp
+++ b/include/RAJA/pattern/kernel/For.hpp
@@ -134,7 +134,6 @@ struct StatementExecutor<
 
     RAJA_EXTRACT_BED_IT(TypedRangeSegment<len_t>(0, len));
 
-    RAJA_NO_SIMD
     for (decltype(distance_it) i = 0; i < distance_it; ++i) {
       for_wrapper(*(begin_it + i));
     }

--- a/include/RAJA/policy/sequential/forall.hpp
+++ b/include/RAJA/policy/sequential/forall.hpp
@@ -72,7 +72,6 @@ forall_impl(Resource res,
 
   expt::ParamMultiplexer::init<seq_exec>(f_params);
 
-  RAJA_NO_SIMD
   for (decltype(distance_it) i = 0; i < distance_it; ++i) {
     expt::invoke_body(f_params, body, *(begin_it + i));
   }
@@ -96,7 +95,6 @@ forall_impl(Resource res,
 {
   RAJA_EXTRACT_BED_IT(iter);
 
-  RAJA_NO_SIMD
   for (decltype(distance_it) i = 0; i < distance_it; ++i) {
     body(*(begin_it + i));
   }

--- a/include/RAJA/policy/sequential/kernel/Collapse.hpp
+++ b/include/RAJA/policy/sequential/kernel/Collapse.hpp
@@ -65,7 +65,6 @@ struct StatementExecutor<statement::Collapse<seq_exec,
 
     auto len0 = segment_length<Arg0>(data);
 
-    RAJA_NO_SIMD
     for (auto i0 = 0; i0 < len0; ++i0) {
       data.template assign_offset<Arg0>(i0);
 

--- a/include/RAJA/policy/sequential/launch.hpp
+++ b/include/RAJA/policy/sequential/launch.hpp
@@ -28,6 +28,20 @@ namespace RAJA
 template <typename SEGMENT>
 struct LoopExecute<seq_exec, SEGMENT> {
 
+  RAJA_SUPPRESS_HD_WARN
+  template <typename BODY>
+  static RAJA_INLINE RAJA_HOST_DEVICE void exec(
+      SEGMENT const &segment,
+      BODY const &body)
+  {
+
+    const int len = segment.end() - segment.begin();
+    for (int i = 0; i < len; i++) {
+
+      body(*(segment.begin() + i));
+    }
+  }
+
   template <typename BODY>
   static RAJA_INLINE RAJA_HOST_DEVICE void exec(
       LaunchContext const RAJA_UNUSED_ARG(&ctx),
@@ -40,7 +54,54 @@ struct LoopExecute<seq_exec, SEGMENT> {
       body(*(segment.begin() + i));
     }
   }
+
+  template <typename BODY>
+  static RAJA_INLINE RAJA_HOST_DEVICE void exec(
+      LaunchContext const RAJA_UNUSED_ARG(&ctx),
+      SEGMENT const &segment0,
+      SEGMENT const &segment1,
+      BODY const &body)
+  {
+
+    // block stride loop
+    const int len1 = segment1.end() - segment1.begin();
+    const int len0 = segment0.end() - segment0.begin();
+
+    for (int j = 0; j < len1; j++) {
+      for (int i = 0; i < len0; i++) {
+
+        body(*(segment0.begin() + i), *(segment1.begin() + j));
+      }
+    }
+  }
+
+  template <typename BODY>
+  static RAJA_INLINE RAJA_HOST_DEVICE void exec(
+      LaunchContext const RAJA_UNUSED_ARG(&ctx),
+      SEGMENT const &segment0,
+      SEGMENT const &segment1,
+      SEGMENT const &segment2,
+      BODY const &body)
+  {
+
+    // block stride loop
+    const int len2 = segment2.end() - segment2.begin();
+    const int len1 = segment1.end() - segment1.begin();
+    const int len0 = segment0.end() - segment0.begin();
+
+    for (int k = 0; k < len2; k++) {
+      for (int j = 0; j < len1; j++) {
+        for (int i = 0; i < len0; i++) {
+          body(*(segment0.begin() + i),
+               *(segment1.begin() + j),
+               *(segment2.begin() + k));
+        }
+      }
+    }
+  }
+
 };
+
 
 template <typename SEGMENT>
 struct LoopICountExecute<seq_exec, SEGMENT> {
@@ -51,12 +112,101 @@ struct LoopICountExecute<seq_exec, SEGMENT> {
       SEGMENT const &segment,
       BODY const &body)
   {
-
     const int len = segment.end() - segment.begin();
     for (int i = 0; i < len; i++) {
       body(*(segment.begin() + i), i);
     }
   }
+
+    template <typename BODY>
+  static RAJA_INLINE RAJA_HOST_DEVICE void exec(
+      LaunchContext const RAJA_UNUSED_ARG(&ctx),
+      SEGMENT const &segment0,
+      SEGMENT const &segment1,
+      BODY const &body)
+  {
+
+    // block stride loop
+    const int len1 = segment1.end() - segment1.begin();
+    const int len0 = segment0.end() - segment0.begin();
+
+    for (int j = 0; j < len1; j++) {
+      for (int i = 0; i < len0; i++) {
+
+        body(*(segment0.begin() + i), *(segment1.begin() + j), i, j);
+      }
+    }
+  }
+
+  template <typename BODY>
+  static RAJA_INLINE RAJA_HOST_DEVICE void exec(
+      LaunchContext const RAJA_UNUSED_ARG(&ctx),
+      SEGMENT const &segment0,
+      SEGMENT const &segment1,
+      SEGMENT const &segment2,
+      BODY const &body)
+  {
+
+    // block stride loop
+    const int len2 = segment2.end() - segment2.begin();
+    const int len1 = segment1.end() - segment1.begin();
+    const int len0 = segment0.end() - segment0.begin();
+
+    for (int k = 0; k < len2; k++) {
+      for (int j = 0; j < len1; j++) {
+        for (int i = 0; i < len0; i++) {
+          body(*(segment0.begin() + i),
+               *(segment1.begin() + j),
+               *(segment2.begin() + k), i, j, k);
+        }
+      }
+    }
+  }
+  
+};
+
+//Tile Execute + variants
+
+template <typename SEGMENT>
+struct TileExecute<seq_exec, SEGMENT> {
+
+  template <typename TILE_T, typename BODY>
+  static RAJA_HOST_DEVICE RAJA_INLINE void exec(
+      LaunchContext const RAJA_UNUSED_ARG(&ctx),
+      TILE_T tile_size,
+      SEGMENT const &segment,
+      BODY const &body)
+  {
+
+    const int len = segment.end() - segment.begin();
+
+    for (int tx = 0; tx < len; tx += tile_size)
+    {
+      body(segment.slice(tx, tile_size));
+    }
+  }
+
+};
+
+template <typename SEGMENT>
+struct TileICountExecute<seq_exec, SEGMENT> {
+
+  template <typename TILE_T, typename BODY>
+  static RAJA_HOST_DEVICE RAJA_INLINE void exec(
+      LaunchContext const RAJA_UNUSED_ARG(&ctx),
+      TILE_T tile_size,
+      SEGMENT const &segment,
+      BODY const &body)
+  {
+
+    const int len = segment.end() - segment.begin();
+
+    for (int tx = 0, bx=0; tx < len; tx += tile_size, bx++)
+    {
+      body(segment.slice(tx, tile_size), bx);
+    }
+  }
+
 };
 
 }  // namespace RAJA

--- a/include/RAJA/policy/sequential/launch.hpp
+++ b/include/RAJA/policy/sequential/launch.hpp
@@ -36,7 +36,6 @@ struct LoopExecute<seq_exec, SEGMENT> {
   {
 
     const int len = segment.end() - segment.begin();
-    RAJA_NO_SIMD
     for (int i = 0; i < len; i++) {
       body(*(segment.begin() + i));
     }
@@ -54,7 +53,6 @@ struct LoopICountExecute<seq_exec, SEGMENT> {
   {
 
     const int len = segment.end() - segment.begin();
-    RAJA_NO_SIMD
     for (int i = 0; i < len; i++) {
       body(*(segment.begin() + i), i);
     }

--- a/include/RAJA/policy/sequential/scan.hpp
+++ b/include/RAJA/policy/sequential/scan.hpp
@@ -54,7 +54,6 @@ inclusive_inplace(
   using ValueT = typename std::remove_reference<decltype(*begin)>::type;
   ValueT agg = *begin;
 
-  RAJA_NO_SIMD
   for (Iter i = ++begin; i != end; ++i) {
     agg = f(agg, *i);
     *i = agg;
@@ -86,7 +85,6 @@ exclusive_inplace(
   using ValueT = typename std::remove_reference<decltype(*begin)>::type;
   ValueT agg = v;
 
-  RAJA_NO_SIMD
   for (DistanceT i = 0; i < n; ++i) {
     auto t = begin[i];
     begin[i] = agg;
@@ -116,7 +114,6 @@ inclusive(
   ValueT agg = *begin;
   *out++ = agg;
 
-  RAJA_NO_SIMD
   for (Iter i = begin + 1; i != end; ++i) {
     agg = f(agg, *i);
     *out++ = agg;
@@ -151,7 +148,6 @@ exclusive(
   OutIter o = out;
   *o++ = v;
 
-  RAJA_NO_SIMD
   for (Iter i = begin; i != end - 1; ++i, ++o) {
     agg = f(agg, *i);
     *o = agg;

--- a/reproducers/openmp-target/reproducer-openmptarget-issue1.cpp
+++ b/reproducers/openmp-target/reproducer-openmptarget-issue1.cpp
@@ -178,7 +178,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using EXEC_POL3 =
     RAJA::KernelPolicy<
       RAJA::statement::For<0, RAJA::omp_parallel_for_exec,
-        RAJA::statement::For<1, RAJA::loop_exec,
+        RAJA::statement::For<1, RAJA::seq_exec,
           RAJA::statement::Lambda<0>
         >
       >
@@ -204,7 +204,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using EXEC_POL4 =
     RAJA::KernelPolicy<
       RAJA::statement::For<0, RAJA::omp_parallel_for_exec,
-        RAJA::statement::For<1, RAJA::loop_exec,
+        RAJA::statement::For<1, RAJA::seq_exec,
           RAJA::statement::Lambda<0, RAJA::Segs<0, 1>>
         >
       >


### PR DESCRIPTION
# Summary

- This PR makes seq_exec policy act the same as loop_exec policy. 
- It is  the first step to deprecating, then removing loop_exec policy.
- Due to header file inclusions and differences in implementation, both exec policy choices remain in place for now.
- loop_exec has been replaced with seq_exec in all example, exercises, reproducers, and tests. 
- Need to walk through RAJA::launch implementation with @artv3 and compare seq_exec and loop_exec functionality so that seq_exec will support everything in both.
