### PR TITLE
Use coarse grained pinned memory with Hip

### DIFF
--- a/include/RAJA/policy/hip/MemUtils_HIP.hpp
+++ b/include/RAJA/policy/hip/MemUtils_HIP.hpp
@@ -58,7 +58,8 @@ struct PinnedAllocator {
   void* malloc(size_t nbytes)
   {
     void* ptr;
-    hipErrchk(hipHostMalloc(&ptr, nbytes, hipHostMallocMapped));
+    hipErrchk(hipHostMalloc(&ptr, nbytes,
+        hipHostMallocMapped | hipHostMallocNonCoherent));
     return ptr;
   }
 


### PR DESCRIPTION
# Use coarse grained pinned memory with Hip

This improves performance because it can be cached on device

- This PR is a  feature
- It does the following:
  - Adds more speed at the request of me