### PR TITLE
New Reducer GPU Indexing

### DIFF
--- a/include/RAJA/pattern/params/forall.hpp
+++ b/include/RAJA/pattern/params/forall.hpp
@@ -56,9 +56,9 @@ namespace expt
     }
     
     // Resolve
-    template<typename EXEC_POL, camp::idx_t... Seq>
-    static constexpr void detail_resolve(EXEC_POL, camp::idx_seq<Seq...>, ForallParamPack& f_params ) {
-      CAMP_EXPAND(detail::resolve<EXEC_POL>( camp::get<Seq>(f_params.param_tup) ));
+    template<typename EXEC_POL, camp::idx_t... Seq, typename ...Args>
+    static constexpr void detail_resolve(EXEC_POL, camp::idx_seq<Seq...>, ForallParamPack& f_params, Args&& ...args) {
+      CAMP_EXPAND(detail::resolve<EXEC_POL>( camp::get<Seq>(f_params.param_tup), std::forward<Args>(args)... ));
     }
 
     // Used to construct the argument TYPES that will be invoked with the lambda.

--- a/include/RAJA/policy/cuda/forall.hpp
+++ b/include/RAJA/policy/cuda/forall.hpp
@@ -629,7 +629,7 @@ forall_impl(resources::Cuda cuda_res,
       void *args[] = {(void*)&body, (void*)&begin, (void*)&len, (void*)&f_params};
       RAJA::cuda::launch(func, dims.blocks, dims.threads, args, shmem, cuda_res, Async);
 
-      RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+      RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params, launch_info);
     }
 
     RAJA_FT_END;

