### PR TITLE
Fix occupancy calculator and Use common types

### DIFF
--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -286,7 +286,7 @@ policies have the prefix ``hip_``.
                                                          Note that the thread-block
                                                          size must be provided,
                                                          there is no default.
- cuda/hip_exec_occupancy<BLOCK_SIZE>       forall        Execute loop iterations
+ cuda/hip_exec_occ_calc<BLOCK_SIZE>        forall        Execute loop iterations
                                                          mapped to global threads via
                                                          grid striding with multiple
                                                          iterations per global thread

--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -279,12 +279,27 @@ policies have the prefix ``hip_``.
  CUDA/HIP Execution Policies               Works with    Brief description
  ========================================= ============= =======================================
  cuda/hip_exec<BLOCK_SIZE>                 forall,       Execute loop iterations
-                                           scan,         in a GPU kernel launched
-                                           sort          with given thread-block
-                                                         size. Note that the
+                                           scan,         directly mapped to global threads
+                                           sort          in a GPU kernel launched
+                                                         with given thread-block
+                                                         size and unbounded grid size.
+                                                         Note that the thread-block
+                                                         size must be provided,
+                                                         there is no default.
+ cuda/hip_exec_occupancy<BLOCK_SIZE>       forall        Execute loop iterations
+                                                         mapped to global threads via
+                                                         grid striding with multiple
+                                                         iterations per global thread
+                                                         in a GPU kernel launched
+                                                         with given thread-block
+                                                         size and grid size bounded
+                                                         by the maximum occupancy of
+                                                         the kernel. Note that the
                                                          thread-block size must
-                                                         be provided, there is
-                                                         no default.
+                                                         be provided, there is no
+                                                         default. Note this can improve
+                                                         reducer performance in kernels
+                                                         with large iteration counts.
  cuda/hip_launch_t                         launch        Launches a device kernel,
                                                          any code expressed within
                                                          the lambda is executed

--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -286,6 +286,16 @@ policies have the prefix ``hip_``.
                                                          Note that the thread-block
                                                          size must be provided,
                                                          there is no default.
+ cuda/hip_exec_grid<BLOCK_SIZE, GRID_SIZE> forall,       Execute loop iterations
+                                                         mapped to global threads via
+                                                         grid striding with multiple
+                                                         iterations per global thread
+                                                         in a GPU kernel launched
+                                                         with given thread-block
+                                                         size and grid size.
+                                                         Note that the thread-block
+                                                         size and grid size must be
+                                                         provided, there is no default.
  cuda/hip_exec_occ_calc<BLOCK_SIZE>        forall        Execute loop iterations
                                                          mapped to global threads via
                                                          grid striding with multiple

--- a/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
+++ b/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
@@ -418,7 +418,7 @@ struct CudaLaunchHelper<cuda_explicit_launch<async0, num_blocks, num_threads, bl
  * maximizing the number of threads (or blocks) in x, y, then z.
  */
 inline
