### PR TITLE
Expose OpenMP task option

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,7 @@ stages:
     include:
       - local: '.gitlab/custom-jobs-and-variables.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: v2023.03.1
+        ref: v2023.06.0
         file: '${CI_MACHINE}-build-and-test.yml'
       - local: '.gitlab/${CI_MACHINE}-build-and-test-extra.yml'
     strategy: depend

--- a/.gitlab/corona-build-and-test-extra.yml
+++ b/.gitlab/corona-build-and-test-extra.yml
@@ -23,6 +23,6 @@
 
 rocmcc_5_5_0_hip_desul_atomics:
   variables:
-    SPEC: " ~shared +rocm ~openmp +tests +desul amdgpu_target=gfx906 %rocmcc@5.4.1 ^hip@5.4.1 ^blt@develop"
+    SPEC: " ~shared +rocm ~openmp +tests +desul amdgpu_target=gfx906 %rocmcc@5.5.0 ^hip@5.5.0 ^blt@develop"
   extends: .build_and_test_on_corona
 

--- a/.gitlab/corona-build-and-test-extra.yml
+++ b/.gitlab/corona-build-and-test-extra.yml
@@ -21,7 +21,7 @@
 # ${PROJECT_<MACHINE>_DEPS} in the extra jobs. There is no reason not to fully
 # describe the spec here.
 
-rocmcc_5_4_1_hip_desul_atomics:
+rocmcc_5_5_0_hip_desul_atomics:
   variables:
     SPEC: " ~shared +rocm ~openmp +tests +desul amdgpu_target=gfx906 %rocmcc@5.4.1 ^hip@5.4.1 ^blt@develop"
   extends: .build_and_test_on_corona

--- a/.gitlab/lassen-build-and-test-extra.yml
+++ b/.gitlab/lassen-build-and-test-extra.yml
@@ -36,6 +36,11 @@ xl_2022_08_19_gcc_8_3_1_cuda_11_7_0:
 # ${PROJECT_<MACHINE>_DEPS} in the extra jobs. There is no reason not to fully
 # describe the spec here.
 
+gcc_8_3_1_omptask:
+  variables:
+    SPEC: " ~shared +openmp +omptask +tests %gcc@8.3.1"
+  extends: .build_and_test_on_lassen
+
 gcc_8_3_1_cuda_11_5_0_ats_disabled:
   extends: .build_and_test_on_lassen
   variables:

--- a/.gitlab/ruby-build-and-test-extra.yml
+++ b/.gitlab/ruby-build-and-test-extra.yml
@@ -12,7 +12,22 @@
 # We keep ${PROJECT_<MACHINE>_VARIANTS} and ${PROJECT_<MACHINE>_DEPS} So that
 # the comparison with the original job is easier.
 
-# No overridden jobs so far.
+clang_14_0_6:
+  variables:
+    SPEC: " ~shared +openmp +omptask +tests %clang@14.0.6"
+  extends: .build_and_test_on_ruby
+
+gcc_10_3_1:
+  variables:
+    SPEC: " ~shared +openmp +omptask +tests %gcc@10.3.1"
+    RUBY_BUILD_AND_TEST_JOB_ALLOC: "--time=60 --nodes=1"
+  extends: .build_and_test_on_ruby
+
+intel_19_1_2_gcc_8_5_0:
+  variables:
+    SPEC: " ~shared +openmp +omptask +tests %intel@19.1.2.gcc.8.5.0"
+    RUBY_BUILD_AND_TEST_JOB_ALLOC: "--time=90 --nodes=1"
+  extends: .build_and_test_on_ruby
 
 ############
 # Extra jobs

--- a/.gitlab/tioga-build-and-test-extra.yml
+++ b/.gitlab/tioga-build-and-test-extra.yml
@@ -28,5 +28,5 @@ rocmcc_5_4_3_hip_desul_atomics:
 
 rocmcc_5_4_3_hip_openmp:
   variables:
-    SPEC: "~shared +rocm +openmp +tests amdgpu_target=gfx90a %rocmcc@5.4.3 ^hip@5.4.3 ^blt@develop"
+    SPEC: "~shared +rocm +openmp +omptask +tests amdgpu_target=gfx90a %rocmcc@5.4.3 ^hip@5.4.3 ^blt@develop"
   extends: .build_and_test_on_tioga

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,42 +71,42 @@ RUN . /opt/spack/share/spack/setup-env.sh && export LD_LIBRARY_PATH=/opt/view/li
     ctest -T test --output-on-failure && \
     cd .. && rm -rf build
 