--- a/include/RAJA/policy/cuda/params/reduce.hpp
+++ b/include/RAJA/policy/cuda/params/reduce.hpp
@@ -15,10 +15,10 @@ namespace detail {
   // Init
   template<typename EXEC_POL, typename OP, typename T>
   camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-  init(Reducer<OP, T>& red, const RAJA::cuda::detail::cudaInfo & cs)
+  init(Reducer<OP, T>& red, RAJA::cuda::detail::cudaInfo& ci)
   {
     red.devicetarget = RAJA::cuda::device_mempool_type::getInstance().template malloc<T>(1);
-    red.device_mem.allocate(cs.gridDim.x * cs.gridDim.y * cs.gridDim.z);
+    red.device_mem.allocate(ci.gridDim.x * ci.gridDim.y * ci.gridDim.z);
     red.device_count = RAJA::cuda::device_zeroed_mempool_type::getInstance().template malloc<unsigned int>(1);
   }
 
@@ -34,11 +34,11 @@ namespace detail {
   // Resolve
   template<typename EXEC_POL, typename OP, typename T>
   camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-  resolve(Reducer<OP, T>& red)
+  resolve(Reducer<OP, T>& red, RAJA::cuda::detail::cudaInfo& ci)
   {
     // complete reduction
-    cudaDeviceSynchronize();
-    cudaMemcpy(&red.val, red.devicetarget, sizeof(T), cudaMemcpyDeviceToHost);
+    ci.res.memcpy(&red.val, red.devicetarget, sizeof(T));
+    ci.res.wait();
     *red.target = OP{}(red.val, *red.target);
 
     // free memory

--- a/include/RAJA/policy/cuda/params/reduce.hpp
+++ b/include/RAJA/policy/cuda/params/reduce.hpp
@@ -28,7 +28,7 @@ namespace detail {
   camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
   combine(Reducer<OP, T>& red)
   {
-    RAJA::cuda::impl::expt::grid_reduce(red);
+    RAJA::cuda::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter>(red);
   }
 
   // Resolve

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -748,6 +748,26 @@ struct IndexGlobal<dim, named_usage::ignored, named_usage::ignored>
   }
 };
 
+// helper to get just the thread indexing part of IndexGlobal
+template < typename index_global >
+struct get_index_thread;
+///
+template < named_dim dim, int BLOCK_SIZE, int GRID_SIZE >
+struct get_index_thread<IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>>
+{
+  using type = IndexGlobal<dim, BLOCK_SIZE, named_usage::ignored>;
+};
+
+// helper to get just the block indexing part of IndexGlobal
+template < typename index_global >
+struct get_index_block;
+///
+template < named_dim dim, int BLOCK_SIZE, int GRID_SIZE >
+struct get_index_block<IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>>
+{
+  using type = IndexGlobal<dim, named_usage::ignored, GRID_SIZE>;
+};
+
 
 template <size_t BLOCK_SIZE=named_usage::unspecified>
 using thread_x = IndexGlobal<named_dim::x, BLOCK_SIZE, named_usage::ignored>;

--- a/include/RAJA/policy/cuda/reduce.hpp
+++ b/include/RAJA/policy/cuda/reduce.hpp
@@ -528,16 +528,14 @@ RAJA_DEVICE RAJA_INLINE bool grid_reduce(T& val,
 
 namespace expt {
 
-template <typename Combiner, typename T>
+template <typename ThreadIterationGetter, typename Combiner, typename T>
 RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
 {
-  int numThreads = blockDim.x * blockDim.y * blockDim.z;
+  const int numThreads = ThreadIterationGetter::size();
+  const int threadId = ThreadIterationGetter::index();
 
-  int threadId = threadIdx.x + blockDim.x * threadIdx.y +
-                 (blockDim.x * blockDim.y) * threadIdx.z;
-
-  int warpId = threadId % RAJA::policy::cuda::WARP_SIZE;
-  int warpNum = threadId / RAJA::policy::cuda::WARP_SIZE;
+  const int warpId = threadId % RAJA::policy::cuda::WARP_SIZE;
+  const int warpNum = threadId / RAJA::policy::cuda::WARP_SIZE;
 
   T temp = val;
 
@@ -604,20 +602,20 @@ RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
 }
 
 
-template <typename OP, typename T>
-RAJA_DEVICE RAJA_INLINE bool grid_reduce(RAJA::expt::detail::Reducer<OP, T>& red) {
+template <typename GlobalIterationGetter, typename OP, typename T>
+RAJA_DEVICE RAJA_INLINE void grid_reduce(RAJA::expt::detail::Reducer<OP, T>& red)
+{
+  using BlockIterationGetter = typename get_index_block<GlobalIterationGetter>::type;
+  using ThreadIterationGetter = typename get_index_thread<GlobalIterationGetter>::type;
 
-  int numBlocks = gridDim.x * gridDim.y * gridDim.z;
-  int numThreads = blockDim.x * blockDim.y * blockDim.z;
-  unsigned int wrap_around = numBlocks - 1;
+  const int numBlocks = BlockIterationGetter::size();
+  const int numThreads = ThreadIterationGetter::size();
+  const unsigned int wrap_around = numBlocks - 1;
 
-  int blockId = blockIdx.x + gridDim.x * blockIdx.y +
-                (gridDim.x * gridDim.y) * blockIdx.z;
+  const int blockId = BlockIterationGetter::index();
+  const int threadId = ThreadIterationGetter::index();
 
-  int threadId = threadIdx.x + blockDim.x * threadIdx.y +
-                 (blockDim.x * blockDim.y) * threadIdx.z;
-
-  T temp = block_reduce<OP>(red.val, OP::identity());
+  T temp = block_reduce<ThreadIterationGetter, OP>(red.val, OP::identity());
 
   // one thread per block writes to device_mem
   bool lastBlock = false;
@@ -641,15 +639,13 @@ RAJA_DEVICE RAJA_INLINE bool grid_reduce(RAJA::expt::detail::Reducer<OP, T>& red
       temp = OP{}(temp, red.device_mem.get(i));
     }
 
-    temp = block_reduce<OP>(temp, OP::identity());
+    temp = block_reduce<ThreadIterationGetter, OP>(temp, OP::identity());
 
     // one thread returns value
     if (threadId == 0) {
       *(red.devicetarget) = temp;
     }
   }
-
-  return lastBlock && threadId == 0;
 }
 
 } //  namespace expt

--- a/include/RAJA/policy/hip/forall.hpp
+++ b/include/RAJA/policy/hip/forall.hpp
@@ -622,7 +622,7 @@ forall_impl(resources::Hip hip_res,
       void *args[] = {(void*)&body, (void*)&begin, (void*)&len, (void*)&f_params};
       RAJA::hip::launch(func, dims.blocks, dims.threads, args, shmem, hip_res, Async);
 
-      RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+      RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params, launch_info);
     }
 
     RAJA_FT_END;

--- a/include/RAJA/policy/hip/params/reduce.hpp
+++ b/include/RAJA/policy/hip/params/reduce.hpp
@@ -15,10 +15,10 @@ namespace detail {
   // Init
   template<typename EXEC_POL, typename OP, typename T>
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  init(Reducer<OP, T>& red, const RAJA::hip::detail::hipInfo & cs)
+  init(Reducer<OP, T>& red, RAJA::hip::detail::hipInfo& hi)
   {
     red.devicetarget = RAJA::hip::device_mempool_type::getInstance().template malloc<T>(1);
-    red.device_mem.allocate(cs.gridDim.x * cs.gridDim.y * cs.gridDim.z);
+    red.device_mem.allocate(hi.gridDim.x * hi.gridDim.y * hi.gridDim.z);
     red.device_count = RAJA::hip::device_zeroed_mempool_type::getInstance().template malloc<unsigned int>(1);
   }
 
@@ -34,11 +34,11 @@ namespace detail {
   // Resolve
   template<typename EXEC_POL, typename OP, typename T>
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  resolve(Reducer<OP, T>& red)
+  resolve(Reducer<OP, T>& red, RAJA::hip::detail::hipInfo& hi)
   {
     // complete reduction
-    hipDeviceSynchronize();
-    hipMemcpy(&red.val, red.devicetarget, sizeof(T), hipMemcpyDeviceToHost);
+    hi.res.memcpy(&red.val, red.devicetarget, sizeof(T));
+    hi.res.wait();
     *red.target = OP{}(red.val, *red.target);
 
     // free memory

--- a/include/RAJA/policy/hip/params/reduce.hpp
+++ b/include/RAJA/policy/hip/params/reduce.hpp
@@ -28,7 +28,7 @@ namespace detail {
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
   combine(Reducer<OP, T>& red)
   {
-    RAJA::hip::impl::expt::grid_reduce(red);
+    RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter>(red);
   }
 
   // Resolve

--- a/include/RAJA/policy/hip/policy.hpp
+++ b/include/RAJA/policy/hip/policy.hpp
@@ -743,6 +743,26 @@ struct IndexGlobal<dim, named_usage::ignored, named_usage::ignored>
   }
 };
 
+// helper to get just the thread indexing part of IndexGlobal
+template < typename index_global >
+struct get_index_thread;
+///
+template < named_dim dim, int BLOCK_SIZE, int GRID_SIZE >
+struct get_index_thread<IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>>
+{
+  using type = IndexGlobal<dim, BLOCK_SIZE, named_usage::ignored>;
+};
+
+// helper to get just the block indexing part of IndexGlobal
+template < typename index_global >
+struct get_index_block;
+///
+template < named_dim dim, int BLOCK_SIZE, int GRID_SIZE >
+struct get_index_block<IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>>
+{
+  using type = IndexGlobal<dim, named_usage::ignored, GRID_SIZE>;
+};
+
 
 template <size_t BLOCK_SIZE=named_usage::unspecified>
 using thread_x = IndexGlobal<named_dim::x, BLOCK_SIZE, named_usage::ignored>;

--- a/include/RAJA/policy/hip/reduce.hpp
+++ b/include/RAJA/policy/hip/reduce.hpp
@@ -401,16 +401,14 @@ RAJA_DEVICE RAJA_INLINE bool grid_reduce(T& val,
 
 namespace expt {
 
-template <typename Combiner, typename T>
+template <typename ThreadIterationGetter, typename Combiner, typename T>
 RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
 {
-  int numThreads = blockDim.x * blockDim.y * blockDim.z;
+  const int numThreads = ThreadIterationGetter::size();
+  const int threadId = ThreadIterationGetter::index();
 
-  int threadId = threadIdx.x + blockDim.x * threadIdx.y +
-                 (blockDim.x * blockDim.y) * threadIdx.z;
-
-  int warpId = threadId % RAJA::policy::hip::WARP_SIZE;
-  int warpNum = threadId / RAJA::policy::hip::WARP_SIZE;
+  const int warpId = threadId % RAJA::policy::hip::WARP_SIZE;
+  const int warpNum = threadId / RAJA::policy::hip::WARP_SIZE;
 
   T temp = val;
 
@@ -477,20 +475,20 @@ RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
 }
 
 
-template <typename OP, typename T>
-RAJA_DEVICE RAJA_INLINE bool grid_reduce(RAJA::expt::detail::Reducer<OP, T>& red) {
+template <typename GlobalIterationGetter, typename OP, typename T>
+RAJA_DEVICE RAJA_INLINE void grid_reduce(RAJA::expt::detail::Reducer<OP, T>& red)
+{
+  using BlockIterationGetter = typename get_index_block<GlobalIterationGetter>::type;
+  using ThreadIterationGetter = typename get_index_thread<GlobalIterationGetter>::type;
 
-  int numBlocks = gridDim.x * gridDim.y * gridDim.z;
-  int numThreads = blockDim.x * blockDim.y * blockDim.z;
-  unsigned int wrap_around = numBlocks - 1;
+  const int numBlocks = BlockIterationGetter::size();
+  const int numThreads = ThreadIterationGetter::size();
+  const unsigned int wrap_around = numBlocks - 1;
 
-  int blockId = blockIdx.x + gridDim.x * blockIdx.y +
-                (gridDim.x * gridDim.y) * blockIdx.z;
+  const int blockId = BlockIterationGetter::index();
+  const int threadId = ThreadIterationGetter::index();
 
-  int threadId = threadIdx.x + blockDim.x * threadIdx.y +
-                 (blockDim.x * blockDim.y) * threadIdx.z;
-
-  T temp = block_reduce<OP>(red.val, OP::identity());
+  T temp = block_reduce<ThreadIterationGetter, OP>(red.val, OP::identity());
 
   // one thread per block writes to device_mem
   bool lastBlock = false;
@@ -514,15 +512,13 @@ RAJA_DEVICE RAJA_INLINE bool grid_reduce(RAJA::expt::detail::Reducer<OP, T>& red
       temp = OP{}(temp, red.device_mem.get(i));
     }
 
-    temp = block_reduce<OP>(temp, OP::identity());
+    temp = block_reduce<ThreadIterationGetter, OP>(temp, OP::identity());
 
     // one thread returns value
     if (threadId == 0) {
       *(red.devicetarget) = temp;
     }
   }
-
-  return lastBlock && threadId == 0;
 }
 
 } //  namespace expt


### PR DESCRIPTION
# Use GPU Indexing info in new reduction interface.

- This PR is a feature and bugfix
- It does the following (modify list as needed):
  - Fixes direct cuda/hipMalloc call and memory leaks
  - Adds compile time block size optimization for new reducer interface at the request of myself
