### PR TITLE
Attempt to fix RTD build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+    - ghostscript
+    - texlive-full
 
 ##
 ## Code for debugging directory structure in readthedocs 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,3 @@
-docutils<0.18
+docutils
+sphinx==6.2.1
+sphinx-rtd-theme==1.2.2


### PR DESCRIPTION
# Summary

- This PR is a bugfix.
- It updates base install requirements for RTD builds so they work. 
- Something changed on read the docs within the last week so that our doc builds were broken.
- @davidbeckingsale @kab163 umpire doc builds are failing similarly. you probably have to make a similar fix there.

The RTD docs for this PR branch are here: https://raja.readthedocs.io/en/task-rhornung67-fix-rtd/