-FROM ghcr.io/rse-ops/cuda:cuda-10.1.243-ubuntu-18.04 AS nvcc10.1.243
-ENV GTEST_COLOR=1
-COPY . /home/raja/workspace
-WORKDIR /home/raja/workspace/build
-RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
-    cmake -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On -DCMAKE_CUDA_STANDARD=14 -DCMAKE_CUDA_ARCHITECTURES=70 -DENABLE_OPENMP=On .. && \
-    make -j 4 && \
-    cd .. && rm -rf build
+##FROM ghcr.io/rse-ops/cuda:cuda-10.1.243-ubuntu-18.04 AS nvcc10.1.243
+##ENV GTEST_COLOR=1
+##COPY . /home/raja/workspace
+##WORKDIR /home/raja/workspace/build
+##RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
+##    cmake -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On -DCMAKE_CUDA_STANDARD=14 -DCMAKE_CUDA_ARCHITECTURES=70 -DENABLE_OPENMP=On .. && \
+##    make -j 4 && \
+##    cd .. && rm -rf build
 
-FROM ghcr.io/rse-ops/cuda-ubuntu-20.04:cuda-11.1.1 AS nvcc11.1.1
-ENV GTEST_COLOR=1
-COPY . /home/raja/workspace
-WORKDIR /home/raja/workspace/build
-RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
-    cmake -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On -DCMAKE_CUDA_STANDARD=14 -DCMAKE_CUDA_ARCHITECTURES=70 -DENABLE_OPENMP=On .. && \
-    make -j 4 && \
-    cd .. && rm -rf build
+##FROM ghcr.io/rse-ops/cuda-ubuntu-20.04:cuda-11.1.1 AS nvcc11.1.1
+##ENV GTEST_COLOR=1
+##COPY . /home/raja/workspace
+##WORKDIR /home/raja/workspace/build
+##RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
+##    cmake -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On -DCMAKE_CUDA_STANDARD=14 -DCMAKE_CUDA_ARCHITECTURES=70 -DENABLE_OPENMP=On .. && \
+##    make -j 4 && \
+##    cd .. && rm -rf build
 
-FROM ghcr.io/rse-ops/cuda-ubuntu-20.04:cuda-11.1.1 AS nvcc11.1.-debug
-ENV GTEST_COLOR=1
-COPY . /home/raja/workspace
-WORKDIR /home/raja/workspace/build
-RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
-    cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On -DCMAKE_CUDA_STANDARD=14 -DCMAKE_CUDA_ARCHITECTURES=70 -DENABLE_OPENMP=On .. && \
-    make -j 4 && \
-    cd .. && rm -rf build
+##FROM ghcr.io/rse-ops/cuda-ubuntu-20.04:cuda-11.1.1 AS nvcc11.1.-debug
+##ENV GTEST_COLOR=1
+##COPY . /home/raja/workspace
+##WORKDIR /home/raja/workspace/build
+##RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
+##    cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On -DCMAKE_CUDA_STANDARD=14 -DCMAKE_CUDA_ARCHITECTURES=70 -DENABLE_OPENMP=On .. && \
+##    make -j 4 && \
+##    cd .. && rm -rf build
 
