### PR TITLE
[Draft] Use resources for allocation

### DIFF
--- a/include/RAJA/pattern/params/reducer.hpp
+++ b/include/RAJA/pattern/params/reducer.hpp
@@ -95,7 +95,7 @@ namespace detail
 #if defined(RAJA_CUDA_ACTIVE) || defined(RAJA_HIP_ACTIVE)
     // Device related attributes.
     value_type * devicetarget = nullptr;
-    RAJA::detail::SoAPtr<value_type, device_mem_pool_t> device_mem;
+    RAJA::detail::SoAPtr<value_type> device_mem;
     unsigned int * device_count = nullptr;
 #endif
 

--- a/include/RAJA/policy/cuda/forall.hpp
+++ b/include/RAJA/policy/cuda/forall.hpp
@@ -187,13 +187,14 @@ __launch_bounds__(BlockSize, 1) __global__
 ////////////////////////////////////////////////////////////////////////
 //
 
-template <typename Iterable, typename LoopBody, size_t BlockSize, size_t BlocksPerSM, bool Async, typename ForallParam>
+template <typename Res, typename Iterable, typename LoopBody, size_t BlockSize, size_t BlocksPerSM, bool Async, typename ForallParam>
 RAJA_INLINE 
 concepts::enable_if_t<
-  resources::EventProxy<resources::Cuda>,
+  resources::EventProxy<Res>,
+  std::is_base_of<resources::Cuda, Res>,
   RAJA::expt::type_traits::is_ForallParamPack<ForallParam>,
   RAJA::expt::type_traits::is_ForallParamPack_empty<ForallParam>>
