### PR TITLE
[Woptim] draft filter fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,7 +75,7 @@ stages:
     include:
       - local: '.gitlab/custom-jobs-and-variables.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: 'v2023.12.0'
+        ref: 'woptim/draft-filter-fix'
         file: 'pipelines/${CI_MACHINE}.yml'
       - artifact: '${CI_MACHINE}-jobs.yml'
         job: 'generate-job-lists'
@@ -102,7 +102,9 @@ trigger-rajaperf:
 include:
   # [Optional] checks preliminary to running the actual CI test
   - project: 'radiuss/radiuss-shared-ci'
-    ref: 'v2023.12.0'
+    ref: 'woptim/draft-filter-fix'
     file: 'utilities/preliminary-ignore-draft-pr.yml'
   # pipelines subscribed by the project
   - local: '.gitlab/subscribed-pipelines.yml'
+
+# THIS WILL BE A DRAFT, REMOVE THIS LINE AFTER FIRST CI RUN.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,4 +107,4 @@ include:
   # pipelines subscribed by the project
   - local: '.gitlab/subscribed-pipelines.yml'
 
-# THIS WILL BE A DRAFT, REMOVE THIS LINE AFTER FIRST CI RUN.
+# THIS WILL BE A DRAFT, REMOVE THIS LINE AFTER FIRST CI RUN (V2).

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,5 +106,3 @@ include:
     file: 'utilities/preliminary-ignore-draft-pr.yml'
   # pipelines subscribed by the project
   - local: '.gitlab/subscribed-pipelines.yml'
-
-# ADD A TAG TO TEST WHETHER GITLAB GETS FOOLED BY IT OR NOT

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,3 +106,5 @@ include:
     file: 'utilities/preliminary-ignore-draft-pr.yml'
   # pipelines subscribed by the project
   - local: '.gitlab/subscribed-pipelines.yml'
+
+# ADD A TAG TO TEST WHETHER GITLAB GETS FOOLED BY IT OR NOT

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,5 +106,3 @@ include:
     file: 'utilities/preliminary-ignore-draft-pr.yml'
   # pipelines subscribed by the project
   - local: '.gitlab/subscribed-pipelines.yml'
-
-# THIS WILL BE A DRAFT, REMOVE THIS LINE AFTER FIRST CI RUN (V2).

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,7 +75,7 @@ stages:
     include:
       - local: '.gitlab/custom-jobs-and-variables.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: 'woptim/draft-filter-fix'
+        ref: 'v2023.12.3'
         file: 'pipelines/${CI_MACHINE}.yml'
       - artifact: '${CI_MACHINE}-jobs.yml'
         job: 'generate-job-lists'
@@ -102,7 +102,7 @@ trigger-rajaperf:
 include:
   # [Optional] checks preliminary to running the actual CI test
   - project: 'radiuss/radiuss-shared-ci'
-    ref: 'woptim/draft-filter-fix'
+    ref: 'v2023.12.3'
     file: 'utilities/preliminary-ignore-draft-pr.yml'
   # pipelines subscribed by the project
   - local: '.gitlab/subscribed-pipelines.yml'

--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -6,7 +6,8 @@
 #############################################################################
 
 # Override reproducer section to define project specific variables.
-.corona_reproducer_vars: &corona_reproducer_vars
+.corona_reproducer_vars:
+  script:
     - |
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""

--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -6,7 +6,8 @@
 ##############################################################################
 
 # Override reproducer section to define project specific variables.
-.lassen_reproducer_vars: &lassen_reproducer_vars
+.lassen_reproducer_vars:
+  script:
     - |
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""

--- a/.gitlab/jobs/poodle.yml
+++ b/.gitlab/jobs/poodle.yml
@@ -6,7 +6,8 @@
 ##############################################################################
 
 # Override reproducer section to define projet specific variables.
-.poodle_reproducer_vars: &poodle_reproducer_vars
+.poodle_reproducer_vars:
+  script:
     - |
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""

--- a/.gitlab/jobs/ruby.yml
+++ b/.gitlab/jobs/ruby.yml
@@ -6,7 +6,8 @@
 ##############################################################################
 
 # Override reproducer section to define project specific variables.
-.ruby_reproducer_vars: &ruby_reproducer_vars
+.ruby_reproducer_vars:
+  script:
     - |
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -6,7 +6,8 @@
 #############################################################################
 
 # Override reproducer section to define project specific variables.
-.tioga_reproducer_vars: &tioga_reproducer_vars
+.tioga_reproducer_vars:
+  script:
     - |
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""


### PR DESCRIPTION
### Summary

A branch pointing at RADIUSS Shared CI with fixes for the Draft PR filter.

- [x] Fixes persistent failure of PRs initially marked as draft.
- [x] Fixes release branches seen as draft because the tag is used instead of the branch name