-FROM ghcr.io/rse-ops/hip-ubuntu-20.04:hip-5.1.3 AS hip5.1.3
-ENV GTEST_COLOR=1
-ENV HCC_AMDGPU_TARGET=gfx900
-COPY . /home/raja/workspace
-WORKDIR /home/raja/workspace/build
-RUN . /opt/spack/share/spack/setup-env.sh && spack load hip llvm-amdgpu && \
-    cmake -DCMAKE_CXX_COMPILER=clang++ -DHIP_PATH=/opt -DENABLE_HIP=On -DENABLE_CUDA=Off -DRAJA_ENABLE_WARNINGS_AS_ERRORS=Off .. && \
-    make -j 6 && \
-    cd .. && rm -rf build
+##FROM ghcr.io/rse-ops/hip-ubuntu-20.04:hip-5.1.3 AS hip5.1.3
+##ENV GTEST_COLOR=1
+##ENV HCC_AMDGPU_TARGET=gfx900
+##COPY . /home/raja/workspace
+##WORKDIR /home/raja/workspace/build
+##RUN . /opt/spack/share/spack/setup-env.sh && spack load hip llvm-amdgpu && \
+##    cmake -DCMAKE_CXX_COMPILER=clang++ -DHIP_PATH=/opt -DENABLE_HIP=On -DENABLE_CUDA=Off -DRAJA_ENABLE_WARNINGS_AS_ERRORS=Off .. && \
+##    make -j 6 && \
+##    cd .. && rm -rf build
 
 FROM ghcr.io/rse-ops/intel-ubuntu-22.04:intel-2022.1.0 AS sycl
 ENV GTEST_COLOR=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
 RUN cmake -DCMAKE_CXX_COMPILER=g++ -DRAJA_ENABLE_WARNINGS=On -DRAJA_ENABLE_TBB=On -DRAJA_DEPRECATED_TESTS=On -DENABLE_OPENMP=On .. && \
     make -j 6 &&\
-    ctest -T test --output-on-failure
+    ctest -T test --output-on-failure && \
+    cd .. && rm -rf build
 
 FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-8.1.0 AS gcc8.1.0
 ENV GTEST_COLOR=1
@@ -19,7 +20,8 @@ COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
 RUN cmake -DCMAKE_CXX_COMPILER=g++ -DRAJA_ENABLE_WARNINGS=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=On -DENABLE_COVERAGE=On -DRAJA_ENABLE_TBB=On -DENABLE_OPENMP=On .. && \
     make -j 6 &&\
-    ctest -T test --output-on-failure
+    ctest -T test --output-on-failure && \
+    cd .. && rm -rf build
 
 FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-9.4.0 AS gcc9.4.0
 ENV GTEST_COLOR=1
@@ -27,7 +29,8 @@ COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
 RUN cmake -DCMAKE_CXX_COMPILER=g++ -DRAJA_ENABLE_WARNINGS=On -DRAJA_ENABLE_TBB=On -DRAJA_ENABLE_RUNTIME_PLUGINS=On -DENABLE_OPENMP=On .. && \
     make -j 6 &&\
-    ctest -T test --output-on-failure
+    ctest -T test --output-on-failure && \
+    cd .. && rm -rf build
 
 FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-11.2.0 AS gcc11.2.0
 ENV GTEST_COLOR=1
@@ -35,7 +38,8 @@ COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
 RUN cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_COMPILER=g++ -DRAJA_ENABLE_WARNINGS=On -DRAJA_ENABLE_TBB=On -DRAJA_ENABLE_BOUNDS_CHECK=ON -DENABLE_OPENMP=On .. && \
     make -j 6 &&\
-    ctest -T test --output-on-failure
+    ctest -T test --output-on-failure && \
+    cd .. && rm -rf build
 
 FROM ghcr.io/rse-ops/clang-ubuntu-20.04:llvm-11.0.0 AS clang11.0.0
 ENV GTEST_COLOR=1
@@ -44,7 +48,8 @@ WORKDIR /home/raja/workspace/build
 RUN . /opt/spack/share/spack/setup-env.sh && export LD_LIBRARY_PATH=/opt/view/lib:$LD_LIBRARY_PATH && \
     cmake -DCMAKE_CXX_COMPILER=clang++ -DRAJA_ENABLE_TBB=On -DENABLE_OPENMP=On .. && \
     make -j 6 &&\
-    ctest -T test --output-on-failure
+    ctest -T test --output-on-failure && \
+    cd .. && rm -rf build
 
 FROM ghcr.io/rse-ops/clang-ubuntu-20.04:llvm-11.0.0 AS clang11.0.0-debug
 ENV GTEST_COLOR=1
@@ -53,7 +58,8 @@ WORKDIR /home/raja/workspace/build
 RUN . /opt/spack/share/spack/setup-env.sh && export LD_LIBRARY_PATH=/opt/view/lib:$LD_LIBRARY_PATH && \
     cmake -DCMAKE_CXX_COMPILER=clang++ -DENABLE_OPENMP=On -DCMAKE_BUILD_TYPE=Debug .. && \
     make -j 6 &&\
