### PR TITLE
[Woptim] RAJAPperf mpi variant

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ variables:
   LLNL_SERVICE_USER: rajasa
 # Use the service user workspace. Solves permission issues, stores everything
 # at the same location whoever triggers a pipeline.
-#  CUSTOM_CI_BUILDS_DIR: /usr/workspace/umdev/gitlab-runner
+#  CUSTOM_CI_BUILDS_DIR: "/usr/workspace/rajasa/gitlab-runner"
 # Tells Gitlab to recursively update the submodules when cloning the project.
   GIT_SUBMODULE_STRATEGY: recursive
 

--- a/docs/sphinx/user_guide/feature/workgroup.rst
+++ b/docs/sphinx/user_guide/feature/workgroup.rst
@@ -79,7 +79,7 @@ loop.
                                         try to force generation of SIMD
                                         instructions via compiler hints in RAJA
                                         internal implementation.
- loop_work                              Execute loop iterations sequentially and
+ seq_work                               Execute loop iterations sequentially and
                                         allow compiler to generate any
                                         optimizations.
  omp_work                               Execute loop iterations in parallel


### PR DESCRIPTION
### Summary

This PR adds the MPI variant to RAJAPerf in RADIUSS Spack Configs.

It is necessary to merge it so that RAJAPerf can point at RAJA@develop is it’s submodule.
