### PR TITLE
SYCL Warnings

### DIFF
--- a/include/RAJA/policy/sycl/launch.hpp
+++ b/include/RAJA/policy/sycl/launch.hpp
@@ -73,8 +73,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>> {
 
       q->submit([&](cl::sycl::handler& h) {
 
-        auto s_vec = cl::sycl::accessor<char, 1, cl::sycl::access::mode::read_write,
-                                        cl::sycl::access::target::local> (params.shared_mem_size, h);
+        auto s_vec = ::sycl::local_accessor<char, 1> (params.shared_mem_size, h);
 
         h.parallel_for
           (cl::sycl::nd_range<3>(gridSize, blockSize),
@@ -84,7 +83,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>> {
             ctx.itm = &itm;
 
             //Point to shared memory
-            ctx.shared_mem_ptr = s_vec.get_pointer().get();
+            ctx.shared_mem_ptr = s_vec.get_multi_ptr<::sycl::access::decorated::yes>().get();
 
             body_in(ctx);
 
@@ -165,8 +164,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>> {
 
       q->submit([&](cl::sycl::handler& h) {
 
-        auto s_vec = cl::sycl::accessor<char, 1, cl::sycl::access::mode::read_write,
-                                        cl::sycl::access::target::local> (params.shared_mem_size, h);
+        auto s_vec = ::sycl::local_accessor<char, 1> (params.shared_mem_size, h);
 
         h.parallel_for
           (cl::sycl::nd_range<3>(gridSize, blockSize),
@@ -176,7 +174,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>> {
             ctx.itm = &itm;
 
             //Point to shared memory
-            ctx.shared_mem_ptr = s_vec.get_pointer().get();
+            ctx.shared_mem_ptr = s_vec.get_multi_ptr<::sycl::access::decorated::yes>().get();
 
             (*lbody)(ctx);
 

--- a/scripts/lc-builds/corona_sycl.sh
+++ b/scripts/lc-builds/corona_sycl.sh
@@ -13,7 +13,7 @@ if [[ $# -lt 1 ]]; then
   echo "   1) SYCL compiler installation path"
   echo
   echo "For example: "
-  echo "    corona_sycl.sh /usr/workspace/raja-dev/clang_sycl_a0117ab8692a_hip_gcc10.2.1_rocm5.6.0"
+  echo "    corona_sycl.sh /usr/workspace/raja-dev/clang_sycl_2f03ef85fee5_hip_gcc10.3.1_rocm5.7.1"
   exit
 fi
 


### PR DESCRIPTION
# Summary

- This PR is a refactoring?
- It does the following:
  - Updates to the SYCL 2020 API. Memory accessors have changed and were generating deprecation warnings.
  - Requires similar CAMP update https://github.com/LLNL/camp/pull/147.