-    ctest -T test --output-on-failure
+    ctest -T test --output-on-failure && \
+    cd .. && rm -rf build
 
 FROM ghcr.io/rse-ops/clang-ubuntu-22.04:llvm-13.0.0 AS clang13.0.0
 ENV GTEST_COLOR=1
@@ -62,7 +68,8 @@ WORKDIR /home/raja/workspace/build
 RUN . /opt/spack/share/spack/setup-env.sh && export LD_LIBRARY_PATH=/opt/view/lib:$LD_LIBRARY_PATH && \
     cmake -DCMAKE_CXX_COMPILER=clang++ -DENABLE_OPENMP=On -DCMAKE_BUILD_TYPE=Release .. && \
     make -j 6 &&\
-    ctest -T test --output-on-failure
+    ctest -T test --output-on-failure && \
+    cd .. && rm -rf build
 
 FROM ghcr.io/rse-ops/cuda:cuda-10.1.243-ubuntu-18.04 AS nvcc10.1.243
 ENV GTEST_COLOR=1
@@ -70,7 +77,8 @@ COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
 RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
     cmake -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On -DCMAKE_CUDA_STANDARD=14 -DCMAKE_CUDA_ARCHITECTURES=70 -DENABLE_OPENMP=On .. && \
-    make -j 4
+    make -j 4 && \
+    cd .. && rm -rf build
 
 FROM ghcr.io/rse-ops/cuda-ubuntu-20.04:cuda-11.1.1 AS nvcc11.1.1
 ENV GTEST_COLOR=1
@@ -78,7 +86,8 @@ COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
 RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
     cmake -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On -DCMAKE_CUDA_STANDARD=14 -DCMAKE_CUDA_ARCHITECTURES=70 -DENABLE_OPENMP=On .. && \
-    make -j 4
+    make -j 4 && \
+    cd .. && rm -rf build
 
 FROM ghcr.io/rse-ops/cuda-ubuntu-20.04:cuda-11.1.1 AS nvcc11.1.-debug
 ENV GTEST_COLOR=1
@@ -86,7 +95,8 @@ COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
 RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
     cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On -DCMAKE_CUDA_STANDARD=14 -DCMAKE_CUDA_ARCHITECTURES=70 -DENABLE_OPENMP=On .. && \
-    make -j 4
+    make -j 4 && \
+    cd .. && rm -rf build
 
 FROM ghcr.io/rse-ops/hip-ubuntu-20.04:hip-5.1.3 AS hip5.1.3
 ENV GTEST_COLOR=1
@@ -95,7 +105,8 @@ COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
 RUN . /opt/spack/share/spack/setup-env.sh && spack load hip llvm-amdgpu && \
     cmake -DCMAKE_CXX_COMPILER=clang++ -DHIP_PATH=/opt -DENABLE_HIP=On -DENABLE_CUDA=Off -DRAJA_ENABLE_WARNINGS_AS_ERRORS=Off .. && \
-    make -j 6
+    make -j 6 && \
+    cd .. && rm -rf build
 
 FROM ghcr.io/rse-ops/intel-ubuntu-22.04:intel-2022.1.0 AS sycl
 ENV GTEST_COLOR=1
@@ -104,4 +115,5 @@ WORKDIR /home/raja/workspace/build
 RUN /bin/bash -c "source /opt/view/setvars.sh && \
     cmake -DCMAKE_CXX_COMPILER=dpcpp -DRAJA_ENABLE_SYCL=On -DENABLE_OPENMP=Off -DENABLE_ALL_WARNINGS=Off -DBLT_CXX_STD=c++17 .. && \
     make -j 6 &&\
-    ctest -T test --output-on-failure"
+    ctest -T test --output-on-failure" && \
+    cd .. && rm -rf build

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,10 @@ Notable changes include:
   * New features / API changes:
 
   * Build changes/improvements:
+     * RAJA_ENABLE_OPENMP_TASK CMake option added to enable/disable algorithm 
+       options based on OpenMP task construct. Currently, this only applies
+       to RAJA's OpenMP sort implementation. The default is 'Off'. The option
+       allows users to choose a task implementation if they wish.
 
   * Bug fixes/improvements:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,14 +48,14 @@ jobs:
         docker_target: clang11.0.0-debug
       clang13.0.0:
         docker_target: clang13.0.0
