### PR TITLE
Adjust launch bounds default parameters to avoid emitting a warning

### DIFF
--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -983,7 +983,8 @@ using cuda_launch_explicit_t = policy::cuda::cuda_launch_explicit_t<Async, num_t
 
 //CUDA will emit warnings if we specify BLOCKS_PER_SM but not num of threads
 template <bool Async, int num_threads = named_usage::unspecified>
-using cuda_launch_t = policy::cuda::cuda_launch_explicit_t<Async, num_threads, named_usage::unspecified>;
+using cuda_launch_t = policy::cuda::cuda_launch_explicit_t<Async, num_threads,
+    (num_threads == named_usage::unspecified) ? named_usage::unspecified : policy::cuda::MIN_BLOCKS_PER_SM>;
 
 
 // policies usable with kernel and launch

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -981,8 +981,9 @@ using policy::cuda::cuda_synchronize;
 template <bool Async, int num_threads = named_usage::unspecified, size_t BLOCKS_PER_SM = policy::cuda::MIN_BLOCKS_PER_SM>
 using cuda_launch_explicit_t = policy::cuda::cuda_launch_explicit_t<Async, num_threads, BLOCKS_PER_SM>;
 
+//CUDA will emit warnings if we specify BLOCKS_PER_SM but not num of threads
 template <bool Async, int num_threads = named_usage::unspecified>
-using cuda_launch_t = policy::cuda::cuda_launch_explicit_t<Async, num_threads, policy::cuda::MIN_BLOCKS_PER_SM>;
+using cuda_launch_t = policy::cuda::cuda_launch_explicit_t<Async, num_threads, named_usage::unspecified>;
 
 
 // policies usable with kernel and launch


### PR DESCRIPTION
# Summary

CUDA emits a warning when specifying min threads per block and not number of threads in launch bounds parameters. 
The warning is of the type: 

```
warning : .minnctapersm is ignored when neither .maxntid nor .reqntid is specified.
```