### PR TITLE
Fixes and Initial Strongly Typed Index Tests for Vectorization API

### DIFF
--- a/include/RAJA/util/TypedViewBase.hpp
+++ b/include/RAJA/util/TypedViewBase.hpp
@@ -404,7 +404,7 @@ namespace internal
    */
   template<typename Expected, typename Arg>
   struct MatchTypedViewArgHelper{
-    static_assert(std::is_convertible<Arg, Expected>::value,
+    static_assert(std::is_convertible<strip_index_type_t<Arg>, strip_index_type_t<Expected>>::value,
         "Argument isn't compatible");
 
     using type = strip_index_type_t<Arg>;
@@ -427,7 +427,7 @@ namespace internal
   template<typename Expected, typename Arg, typename VectorType, camp::idx_t DIM>
   struct MatchTypedViewArgHelper<Expected, RAJA::expt::TensorIndex<Arg, VectorType, DIM> >{
 
-    static_assert(std::is_convertible<Arg, Expected>::value,
+    static_assert(std::is_convertible<strip_index_type_t<Arg>, strip_index_type_t<Expected>>::value,
         "Argument isn't compatible");
 
     using arg_type = strip_index_type_t<Arg>;

--- a/include/RAJA/util/TypedViewBase.hpp
+++ b/include/RAJA/util/TypedViewBase.hpp
@@ -439,6 +439,28 @@ namespace internal
       return type(stripIndexType(*vec_arg), vec_arg.size());
     }
   };
+
+  /**
+   * Specialization where expected type is wrapped in a StaticTensorIndex type
+   *
+   * In this case, there is no StaticTensorIndex to unpack, just strip any strongly
+   * typed indices.
+   */
+  template<typename Expected, typename Arg, typename VectorType, camp::idx_t DIM, Arg BEGIN, strip_index_type_t<Arg> LENGTH>
+  struct MatchTypedViewArgHelper<Expected, RAJA::expt::StaticTensorIndex<RAJA::expt::StaticTensorIndexInner<Arg, VectorType, DIM, BEGIN, LENGTH>> >{
+
+    static_assert(std::is_convertible<strip_index_type_t<Arg>, strip_index_type_t<Expected>>::value,
+        "Argument isn't compatible");
+
+    using arg_type = strip_index_type_t<Arg>;
+
+    using type = RAJA::expt::StaticTensorIndex<RAJA::expt::StaticTensorIndexInner<arg_type, VectorType, DIM, BEGIN, LENGTH>>;
+
+    static constexpr RAJA_HOST_DEVICE RAJA_INLINE
+    type extract(RAJA::expt::StaticTensorIndex<RAJA::expt::StaticTensorIndexInner<Arg, VectorType, DIM, BEGIN, LENGTH>> vec_arg){
+      return type();
+    }
+  };
 #endif
 
   } //namespace detail

--- a/test/functional/kernel/tile-variants/tests/test-kernel-tile-Fixed2DSum.hpp
+++ b/test/functional/kernel/tile-variants/tests/test-kernel-tile-Fixed2DSum.hpp
@@ -21,8 +21,8 @@ void KernelTileFixed2DSumTestImpl(const int rowsin, const int colsin)
   if ( std::is_same<DATA_TYPE, float>::value )
   {
     // Restrict to a small data size for better float precision.
-    rows = 5;
-    cols = 5;
+    rows = 3;
+    cols = 3;
   }
   else
   {

--- a/test/functional/tensor/matrix/tests/test-tensor-matrix-ET_MatrixMatrixMultiplyAdd.hpp
+++ b/test/functional/tensor/matrix/tests/test-tensor-matrix-ET_MatrixMatrixMultiplyAdd.hpp
@@ -10,6 +10,9 @@
 
 #include<RAJA/RAJA.hpp>
 
+RAJA_INDEX_VALUE( TX, "TX" );
+RAJA_INDEX_VALUE( TY, "TY" );
+
 template <typename MATRIX_TYPE>
 void ET_MatrixMatrixMultiplyAddImpl()
 {
@@ -50,10 +53,10 @@ void ET_MatrixMatrixMultiplyAddImpl()
   // alloc data3 - The result matrix
 
   std::vector<element_t> data3_vec(N*N);
-  RAJA::View<element_t, RAJA::Layout<2>> data3_h(data3_vec.data(),  N, N);
+  RAJA::TypedView<element_t, RAJA::Layout<2>, TX, TY> data3_h(data3_vec.data(),  N, N);
 
   element_t *data3_ptr = tensor_malloc<policy_t>(data3_vec);
-  RAJA::View<element_t, RAJA::Layout<2>> data3_d(data3_ptr,  N, N);
+  RAJA::TypedView<element_t, RAJA::Layout<2>, TX, TY> data3_d(data3_ptr,  N, N);
 
 
 

--- a/test/functional/tensor/matrix/tests/test-tensor-matrix-ET_MatrixMatrixMultiplyAdd.hpp
+++ b/test/functional/tensor/matrix/tests/test-tensor-matrix-ET_MatrixMatrixMultiplyAdd.hpp
@@ -35,19 +35,19 @@ void ET_MatrixMatrixMultiplyAddImpl()
   // alloc data1 - The left matrix
 
   std::vector<element_t> data1_vec(N*N);
-  RAJA::View<element_t, RAJA::StaticLayout<RAJA::PERM_IJ,N,N>> data1_h(data1_vec.data());
+  RAJA::TypedView<element_t, RAJA::StaticLayout<RAJA::PERM_IJ,N,N>, TX, TY> data1_h(data1_vec.data());
 
   element_t *data1_ptr = tensor_malloc<policy_t>(data1_vec);
-  RAJA::View<element_t, RAJA::StaticLayout<RAJA::PERM_IJ,N,N>> data1_d(data1_ptr);
+  RAJA::TypedView<element_t, RAJA::StaticLayout<RAJA::PERM_IJ,N,N>, TX, TY> data1_d(data1_ptr);
 
 
   // alloc data2 - The right matrix
 
   std::vector<element_t> data2_vec(N*N);
-  RAJA::View<element_t, RAJA::StaticLayout<RAJA::PERM_IJ,N,N>> data2_h(data2_vec.data());
+  RAJA::TypedView<element_t, RAJA::StaticLayout<RAJA::PERM_IJ,N,N>, TX, TY> data2_h(data2_vec.data());
 
   element_t *data2_ptr = tensor_malloc<policy_t>(data2_vec);
-  RAJA::View<element_t, RAJA::StaticLayout<RAJA::PERM_IJ,N,N>> data2_d(data2_ptr);
+  RAJA::TypedView<element_t, RAJA::StaticLayout<RAJA::PERM_IJ,N,N>, TX, TY> data2_d(data2_ptr);
 
 
   // alloc data3 - The result matrix

--- a/test/functional/tensor/vector/tests/test-tensor-vector-ForallVectorRef1d.hpp
+++ b/test/functional/tensor/vector/tests/test-tensor-vector-ForallVectorRef1d.hpp
@@ -10,6 +10,8 @@
 
 #include<RAJA/RAJA.hpp>
 
+RAJA_INDEX_VALUE( TX, "TX" );
+
 template <typename VECTOR_TYPE>
 void ForallVectorRef1dImpl()
 {
@@ -38,13 +40,13 @@ void ForallVectorRef1dImpl()
     C[i] = 0.0;
   }
 
-  RAJA::View<element_t, RAJA::Layout<1>> X(A.data(), N);
-  RAJA::View<element_t, RAJA::Layout<1>> Y(B.data(), N);
-  RAJA::View<element_t, RAJA::Layout<1>> Z(C.data(), N);
+  RAJA::TypedView<element_t, RAJA::Layout<1>, TX> X(A.data(), N);
+  RAJA::TypedView<element_t, RAJA::Layout<1>, TX> Y(B.data(), N);
+  RAJA::TypedView<element_t, RAJA::Layout<1>, TX> Z(C.data(), N);
 
-  RAJA::View<element_t, RAJA::Layout<1>> X_d(A_ptr, N);
-  RAJA::View<element_t, RAJA::Layout<1>> Y_d(B_ptr, N);
-  RAJA::View<element_t, RAJA::Layout<1>> Z_d(C_ptr, N);
+  RAJA::TypedView<element_t, RAJA::Layout<1>, TX> X_d(A_ptr, N);
+  RAJA::TypedView<element_t, RAJA::Layout<1>, TX> Y_d(B_ptr, N);
+  RAJA::TypedView<element_t, RAJA::Layout<1>, TX> Z_d(C_ptr, N);
 
   using idx_t = RAJA::expt::VectorIndex<int, vector_t>;
 
@@ -121,8 +123,8 @@ void ForallVectorRef1dImpl()
   }
 
   // vector_exec only works on the host due to its use of RAJA::seq_exec
-  RAJA::forall<RAJA::expt::vector_exec<vector_t>>(RAJA::TypedRangeSegment<int>(0,N/2),
-      [=](int i){
+  RAJA::forall<RAJA::expt::vector_exec<vector_t>>(RAJA::TypedRangeSegment<TX>(0,N/2),
+      [=](TX i){
 
      Z[i] = 3 + (X[i]*(5/Y[i])) + 9;
   });


### PR DESCRIPTION
# Summary

- This PR is a refactoring
- It does the following:
  - Fixes `TypedView` to allow strongly typed indices with basic Layouts, and StaticLayouts.
  - Modifies some existing tests to use strongly typed indices. More thorough testing will be done after impending release.