-      nvcc10.1.243:
-        docker_target: nvcc10.1.243
-      nvcc11.1.1:
-        docker_target: nvcc11.1.1
+##      nvcc10.1.243:
+##        docker_target: nvcc10.1.243
+##      nvcc11.1.1:
+##        docker_target: nvcc11.1.1
 ##      nvcc11.1.1-debug:
 ##        docker_target: nvcc11.1.1-debug
-      hip5.1.3:
-        docker_target: hip5.1.3
+##      hip5.1.3:
+##        docker_target: hip5.1.3
       sycl:
         docker_target: sycl
   pool:

--- a/cmake/SetupRajaOptions.cmake
+++ b/cmake/SetupRajaOptions.cmake
@@ -17,6 +17,8 @@ option(RAJA_ENABLE_SYCL "Build SYCL support" Off)
 
 option(RAJA_ENABLE_VECTORIZATION "Build experimental vectorization support" On)
 
+option(RAJA_ENABLE_OPENMP_TASK "Build OpenMP task variants of certain algorithms" Off)
+
 option(RAJA_ENABLE_REPRODUCERS "Build issue reproducers" Off)
 
 option(RAJA_ENABLE_EXERCISES "Build exercises " On)

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -254,12 +254,14 @@ namespace RAJA {
 #if defined(RAJA_ENABLE_OPENMP) && !defined(__HIP_DEVICE_COMPILE__)
 #if defined(_OPENMP)
 #if (_OPENMP >= 200805)
-#define RAJA_ENABLE_OPENMP_TASK
+#if defined(RAJA_ENABLE_OPENMP_TASK)
+#define RAJA_ENABLE_OPENMP_TASK_INTERNAL
 #endif
+#endif // _OPENMP >= 200805
 #else
 #error RAJA configured with RAJA_ENABLE_OPENMP, but _OPENMP is not defined in this code section
-#endif // _OPENMP
-#endif // RAJA_ENABLE_OPENMP && __HIP_DEVICE_COMPILE__
+#endif // else
+#endif // RAJA_ENABLE_OPENMP && !__HIP_DEVICE_COMPILE__
 
 #if defined(RAJA_ENABLE_CUDA) && defined(__CUDACC__)
 #define RAJA_CUDA_ACTIVE

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -176,6 +176,8 @@ static_assert(RAJA_HAS_SOME_CXX14,
 #cmakedefine RAJA_ENABLE_CLANG_CUDA
 #cmakedefine RAJA_ENABLE_HIP
 #cmakedefine RAJA_ENABLE_SYCL
+
+#cmakedefine RAJA_ENABLE_OMP_TASK
 #cmakedefine RAJA_ENABLE_VECTORIZATION
 
 #cmakedefine RAJA_ENABLE_NV_TOOLS_EXT

--- a/include/RAJA/policy/openmp/sort.hpp
+++ b/include/RAJA/policy/openmp/sort.hpp
@@ -49,7 +49,7 @@ namespace openmp
 // this number is arbitrary
 constexpr int get_min_iterates_per_task() { return 128; }
 
-#ifdef RAJA_ENABLE_OPENMP_TASK
+#if defined(RAJA_ENABLE_OPENMP_TASK_INTERNAL)
 /*!
         \brief sort given range using sorter and comparison function
                by spawning tasks
@@ -159,7 +159,7 @@ void sort(Sorter sorter,
 
     const diff_type max_threads = omp_get_max_threads();
 
-#ifdef RAJA_ENABLE_OPENMP_TASK
+#if defined(RAJA_ENABLE_OPENMP_TASK_INTERNAL)
 
     const diff_type iterates_per_task = std::max(n/(2*max_threads), min_iterates_per_task);
 


### PR DESCRIPTION
# Summary

- This PR alters CMake logic to allow users to control whether OpenMP task variants of internal algorithms are on or off.
- It also updates the RADIUSS Spack configs submodule to a branch where the OpenMP task option is exposed as a Spack variant. That submodule branch also updates RAJA version constraints after v2023.06.0 release.