### PR TITLE
Shorten Workgroup Enqueue Multiple Tests

### DIFF
--- a/test/unit/workgroup/tests/test-workgroup-Enqueue-Multiple.hpp
+++ b/test/unit/workgroup/tests/test-workgroup-Enqueue-Multiple.hpp
@@ -145,10 +145,13 @@ TYPED_TEST_P(WorkGroupBasicEnqueueMultipleUnitTest, BasicWorkGroupEnqueueMultipl
   using Allocator = typename camp::at<TypeParam, camp::num<6>>::type;
 
   std::mt19937 rng(std::random_device{}());
-  std::uniform_int_distribution<size_t> dist(0, 128);
+  std::uniform_int_distribution<size_t> dist_rep(0, 16);
+  std::uniform_int_distribution<size_t> dist_num(0, 64);
 
-  testWorkGroupEnqueueMultiple< ExecPolicy, OrderPolicy, StoragePolicy, DispatchTyper, IndexType, Allocator >{}(Xargs{}, false, dist(rng), dist(rng));
-  testWorkGroupEnqueueMultiple< ExecPolicy, OrderPolicy, StoragePolicy, DispatchTyper, IndexType, Allocator >{}(Xargs{}, true, dist(rng), dist(rng));
+  testWorkGroupEnqueueMultiple< ExecPolicy, OrderPolicy, StoragePolicy, DispatchTyper, IndexType, Allocator >{}(
+      Xargs{}, false, dist_rep(rng), dist_num(rng));
+  testWorkGroupEnqueueMultiple< ExecPolicy, OrderPolicy, StoragePolicy, DispatchTyper, IndexType, Allocator >{}(
+      Xargs{}, true, dist_rep(rng), dist_num(rng));
 }
 
 #endif  //__TEST_WORKGROUP_ENQUEUEMULTIPLE__


### PR DESCRIPTION
# Shorten Workgroup Enqueue Multiple Tests

Reduce number of reps and number of enqueues per rep to improve testing times.
This helps asan tests complete without timing out.

- This PR is a refactoring
- It does the following:
  - Modifies/refactors Workgroup Enqueue Multiple Tests