-forall_impl(resources::Cuda cuda_res,
+forall_impl(Res cuda_res,
             cuda_exec_explicit<BlockSize, BlocksPerSM, Async>,
             Iterable&& iter,
             LoopBody&& loop_body,
@@ -250,16 +251,17 @@ forall_impl(resources::Cuda cuda_res,
     RAJA_FT_END;
   }
 
-  return resources::EventProxy<resources::Cuda>(cuda_res);
+  return resources::EventProxy<Res>(cuda_res);
 }
 
-template <typename Iterable, typename LoopBody, size_t BlockSize, size_t BlocksPerSM, bool Async, typename ForallParam>
+template <typename Res, typename Iterable, typename LoopBody, size_t BlockSize, size_t BlocksPerSM, bool Async, typename ForallParam>
 RAJA_INLINE 
 concepts::enable_if_t<
-  resources::EventProxy<resources::Cuda>,
+  resources::EventProxy<Res>,
+  std::is_base_of<resources::Cuda, Res>,
   RAJA::expt::type_traits::is_ForallParamPack<ForallParam>,
   concepts::negate< RAJA::expt::type_traits::is_ForallParamPack_empty<ForallParam>> >
-forall_impl(resources::Cuda cuda_res,
+forall_impl(Res cuda_res,
             cuda_exec_explicit<BlockSize, BlocksPerSM, Async>,
             Iterable&& iter,
             LoopBody&& loop_body,
@@ -325,7 +327,7 @@ forall_impl(resources::Cuda cuda_res,
     RAJA_FT_END;
   }
 
-  return resources::EventProxy<resources::Cuda>(cuda_res);
+  return resources::EventProxy<Res>(cuda_res);
 }
 
 
@@ -348,13 +350,17 @@ forall_impl(resources::Cuda cuda_res,
  *
  ******************************************************************************
  */
-template <typename LoopBody,
+template <typename Res,
+          typename LoopBody,
           size_t BlockSize,
           size_t BlocksPerSM,
           bool Async,
           typename... SegmentTypes>
-RAJA_INLINE resources::EventProxy<resources::Cuda>
-forall_impl(resources::Cuda r,
+RAJA_INLINE
+concepts::enable_if_t<
+  resources::EventProxy<Res>,
+  std::is_base_of<resources::Cuda, Res> >
+forall_impl(Res r,
             ExecPolicy<seq_segit, cuda_exec_explicit<BlockSize, BlocksPerSM, Async>>,
             const TypedIndexSet<SegmentTypes...>& iset,
             LoopBody&& loop_body)
@@ -369,7 +375,7 @@ forall_impl(resources::Cuda r,
   }  // iterate over segments of index set
 
   if (!Async) RAJA::cuda::synchronize(r);
-  return resources::EventProxy<resources::Cuda>(r);
+  return resources::EventProxy<Res>(r);
 }
 
 }  // namespace cuda

--- a/include/RAJA/policy/cuda/params/reduce.hpp
+++ b/include/RAJA/policy/cuda/params/reduce.hpp
@@ -15,10 +15,10 @@ namespace detail {
   // Init
   template<typename EXEC_POL, typename OP, typename T>
   camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-  init(Reducer<OP, T>& red, const RAJA::cuda::detail::cudaInfo & cs)
+  init(Reducer<OP, T>& red, RAJA::cuda::detail::cudaInfo& cs)
   {
     cudaMalloc( (void**)(&(red.devicetarget)), sizeof(T));
-    red.device_mem.allocate(cs.gridDim.x * cs.gridDim.y * cs.gridDim.z);
+    red.device_mem.allocate(cs.gridDim.x * cs.gridDim.y * cs.gridDim.z, cs.res);
     red.device_count = RAJA::cuda::device_zeroed_mempool_type::getInstance().template malloc<unsigned int>(1);
   }
 

--- a/include/RAJA/policy/cuda/scan.hpp
+++ b/include/RAJA/policy/cuda/scan.hpp
@@ -42,11 +42,13 @@ namespace scan
         \brief explicit inclusive inplace scan given range, function, and
    initial value
 */
-template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, bool Async, typename InputIter, typename Function>
+template <typename Res, size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, bool Async, typename InputIter, typename Function>
 RAJA_INLINE
-resources::EventProxy<resources::Cuda>
+concepts::enable_if_t<
+  resources::EventProxy<Res>,
+  std::is_base_of<resources::Cuda, Res> >
 inclusive_inplace(
-    resources::Cuda cuda_res,
+    Res cuda_res,
     cuda_exec_explicit<BLOCK_SIZE, BLOCKS_PER_SM, Async>,
     InputIter begin,
     InputIter end,
@@ -66,9 +68,8 @@ inclusive_inplace(
                                               len,
                                               stream));
   // Allocate temporary storage
-  d_temp_storage =
-      cuda::device_mempool_type::getInstance().malloc<unsigned char>(
-          temp_storage_bytes);
+  d_temp_storage = cuda_res.template allocate<unsigned char>(
+      temp_storage_bytes, ::RAJA::resources::MemoryAccess::Device);
   // Run
   cudaErrchk(::cub::DeviceScan::InclusiveScan(d_temp_storage,
                                               temp_storage_bytes,
@@ -78,27 +79,30 @@ inclusive_inplace(
                                               len,
                                               stream));
   // Free temporary storage
-  cuda::device_mempool_type::getInstance().free(d_temp_storage);
+  cuda_res.deallocate(d_temp_storage, ::RAJA::resources::MemoryAccess::Device);
 
   cuda::launch(cuda_res, Async);
 
-  return resources::EventProxy<resources::Cuda>(cuda_res);
+  return resources::EventProxy<Res>(cuda_res);
 }
 
 /*!
         \brief explicit exclusive inplace scan given range, function, and
    initial value
 */
-template <size_t BLOCK_SIZE,
+template <typename Res,
+          size_t BLOCK_SIZE,
           size_t BLOCKS_PER_SM,
           bool Async,
           typename InputIter,
           typename Function,
           typename T>
 RAJA_INLINE
-resources::EventProxy<resources::Cuda>
+concepts::enable_if_t<
+  resources::EventProxy<Res>,
+  std::is_base_of<resources::Cuda, Res> >
 exclusive_inplace(
-    resources::Cuda cuda_res,
+    Res cuda_res,
     cuda_exec_explicit<BLOCK_SIZE, BLOCKS_PER_SM, Async>,
     InputIter begin,
     InputIter end,
@@ -120,9 +124,8 @@ exclusive_inplace(
                                               len,
                                               stream));
   // Allocate temporary storage
-  d_temp_storage =
-      cuda::device_mempool_type::getInstance().malloc<unsigned char>(
-          temp_storage_bytes);
+  d_temp_storage = cuda_res.template allocate<unsigned char>(
+      temp_storage_bytes, ::RAJA::resources::MemoryAccess::Device);
   // Run
   cudaErrchk(::cub::DeviceScan::ExclusiveScan(d_temp_storage,
                                               temp_storage_bytes,
@@ -133,27 +136,30 @@ exclusive_inplace(
                                               len,
                                               stream));
   // Free temporary storage
-  cuda::device_mempool_type::getInstance().free(d_temp_storage);
+  cuda_res.deallocate(d_temp_storage, ::RAJA::resources::MemoryAccess::Device);
 
   cuda::launch(cuda_res, Async);
 
-  return resources::EventProxy<resources::Cuda>(cuda_res);
+  return resources::EventProxy<Res>(cuda_res);
 }
 
 /*!
         \brief explicit inclusive scan given input range, output, function, and
    initial value
 */
-template <size_t BLOCK_SIZE,
+template <typename Res,
+          size_t BLOCK_SIZE,
           size_t BLOCKS_PER_SM,
           bool Async,
           typename InputIter,
           typename OutputIter,
           typename Function>
 RAJA_INLINE
-resources::EventProxy<resources::Cuda>
+concepts::enable_if_t<
+  resources::EventProxy<Res>,
+  std::is_base_of<resources::Cuda, Res> >
 inclusive(
-    resources::Cuda cuda_res,
+    Res cuda_res,
     cuda_exec_explicit<BLOCK_SIZE, BLOCKS_PER_SM, Async>,
     InputIter begin,
     InputIter end,
@@ -174,9 +180,8 @@ inclusive(
                                               len,
                                               stream));
   // Allocate temporary storage
-  d_temp_storage =
-      cuda::device_mempool_type::getInstance().malloc<unsigned char>(
-          temp_storage_bytes);
+  d_temp_storage = cuda_res.template allocate<unsigned char>(
+      temp_storage_bytes, ::RAJA::resources::MemoryAccess::Device);
   // Run
   cudaErrchk(::cub::DeviceScan::InclusiveScan(d_temp_storage,
                                               temp_storage_bytes,
@@ -186,18 +191,19 @@ inclusive(
                                               len,
                                               stream));
   // Free temporary storage
-  cuda::device_mempool_type::getInstance().free(d_temp_storage);
+  cuda_res.deallocate(d_temp_storage, ::RAJA::resources::MemoryAccess::Device);
 
   cuda::launch(cuda_res, Async);
 
-  return resources::EventProxy<resources::Cuda>(cuda_res);
+  return resources::EventProxy<Res>(cuda_res);
 }
 
 /*!
         \brief explicit exclusive scan given input range, output, function, and
    initial value
 */
-template <size_t BLOCK_SIZE,
+template <typename Res,
+          size_t BLOCK_SIZE,
           size_t BLOCKS_PER_SM,
           bool Async,
           typename InputIter,
@@ -205,9 +211,11 @@ template <size_t BLOCK_SIZE,
           typename Function,
           typename T>
 RAJA_INLINE
-resources::EventProxy<resources::Cuda>
+concepts::enable_if_t<
+  resources::EventProxy<Res>,
+  std::is_base_of<resources::Cuda, Res> >
 exclusive(
-    resources::Cuda cuda_res,
+    Res cuda_res,
     cuda_exec_explicit<BLOCK_SIZE, BLOCKS_PER_SM, Async>,
     InputIter begin,
     InputIter end,
@@ -230,9 +238,8 @@ exclusive(
                                               len,
                                               stream));
   // Allocate temporary storage
-  d_temp_storage =
-      cuda::device_mempool_type::getInstance().malloc<unsigned char>(
-          temp_storage_bytes);
+  d_temp_storage = cuda_res.template allocate<unsigned char>(
+      temp_storage_bytes, ::RAJA::resources::MemoryAccess::Device);
   // Run
   cudaErrchk(::cub::DeviceScan::ExclusiveScan(d_temp_storage,
                                               temp_storage_bytes,
@@ -243,11 +250,11 @@ exclusive(
                                               len,
                                               stream));
   // Free temporary storage
-  cuda::device_mempool_type::getInstance().free(d_temp_storage);
+  cuda_res.deallocate(d_temp_storage, ::RAJA::resources::MemoryAccess::Device);
 
   cuda::launch(cuda_res, Async);
 
-  return resources::EventProxy<resources::Cuda>(cuda_res);
+  return resources::EventProxy<Res>(cuda_res);
 }
 
 }  // namespace scan

--- a/include/RAJA/util/resource.hpp
+++ b/include/RAJA/util/resource.hpp
@@ -151,19 +151,19 @@ namespace RAJA
 
   namespace type_traits
   {
-    template <typename T> struct is_resource : std::false_type {};
-    template <> struct is_resource<resources::Host> : std::true_type {};
+    template <typename T, typename=void> struct is_resource : std::false_type {};
+    template <typename T> struct is_resource<T, std::enable_if_t<std::is_base_of<resources::Host, T>::value>> : std::true_type {};
 #if defined(RAJA_CUDA_ACTIVE)
-    template <> struct is_resource<resources::Cuda> : std::true_type {};
+    template <typename T> struct is_resource<T, std::enable_if_t<std::is_base_of<resources::Cuda, T>::value>> : std::true_type {};
 #endif
 #if defined(RAJA_HIP_ACTIVE)
-    template <> struct is_resource<resources::Hip> : std::true_type {};
+    template <typename T> struct is_resource<T, std::enable_if_t<std::is_base_of<resources::Hip, T>::value>> : std::true_type {};
 #endif
 #if defined(RAJA_SYCL_ACTIVE)
-    template <> struct is_resource<resources::Sycl> : std::true_type {};
+    template <typename T> struct is_resource<T, std::enable_if_t<std::is_base_of<resources::Sycl, T>::value>> : std::true_type {};
 #endif
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
-    template <> struct is_resource<resources::Omp> : std::true_type {};
+    template <typename T> struct is_resource<T, std::enable_if_t<std::is_base_of<resources::Omp, T>::value>> : std::true_type {};
 #endif
   } // end namespace type_traits
 


### PR DESCRIPTION
# Use resources for allocations

There are allocations in reducers, sorts, and scans that we currently use internal memory pools to satisfy for GPU backends.
Use the resource provided to satisfy those allocations instead.

- This PR is a feature
- It does the following:
  - Adds resource allocation of internal buffers at the request of me and Alan

# Design review (for API changes or additions---delete if unneeded)

On (date), we reviewed this PR.  We discussed the design ideas:

1. First idea or goal
2. Second idea
3. Third idea

This PR implements 1. and 3.  It leaves out 2. for the following reasons

- (impractical)
- (too big)
- (not a good idea anyway)