-cuda_dim_t fitCudaDims(int limit, cuda_dim_t result, cuda_dim_t minimum = cuda_dim_t()){
+cuda_dim_t fitCudaDims(cuda_dim_member_t limit, cuda_dim_t result, cuda_dim_t minimum = cuda_dim_t()){
 
 
   // clamp things to at least 1

--- a/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
+++ b/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
@@ -50,7 +50,7 @@ namespace RAJA
  * Num_blocks is chosen to maximize the number of blocks running concurrently.
  * Blocks per SM must be chosen by the user.
  */
-template <bool async0, size_t num_blocks, size_t num_threads, size_t blocks_per_sm>
+template <bool async0, int num_blocks, int num_threads, int blocks_per_sm>
 struct cuda_explicit_launch {};
 
 /*!
@@ -66,7 +66,7 @@ struct cuda_explicit_launch {};
  * Num_threads is 1024, which may not be appropriate for all kernels.
  * Blocks per SM defaults to 1.
  */
-template <bool async0, size_t num_blocks, size_t num_threads>
+template <bool async0, int num_blocks, int num_threads>
 using cuda_launch = cuda_explicit_launch<async0, num_blocks, num_threads, policy::cuda::MIN_BLOCKS_PER_SM>;
 
 /*!
@@ -74,7 +74,7 @@ using cuda_launch = cuda_explicit_launch<async0, num_blocks, num_threads, policy
  * are determined by the CUDA occupancy calculator.
  * If num_threads is 0 then num_threads is chosen at runtime.
  */
-template <size_t num_threads0, bool async0>
+template <int num_threads0, bool async0>
 using cuda_occ_calc_launch = cuda_explicit_launch<async0, 0, num_threads0, policy::cuda::MIN_BLOCKS_PER_SM>;
 
 namespace statement
@@ -97,7 +97,7 @@ struct CudaKernelExt
  * calculator determine the unspecified values.
  * The kernel launch is synchronous.
  */
-template <size_t num_blocks, size_t num_threads, typename... EnclosedStmts>
+template <int num_blocks, int num_threads, typename... EnclosedStmts>
 using CudaKernelExp =
     CudaKernelExt<cuda_launch<false, num_blocks, num_threads>, EnclosedStmts...>;
 
@@ -107,7 +107,7 @@ using CudaKernelExp =
  * calculator determine the unspecified values.
  * The kernel launch is asynchronous.
  */
-template <size_t num_blocks, size_t num_threads, typename... EnclosedStmts>
+template <int num_blocks, int num_threads, typename... EnclosedStmts>
 using CudaKernelExpAsync =
     CudaKernelExt<cuda_launch<true, num_blocks, num_threads>, EnclosedStmts...>;
 
@@ -134,9 +134,9 @@ using CudaKernelOccAsync =
  * number of threads (specified by num_threads)
  * The kernel launch is synchronous.
  */
-template <size_t num_threads, typename... EnclosedStmts>
+template <int num_threads, typename... EnclosedStmts>
 using CudaKernelFixed =
-    CudaKernelExt<cuda_launch<false, operators::limits<size_t>::max(), num_threads>,
+    CudaKernelExt<cuda_launch<false, operators::limits<int>::max(), num_threads>,
                   EnclosedStmts...>;
 
 /*!
@@ -144,9 +144,9 @@ using CudaKernelFixed =
  * number of threads (specified by num_threads)
  * The kernel launch is asynchronous.
  */
-template <size_t num_threads, typename... EnclosedStmts>
+template <int num_threads, typename... EnclosedStmts>
 using CudaKernelFixedAsync =
-    CudaKernelExt<cuda_launch<true, operators::limits<size_t>::max(), num_threads>,
+    CudaKernelExt<cuda_launch<true, operators::limits<int>::max(), num_threads>,
                   EnclosedStmts...>;
 
 /*!
@@ -154,9 +154,9 @@ using CudaKernelFixedAsync =
  * number of threads (specified by num_threads) and min blocks per sm.
  * The kernel launch is synchronous.
  */
-template <size_t num_threads, size_t blocks_per_sm, typename... EnclosedStmts>
+template <int num_threads, int blocks_per_sm, typename... EnclosedStmts>
 using CudaKernelFixedSM =
-    CudaKernelExt<cuda_explicit_launch<false, operators::limits<size_t>::max(), num_threads, blocks_per_sm>,
+    CudaKernelExt<cuda_explicit_launch<false, operators::limits<int>::max(), num_threads, blocks_per_sm>,
                   EnclosedStmts...>;
 
 /*!
@@ -164,9 +164,9 @@ using CudaKernelFixedSM =
  * number of threads (specified by num_threads) and min blocks per sm.
  * The kernel launch is asynchronous.
  */
-template <size_t num_threads, size_t blocks_per_sm, typename... EnclosedStmts>
+template <int num_threads, int blocks_per_sm, typename... EnclosedStmts>
 using CudaKernelFixedSMAsync =
-    CudaKernelExt<cuda_explicit_launch<true, operators::limits<size_t>::max(), num_threads, blocks_per_sm>,
+    CudaKernelExt<cuda_explicit_launch<true, operators::limits<int>::max(), num_threads, blocks_per_sm>,
                   EnclosedStmts...>;
 
 /*!
@@ -210,7 +210,7 @@ __global__ void CudaKernelLauncher(Data data)
  *
  * This launcher is used by the CudaKerelFixed policies.
  */
-template <size_t BlockSize, size_t BlocksPerSM, typename Data, typename Exec>
+template <int BlockSize, int BlocksPerSM, typename Data, typename Exec>
 __launch_bounds__(BlockSize, BlocksPerSM) __global__
     void CudaKernelLauncherFixed(Data data)
 {
@@ -231,7 +231,7 @@ __launch_bounds__(BlockSize, BlocksPerSM) __global__
  * The default case handles BlockSize != 0 and gets the fixed max block size
  * version of the kernel.
  */
-template<size_t BlockSize, size_t BlocksPerSM, typename Data, typename executor_t>
+template<int BlockSize, int BlocksPerSM, typename Data, typename executor_t>
 struct CudaKernelLauncherGetter
 {
   using type = camp::decay<decltype(&internal::CudaKernelLauncherFixed<BlockSize, BlocksPerSM, Data, executor_t>)>;
@@ -270,7 +270,7 @@ struct CudaLaunchHelper;
  * The user may specify the number of threads and blocks or let one or both be
  * determined at runtime using the CUDA occupancy calculator.
  */
-template<bool async0, size_t num_blocks, size_t num_threads, size_t blocks_per_sm, typename StmtList, typename Data, typename Types>
+template<bool async0, int num_blocks, int num_threads, int blocks_per_sm, typename StmtList, typename Data, typename Types>
 struct CudaLaunchHelper<cuda_explicit_launch<async0, num_blocks, num_threads, blocks_per_sm>,StmtList,Data,Types>
 {
   using Self = CudaLaunchHelper;
@@ -281,8 +281,8 @@ struct CudaLaunchHelper<cuda_explicit_launch<async0, num_blocks, num_threads, bl
 
   using kernelGetter_t = CudaKernelLauncherGetter<(num_threads <= 0) ? 0 : num_threads, (blocks_per_sm <= 0) ? 0 : blocks_per_sm, Data, executor_t>;
 
-  inline static void recommended_blocks_threads(int shmem_size,
-      size_t &recommended_blocks, size_t &recommended_threads)
+  inline static void recommended_blocks_threads(size_t shmem_size,
+      int &recommended_blocks, int &recommended_threads)
   {
     auto func = kernelGetter_t::get();
 
@@ -337,7 +337,7 @@ struct CudaLaunchHelper<cuda_explicit_launch<async0, num_blocks, num_threads, bl
     }
   }
 
-  inline static void max_threads(int RAJA_UNUSED_ARG(shmem_size), size_t &max_threads)
+  inline static void max_threads(size_t RAJA_UNUSED_ARG(shmem_size), int &max_threads)
   {
     if (num_threads <= 0) {
 
@@ -357,8 +357,8 @@ struct CudaLaunchHelper<cuda_explicit_launch<async0, num_blocks, num_threads, bl
     }
   }
 
-  inline static void max_blocks(int shmem_size,
-      size_t &max_blocks, size_t actual_threads)
+  inline static void max_blocks(size_t shmem_size,
+      int &max_blocks, int actual_threads)
   {
     auto func = kernelGetter_t::get();
 
@@ -418,7 +418,7 @@ struct CudaLaunchHelper<cuda_explicit_launch<async0, num_blocks, num_threads, bl
  * maximizing the number of threads (or blocks) in x, y, then z.
  */
 inline
-cuda_dim_t fitCudaDims(size_t limit, cuda_dim_t result, cuda_dim_t minimum = cuda_dim_t()){
+cuda_dim_t fitCudaDims(int limit, cuda_dim_t result, cuda_dim_t minimum = cuda_dim_t()){
 
 
   // clamp things to at least 1
@@ -496,21 +496,21 @@ struct StatementExecutor<
 
 
     // Only launch kernel if we have something to iterate over
-    size_t num_blocks = launch_dims.num_blocks();
-    size_t num_threads = launch_dims.num_threads();
+    int num_blocks = launch_dims.num_blocks();
+    int num_threads = launch_dims.num_threads();
     if (num_blocks > 0 || num_threads > 0) {
 
       //
       // Setup shared memory buffers
       //
-      int shmem = 0;
+      size_t shmem = 0;
 
 
       //
       // Compute the recommended physical kernel blocks and threads
       //
-      size_t recommended_blocks;
-      size_t recommended_threads;
+      int recommended_blocks;
+      int recommended_threads;
       launch_t::recommended_blocks_threads(
           shmem, recommended_blocks, recommended_threads);
 
@@ -518,7 +518,7 @@ struct StatementExecutor<
       //
       // Compute the MAX physical kernel threads
       //
-      size_t max_threads;
+      int max_threads;
       launch_t::max_threads(shmem, max_threads);
 
 
@@ -551,10 +551,10 @@ struct StatementExecutor<
       //
       // Compute the MAX physical kernel blocks
       //
-      size_t max_blocks;
+      int max_blocks;
       launch_t::max_blocks(shmem, max_blocks, launch_dims.num_threads());
 
-      size_t use_blocks;
+      int use_blocks;
 
       if ( launch_dims.num_threads() == recommended_threads ) {
 

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -775,19 +775,19 @@ using global_z = IndexGlobal<named_dim::z, BLOCK_SIZE, GRID_SIZE>;
 // policies usable with forall, scan, and sort
 template <size_t BLOCK_SIZE, size_t GRID_SIZE, size_t BLOCKS_PER_SM, bool Async = false>
 using cuda_exec_grid_explicit = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::Direct, cuda::global_x<BLOCK_SIZE, GRID_SIZE>, BLOCKS_PER_SM, Async>;
+    iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE, GRID_SIZE>, BLOCKS_PER_SM, Async>;
 
 template <size_t BLOCK_SIZE, size_t GRID_SIZE, size_t BLOCKS_PER_SM>
 using cuda_exec_grid_explicit_async = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::Direct, cuda::global_x<BLOCK_SIZE, GRID_SIZE>, BLOCKS_PER_SM, true>;
+    iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE, GRID_SIZE>, BLOCKS_PER_SM, true>;
 
 template <size_t BLOCK_SIZE, size_t GRID_SIZE, bool Async = false>
 using cuda_exec_grid = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::Direct, cuda::global_x<BLOCK_SIZE, GRID_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
+    iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE, GRID_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
 
 template <size_t BLOCK_SIZE, size_t GRID_SIZE>
 using cuda_exec_grid_async = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::Direct, cuda::global_x<BLOCK_SIZE, GRID_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
+    iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE, GRID_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
 
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, bool Async = false>
 using cuda_exec_explicit = policy::cuda::cuda_exec_explicit<

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -806,19 +806,19 @@ using cuda_exec_async = policy::cuda::cuda_exec_explicit<
     iteration_mapping::Direct, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
 
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, bool Async = false>
-using cuda_exec_occupancy_explicit = policy::cuda::cuda_exec_explicit<
+using cuda_exec_occ_calc_explicit = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, Async>;
 
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM>
-using cuda_exec_occupancy_explicit_async = policy::cuda::cuda_exec_explicit<
+using cuda_exec_occ_calc_explicit_async = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, true>;
 
 template <size_t BLOCK_SIZE, bool Async = false>
-using cuda_exec_occupancy = policy::cuda::cuda_exec_explicit<
+using cuda_exec_occ_calc = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
 
 template <size_t BLOCK_SIZE>
-using cuda_exec_occupancy_async = policy::cuda::cuda_exec_explicit<
+using cuda_exec_occ_calc_async = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
 
 // policies usable with WorkGroup

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -805,6 +805,22 @@ template <size_t BLOCK_SIZE>
 using cuda_exec_async = policy::cuda::cuda_exec_explicit<
     iteration_mapping::Direct, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
 
+template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, bool Async = false>
+using cuda_exec_occupancy_explicit = policy::cuda::cuda_exec_explicit<
+    iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, Async>;
+
+template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM>
+using cuda_exec_occupancy_explicit_async = policy::cuda::cuda_exec_explicit<
+    iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, true>;
+
+template <size_t BLOCK_SIZE, bool Async = false>
+using cuda_exec_occupancy = policy::cuda::cuda_exec_explicit<
+    iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
+
+template <size_t BLOCK_SIZE>
+using cuda_exec_occupancy_async = policy::cuda::cuda_exec_explicit<
+    iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
+
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM = policy::cuda::MIN_BLOCKS_PER_SM, bool Async = false>
 using cuda_work_explicit = policy::cuda::cuda_work_explicit<BLOCK_SIZE, BLOCKS_PER_SM, Async>;
 

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -772,7 +772,7 @@ using global_z = IndexGlobal<named_dim::z, BLOCK_SIZE, GRID_SIZE>;
 
 } // namespace cuda
 
-
+// policies usable with forall, scan, and sort
 template <size_t BLOCK_SIZE, size_t GRID_SIZE, size_t BLOCKS_PER_SM, bool Async = false>
 using cuda_exec_grid_explicit = policy::cuda::cuda_exec_explicit<
     iteration_mapping::Direct, cuda::global_x<BLOCK_SIZE, GRID_SIZE>, BLOCKS_PER_SM, Async>;
@@ -821,6 +821,7 @@ template <size_t BLOCK_SIZE>
 using cuda_exec_occupancy_async = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
 
+// policies usable with WorkGroup
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM = policy::cuda::MIN_BLOCKS_PER_SM, bool Async = false>
 using cuda_work_explicit = policy::cuda::cuda_work_explicit<BLOCK_SIZE, BLOCKS_PER_SM, Async>;
 
@@ -835,13 +836,16 @@ using cuda_work_async = policy::cuda::cuda_work_explicit<BLOCK_SIZE, policy::cud
 
 using policy::cuda::unordered_cuda_loop_y_block_iter_x_threadblock_average;
 
+// policies usable with atomics
 using policy::cuda::cuda_atomic;
 using policy::cuda::cuda_atomic_explicit;
 
+// policies usable with reducers
 using policy::cuda::cuda_reduce_base;
 using policy::cuda::cuda_reduce;
 using policy::cuda::cuda_reduce_atomic;
 
+// policies usable with kernel
 using policy::cuda::cuda_block_reduce;
 using policy::cuda::cuda_warp_reduce;
 
@@ -860,8 +864,10 @@ using policy::cuda::cuda_warp_masked_loop;
 using policy::cuda::cuda_thread_masked_direct;
 using policy::cuda::cuda_thread_masked_loop;
 
+// policies usable with synchronize
 using policy::cuda::cuda_synchronize;
 
+// policies usable with launch
 template <bool Async, int num_threads = named_usage::unspecified, size_t BLOCKS_PER_SM = policy::cuda::MIN_BLOCKS_PER_SM>
 using cuda_launch_explicit_t = policy::cuda::cuda_launch_explicit_t<Async, num_threads, BLOCKS_PER_SM>;
 
@@ -869,6 +875,7 @@ template <bool Async, int num_threads = named_usage::unspecified>
 using cuda_launch_t = policy::cuda::cuda_launch_explicit_t<Async, num_threads, policy::cuda::MIN_BLOCKS_PER_SM>;
 
 
+// policies usable with kernel and launch
 template < typename ... indexers >
 using cuda_indexer_direct = policy::cuda::cuda_indexer<
     iteration_mapping::Direct,

--- a/include/RAJA/policy/hip/MemUtils_HIP.hpp
+++ b/include/RAJA/policy/hip/MemUtils_HIP.hpp
@@ -319,19 +319,20 @@ int hip_max_blocks(int block_size)
 
 struct HipOccMaxBlocksThreadsData
 {
-  int prev_shmem_size;
+  size_t prev_shmem_size;
   int max_blocks;
   int max_threads;
 };
 
 template < typename RAJA_UNUSED_ARG(UniqueMarker), typename Func >
 RAJA_INLINE
-void hip_occupancy_max_blocks_threads(Func&& func, int shmem_size,
+void hip_occupancy_max_blocks_threads(Func&& func, size_t shmem_size,
                                        int &max_blocks, int &max_threads)
 {
   static constexpr int uninitialized = -1;
+  static constexpr size_t uninitialized_size_t = std::numeric_limits<size_t>::max();
   static thread_local HipOccMaxBlocksThreadsData data = {
-      uninitialized, uninitialized, uninitialized};
+      uninitialized_size_t, uninitialized, uninitialized};
 
   if (data.prev_shmem_size != shmem_size) {
 
@@ -356,19 +357,20 @@ void hip_occupancy_max_blocks_threads(Func&& func, int shmem_size,
 
 struct HipOccMaxBlocksFixedThreadsData
 {
-  int prev_shmem_size;
+  size_t prev_shmem_size;
   int max_blocks;
   int multiProcessorCount;
 };
 
 template < typename RAJA_UNUSED_ARG(UniqueMarker), int num_threads, typename Func >
 RAJA_INLINE
-void hip_occupancy_max_blocks(Func&& func, int shmem_size,
+void hip_occupancy_max_blocks(Func&& func, size_t shmem_size,
                                int &max_blocks)
 {
   static constexpr int uninitialized = -1;
+  static constexpr size_t uninitialized_size_t = std::numeric_limits<size_t>::max();
   static thread_local HipOccMaxBlocksFixedThreadsData data = {
-      uninitialized, uninitialized, uninitialized};
+      uninitialized_size_t, uninitialized, uninitialized};
 
   if (data.prev_shmem_size != shmem_size) {
 
@@ -399,7 +401,7 @@ void hip_occupancy_max_blocks(Func&& func, int shmem_size,
 
 struct HipOccMaxBlocksVariableThreadsData
 {
-  int prev_shmem_size;
+  size_t prev_shmem_size;
   int prev_num_threads;
   int max_blocks;
   int multiProcessorCount;
@@ -407,12 +409,13 @@ struct HipOccMaxBlocksVariableThreadsData
 
 template < typename RAJA_UNUSED_ARG(UniqueMarker), typename Func >
 RAJA_INLINE
-void hip_occupancy_max_blocks(Func&& func, int shmem_size,
+void hip_occupancy_max_blocks(Func&& func, size_t shmem_size,
                                int &max_blocks, int num_threads)
 {
   static constexpr int uninitialized = 0;
+  static constexpr size_t uninitialized_size_t = std::numeric_limits<size_t>::max();
   static thread_local HipOccMaxBlocksVariableThreadsData data = {
-      uninitialized, uninitialized, uninitialized, uninitialized};
+      uninitialized_size_t, uninitialized, uninitialized, uninitialized};
 
   if ( data.prev_shmem_size  != shmem_size ||
        data.prev_num_threads != num_threads ) {

--- a/include/RAJA/policy/hip/kernel/HipKernel.hpp
+++ b/include/RAJA/policy/hip/kernel/HipKernel.hpp
@@ -189,7 +189,7 @@ __global__ void HipKernelLauncher(Data data)
  *
  * This launcher is used by the HipKerelFixed policies.
  */
-template <size_t BlockSize, typename Data, typename Exec>
+template <int BlockSize, typename Data, typename Exec>
 __launch_bounds__(BlockSize, 1) __global__
     void HipKernelLauncherFixed(Data data)
 {
@@ -210,7 +210,7 @@ __launch_bounds__(BlockSize, 1) __global__
  * The default case handles BlockSize != 0 and gets the fixed max block size
  * version of the kernel.
  */
-template<size_t BlockSize, typename Data, typename executor_t>
+template<int BlockSize, typename Data, typename executor_t>
 struct HipKernelLauncherGetter
 {
   using type = camp::decay<decltype(&internal::HipKernelLauncherFixed<BlockSize, Data, executor_t>)>;
@@ -260,7 +260,7 @@ struct HipLaunchHelper<hip_explicit_launch<async0, num_blocks, num_threads>,Stmt
 
   using kernelGetter_t = HipKernelLauncherGetter<(num_threads <= 0) ? 0 : num_threads, Data, executor_t>;
 
-  inline static void recommended_blocks_threads(int shmem_size,
+  inline static void recommended_blocks_threads(size_t shmem_size,
       int &recommended_blocks, int &recommended_threads)
   {
     auto func = kernelGetter_t::get();
@@ -316,7 +316,7 @@ struct HipLaunchHelper<hip_explicit_launch<async0, num_blocks, num_threads>,Stmt
     }
   }
 
-  inline static void max_threads(int RAJA_UNUSED_ARG(shmem_size), int &max_threads)
+  inline static void max_threads(size_t RAJA_UNUSED_ARG(shmem_size), int &max_threads)
   {
     if (num_threads <= 0) {
 
@@ -336,7 +336,7 @@ struct HipLaunchHelper<hip_explicit_launch<async0, num_blocks, num_threads>,Stmt
     }
   }
 
-  inline static void max_blocks(int shmem_size,
+  inline static void max_blocks(size_t shmem_size,
       int &max_blocks, int actual_threads)
   {
     auto func = kernelGetter_t::get();
@@ -482,7 +482,7 @@ struct StatementExecutor<
       //
       // Setup shared memory buffers
       //
-      int shmem = 0;
+      size_t shmem = 0;
 
 
       //

--- a/include/RAJA/policy/hip/kernel/HipKernel.hpp
+++ b/include/RAJA/policy/hip/kernel/HipKernel.hpp
@@ -397,7 +397,7 @@ struct HipLaunchHelper<hip_explicit_launch<async0, num_blocks, num_threads>,Stmt
  * maximizing the number of threads (or blocks) in x, y, then z.
  */
 inline
-hip_dim_t fitHipDims(unsigned int limit, hip_dim_t result, hip_dim_t minimum = hip_dim_t()){
+hip_dim_t fitHipDims(hip_dim_member_t limit, hip_dim_t result, hip_dim_t minimum = hip_dim_t()){
 
 
   // clamp things to at least 1

--- a/include/RAJA/policy/hip/policy.hpp
+++ b/include/RAJA/policy/hip/policy.hpp
@@ -785,11 +785,11 @@ using hip_exec_async = policy::hip::hip_exec<
     iteration_mapping::Direct, hip::global_x<BLOCK_SIZE>, true>;
 
 template <size_t BLOCK_SIZE, bool Async = false>
-using hip_exec_occupancy = policy::hip::hip_exec<
+using hip_exec_occ_calc = policy::hip::hip_exec<
     iteration_mapping::StridedLoop, hip::global_x<BLOCK_SIZE>, Async>;
 
 template <size_t BLOCK_SIZE>
-using hip_exec_occupancy_async = policy::hip::hip_exec<
+using hip_exec_occ_calc_async = policy::hip::hip_exec<
     iteration_mapping::StridedLoop, hip::global_x<BLOCK_SIZE>, true>;
 
 // policies usable with WorkGroup

--- a/include/RAJA/policy/hip/policy.hpp
+++ b/include/RAJA/policy/hip/policy.hpp
@@ -767,6 +767,7 @@ using global_z = IndexGlobal<named_dim::z, BLOCK_SIZE, GRID_SIZE>;
 
 } // namespace hip
 
+// policies usable with forall, scan, and sort
 template <size_t BLOCK_SIZE, size_t GRID_SIZE, bool Async = false>
 using hip_exec_grid = policy::hip::hip_exec<
     iteration_mapping::Direct, hip::global_x<BLOCK_SIZE, GRID_SIZE>, Async>;
@@ -791,6 +792,7 @@ template <size_t BLOCK_SIZE>
 using hip_exec_occupancy_async = policy::hip::hip_exec<
     iteration_mapping::StridedLoop, hip::global_x<BLOCK_SIZE>, true>;
 
+// policies usable with WorkGroup
 using policy::hip::hip_work;
 
 template <size_t BLOCK_SIZE>
@@ -798,13 +800,16 @@ using hip_work_async = policy::hip::hip_work<BLOCK_SIZE, true>;
 
 using policy::hip::unordered_hip_loop_y_block_iter_x_threadblock_average;
 
+// policies usable with atomics
 using policy::hip::hip_atomic;
 using policy::hip::hip_atomic_explicit;
 
+// policies usable with reducers
 using policy::hip::hip_reduce_base;
 using policy::hip::hip_reduce;
 using policy::hip::hip_reduce_atomic;
 
+// policies usable with kernel
 using policy::hip::hip_block_reduce;
 using policy::hip::hip_warp_reduce;
 
@@ -823,11 +828,14 @@ using policy::hip::hip_warp_masked_loop;
 using policy::hip::hip_thread_masked_direct;
 using policy::hip::hip_thread_masked_loop;
 
+// policies usable with synchronize
 using policy::hip::hip_synchronize;
 
+// policies usable with launch
 using policy::hip::hip_launch_t;
 
 
+// policies usable with kernel and launch
 template < typename ... indexers >
 using hip_indexer_direct = policy::hip::hip_indexer<
     iteration_mapping::Direct,

--- a/include/RAJA/policy/hip/policy.hpp
+++ b/include/RAJA/policy/hip/policy.hpp
@@ -770,11 +770,11 @@ using global_z = IndexGlobal<named_dim::z, BLOCK_SIZE, GRID_SIZE>;
 // policies usable with forall, scan, and sort
 template <size_t BLOCK_SIZE, size_t GRID_SIZE, bool Async = false>
 using hip_exec_grid = policy::hip::hip_exec<
-    iteration_mapping::Direct, hip::global_x<BLOCK_SIZE, GRID_SIZE>, Async>;
+    iteration_mapping::StridedLoop, hip::global_x<BLOCK_SIZE, GRID_SIZE>, Async>;
 
 template <size_t BLOCK_SIZE, size_t GRID_SIZE>
 using hip_exec_grid_async = policy::hip::hip_exec<
-    iteration_mapping::Direct, hip::global_x<BLOCK_SIZE, GRID_SIZE>, true>;
+    iteration_mapping::StridedLoop, hip::global_x<BLOCK_SIZE, GRID_SIZE>, true>;
 
 template <size_t BLOCK_SIZE, bool Async = false>
 using hip_exec = policy::hip::hip_exec<

--- a/include/RAJA/policy/hip/policy.hpp
+++ b/include/RAJA/policy/hip/policy.hpp
@@ -783,6 +783,14 @@ template <size_t BLOCK_SIZE>
 using hip_exec_async = policy::hip::hip_exec<
     iteration_mapping::Direct, hip::global_x<BLOCK_SIZE>, true>;
 
+template <size_t BLOCK_SIZE, bool Async = false>
+using hip_exec_occupancy = policy::hip::hip_exec<
+    iteration_mapping::StridedLoop, hip::global_x<BLOCK_SIZE>, Async>;
+
+template <size_t BLOCK_SIZE>
+using hip_exec_occupancy_async = policy::hip::hip_exec<
+    iteration_mapping::StridedLoop, hip::global_x<BLOCK_SIZE>, true>;
+
 using policy::hip::hip_work;
 
 template <size_t BLOCK_SIZE>

--- a/test/include/RAJA_test-forall-execpol.hpp
+++ b/test/include/RAJA_test-forall-execpol.hpp
@@ -120,7 +120,8 @@ using OpenMPTargetForallAtomicExecPols = OpenMPTargetForallExecPols;
 
 #if defined(RAJA_ENABLE_CUDA)
 using CudaForallExecPols = camp::list< RAJA::cuda_exec<128>,
-                                       RAJA::cuda_exec<256>,
+                                       RAJA::cuda_exec_occ_calc<256>,
+                                       RAJA::cuda_exec_grid<256, 64>,
                                        RAJA::cuda_exec_explicit<256,2> >;
 
 using CudaForallReduceExecPols = CudaForallExecPols;
@@ -131,7 +132,8 @@ using CudaForallAtomicExecPols = CudaForallExecPols;
 
 #if defined(RAJA_ENABLE_HIP)
 using HipForallExecPols = camp::list< RAJA::hip_exec<128>,
-                                      RAJA::hip_exec<256>  >;
+                                      RAJA::hip_exec_occ_calc<256>,
+                                      RAJA::hip_exec_grid<256, 64>  >;
 
 using HipForallReduceExecPols = HipForallExecPols;
 


### PR DESCRIPTION
# Summary
Fix the compilation of the occupancy calculator and Use common types between the hip and cuda backends in the occupancy calculator and kernel policies and kernel launch helper routines.

- This PR is a refactoring, bugfix
- It does the following (modify list as needed):
  - Modifies/refactors occupancy calcualtor and kernel policies and helpers
  - Fixes Occupancy Calculator compilation in certain circumstances
