### PR TITLE
Suppresses nodiscard warnings

### DIFF
--- a/include/RAJA/pattern/tensor/internal/MatrixMatrixMultiply.hpp
+++ b/include/RAJA/pattern/tensor/internal/MatrixMatrixMultiply.hpp
@@ -99,12 +99,10 @@ namespace expt
 
         constexpr camp::idx_t num_bc_reg_per_row = s_C_minor_dim_registers;
 
-        RAJA_UNROLL
         for(camp::idx_t c_reg = 0;c_reg < result_type::s_num_registers;++ c_reg){
           camp::idx_t bc_col_reg = c_reg % num_bc_reg_per_row;
           camp::idx_t ac_row = c_reg / num_bc_reg_per_row;
 
-          RAJA_UNROLL
           for(camp::idx_t a_col = 0;a_col < M_SIZE;++ a_col){
             camp::idx_t b_reg = a_col * num_bc_reg_per_row + bc_col_reg;
 
@@ -131,13 +129,11 @@ namespace expt
         constexpr camp::idx_t bc_segbits = result_type::s_segbits;
         constexpr camp::idx_t a_segments_per_register = 1<<bc_segbits;
 
-        RAJA_UNROLL
         for(camp::idx_t ac_row = 0;ac_row < N_SIZE;++ ac_row){
           camp::idx_t c_reg     = ac_row / result_type::s_major_dim_per_register;
           camp::idx_t c_segment = ac_row % result_type::s_major_dim_per_register;
           register_type c_tmp;
 
-          RAJA_UNROLL
           for(camp::idx_t b_reg = 0;b_reg < right_type::s_num_registers;++ b_reg){
 
             camp::idx_t a_segment = ac_row*right_type::s_num_registers + b_reg;
@@ -244,12 +240,10 @@ namespace expt
 
           constexpr camp::idx_t num_ac_reg_per_col = s_C_minor_dim_registers;
 
-          RAJA_UNROLL
           for(camp::idx_t c_reg = 0;c_reg < result_type::s_num_registers;++ c_reg){
             camp::idx_t ac_row_reg = c_reg % num_ac_reg_per_col;
             camp::idx_t bc_col = c_reg / num_ac_reg_per_col;
 
-            RAJA_UNROLL
             for(camp::idx_t b_row = 0;b_row < M_SIZE;++ b_row){
               camp::idx_t a_reg = b_row * num_ac_reg_per_col + ac_row_reg;
 
@@ -279,15 +273,12 @@ namespace expt
 
           camp::idx_t bc_col = 0;
 
-          RAJA_UNROLL
           for(camp::idx_t c_reg = 0;c_reg < N_SIZE/result_type::s_major_dim_per_register;++ c_reg){
 
-            RAJA_UNROLL
             for(camp::idx_t c_segment = 0;c_segment < result_type::s_major_dim_per_register;++ c_segment){
 
               register_type c_tmp;
 
-              RAJA_UNROLL
               for(camp::idx_t a_reg = 0;a_reg < right_type::s_num_registers;++ a_reg){
 
 

--- a/include/RAJA/pattern/tensor/internal/MatrixRegisterImpl.hpp
+++ b/include/RAJA/pattern/tensor/internal/MatrixRegisterImpl.hpp
@@ -1333,7 +1333,6 @@ namespace expt
 
             // loop over output segments, which is also the number of
             // registers in the matrix (no kidding!)
-            RAJA_UNROLL
             for(camp::idx_t outseg = 0;outseg < s_num_registers;++ outseg){
 
               // compute which result register we are accumulating into
@@ -1355,12 +1354,10 @@ namespace expt
 
             // Loop over rows
             camp::idx_t reg = 0;
-            RAJA_UNROLL
             for(camp::idx_t row = 0;row < s_num_rows;++ row){
 
               // compute partial dot products for all registers in this row
               auto rowsum = register_type(0);
-              RAJA_UNROLL
               for(camp::idx_t colreg = 0;colreg < s_minor_dim_registers;++ colreg){
 
                 rowsum = m_registers[reg].multiply_add(v.get_register(colreg), rowsum);
@@ -1385,7 +1382,6 @@ namespace expt
             auto &mv = result.get_register(0);
 
             // Loop over registers, which are also the segments in v
-            RAJA_UNROLL
             for(camp::idx_t m_reg = 0;m_reg < s_num_registers;++ m_reg){
               camp::idx_t v_reg = m_reg >> s_segbits;
               camp::idx_t v_seg = m_reg & ( (1<<s_segbits) - 1);
@@ -1404,14 +1400,12 @@ namespace expt
 
             // Loop over columns (which is also registers)
             camp::idx_t reg = 0;
-            RAJA_UNROLL
             for(camp::idx_t col = 0;col < s_num_columns;++ col){
 
               // extract column value from v
               auto v_col = register_type(v.get(col));
 
               // apply v_col to entire column (1 or more registers)
-              RAJA_UNROLL
               for(camp::idx_t rowreg = 0;rowreg < s_minor_dim_registers;++ rowreg){
 
                 auto &mv = result.get_register(rowreg);
@@ -1444,7 +1438,6 @@ namespace expt
             auto &vm = result.get_register(0);
 
             // Loop over registers, which are also the segments in v
-            RAJA_UNROLL
             for(camp::idx_t m_reg = 0;m_reg < s_num_registers;++ m_reg){
               camp::idx_t v_reg = m_reg >> s_segbits;
               camp::idx_t v_seg = m_reg & ( (1<<s_segbits) - 1);
@@ -1463,10 +1456,8 @@ namespace expt
 
             // Loop over rows
             camp::idx_t reg = 0;
-            RAJA_UNROLL
             for(camp::idx_t row = 0;row < s_num_rows;++ row){
               auto lhs_bcat = register_type(v.get(row));
-              RAJA_UNROLL
               for(camp::idx_t colreg = 0;colreg < s_minor_dim_registers;++ colreg){
 
                 result.get_register(colreg) =
@@ -1493,7 +1484,6 @@ namespace expt
 
             // loop over output segments, which is also the number of
             // registers in the matrix (no kidding!)
-            RAJA_UNROLL
             for(camp::idx_t outseg = 0;outseg < s_num_registers;++ outseg){
 
               // compute which result register we are accumulating into
@@ -1514,12 +1504,10 @@ namespace expt
           else{
             // Loop over rows
             camp::idx_t reg = 0;
-            RAJA_UNROLL
             for(camp::idx_t col = 0;col < s_num_columns;++ col){
 
               // compute partial dot products for all registers in this row
               auto colsum = register_type(0);
-              RAJA_UNROLL
               for(camp::idx_t rowreg = 0;rowreg < s_minor_dim_registers;++ rowreg){
                 colsum = m_registers[reg].multiply_add(v.get_register(rowreg), colsum);
                 reg ++;

--- a/include/RAJA/policy/hip/params/reduce.hpp
+++ b/include/RAJA/policy/hip/params/reduce.hpp
@@ -17,7 +17,7 @@ namespace detail {
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
   init(Reducer<OP, T>& red, const RAJA::hip::detail::hipInfo & cs)
   {
-    hipMalloc( (void**)(&(red.devicetarget)), sizeof(T));
+    (void)hipMalloc( (void**)(&(red.devicetarget)), sizeof(T));
     red.device_mem.allocate(cs.gridDim.x * cs.gridDim.y * cs.gridDim.z);
     red.device_count = RAJA::hip::device_zeroed_mempool_type::getInstance().template malloc<unsigned int>(1);
   }
@@ -34,8 +34,8 @@ namespace detail {
   template<typename EXEC_POL, typename OP, typename T>
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
   resolve(Reducer<OP, T>& red) {
-    hipDeviceSynchronize();
-    hipMemcpy(&red.val, red.devicetarget, sizeof(T), hipMemcpyDeviceToHost);
+    (void)hipDeviceSynchronize();
+    (void)hipMemcpy(&red.val, red.devicetarget, sizeof(T), hipMemcpyDeviceToHost);
     *red.target = OP{}(red.val, *red.target);
   }
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following (modify list as needed):
  - Uses (void) to suppress warnings of hip functions that are marked nodiscard for which RAJA ignores the output.
  - Fixes hip compilation warnings at the request of myself
