### PR TITLE
Add Max Occupancy Fraction Option

### DIFF
--- a/docs/sphinx/user_guide/cook_book.rst
+++ b/docs/sphinx/user_guide/cook_book.rst
@@ -14,8 +14,7 @@ RAJA Cook Book
 
 The following sections show common use case patterns and the recommended
 RAJA features and policies to use with them. They are intended
-for users to copy and paste into their code and provide guidance on
-which policy to use with each backend to get good performance.
+to provide users with complete beyond usage examples beyond what can be found in other parts of the RAJA User Guide. In particular, the examples and discussion provide guidance on RAJA execution policy selection to improve performance of user application codes.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/sphinx/user_guide/cook_book.rst
+++ b/docs/sphinx/user_guide/cook_book.rst
@@ -1,0 +1,24 @@
+.. ##
+.. ## Copyright (c) 2016-24, Lawrence Livermore National Security, LLC
+.. ## and RAJA project contributors. See the RAJA/LICENSE file
+.. ## for details.
+.. ##
+.. ## SPDX-License-Identifier: (BSD-3-Clause)
+.. ##
+
+.. _cook-book-label:
+
+************************
+RAJA Cook Book
+************************
+
+The following sections show common use case patterns and the recommended
+RAJA features and policies to use with them. They are intended
+for users to copy and paste into their code and provide guidance on
+which policy to use with each backend to get good performance.
+
+.. toctree::
+   :maxdepth: 2
+
+   cook_book/reduction
+

--- a/docs/sphinx/user_guide/cook_book/reduction.rst
+++ b/docs/sphinx/user_guide/cook_book/reduction.rst
@@ -12,7 +12,7 @@
 Cooking with Reductions
 =======================
 
-Please see the following section for more info on RAJA reductions:
+Please see the following section for overview discussion about RAJA reductions:
 
  * :ref:`feat-reductions-label`.
 
@@ -50,10 +50,10 @@ The results of these operations will yield the following values:
 
 RAJA uses policy types to specify how things are implemented.
 
-The forall execution policy specifies how the loop is run in the forall.
-For example ``RAJA::seq_exec`` runs a c-style for loop. The
-``RAJA::cuda_exec_rec_for_reduce<256>`` runs the loop as a cuda kernel with
-256 threads per block and other cuda kernel launch parameters, like the
+The forall *execution policy* specifies how the loop is run by the ``RAJA::forall`` method. The following discussion includes examples of several other RAJA execution policies that could be applied.
+For example ``RAJA::seq_exec`` runs a C-style for loop sequentially on a CPU. The
+``RAJA::cuda_exec_rec_for_reduce<256>`` runs the loop as a CUDA GPU kernel with
+256 threads per block and other CUDA kernel launch parameters, like the
 number of blocks, optimized for performance with reducers.::
 
   using exec_policy = RAJA::seq_exec;
@@ -67,7 +67,7 @@ The reduction policy specifies how the reduction is done and must match the
 execution policy. For example ``RAJA::seq_reduce`` does a sequential reduction
 and can only be used with sequential execution policies. The
 ``RAJA::cuda_reduce_atomic`` policy uses atomics, if possible with the given
-data type, and can only be used with cuda execution policies.::
+data type, and can only be used with cuda execution policies. Similarly for other RAJA execution back-ends, such as HIP and OpenMP. Here are example RAJA reduction policies whose names are indicative of which execution policies they work with::
 
   using reduce_policy = RAJA::seq_reduce;
   // using reduce_policy = RAJA::omp_reduce;

--- a/docs/sphinx/user_guide/cook_book/reduction.rst
+++ b/docs/sphinx/user_guide/cook_book/reduction.rst
@@ -48,14 +48,13 @@ The results of these operations will yield the following values:
 
  * vsum == 1000
 
-Here a simple sum reduction is performed using RAJA::
+RAJA uses policy types to specify how things are implemented.
 
-  using reduce_policy = RAJA::seq_reduce;
-  // using reduce_policy = RAJA::omp_reduce;
-  // using reduce_policy = RAJA::omp_target_reduce;
-  // using reduce_policy = RAJA::cuda_reduce;
-  // using reduce_policy = RAJA::hip_reduce;
-  // using reduce_policy = RAJA::sycl_reduce;
+The forall execution policy specifies how the loop is run in the forall.
+For example ``RAJA::seq_exec`` runs a c-style for loop. The
+``RAJA::cuda_exec_rec_for_reduce<256>`` runs the loop as a cuda kernel with
+256 threads per block and other cuda kernel launch parameters, like the
+number of blocks, optimized for performance with reducers.::
 
   using exec_policy = RAJA::seq_exec;
   // using exec_policy = RAJA::omp_parallel_for_exec;
@@ -63,6 +62,22 @@ Here a simple sum reduction is performed using RAJA::
   // using exec_policy = RAJA::cuda_exec_rec_for_reduce<256>;
   // using exec_policy = RAJA::hip_exec_rec_for_reduce<256>;
   // using exec_policy = RAJA::sycl_exec<256>;
+
+The reduction policy specifies how the reduction is done and must match the
+execution policy. For example ``RAJA::seq_reduce`` does a sequential reduction
+and can only be used with sequential execution policies. The
+``RAJA::cuda_reduce_atomic`` policy uses atomics, if possible with the given
+data type, and can only be used with cuda execution policies.::
+
+  using reduce_policy = RAJA::seq_reduce;
+  // using reduce_policy = RAJA::omp_reduce;
+  // using reduce_policy = RAJA::omp_target_reduce;
+  // using reduce_policy = RAJA::cuda_reduce_atomic;
+  // using reduce_policy = RAJA::hip_reduce_atomic;
+  // using reduce_policy = RAJA::sycl_reduce;
+
+
+Here a simple sum reduction is performed using RAJA::
 
   RAJA::ReduceSum<reduce_policy, int> vsum(0);
 

--- a/docs/sphinx/user_guide/cook_book/reduction.rst
+++ b/docs/sphinx/user_guide/cook_book/reduction.rst
@@ -1,0 +1,78 @@
+.. ##
+.. ## Copyright (c) 2016-24, Lawrence Livermore National Security, LLC
+.. ## and other RAJA project contributors. See the RAJA/LICENSE file
+.. ## for details.
+.. ##
+.. ## SPDX-License-Identifier: (BSD-3-Clause)
+.. ##
+
+.. _cook-book-reductions-label:
+
+=======================
+Cooking with Reductions
+=======================
+
+Please see the following section for more info on RAJA reductions:
+
+ * :ref:`feat-reductions-label`.
+
+
+----------------------------
+Reductions with RAJA::forall
+----------------------------
+
+Here is the setup for a simple reduction example::
+
+  const int N = 1000;
+
+  int vec[N];
+
+  for (int i = 0; i < N; ++i) {
+
+    vec[i] = 1;
+
+  }
+
+Here a simple sum reduction is performed in a for loop::
+
+  int vsum = 0;
+
+  // Run a kernel using the reduction objects
+  for (int i = 0; i < N; ++i) {
+
+    vsum += vec[i];
+
+  }
+
+The results of these operations will yield the following values:
+
+ * vsum == 1000
+
+Here a simple sum reduction is performed using RAJA::
+
+  using reduce_policy = RAJA::seq_reduce;
+  // using reduce_policy = RAJA::omp_reduce;
+  // using reduce_policy = RAJA::omp_target_reduce;
+  // using reduce_policy = RAJA::cuda_reduce;
+  // using reduce_policy = RAJA::hip_reduce;
+  // using reduce_policy = RAJA::sycl_reduce;
+
+  using exec_policy = RAJA::seq_exec;
+  // using exec_policy = RAJA::omp_parallel_for_exec;
+  // using exec_policy = RAJA::omp_target_parallel_for_exec<256>;
+  // using exec_policy = RAJA::cuda_exec_rec_for_reduce<256>;
+  // using exec_policy = RAJA::hip_exec_rec_for_reduce<256>;
+  // using exec_policy = RAJA::sycl_exec<256>;
+
+  RAJA::ReduceSum<reduce_policy, int> vsum(0);
+
+  RAJA::forall<exec_policy>( RAJA::RangeSegment(0, N),
+    [=](RAJA::Index_type i) {
+
+    vsum += vec[i];
+
+  });
+
+The results of these operations will yield the following values:
+
+ * vsum.get() == 1000

--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -269,6 +269,7 @@ policies have the prefix ``hip_``.
  cuda/hip_exec_occ_calc<BLOCK_SIZE>        forall        Similar to the occ_max
                                                          policy but may use less
                                                          than the maximum occupancy
+                                                         determined by the occupancy calculator
                                                          of the kernel for performance
                                                          reasons.
  cuda/hip_exec_occ_fraction<BLOCK_SIZE,    forall        Similar to the occ_max
@@ -281,7 +282,13 @@ policies have the prefix ``hip_``.
                                                          concretizer.
  cuda/hip_exec_rec_for_reduce<BLOCK_SIZE>  forall        The cuda/hip exec policy
                                                          that is recommended for
-                                                         use with reducers.
+                                                         use with reducers. In general using
+                                                         the occupancy calculator policies
+                                                         are better but exactly how much
+                                                         occupancy to use differs by platform
+                                                         so this policy provides a simple way
+                                                         to get what works best for that platform
+                                                         without having to know the details.
  cuda/hip_launch_t                         launch        Launches a device kernel,
                                                          any code expressed within
                                                          the lambda is executed

--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -431,7 +431,7 @@ policies have the prefix ``hip_``.
 
 When a cuda/hip policy leaves parameters like the block size and/or grid size
 unspecified a concretizer object is used to decide those parameters. The
-following concretizers are available to use in the cuda/hip_exec_occ_custom
+following concretizers are available to use in the ``cuda/hip_exec_occ_custom``
 policies:
 
 =================================================== =========================================
@@ -451,12 +451,12 @@ Cuda/HipMaxOccupancyConcretizer                     Uses max occupancy.
 Cuda/HipAvoidDeviceMaxThreadOccupancyConcretizer    Avoids using the max occupancy of the
                                                     device in terms of threads.
                                                     Note that it may use the max occupancy
-                                                    of the function if that is below the max
+                                                    of the kernel if that is below the max
                                                     occupancy of the device.
 
 Cuda/HipFractionOffsetOccupancyConcretizer<         Uses a fraction and offset to choose an
     Fraction<size_t, numerator, denomenator>,       occupancy based on the max occupancy
-    BLOCKS_PER_SM_OFFSET>                           Using the following formula.
+    BLOCKS_PER_SM_OFFSET>                           Using the following formula:
                                                     (Fraction * kernel_max_blocks_per_sm +
                                                      BLOCKS_PER_SM_OFFSET) * sm_per_device
 

--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -429,7 +429,7 @@ policies have the prefix ``hip_``.
                                                          thread warp.
  ========================================= ============= =======================================
 
-When a cuda/hip policy leaves parameters like the block size and/or grid size
+When a CUDA or HIP policy leaves parameters like the block size and/or grid size
 unspecified a concretizer object is used to decide those parameters. The
 following concretizers are available to use in the ``cuda/hip_exec_occ_custom``
 policies:

--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -271,13 +271,9 @@ policies have the prefix ``hip_``.
                                                          default. Note this can improve
                                                          reducer performance in kernels
                                                          with large iteration counts.
- cuda/hip_exec_occ_calc_recommended<BLOCK_SIZE> forall   The same as
-                                                         cuda/hip_exec_occ_calc<BLOCK_SIZE>
-                                                         except the grid size upper bound
-                                                         may be modified from the
-                                                         maximum occupancy to improve performance.
-                                                         Note this is the recommended
-                                                         policy to use with reducers.
+ cuda/hip_exec_rec_for_reduce<BLOCK_SIZE>  forall        The cuda/hip exec policy
+                                                         that is recommended for
+                                                         use with reducers.
  cuda/hip_launch_t                         launch        Launches a device kernel,
                                                          any code expressed within
                                                          the lambda is executed

--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -271,6 +271,13 @@ policies have the prefix ``hip_``.
                                                          default. Note this can improve
                                                          reducer performance in kernels
                                                          with large iteration counts.
+ cuda/hip_exec_occ_calc_recommended<BLOCK_SIZE> forall   The same as
+                                                         cuda/hip_exec_occ_calc<BLOCK_SIZE>
+                                                         except the grid size upper bound
+                                                         may be modified from the
+                                                         maximum occupancy to improve performance.
+                                                         Note this is the recommended
+                                                         policy to use with reducers.
  cuda/hip_launch_t                         launch        Launches a device kernel,
                                                          any code expressed within
                                                          the lambda is executed

--- a/docs/sphinx/user_guide/feature/reduction.rst
+++ b/docs/sphinx/user_guide/feature/reduction.rst
@@ -39,6 +39,10 @@ RAJA reductions:
 
  * :ref:`tut-reduction-label`.
 
+Please see the following cook book sections for guidance on policy usage:
+
+ * :ref:`cook-book-reductions-label`.
+
 
 ----------------
 Reduction Types

--- a/docs/sphinx/user_guide/index.rst
+++ b/docs/sphinx/user_guide/index.rst
@@ -32,5 +32,6 @@ to use RAJA in an application can be found in :ref:`app-considerations-label`.
    using_raja
    config_options
    features
+   cook_book
    app_considerations
    tutorial

--- a/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
+++ b/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
@@ -299,184 +299,207 @@ cudaDeviceProp& device_prop()
 
 struct CudaFixedMaxBlocksData
 {
-  int multiProcessorCount;
-  int maxThreadsPerMultiProcessor;
+  int device_sm_per_device;
+  int device_max_threads_per_sm;
 };
 
 RAJA_INLINE
-size_t cuda_max_blocks(size_t block_size)
+CudaFixedMaxBlocksData cuda_max_blocks()
 {
-  static CudaFixedMaxBlocksData data = []() {
-    cudaDeviceProp& prop = cuda::device_prop();
-    return CudaFixedMaxBlocksData{prop.multiProcessorCount,
-                                  prop.maxThreadsPerMultiProcessor};
-  }();
+  static thread_local CudaFixedMaxBlocksData data {
+      cuda::device_prop().multiProcessorCount,
+      cuda::device_prop().maxThreadsPerMultiProcessor };
 
-  size_t max_blocks = data.multiProcessorCount *
-                  (data.maxThreadsPerMultiProcessor / block_size);
-
-  return max_blocks;
+  return data;
 }
 
 struct CudaOccMaxBlocksThreadsData
 {
-  size_t prev_shmem_size;
-  int max_blocks;
-  int max_threads;
+  size_t func_dynamic_shmem_per_block;
+  int func_max_blocks_per_device;
+  int func_max_threads_per_block;
 };
 
-template < typename RAJA_UNUSED_ARG(UniqueMarker), typename Func >
+template < typename RAJA_UNUSED_ARG(UniqueMarker) >
 RAJA_INLINE
-void cuda_occupancy_max_blocks_threads(Func&& func, size_t shmem_size,
-                                       int &max_blocks, int &max_threads)
+CudaOccMaxBlocksThreadsData cuda_occupancy_max_blocks_threads(const void* func,
+    size_t func_dynamic_shmem_per_block)
 {
-  static constexpr int uninitialized = -1;
-  static constexpr size_t uninitialized_size_t = std::numeric_limits<size_t>::max();
-  static thread_local CudaOccMaxBlocksThreadsData data = {
-      uninitialized_size_t, uninitialized, uninitialized};
+  static thread_local CudaOccMaxBlocksThreadsData data {
+      std::numeric_limits<size_t>::max(),
+      -1,
+      -1 };
 
-  if (data.prev_shmem_size != shmem_size) {
+  if (data.func_dynamic_shmem_per_block != func_dynamic_shmem_per_block) {
 
     cudaErrchk(cudaOccupancyMaxPotentialBlockSize(
-        &data.max_blocks, &data.max_threads, func, shmem_size));
+        &data.func_max_blocks_per_device, &data.func_max_threads_per_block, func, func_dynamic_shmem_per_block));
 
-    data.prev_shmem_size = shmem_size;
+    data.func_dynamic_shmem_per_block = func_dynamic_shmem_per_block;
 
   }
 
-  max_blocks  = data.max_blocks;
-  max_threads = data.max_threads;
-
+  return data;
 }
 
-struct CudaOccMaxBlocksFixedThreadsData
+struct CudaOccMaxBlocksData
 {
-  size_t prev_shmem_size;
-  int max_blocks;
-  int multiProcessorCount;
+  size_t func_dynamic_shmem_per_block;
+  int func_threads_per_block;
+  int device_sm_per_device;
+  int device_max_threads_per_sm;
+  int func_max_blocks_per_sm;
 };
 
-template < typename RAJA_UNUSED_ARG(UniqueMarker), int num_threads, typename Func >
+template < typename RAJA_UNUSED_ARG(UniqueMarker), int func_threads_per_block >
 RAJA_INLINE
-void cuda_occupancy_max_blocks(Func&& func, size_t shmem_size,
-                               int &max_blocks)
+CudaOccMaxBlocksData cuda_occupancy_max_blocks(const void* func,
+    size_t func_dynamic_shmem_per_block)
 {
-  static constexpr int uninitialized = -1;
-  static constexpr size_t uninitialized_size_t = std::numeric_limits<size_t>::max();
-  static thread_local CudaOccMaxBlocksFixedThreadsData data = {
-      uninitialized_size_t, uninitialized, uninitialized};
+  static thread_local CudaOccMaxBlocksData data {
+      std::numeric_limits<size_t>::max(),
+      func_threads_per_block,
+      cuda::device_prop().multiProcessorCount,
+      cuda::device_prop().maxThreadsPerMultiProcessor,
+      -1 };
 
-  if (data.prev_shmem_size != shmem_size) {
+  if (data.func_dynamic_shmem_per_block != func_dynamic_shmem_per_block) {
+
+    data.func_dynamic_shmem_per_block = func_dynamic_shmem_per_block;
 
     cudaErrchk(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-        &data.max_blocks, func, num_threads, shmem_size));
-
-    if (data.multiProcessorCount == uninitialized) {
-
-      data.multiProcessorCount = cuda::device_prop().multiProcessorCount;
-
-    }
-
-    data.max_blocks *= data.multiProcessorCount;
-
-    data.prev_shmem_size = shmem_size;
+        &data.func_max_blocks_per_sm, func, func_threads_per_block, func_dynamic_shmem_per_block));
 
   }
 
-  max_blocks = data.max_blocks;
-
+  return data;
 }
 
-struct CudaOccMaxBlocksVariableThreadsData
-{
-  size_t prev_shmem_size;
-  int prev_num_threads;
-  int max_blocks;
-  int multiProcessorCount;
-};
-
-template < typename RAJA_UNUSED_ARG(UniqueMarker), typename Func >
+template < typename RAJA_UNUSED_ARG(UniqueMarker) >
 RAJA_INLINE
-void cuda_occupancy_max_blocks(Func&& func, size_t shmem_size,
-                               int &max_blocks, int num_threads)
+CudaOccMaxBlocksData cuda_occupancy_max_blocks(const void* func,
+    size_t func_dynamic_shmem_per_block, int func_threads_per_block)
 {
-  static constexpr int uninitialized = 0;
-  static constexpr size_t uninitialized_size_t = std::numeric_limits<size_t>::max();
-  static thread_local CudaOccMaxBlocksVariableThreadsData data = {
-      uninitialized_size_t, uninitialized, uninitialized, uninitialized};
+  static thread_local CudaOccMaxBlocksData data {
+      std::numeric_limits<size_t>::max(),
+      -1,
+      cuda::device_prop().multiProcessorCount,
+      cuda::device_prop().maxThreadsPerMultiProcessor,
+      -1 };
 
-  if ( data.prev_shmem_size  != shmem_size ||
-       data.prev_num_threads != num_threads ) {
+  if ( data.func_dynamic_shmem_per_block != func_dynamic_shmem_per_block ||
+       data.func_threads_per_block != func_threads_per_block ) {
+
+    data.func_dynamic_shmem_per_block = func_dynamic_shmem_per_block;
+    data.func_threads_per_block = func_threads_per_block;
 
     cudaErrchk(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-    &data.max_blocks, func, num_threads, shmem_size));
-
-    if (data.multiProcessorCount == uninitialized) {
-
-      data.multiProcessorCount = cuda::device_prop().multiProcessorCount;
-
-    }
-
-    data.max_blocks *= data.multiProcessorCount;
-
-    data.prev_shmem_size  = shmem_size;
-    data.prev_num_threads = num_threads;
+    &data.func_max_blocks_per_sm, func, func_threads_per_block, func_dynamic_shmem_per_block));
 
   }
 
-  max_blocks = data.max_blocks;
-
+  return data;
 }
 
-struct CudaOccupancyDefaults
+/*!
+ ******************************************************************************
+ *
+ * \brief  Cuda Concretizer Implementation.
+ *
+ * \tparam IdxT Index type to use for integer calculations.
+ * \tparam Concretizer Class the determines the max number of blocks to use when
+ *         fitting for the device.
+ * \tparam UniqueMarker A type that is unique to each global function, used to
+ *         help cache the occupancy data for that global function.
+ *
+ ******************************************************************************
+ */
+template < typename IdxT, typename Concretizer, typename UniqueMarker>
+struct ConcretizerImpl
 {
-  CudaOccupancyDefaults(const void* RAJA_UNUSED_ARG(func))
-  { }
-
-  template < typename IdxT >
-  inline auto get_max_grid_size(size_t RAJA_UNUSED_ARG(dynamic_shmem_size),
-                                IdxT RAJA_UNUSED_ARG(block_size)) const
-  {
-    return std::numeric_limits<IdxT>::max();
-  }
-
-  template < typename IdxT = cuda_dim_member_t >
-  inline auto get_max_block_size_and_grid_size(size_t RAJA_UNUSED_ARG(dynamic_shmem_size)) const
-  {
-    return std::make_pair(static_cast<IdxT>(::RAJA::policy::cuda::MAX_BLOCK_SIZE),
-                          std::numeric_limits<IdxT>::max());
-  }
-};
-
-template < typename UniqueMarker >
-struct CudaOccupancyCalculator
-{
-  CudaOccupancyCalculator(const void* func)
+  ConcretizerImpl(const void* func, size_t func_dynamic_shmem_per_block, IdxT len)
     : m_func(func)
+    , m_func_dynamic_shmem_per_block(func_dynamic_shmem_per_block)
+    , m_len(len)
   { }
 
-  template < typename IdxT >
-  inline auto get_max_grid_size(size_t dynamic_shmem_size, IdxT block_size) const
+  // Get the maximum block size
+  IdxT get_max_block_size() const
   {
-    int max_grid_size = -1;
-    ::RAJA::cuda::cuda_occupancy_max_blocks<UniqueMarker>(
-        m_func, dynamic_shmem_size, max_grid_size, block_size);
-    return static_cast<IdxT>(max_grid_size);
+    auto data = cuda_occupancy_max_blocks_threads<UniqueMarker>(
+        m_func, m_func_dynamic_shmem_per_block);
+    IdxT func_max_threads_per_block = data.func_max_threads_per_block;
+    return func_max_threads_per_block;
   }
 
-  template < typename IdxT = cuda_dim_member_t >
-  inline auto get_max_block_size_and_grid_size(size_t dynamic_shmem_size) const
+  // Get a block size that combined with the given grid size is large enough
+  // to do len work, or 0 if not possible
+  IdxT get_block_size_to_fit_len(IdxT func_blocks_per_device) const
   {
-    int max_block_size = -1;
-    int max_grid_size = -1;
-    ::RAJA::cuda::cuda_occupancy_max_blocks_threads<UniqueMarker>(
-        m_func, dynamic_shmem_size, max_grid_size, max_block_size);
-    return std::make_pair(static_cast<IdxT>(max_block_size),
-                          static_cast<IdxT>(max_grid_size));
+    IdxT func_max_threads_per_block = this->get_max_block_size();
+    IdxT func_threads_per_block = RAJA_DIVIDE_CEILING_INT(m_len, func_blocks_per_device);
+    if (func_threads_per_block <= func_max_threads_per_block) {
+      return func_threads_per_block;
+    } else {
+      return IdxT(0);
+    }
+  }
+
+  // Get a grid size that combined with the given block size is large enough
+  // to do len work
+  IdxT get_grid_size_to_fit_len(IdxT func_threads_per_block) const
+  {
+    IdxT func_blocks_per_device = RAJA_DIVIDE_CEILING_INT(m_len, func_threads_per_block);
+    return func_blocks_per_device;
+  }
+
+  // Get a block size and grid size that combined is large enough
+  // to do len work
+  auto get_block_and_grid_size_to_fit_len() const
+  {
+    IdxT func_max_threads_per_block = this->get_max_block_size();
+    IdxT func_blocks_per_device = RAJA_DIVIDE_CEILING_INT(m_len, func_max_threads_per_block);
+    return std::make_pair(func_max_threads_per_block,
+                          func_blocks_per_device);
+  }
+
+  // Get a block size that combined with the given grid size is the smaller of
+  // the amount need to achieve maximum occupancy on the device or
+  // the amount needed to do len work
+  IdxT get_block_size_to_fit_device(IdxT func_blocks_per_device) const
+  {
+    IdxT func_max_threads_per_block = this->get_max_block_size();
+    IdxT func_threads_per_block = RAJA_DIVIDE_CEILING_INT(m_len, func_blocks_per_device);
+    return std::min(func_threads_per_block, func_max_threads_per_block);
+  }
+
+  // Get a grid size that combined with the given block size is the smaller of
+  // the amount need to achieve maximum occupancy on the device or
+  // the amount needed to do len work
+  IdxT get_grid_size_to_fit_device(IdxT func_threads_per_block) const
+  {
+    auto data = cuda_occupancy_max_blocks<UniqueMarker>(
+        m_func, m_func_dynamic_shmem_per_block, func_threads_per_block);
+    IdxT func_max_blocks_per_device = Concretizer::template get_max_grid_size<IdxT>(data);
+    IdxT func_blocks_per_device = RAJA_DIVIDE_CEILING_INT(m_len, func_threads_per_block);
+    return std::min(func_blocks_per_device, func_max_blocks_per_device);
+  }
+
+  // Get a block size and grid size that combined is the smaller of
+  // the amount need to achieve maximum occupancy on the device or
+  // the amount needed to do len work
+  auto get_block_and_grid_size_to_fit_device() const
+  {
+    IdxT func_max_threads_per_block = this->get_max_block_size();
+    IdxT func_blocks_per_device = this->get_grid_size_to_fit_device(func_max_threads_per_block);
+    return std::make_pair(func_max_threads_per_block,
+                          func_blocks_per_device);
   }
 
 private:
   const void* m_func;
+  size_t m_func_dynamic_shmem_per_block;
+  IdxT m_len;
 };
 
 }  // namespace cuda

--- a/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
+++ b/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
@@ -290,7 +290,7 @@ cudaDeviceProp get_device_prop()
   return prop;
 }
 
-//! Get a cached copy of the device properties
+//! Get a copy of the device properties, this copy is cached on first use to speedup later calls
 RAJA_INLINE
 cudaDeviceProp& device_prop()
 {
@@ -421,7 +421,7 @@ CudaOccMaxBlocksData cuda_occupancy_max_blocks(const void* func,
  ******************************************************************************
  *
  * \brief  Concretizer Implementation that chooses block size and/or grid
- *         size when they has not been specified at compile time.
+ *         size when one or both has not been specified at compile time.
  *
  * \tparam IdxT Index type to use for integer calculations.
  * \tparam Concretizer Class that determines the max number of blocks to use

--- a/include/RAJA/policy/cuda/forall.hpp
+++ b/include/RAJA/policy/cuda/forall.hpp
@@ -58,57 +58,6 @@ namespace impl
 /*!
  ******************************************************************************
  *
- * \brief  Cuda grid dimension helper for strided loops template.
- *
- * \tparam MappingModifiers Decide how many blocks to use cased on the . For example StridedLoop uses a grid
- *         stride loop to run multiple iterates in a single thread.
- *
- ******************************************************************************
- */
-template<typename IterationMapping>
-struct GridStrideHelper;
-
-/// handle direct policies with no modifiers
-template<>
-struct GridStrideHelper<::RAJA::iteration_mapping::Direct<>>
-{
-  template < typename IdxT >
-  static constexpr IdxT get_grid_size(IdxT normal_grid_size, IdxT RAJA_UNUSED_ARG(max_grid_size))
-  {
-    return normal_grid_size;
-  }
-};
-
-/// handle strided loop policies with no modifiers
-template<>
-struct GridStrideHelper<::RAJA::iteration_mapping::StridedLoop<
-    named_usage::unspecified>>
-{
-  template < typename IdxT >
-  static constexpr IdxT get_grid_size(IdxT normal_grid_size, IdxT max_grid_size)
-  {
-    return std::min(normal_grid_size, max_grid_size);
-  }
-};
-
-/// handle strided loop policies with multiplier on iterates per thread
-template<typename FractionIdxT, FractionIdxT numerator, FractionIdxT demoninator>
-struct GridStrideHelper<::RAJA::iteration_mapping::StridedLoop<
-    named_usage::unspecified, Fraction<FractionIdxT, numerator, demoninator>>>
-{
-  template < typename IdxT >
-  static constexpr IdxT get_grid_size(IdxT normal_grid_size, IdxT max_grid_size)
-  {
-    // use inverse multiplier on max grid size to affect number of threads
-    using Frac = typename Fraction<IdxT, IdxT(numerator), IdxT(demoninator)>::inverse;
-    max_grid_size = Frac::multiply(max_grid_size);
-    return std::min(normal_grid_size, max_grid_size);
-  }
-};
-
-/*!
- ******************************************************************************
- *
  * \brief  Cuda kernel block and grid dimension calculator template.
  *
  * \tparam IterationMapping Way of mapping from threads in the kernel to
@@ -121,21 +70,21 @@ struct GridStrideHelper<::RAJA::iteration_mapping::StridedLoop<
  *
  ******************************************************************************
  */
-template<typename IterationMapping, typename IterationGetter, typename UniqueMarker>
+template<typename IterationMapping, typename IterationGetter, typename Concretizer, typename UniqueMarker>
 struct ForallDimensionCalculator;
 
 // The general cases handle fixed BLOCK_SIZE > 0 and/or GRID_SIZE > 0
 // there are specializations for named_usage::unspecified
 // but named_usage::ignored is not supported so no specializations are provided
 // and static_asserts in the general case catch unsupported values
-template<named_dim dim, int BLOCK_SIZE, int GRID_SIZE, typename UniqueMarker, typename ... MappingModifiers>
-struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct<MappingModifiers...>,
+template<named_dim dim, int BLOCK_SIZE, int GRID_SIZE, typename Concretizer, typename UniqueMarker>
+struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct,
                                  ::RAJA::cuda::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>,
+                                 Concretizer,
                                  UniqueMarker>
 {
   static_assert(BLOCK_SIZE > 0, "block size must be > 0 or named_usage::unspecified with forall");
   static_assert(GRID_SIZE > 0, "grid size must be > 0 or named_usage::unspecified with forall");
-  static_assert(sizeof...(MappingModifiers) == 0, "MappingModifiers not supported in this configuration");
 
   using IndexGetter = ::RAJA::cuda::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>;
 
@@ -143,8 +92,10 @@ struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct<MappingModifi
   static void set_dimensions(internal::CudaDims& dims, IdxT len,
                              const void* RAJA_UNUSED_ARG(func), size_t RAJA_UNUSED_ARG(dynamic_shmem_size))
   {
-    if ( len > (static_cast<IdxT>(IndexGetter::block_size) *
-                static_cast<IdxT>(IndexGetter::grid_size)) ) {
+    const IdxT block_size = static_cast<IdxT>(IndexGetter::block_size);
+    const IdxT grid_size = static_cast<IdxT>(IndexGetter::grid_size);
+
+    if ( len > (block_size * grid_size) ) {
       RAJA_ABORT_OR_THROW("len exceeds the size of the directly mapped index space");
     }
 
@@ -153,160 +104,168 @@ struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct<MappingModifi
   }
 };
 
-template<named_dim dim, int GRID_SIZE, typename UniqueMarker, typename ... MappingModifiers>
-struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct<MappingModifiers...>,
+template<named_dim dim, int GRID_SIZE, typename Concretizer, typename UniqueMarker>
+struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct,
                                  ::RAJA::cuda::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>,
+                                 Concretizer,
                                  UniqueMarker>
 {
   static_assert(GRID_SIZE > 0, "grid size must be > 0 or named_usage::unspecified with forall");
-  static_assert(sizeof...(MappingModifiers) == 0, "MappingModifiers not supported in this configuration");
 
   using IndexGetter = ::RAJA::cuda::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>;
 
   template < typename IdxT >
   static void set_dimensions(internal::CudaDims& dims, IdxT len,
-                             const void* RAJA_UNUSED_ARG(func), size_t RAJA_UNUSED_ARG(dynamic_shmem_size))
+                             const void* func, size_t dynamic_shmem_size)
   {
-    // BEWARE: if calculated block_size is too high then the kernel launch will fail
-    internal::set_cuda_dim<dim>(dims.threads, RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexGetter::grid_size)));
-    internal::set_cuda_dim<dim>(dims.blocks, static_cast<IdxT>(IndexGetter::grid_size));
+    ::RAJA::cuda::ConcretizerImpl<IdxT, Concretizer, UniqueMarker> concretizer{func, dynamic_shmem_size, len};
+
+    const IdxT grid_size = static_cast<IdxT>(IndexGetter::grid_size);
+    const IdxT block_size = concretizer.get_block_size_to_fit_len(grid_size);
+
+    if ( block_size == IdxT(0) ) {
+      RAJA_ABORT_OR_THROW("len exceeds the size of the directly mapped index space");
+    }
+
+    internal::set_cuda_dim<dim>(dims.threads, block_size);
+    internal::set_cuda_dim<dim>(dims.blocks, grid_size);
   }
 };
 
-template<named_dim dim, int BLOCK_SIZE, typename UniqueMarker, typename ... MappingModifiers>
-struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct<MappingModifiers...>,
+template<named_dim dim, int BLOCK_SIZE, typename Concretizer, typename UniqueMarker>
+struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct,
                                  ::RAJA::cuda::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>,
+                                 Concretizer,
                                  UniqueMarker>
 {
   static_assert(BLOCK_SIZE > 0, "block size must be > 0 or named_usage::unspecified with forall");
-  static_assert(sizeof...(MappingModifiers) == 0, "MappingModifiers not supported in this configuration");
 
   using IndexGetter = ::RAJA::cuda::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>;
 
   template < typename IdxT >
   static void set_dimensions(internal::CudaDims& dims, IdxT len,
-                             const void* RAJA_UNUSED_ARG(func), size_t RAJA_UNUSED_ARG(dynamic_shmem_size))
+                             const void* func, size_t dynamic_shmem_size)
   {
-    internal::set_cuda_dim<dim>(dims.threads, static_cast<IdxT>(IndexGetter::block_size));
-    internal::set_cuda_dim<dim>(dims.blocks, RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexGetter::block_size)));
+    ::RAJA::cuda::ConcretizerImpl<IdxT, Concretizer, UniqueMarker> concretizer{func, dynamic_shmem_size, len};
+
+    const IdxT block_size = static_cast<IdxT>(IndexGetter::block_size);
+    const IdxT grid_size = concretizer.get_grid_size_to_fit_len(block_size);
+
+    internal::set_cuda_dim<dim>(dims.threads, block_size);
+    internal::set_cuda_dim<dim>(dims.blocks, grid_size);
   }
 };
 
-template<named_dim dim, typename UniqueMarker, typename ... MappingModifiers>
-struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct<MappingModifiers...>,
+template<named_dim dim, typename Concretizer, typename UniqueMarker>
+struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct,
                                  ::RAJA::cuda::IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>,
+                                 Concretizer,
                                  UniqueMarker>
 {
-  static_assert(sizeof...(MappingModifiers) == 0, "MappingModifiers not supported in this configuration");
-
   using IndexGetter = ::RAJA::cuda::IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>;
 
   template < typename IdxT >
   static void set_dimensions(internal::CudaDims& dims, IdxT len,
                              const void* func, size_t dynamic_shmem_size)
   {
-    ::RAJA::cuda::CudaOccupancyCalculator<UniqueMarker> oc(func);
-    auto max_sizes = oc.get_max_block_size_and_grid_size(dynamic_shmem_size);
+    ::RAJA::cuda::ConcretizerImpl<IdxT, Concretizer, UniqueMarker> concretizer{func, dynamic_shmem_size, len};
 
-    internal::set_cuda_dim<dim>(dims.threads, static_cast<IdxT>(max_sizes.first));
-    internal::set_cuda_dim<dim>(dims.blocks, RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(max_sizes.first)));
+    const auto sizes = concretizer.get_block_and_grid_size_to_fit_len();
+
+    internal::set_cuda_dim<dim>(dims.threads, sizes.first);
+    internal::set_cuda_dim<dim>(dims.blocks, sizes.second);
   }
 };
 
-template<named_dim dim, int BLOCK_SIZE, int GRID_SIZE, typename UniqueMarker, typename ... MappingModifiers>
-struct ForallDimensionCalculator<::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified, MappingModifiers...>,
+template<named_dim dim, int BLOCK_SIZE, int GRID_SIZE, typename Concretizer, typename UniqueMarker>
+struct ForallDimensionCalculator<::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                  ::RAJA::cuda::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>,
+                                 Concretizer,
                                  UniqueMarker>
 {
   static_assert(BLOCK_SIZE > 0, "block size must be > 0 or named_usage::unspecified with forall");
   static_assert(GRID_SIZE > 0, "grid size must be > 0 or named_usage::unspecified with forall");
-  static_assert(sizeof...(MappingModifiers) == 0, "MappingModifiers not supported in this configuration");
 
-  using IndexMapper = ::RAJA::cuda::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>;
+  using IndexGetter = ::RAJA::cuda::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>;
 
   template < typename IdxT >
   static void set_dimensions(internal::CudaDims& dims, IdxT RAJA_UNUSED_ARG(len),
                              const void* RAJA_UNUSED_ARG(func), size_t RAJA_UNUSED_ARG(dynamic_shmem_size))
   {
-    internal::set_cuda_dim<dim>(dims.threads, static_cast<IdxT>(IndexMapper::block_size));
-    internal::set_cuda_dim<dim>(dims.blocks, static_cast<IdxT>(IndexMapper::grid_size));
+    const IdxT block_size = static_cast<IdxT>(IndexGetter::block_size);
+    const IdxT grid_size = static_cast<IdxT>(IndexGetter::grid_size);
+
+    internal::set_cuda_dim<dim>(dims.threads, block_size);
+    internal::set_cuda_dim<dim>(dims.blocks, grid_size);
   }
 };
 
-template<named_dim dim, int GRID_SIZE, typename UniqueMarker, typename ... MappingModifiers>
-struct ForallDimensionCalculator<::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified, MappingModifiers...>,
+template<named_dim dim, int GRID_SIZE, typename Concretizer, typename UniqueMarker>
+struct ForallDimensionCalculator<::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                  ::RAJA::cuda::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>,
+                                 Concretizer,
                                  UniqueMarker>
 {
   static_assert(GRID_SIZE > 0, "grid size must be > 0 or named_usage::unspecified with forall");
-  static_assert(sizeof...(MappingModifiers) == 0, "MappingModifiers not supported in this configuration");
 
-  using IndexMapper = ::RAJA::cuda::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>;
+  using IndexGetter = ::RAJA::cuda::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>;
 
   template < typename IdxT >
   static void set_dimensions(internal::CudaDims& dims, IdxT len,
                              const void* func, size_t dynamic_shmem_size)
   {
-    ::RAJA::cuda::CudaOccupancyCalculator<UniqueMarker> oc(func);
-    auto max_sizes = oc.get_max_block_size_and_grid_size(dynamic_shmem_size);
+    ::RAJA::cuda::ConcretizerImpl<IdxT, Concretizer, UniqueMarker> concretizer{func, dynamic_shmem_size, len};
 
-    IdxT calculated_block_size = std::min(
-        RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::grid_size)),
-        static_cast<IdxT>(max_sizes.first));
+    const IdxT grid_size = static_cast<IdxT>(IndexGetter::grid_size);
+    const IdxT block_size = concretizer.get_block_size_to_fit_device(grid_size);
 
-    internal::set_cuda_dim<dim>(dims.threads, calculated_block_size);
-    internal::set_cuda_dim<dim>(dims.blocks, static_cast<IdxT>(IndexMapper::grid_size));
+    internal::set_cuda_dim<dim>(dims.threads, block_size);
+    internal::set_cuda_dim<dim>(dims.blocks, grid_size);
   }
 };
 
-template<named_dim dim, int BLOCK_SIZE, typename UniqueMarker, typename ... MappingModifiers>
-struct ForallDimensionCalculator<::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified, MappingModifiers...>,
+template<named_dim dim, int BLOCK_SIZE, typename Concretizer, typename UniqueMarker>
+struct ForallDimensionCalculator<::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                  ::RAJA::cuda::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>,
+                                 Concretizer,
                                  UniqueMarker>
 {
   static_assert(BLOCK_SIZE > 0, "block size must be > 0 or named_usage::unspecified with forall");
 
-  using IterationMapping = ::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified, MappingModifiers...>;
-  using IndexMapper = ::RAJA::cuda::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>;
+  using IndexGetter = ::RAJA::cuda::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>;
 
   template < typename IdxT >
   static void set_dimensions(internal::CudaDims& dims, IdxT len,
                              const void* func, size_t dynamic_shmem_size)
   {
-    ::RAJA::cuda::CudaOccupancyCalculator<UniqueMarker> oc(func);
-    auto max_grid_size = oc.get_max_grid_size(dynamic_shmem_size,
-                                              static_cast<IdxT>(IndexMapper::block_size));
+    ::RAJA::cuda::ConcretizerImpl<IdxT, Concretizer, UniqueMarker> concretizer{func, dynamic_shmem_size, len};
 
-    IdxT calculated_grid_size = GridStrideHelper<IterationMapping>::get_grid_size(
-        RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::block_size)),
-        static_cast<IdxT>(max_grid_size));
+    const IdxT block_size = static_cast<IdxT>(IndexGetter::block_size);
+    const IdxT grid_size = concretizer.get_grid_size_to_fit_device(block_size);
 
-    internal::set_cuda_dim<dim>(dims.threads, static_cast<IdxT>(IndexMapper::block_size));
-    internal::set_cuda_dim<dim>(dims.blocks, calculated_grid_size);
+    internal::set_cuda_dim<dim>(dims.threads, block_size);
+    internal::set_cuda_dim<dim>(dims.blocks, grid_size);
   }
 };
 
-template<named_dim dim, typename UniqueMarker, typename ... MappingModifiers>
-struct ForallDimensionCalculator<::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified, MappingModifiers...>,
+template<named_dim dim, typename Concretizer, typename UniqueMarker>
+struct ForallDimensionCalculator<::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                  ::RAJA::cuda::IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>,
+                                 Concretizer,
                                  UniqueMarker>
 {
-  using IterationMapping = ::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified, MappingModifiers...>;
-  using IndexMapper = ::RAJA::cuda::IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>;
+  using IndexGetter = ::RAJA::cuda::IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>;
 
   template < typename IdxT >
   static void set_dimensions(internal::CudaDims& dims, IdxT len,
                              const void* func, size_t dynamic_shmem_size)
   {
-    ::RAJA::cuda::CudaOccupancyCalculator<UniqueMarker> oc(func);
-    auto max_sizes = oc.get_max_block_size_and_grid_size(dynamic_shmem_size);
+    ::RAJA::cuda::ConcretizerImpl<IdxT, Concretizer, UniqueMarker> concretizer{func, dynamic_shmem_size, len};
 
-    IdxT calculated_grid_size = GridStrideHelper<IterationMapping>::get_grid_size(
-        RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(max_sizes.first)),
-        static_cast<IdxT>(max_sizes.second));
+    const auto sizes = concretizer.get_block_and_grid_size_to_fit_device();
 
-    internal::set_cuda_dim<dim>(dims.threads, static_cast<IdxT>(max_sizes.first));
-    internal::set_cuda_dim<dim>(dims.blocks, calculated_grid_size);
+    internal::set_cuda_dim<dim>(dims.threads, sizes.first);
+    internal::set_cuda_dim<dim>(dims.blocks, sizes.second);
   }
 };
 
@@ -558,7 +517,7 @@ void forallp_cuda_kernel(LOOP_BODY loop_body,
 
 template <typename Iterable, typename LoopBody,
           typename IterationMapping, typename IterationGetter,
-          size_t BlocksPerSM, bool Async,
+          typename Concretizer, size_t BlocksPerSM, bool Async,
           typename ForallParam>
 RAJA_INLINE 
 concepts::enable_if_t<
@@ -566,7 +525,7 @@ concepts::enable_if_t<
   RAJA::expt::type_traits::is_ForallParamPack<ForallParam>,
   RAJA::expt::type_traits::is_ForallParamPack_empty<ForallParam>>
 forall_impl(resources::Cuda cuda_res,
-            ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BlocksPerSM, Async>const&,
+            ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BlocksPerSM, Async>const&,
             Iterable&& iter,
             LoopBody&& loop_body,
             ForallParam)
@@ -574,9 +533,9 @@ forall_impl(resources::Cuda cuda_res,
   using Iterator  = camp::decay<decltype(std::begin(iter))>;
   using LOOP_BODY = camp::decay<LoopBody>;
   using IndexType = camp::decay<decltype(std::distance(std::begin(iter), std::end(iter)))>;
-  using EXEC_POL = ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BlocksPerSM, Async>;
+  using EXEC_POL = ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BlocksPerSM, Async>;
   using UniqueMarker = ::camp::list<IterationMapping, IterationGetter, LOOP_BODY, Iterator, ForallParam>;
-  using DimensionCalculator = impl::ForallDimensionCalculator<IterationMapping, IterationGetter, UniqueMarker>;
+  using DimensionCalculator = impl::ForallDimensionCalculator<IterationMapping, IterationGetter, Concretizer, UniqueMarker>;
 
   //
   // Compute the requested iteration space size
@@ -627,7 +586,7 @@ forall_impl(resources::Cuda cuda_res,
 
 template <typename Iterable, typename LoopBody,
           typename IterationMapping, typename IterationGetter,
-          size_t BlocksPerSM, bool Async,
+          typename Concretizer, size_t BlocksPerSM, bool Async,
           typename ForallParam>
 RAJA_INLINE 
 concepts::enable_if_t<
@@ -635,7 +594,7 @@ concepts::enable_if_t<
   RAJA::expt::type_traits::is_ForallParamPack<ForallParam>,
   concepts::negate< RAJA::expt::type_traits::is_ForallParamPack_empty<ForallParam>> >
 forall_impl(resources::Cuda cuda_res,
-            ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BlocksPerSM, Async> const&,
+            ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BlocksPerSM, Async> const&,
             Iterable&& iter,
             LoopBody&& loop_body,
             ForallParam f_params)
@@ -643,9 +602,9 @@ forall_impl(resources::Cuda cuda_res,
   using Iterator  = camp::decay<decltype(std::begin(iter))>;
   using LOOP_BODY = camp::decay<LoopBody>;
   using IndexType = camp::decay<decltype(std::distance(std::begin(iter), std::end(iter)))>;
-  using EXEC_POL = ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BlocksPerSM, Async>;
+  using EXEC_POL = ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BlocksPerSM, Async>;
   using UniqueMarker = ::camp::list<IterationMapping, IterationGetter, camp::num<BlocksPerSM>, LOOP_BODY, Iterator, ForallParam>;
-  using DimensionCalculator = impl::ForallDimensionCalculator<IterationMapping, IterationGetter, UniqueMarker>;
+  using DimensionCalculator = impl::ForallDimensionCalculator<IterationMapping, IterationGetter, Concretizer, UniqueMarker>;
 
   //
   // Compute the requested iteration space size
@@ -723,11 +682,11 @@ forall_impl(resources::Cuda cuda_res,
  */
 template <typename LoopBody,
           typename IterationMapping, typename IterationGetter,
-          size_t BlocksPerSM, bool Async,
+          typename Concretizer, size_t BlocksPerSM, bool Async,
           typename... SegmentTypes>
 RAJA_INLINE resources::EventProxy<resources::Cuda>
 forall_impl(resources::Cuda r,
-            ExecPolicy<seq_segit, ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BlocksPerSM, Async>>,
+            ExecPolicy<seq_segit, ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BlocksPerSM, Async>>,
             const TypedIndexSet<SegmentTypes...>& iset,
             LoopBody&& loop_body)
 {
@@ -736,7 +695,7 @@ forall_impl(resources::Cuda r,
     iset.segmentCall(r,
                      isi,
                      detail::CallForall(),
-                     ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BlocksPerSM, true>(),
+                     ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BlocksPerSM, true>(),
                      loop_body);
   }  // iterate over segments of index set
 

--- a/include/RAJA/policy/cuda/kernel/For.hpp
+++ b/include/RAJA/policy/cuda/kernel/For.hpp
@@ -45,7 +45,7 @@ template <typename Data,
 struct CudaStatementExecutor<
     Data,
     statement::For<ArgumentId,
-                   RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
+                   RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>,
                    EnclosedStmts...>,
     Types> {
 
@@ -60,7 +60,7 @@ struct CudaStatementExecutor<
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
   using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<
-      RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>>;
+      RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>>;
 
   static inline RAJA_DEVICE
   void exec(Data &data, bool thread_active)

--- a/include/RAJA/policy/cuda/kernel/For.hpp
+++ b/include/RAJA/policy/cuda/kernel/For.hpp
@@ -45,7 +45,7 @@ template <typename Data,
 struct CudaStatementExecutor<
     Data,
     statement::For<ArgumentId,
-                   RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>,
+                   RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
                    EnclosedStmts...>,
     Types> {
 
@@ -60,7 +60,7 @@ struct CudaStatementExecutor<
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
   using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<
-      RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>>;
+      RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>>;
 
   static inline RAJA_DEVICE
   void exec(Data &data, bool thread_active)
@@ -108,7 +108,7 @@ template <typename Data,
 struct CudaStatementExecutor<
     Data,
     statement::For<ArgumentId,
-                   RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>,
+                   RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>,
                    EnclosedStmts...>,
     Types> {
 
@@ -123,7 +123,7 @@ struct CudaStatementExecutor<
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
   using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<
-      RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>>;
+      RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>>;
 
 
   static inline RAJA_DEVICE
@@ -180,7 +180,7 @@ template <typename Data,
 struct CudaStatementExecutor<
     Data,
     statement::For<ArgumentId,
-                   RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>,
+                   RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>,
                    EnclosedStmts...>,
     Types> {
 
@@ -195,7 +195,7 @@ struct CudaStatementExecutor<
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
   using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<
-      RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>>;
+      RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>>;
 
 
   static inline RAJA_DEVICE
@@ -246,7 +246,7 @@ struct CudaStatementExecutor<
     statement::For<ArgumentId, seq_exec, EnclosedStmts...>,
     Types>
 : CudaStatementExecutor<Data, statement::For<ArgumentId,
-      RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop,
+      RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                      kernel_sync_requirement::none,
                                      cuda::IndexGlobal<named_dim::x, named_usage::ignored, named_usage::ignored>>,
       EnclosedStmts...>, Types>

--- a/include/RAJA/policy/cuda/kernel/ForICount.hpp
+++ b/include/RAJA/policy/cuda/kernel/ForICount.hpp
@@ -47,20 +47,20 @@ template <typename Data,
 struct CudaStatementExecutor<
     Data,
     statement::ForICount<ArgumentId, ParamId,
-                         RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
+                         RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>,
                          EnclosedStmts...>,
     Types>
     : CudaStatementExecutor<
         Data,
         statement::For<ArgumentId,
-                       RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
+                       RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>,
                        EnclosedStmts...>,
         Types> {
 
   using Base = CudaStatementExecutor<
       Data,
       statement::For<ArgumentId,
-                     RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
+                     RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>,
                      EnclosedStmts...>,
       Types>;
 

--- a/include/RAJA/policy/cuda/kernel/ForICount.hpp
+++ b/include/RAJA/policy/cuda/kernel/ForICount.hpp
@@ -47,20 +47,20 @@ template <typename Data,
 struct CudaStatementExecutor<
     Data,
     statement::ForICount<ArgumentId, ParamId,
-                         RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>,
+                         RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
                          EnclosedStmts...>,
     Types>
     : CudaStatementExecutor<
         Data,
         statement::For<ArgumentId,
-                       RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>,
+                       RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
                        EnclosedStmts...>,
         Types> {
 
   using Base = CudaStatementExecutor<
       Data,
       statement::For<ArgumentId,
-                     RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>,
+                     RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
                      EnclosedStmts...>,
       Types>;
 
@@ -103,20 +103,20 @@ template <typename Data,
 struct CudaStatementExecutor<
     Data,
     statement::ForICount<ArgumentId, ParamId,
-                         RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>,
+                         RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>,
                          EnclosedStmts...>,
     Types>
     : public CudaStatementExecutor<
         Data,
         statement::For<ArgumentId,
-                       RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>,
+                       RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>,
                        EnclosedStmts...>,
         Types> {
 
   using Base = CudaStatementExecutor<
       Data,
       statement::For<ArgumentId,
-                     RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>,
+                     RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>,
                      EnclosedStmts...>,
       Types>;
 
@@ -166,20 +166,20 @@ template <typename Data,
 struct CudaStatementExecutor<
     Data,
     statement::ForICount<ArgumentId, ParamId,
-                         RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>,
+                         RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>,
                          EnclosedStmts...>,
     Types>
     : public CudaStatementExecutor<
         Data,
         statement::For<ArgumentId,
-                       RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>,
+                       RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>,
                        EnclosedStmts...>,
         Types> {
 
   using Base = CudaStatementExecutor<
       Data,
       statement::For<ArgumentId,
-                     RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>,
+                     RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>,
                      EnclosedStmts...>,
       Types>;
 
@@ -226,7 +226,7 @@ struct CudaStatementExecutor<
     statement::ForICount<ArgumentId, ParamId, seq_exec, EnclosedStmts...>,
     Types>
 : CudaStatementExecutor<Data, statement::ForICount<ArgumentId,
-      RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop,
+      RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                      kernel_sync_requirement::none,
                                      cuda::IndexGlobal<named_dim::x, named_usage::ignored, named_usage::ignored>>,
       EnclosedStmts...>, Types>

--- a/include/RAJA/policy/cuda/kernel/Tile.hpp
+++ b/include/RAJA/policy/cuda/kernel/Tile.hpp
@@ -58,7 +58,7 @@ struct CudaStatementExecutor<
     Data,
     statement::Tile<ArgumentId,
                     RAJA::tile_fixed<chunk_size>,
-                    RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
+                    RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>,
                     EnclosedStmts...>,
                     Types>
   {
@@ -69,7 +69,7 @@ struct CudaStatementExecutor<
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
-  using DimensionCalculator = KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>>;
+  using DimensionCalculator = KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>>;
 
   static inline RAJA_DEVICE
   void exec(Data &data, bool thread_active)

--- a/include/RAJA/policy/cuda/kernel/Tile.hpp
+++ b/include/RAJA/policy/cuda/kernel/Tile.hpp
@@ -58,7 +58,7 @@ struct CudaStatementExecutor<
     Data,
     statement::Tile<ArgumentId,
                     RAJA::tile_fixed<chunk_size>,
-                    RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>,
+                    RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
                     EnclosedStmts...>,
                     Types>
   {
@@ -69,7 +69,7 @@ struct CudaStatementExecutor<
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
-  using DimensionCalculator = KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>>;
+  using DimensionCalculator = KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>>;
 
   static inline RAJA_DEVICE
   void exec(Data &data, bool thread_active)
@@ -143,7 +143,7 @@ struct CudaStatementExecutor<
     Data,
     statement::Tile<ArgumentId,
                     RAJA::tile_fixed<chunk_size>,
-                    RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>,
+                    RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>,
                     EnclosedStmts...>, Types>
   {
 
@@ -153,7 +153,7 @@ struct CudaStatementExecutor<
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
-  using DimensionCalculator = KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>>;
+  using DimensionCalculator = KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>>;
 
   static inline RAJA_DEVICE
   void exec(Data &data, bool thread_active)
@@ -233,7 +233,7 @@ struct CudaStatementExecutor<
     Data,
     statement::Tile<ArgumentId,
                     RAJA::tile_fixed<chunk_size>,
-                    RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>,
+                    RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>,
                     EnclosedStmts...>, Types>
   {
 
@@ -243,7 +243,7 @@ struct CudaStatementExecutor<
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
-  using DimensionCalculator = KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>>;
+  using DimensionCalculator = KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>>;
 
   static inline RAJA_DEVICE
   void exec(Data &data, bool thread_active)
@@ -318,7 +318,7 @@ struct CudaStatementExecutor<
     Data,
     statement::Tile<ArgumentId, TPol, seq_exec, EnclosedStmts...>, Types>
 : CudaStatementExecutor<Data, statement::Tile<ArgumentId, TPol,
-    RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop,
+    RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                    kernel_sync_requirement::none,
                                    cuda::IndexGlobal<named_dim::x, named_usage::ignored, named_usage::ignored>>,
     EnclosedStmts...>, Types>

--- a/include/RAJA/policy/cuda/kernel/TileTCount.hpp
+++ b/include/RAJA/policy/cuda/kernel/TileTCount.hpp
@@ -60,14 +60,14 @@ struct CudaStatementExecutor<
     Data,
     statement::TileTCount<ArgumentId, ParamId,
                     RAJA::tile_fixed<chunk_size>,
-                    RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
+                    RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>,
                     EnclosedStmts...>,
                     Types>
     : public CudaStatementExecutor<
         Data,
         statement::Tile<ArgumentId,
                         RAJA::tile_fixed<chunk_size>,
-                        RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
+                        RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>,
                         EnclosedStmts...>,
                         Types> {
 
@@ -75,7 +75,7 @@ struct CudaStatementExecutor<
       Data,
       statement::Tile<ArgumentId,
                       RAJA::tile_fixed<chunk_size>,
-                      RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
+                      RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>,
                       EnclosedStmts...>,
                       Types>;
 

--- a/include/RAJA/policy/cuda/kernel/TileTCount.hpp
+++ b/include/RAJA/policy/cuda/kernel/TileTCount.hpp
@@ -60,14 +60,14 @@ struct CudaStatementExecutor<
     Data,
     statement::TileTCount<ArgumentId, ParamId,
                     RAJA::tile_fixed<chunk_size>,
-                    RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>,
+                    RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
                     EnclosedStmts...>,
                     Types>
     : public CudaStatementExecutor<
         Data,
         statement::Tile<ArgumentId,
                         RAJA::tile_fixed<chunk_size>,
-                        RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>,
+                        RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
                         EnclosedStmts...>,
                         Types> {
 
@@ -75,7 +75,7 @@ struct CudaStatementExecutor<
       Data,
       statement::Tile<ArgumentId,
                       RAJA::tile_fixed<chunk_size>,
-                      RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct, sync, IndexMapper>,
+                      RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
                       EnclosedStmts...>,
                       Types>;
 
@@ -131,14 +131,14 @@ struct CudaStatementExecutor<
     Data,
     statement::TileTCount<ArgumentId, ParamId,
                     RAJA::tile_fixed<chunk_size>,
-                    RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>,
+                    RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>,
                     EnclosedStmts...>,
                     Types>
     : public CudaStatementExecutor<
         Data,
         statement::Tile<ArgumentId,
                         RAJA::tile_fixed<chunk_size>,
-                        RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>,
+                        RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>,
                         EnclosedStmts...>,
                         Types> {
 
@@ -146,7 +146,7 @@ struct CudaStatementExecutor<
       Data,
       statement::Tile<ArgumentId,
                       RAJA::tile_fixed<chunk_size>,
-                      RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>,
+                      RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>,
                       EnclosedStmts...>,
                       Types>;
 
@@ -209,14 +209,14 @@ struct CudaStatementExecutor<
     Data,
     statement::TileTCount<ArgumentId, ParamId,
                     RAJA::tile_fixed<chunk_size>,
-                    RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>,
+                    RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>,
                     EnclosedStmts...>,
                     Types>
     : public CudaStatementExecutor<
         Data,
         statement::Tile<ArgumentId,
                         RAJA::tile_fixed<chunk_size>,
-                        RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>,
+                        RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>,
                         EnclosedStmts...>,
                         Types> {
 
@@ -224,7 +224,7 @@ struct CudaStatementExecutor<
       Data,
       statement::Tile<ArgumentId,
                       RAJA::tile_fixed<chunk_size>,
-                      RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>,
+                      RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>,
                       EnclosedStmts...>,
                       Types>;
 
@@ -281,7 +281,7 @@ struct CudaStatementExecutor<
     Data,
     statement::TileTCount<ArgumentId, ParamId, TPol, seq_exec, EnclosedStmts...>, Types>
 : CudaStatementExecutor<Data, statement::TileTCount<ArgumentId, ParamId, TPol,
-    RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop,
+    RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                    kernel_sync_requirement::none,
                                    cuda::IndexGlobal<named_dim::x, named_usage::ignored, named_usage::ignored>>,
     EnclosedStmts...>, Types>

--- a/include/RAJA/policy/cuda/kernel/internal.hpp
+++ b/include/RAJA/policy/cuda/kernel/internal.hpp
@@ -217,7 +217,7 @@ struct KernelDimensionCalculator;
 
 // specialization for direct sequential policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::ignored, named_usage::ignored>>>
 {
@@ -234,7 +234,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 
 // specialization for direct thread policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::unspecified, named_usage::ignored>>>
 {
@@ -250,7 +250,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, BLOCK_SIZE, named_usage::ignored>>>
 {
@@ -271,7 +271,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 
 // specialization for direct block policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::ignored, named_usage::unspecified>>>
 {
@@ -286,7 +286,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 };
 ///
 template<named_dim dim, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::ignored, GRID_SIZE>>>
 {
@@ -307,7 +307,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 
 // specialization for direct global policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>>>
 {
@@ -323,7 +323,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 };
 ///
 template<named_dim dim, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>>>
 {
@@ -343,7 +343,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>>>
 {
@@ -362,7 +362,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>>>
 {
@@ -388,7 +388,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 
 // specialization for strided loop sequential policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::ignored, named_usage::ignored>>>
 {
@@ -402,7 +402,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 
 // specialization for strided loop thread policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::unspecified, named_usage::ignored>>>
 {
@@ -418,7 +418,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, BLOCK_SIZE, named_usage::ignored>>>
 {
@@ -436,7 +436,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 
 // specialization for strided loop block policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::ignored, named_usage::unspecified>>>
 {
@@ -451,7 +451,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 };
 ///
 template<named_dim dim, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::ignored, GRID_SIZE>>>
 {
@@ -469,7 +469,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 
 // specialization for strided loop global policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>>>
 {
@@ -488,7 +488,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 };
 ///
 template<named_dim dim, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>>>
 {
@@ -508,7 +508,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>>>
 {
@@ -527,7 +527,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     cuda::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>>>
 {

--- a/include/RAJA/policy/cuda/kernel/internal.hpp
+++ b/include/RAJA/policy/cuda/kernel/internal.hpp
@@ -217,7 +217,7 @@ struct KernelDimensionCalculator;
 
 // specialization for direct sequential policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::ignored, named_usage::ignored>>>
 {
@@ -234,7 +234,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 
 // specialization for direct thread policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::unspecified, named_usage::ignored>>>
 {
@@ -250,7 +250,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     cuda::IndexGlobal<dim, BLOCK_SIZE, named_usage::ignored>>>
 {
@@ -271,7 +271,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 
 // specialization for direct block policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::ignored, named_usage::unspecified>>>
 {
@@ -286,7 +286,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 };
 ///
 template<named_dim dim, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::ignored, GRID_SIZE>>>
 {
@@ -307,7 +307,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 
 // specialization for direct global policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>>>
 {
@@ -323,7 +323,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 };
 ///
 template<named_dim dim, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     cuda::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>>>
 {
@@ -343,7 +343,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     cuda::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>>>
 {
@@ -362,7 +362,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapp
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     cuda::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>>>
 {

--- a/include/RAJA/policy/cuda/launch.hpp
+++ b/include/RAJA/policy/cuda/launch.hpp
@@ -348,7 +348,7 @@ struct LaunchExecute<RAJA::policy::cuda::cuda_launch_explicit_t<async, nthreads,
    CUDA generic loop implementations
 */
 template <typename SEGMENT, typename IndexMapper>
-struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
+struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper>,
                    SEGMENT> {
@@ -371,7 +371,7 @@ struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Dir
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
+struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper0,
                                                   IndexMapper1>,
@@ -399,7 +399,7 @@ struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Dir
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
+struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper0,
                                                   IndexMapper1,
@@ -433,7 +433,7 @@ struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Dir
 };
 
 template <typename SEGMENT, typename IndexMapper>
-struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper>,
                    SEGMENT> {
@@ -457,7 +457,7 @@ struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Str
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper0,
                                                   IndexMapper1>,
@@ -493,7 +493,7 @@ struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Str
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper0,
                                                   IndexMapper1,
@@ -538,7 +538,7 @@ struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Str
 };
 
 template <typename SEGMENT, typename IndexMapper>
-struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
+struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper>,
                          SEGMENT> {
@@ -560,7 +560,7 @@ struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mappin
   }
 };
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
+struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper0,
                                                         IndexMapper1>,
@@ -590,7 +590,7 @@ struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mappin
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
+struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper0,
                                                         IndexMapper1,
@@ -625,7 +625,7 @@ struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mappin
 };
 
 template <typename SEGMENT, typename IndexMapper>
-struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper>,
                          SEGMENT> {
@@ -649,7 +649,7 @@ struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mappin
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper0,
                                                         IndexMapper1>,
@@ -686,7 +686,7 @@ struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mappin
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper0,
                                                         IndexMapper1,
@@ -736,18 +736,18 @@ struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mappin
    CUDA generic flattened loop implementations
 */
 template<typename SEGMENT, kernel_sync_requirement sync, typename IndexMapper0>
-struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::Direct,
+struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::Direct<>,
                                                           sync,
                                                           IndexMapper0>,
                    SEGMENT>
-    :  LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
+    :  LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
                                                   sync,
                                                   IndexMapper0>,
                    SEGMENT>
 {};
 
 template<typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::Direct,
+struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::Direct<>,
                                                           kernel_sync_requirement::none,
                                                           IndexMapper0,
                                                           IndexMapper1>,
@@ -777,7 +777,7 @@ struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapp
 };
 
 template<typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::Direct,
+struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::Direct<>,
                                                           kernel_sync_requirement::none,
                                                           IndexMapper0,
                                                           IndexMapper1,
@@ -810,18 +810,18 @@ struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapp
 };
 
 template<typename SEGMENT, kernel_sync_requirement sync, typename IndexMapper0>
-struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                           sync,
                                                           IndexMapper0>,
                    SEGMENT>
-    :  LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop,
+    :  LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                   sync,
                                                   IndexMapper0>,
                    SEGMENT>
 {};
 
 template<typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                           kernel_sync_requirement::none,
                                                           IndexMapper0,
                                                           IndexMapper1>,
@@ -852,7 +852,7 @@ struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapp
 };
 
 template<typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                           kernel_sync_requirement::none,
                                                           IndexMapper0,
                                                           IndexMapper1,
@@ -890,7 +890,7 @@ struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapp
    CUDA generic tile implementations
 */
 template <typename SEGMENT, typename IndexMapper>
-struct TileExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
+struct TileExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper>,
                    SEGMENT> {
@@ -914,7 +914,7 @@ struct TileExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Dir
 };
 
 template <typename SEGMENT, typename IndexMapper>
-struct TileExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop,
+struct TileExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper>,
                    SEGMENT> {
@@ -939,7 +939,7 @@ struct TileExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Str
 };
 
 template <typename SEGMENT, typename IndexMapper>
-struct TileTCountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
+struct TileTCountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper>,
                          SEGMENT> {
@@ -964,7 +964,7 @@ struct TileTCountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mappin
 };
 
 template <typename SEGMENT, typename IndexMapper>
-struct TileTCountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop,
+struct TileTCountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper>,
                          SEGMENT> {

--- a/include/RAJA/policy/cuda/launch.hpp
+++ b/include/RAJA/policy/cuda/launch.hpp
@@ -348,7 +348,7 @@ struct LaunchExecute<RAJA::policy::cuda::cuda_launch_explicit_t<async, nthreads,
    CUDA generic loop implementations
 */
 template <typename SEGMENT, typename IndexMapper>
-struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper>,
                    SEGMENT> {
@@ -371,7 +371,7 @@ struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Dir
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper0,
                                                   IndexMapper1>,
@@ -399,7 +399,7 @@ struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Dir
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper0,
                                                   IndexMapper1,
@@ -538,7 +538,7 @@ struct LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Str
 };
 
 template <typename SEGMENT, typename IndexMapper>
-struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper>,
                          SEGMENT> {
@@ -560,7 +560,7 @@ struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mappin
   }
 };
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper0,
                                                         IndexMapper1>,
@@ -590,7 +590,7 @@ struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mappin
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper0,
                                                         IndexMapper1,
@@ -736,18 +736,18 @@ struct LoopICountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mappin
    CUDA generic flattened loop implementations
 */
 template<typename SEGMENT, kernel_sync_requirement sync, typename IndexMapper0>
-struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::Direct,
                                                           sync,
                                                           IndexMapper0>,
                    SEGMENT>
-    :  LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
+    :  LoopExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
                                                   sync,
                                                   IndexMapper0>,
                    SEGMENT>
 {};
 
 template<typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::Direct,
                                                           kernel_sync_requirement::none,
                                                           IndexMapper0,
                                                           IndexMapper1>,
@@ -777,7 +777,7 @@ struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapp
 };
 
 template<typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapping::Direct,
                                                           kernel_sync_requirement::none,
                                                           IndexMapper0,
                                                           IndexMapper1,
@@ -890,7 +890,7 @@ struct LoopExecute<RAJA::policy::cuda::cuda_flatten_indexer<RAJA::iteration_mapp
    CUDA generic tile implementations
 */
 template <typename SEGMENT, typename IndexMapper>
-struct TileExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
+struct TileExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper>,
                    SEGMENT> {
@@ -939,7 +939,7 @@ struct TileExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Str
 };
 
 template <typename SEGMENT, typename IndexMapper>
-struct TileTCountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct<>,
+struct TileTCountExecute<RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::Direct,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper>,
                          SEGMENT> {

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -883,53 +883,70 @@ using global_z = IndexGlobal<named_dim::z, BLOCK_SIZE, GRID_SIZE>;
 } // namespace cuda
 
 // policies usable with forall, scan, and sort
+
 template <size_t BLOCK_SIZE, size_t GRID_SIZE, size_t BLOCKS_PER_SM, bool Async = false>
 using cuda_exec_grid_explicit = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE, GRID_SIZE>, BLOCKS_PER_SM, Async>;
+    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE, GRID_SIZE>, BLOCKS_PER_SM, Async>;
 
 template <size_t BLOCK_SIZE, size_t GRID_SIZE, size_t BLOCKS_PER_SM>
 using cuda_exec_grid_explicit_async = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE, GRID_SIZE>, BLOCKS_PER_SM, true>;
+    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE, GRID_SIZE>, BLOCKS_PER_SM, true>;
 
 template <size_t BLOCK_SIZE, size_t GRID_SIZE, bool Async = false>
 using cuda_exec_grid = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE, GRID_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
+    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE, GRID_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
 
 template <size_t BLOCK_SIZE, size_t GRID_SIZE>
 using cuda_exec_grid_async = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE, GRID_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
+    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE, GRID_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
 
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, bool Async = false>
 using cuda_exec_explicit = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::Direct, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, Async>;
+    iteration_mapping::Direct<>, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, Async>;
 
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM>
 using cuda_exec_explicit_async = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::Direct, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, true>;
+    iteration_mapping::Direct<>, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, true>;
 
 template <size_t BLOCK_SIZE, bool Async = false>
 using cuda_exec = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::Direct, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
+    iteration_mapping::Direct<>, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
 
 template <size_t BLOCK_SIZE>
 using cuda_exec_async = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::Direct, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
+    iteration_mapping::Direct<>, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
 
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, bool Async = false>
 using cuda_exec_occ_calc_explicit = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, Async>;
+    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, Async>;
 
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM>
 using cuda_exec_occ_calc_explicit_async = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, true>;
+    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, true>;
 
 template <size_t BLOCK_SIZE, bool Async = false>
 using cuda_exec_occ_calc = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
+    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
 
 template <size_t BLOCK_SIZE>
 using cuda_exec_occ_calc_async = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::StridedLoop, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
+    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
+
+template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, typename Fraction, bool Async = false>
+using cuda_exec_occ_calc_fraction_explicit = policy::cuda::cuda_exec_explicit<
+    iteration_mapping::StridedLoop<named_usage::unspecified, typename Fraction::inverse>, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, Async>;
+
+template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, typename Fraction>
+using cuda_exec_occ_calc_fraction_explicit_async = policy::cuda::cuda_exec_explicit<
+    iteration_mapping::StridedLoop<named_usage::unspecified, typename Fraction::inverse>, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, true>;
+
+template <size_t BLOCK_SIZE, typename Fraction, bool Async = false>
+using cuda_exec_occ_calc_fraction = policy::cuda::cuda_exec_explicit<
+    iteration_mapping::StridedLoop<named_usage::unspecified, typename Fraction::inverse>, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
+
+template <size_t BLOCK_SIZE, typename Fraction>
+using cuda_exec_occ_calc_fraction_async = policy::cuda::cuda_exec_explicit<
+    iteration_mapping::StridedLoop<named_usage::unspecified, typename Fraction::inverse>, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
 
 // policies usable with WorkGroup
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM = policy::cuda::MIN_BLOCKS_PER_SM, bool Async = false>
@@ -960,11 +977,11 @@ using policy::cuda::cuda_block_reduce;
 using policy::cuda::cuda_warp_reduce;
 
 using cuda_warp_direct = RAJA::policy::cuda::cuda_indexer<
-    iteration_mapping::Direct,
+    iteration_mapping::Direct<>,
     kernel_sync_requirement::none,
     cuda::thread_x<RAJA::policy::cuda::WARP_SIZE>>;
 using cuda_warp_loop = RAJA::policy::cuda::cuda_indexer<
-    iteration_mapping::StridedLoop,
+    iteration_mapping::StridedLoop<named_usage::unspecified>,
     kernel_sync_requirement::none,
     cuda::thread_x<RAJA::policy::cuda::WARP_SIZE>>;
 
@@ -990,31 +1007,31 @@ using cuda_launch_t = policy::cuda::cuda_launch_explicit_t<Async, num_threads,
 // policies usable with kernel and launch
 template < typename ... indexers >
 using cuda_indexer_direct = policy::cuda::cuda_indexer<
-    iteration_mapping::Direct,
+    iteration_mapping::Direct<>,
     kernel_sync_requirement::none,
     indexers...>;
 
 template < typename ... indexers >
 using cuda_indexer_loop = policy::cuda::cuda_indexer<
-    iteration_mapping::StridedLoop,
+    iteration_mapping::StridedLoop<named_usage::unspecified>,
     kernel_sync_requirement::none,
     indexers...>;
 
 template < typename ... indexers >
 using cuda_indexer_syncable_loop = policy::cuda::cuda_indexer<
-    iteration_mapping::StridedLoop,
+    iteration_mapping::StridedLoop<named_usage::unspecified>,
     kernel_sync_requirement::sync,
     indexers...>;
 
 template < typename ... indexers >
 using cuda_flatten_indexer_direct = policy::cuda::cuda_flatten_indexer<
-    iteration_mapping::Direct,
+    iteration_mapping::Direct<>,
     kernel_sync_requirement::none,
     indexers...>;
 
 template < typename ... indexers >
 using cuda_flatten_indexer_loop = policy::cuda::cuda_flatten_indexer<
-    iteration_mapping::StridedLoop,
+    iteration_mapping::StridedLoop<named_usage::unspecified>,
     kernel_sync_requirement::none,
     indexers...>;
 

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -949,20 +949,16 @@ using cuda_exec_occ_calc_fraction_async = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop<named_usage::unspecified, typename Fraction::inverse>, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
 
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, bool Async = false>
-using cuda_exec_occ_calc_recommended_explicit = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, Async>;
+using cuda_exec_rec_for_reduce_explicit = cuda_exec_occ_calc_explicit<BLOCK_SIZE, BLOCKS_PER_SM, Async>;
 
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM>
-using cuda_exec_occ_calc_recommended_explicit_async = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, true>;
+using cuda_exec_rec_for_reduce_explicit_async = cuda_exec_occ_calc_explicit_async<BLOCK_SIZE, BLOCKS_PER_SM>;
 
 template <size_t BLOCK_SIZE, bool Async = false>
-using cuda_exec_occ_calc_recommended = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
+using cuda_exec_rec_for_reduce = cuda_exec_occ_calc<BLOCK_SIZE, Async>;
 
 template <size_t BLOCK_SIZE>
-using cuda_exec_occ_calc_recommended_async = policy::cuda::cuda_exec_explicit<
-    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
+using cuda_exec_rec_for_reduce_async = cuda_exec_occ_calc_async<BLOCK_SIZE>;
 
 // policies usable with WorkGroup
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM = policy::cuda::MIN_BLOCKS_PER_SM, bool Async = false>

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -948,6 +948,22 @@ template <size_t BLOCK_SIZE, typename Fraction>
 using cuda_exec_occ_calc_fraction_async = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop<named_usage::unspecified, typename Fraction::inverse>, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
 
+template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, bool Async = false>
+using cuda_exec_occ_calc_recommended_explicit = policy::cuda::cuda_exec_explicit<
+    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, Async>;
+
+template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM>
+using cuda_exec_occ_calc_recommended_explicit_async = policy::cuda::cuda_exec_explicit<
+    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>, BLOCKS_PER_SM, true>;
+
+template <size_t BLOCK_SIZE, bool Async = false>
+using cuda_exec_occ_calc_recommended = policy::cuda::cuda_exec_explicit<
+    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
+
+template <size_t BLOCK_SIZE>
+using cuda_exec_occ_calc_recommended_async = policy::cuda::cuda_exec_explicit<
+    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
+
 // policies usable with WorkGroup
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM = policy::cuda::MIN_BLOCKS_PER_SM, bool Async = false>
 using cuda_work_explicit = policy::cuda::cuda_work_explicit<BLOCK_SIZE, BLOCKS_PER_SM, Async>;

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -1022,20 +1022,40 @@ using cuda_exec_async = policy::cuda::cuda_exec_explicit<
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, bool Async = false>
 using cuda_exec_occ_calc_explicit = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
-    CudaMaxOccupancyConcretizer, BLOCKS_PER_SM, Async>;
+    CudaDefaultConcretizer, BLOCKS_PER_SM, Async>;
 
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM>
 using cuda_exec_occ_calc_explicit_async = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
-    CudaMaxOccupancyConcretizer, BLOCKS_PER_SM, true>;
+    CudaDefaultConcretizer, BLOCKS_PER_SM, true>;
 
 template <size_t BLOCK_SIZE, bool Async = false>
 using cuda_exec_occ_calc = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
-    CudaMaxOccupancyConcretizer, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
+    CudaDefaultConcretizer, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
 
 template <size_t BLOCK_SIZE>
 using cuda_exec_occ_calc_async = policy::cuda::cuda_exec_explicit<
+    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
+    CudaDefaultConcretizer, policy::cuda::MIN_BLOCKS_PER_SM, true>;
+
+template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, bool Async = false>
+using cuda_exec_occ_max_explicit = policy::cuda::cuda_exec_explicit<
+    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
+    CudaMaxOccupancyConcretizer, BLOCKS_PER_SM, Async>;
+
+template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM>
+using cuda_exec_occ_max_explicit_async = policy::cuda::cuda_exec_explicit<
+    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
+    CudaMaxOccupancyConcretizer, BLOCKS_PER_SM, true>;
+
+template <size_t BLOCK_SIZE, bool Async = false>
+using cuda_exec_occ_max = policy::cuda::cuda_exec_explicit<
+    iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
+    CudaMaxOccupancyConcretizer, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
+
+template <size_t BLOCK_SIZE>
+using cuda_exec_occ_max_async = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
     CudaMaxOccupancyConcretizer, policy::cuda::MIN_BLOCKS_PER_SM, true>;
 
@@ -1059,25 +1079,25 @@ using cuda_exec_occ_fraction_async = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
     CudaFractionOffsetOccupancyConcretizer<Fraction, 0>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
 
-template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, bool Async = false>
-using cuda_exec_occ_avoid_max_explicit = policy::cuda::cuda_exec_explicit<
+template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, typename Concretizer, bool Async = false>
+using cuda_exec_occ_custom_explicit = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
-    CudaAvoidDeviceMaxThreadOccupancyConcretizer, BLOCKS_PER_SM, Async>;
+    Concretizer, BLOCKS_PER_SM, Async>;
 
-template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM>
-using cuda_exec_occ_avoid_max_explicit_async = policy::cuda::cuda_exec_explicit<
+template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, typename Concretizer>
+using cuda_exec_occ_custom_explicit_async = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
-    CudaAvoidDeviceMaxThreadOccupancyConcretizer, BLOCKS_PER_SM, true>;
+    Concretizer, BLOCKS_PER_SM, true>;
 
-template <size_t BLOCK_SIZE, bool Async = false>
-using cuda_exec_occ_avoid_max = policy::cuda::cuda_exec_explicit<
+template <size_t BLOCK_SIZE, typename Concretizer, bool Async = false>
+using cuda_exec_occ_custom = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
-    CudaAvoidDeviceMaxThreadOccupancyConcretizer, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
+    Concretizer, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
 
-template <size_t BLOCK_SIZE>
-using cuda_exec_occ_avoid_max_async = policy::cuda::cuda_exec_explicit<
+template <size_t BLOCK_SIZE, typename Concretizer>
+using cuda_exec_occ_custom_async = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
-    CudaAvoidDeviceMaxThreadOccupancyConcretizer, policy::cuda::MIN_BLOCKS_PER_SM, true>;
+    Concretizer, policy::cuda::MIN_BLOCKS_PER_SM, true>;
 
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, bool Async = false>
 using cuda_exec_rec_for_reduce_explicit = policy::cuda::cuda_exec_explicit<

--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -966,19 +966,16 @@ using global_z = IndexGlobal<named_dim::z, BLOCK_SIZE, GRID_SIZE>;
 
 // contretizers used in forall, scan, and sort policies
 
-using CudaDefaultAvoidMaxOccupancyConcretizer = cuda::FractionOffsetOccupancyConcretizer<Fraction<size_t, 1, 1>, -1>;
-
-template < typename AvoidMaxOccupancyConcretizer >
-using CudaAvoidDeviceMaxThreadOccupancyConcretizer = cuda::AvoidDeviceMaxThreadOccupancyConcretizer<AvoidMaxOccupancyConcretizer>;
+using CudaAvoidDeviceMaxThreadOccupancyConcretizer = cuda::AvoidDeviceMaxThreadOccupancyConcretizer<cuda::FractionOffsetOccupancyConcretizer<Fraction<size_t, 1, 1>, -1>>;
 
 template < typename Fraction, std::ptrdiff_t BLOCKS_PER_SM_OFFSET >
 using CudaFractionOffsetOccupancyConcretizer = cuda::FractionOffsetOccupancyConcretizer<Fraction, BLOCKS_PER_SM_OFFSET>;
 
 using CudaMaxOccupancyConcretizer = cuda::MaxOccupancyConcretizer;
 
-using CudaRecForReduceConcretizer = cuda::MaxOccupancyConcretizer;
+using CudaRecForReduceConcretizer = CudaMaxOccupancyConcretizer;
 
-using CudaDefaultConcretizer = cuda::MaxOccupancyConcretizer;
+using CudaDefaultConcretizer = CudaMaxOccupancyConcretizer;
 
 // policies usable with forall, scan, and sort
 
@@ -1062,25 +1059,25 @@ using cuda_exec_occ_fraction_async = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
     CudaFractionOffsetOccupancyConcretizer<Fraction, 0>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
 
-template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, typename AvoidMaxOccupancyConcretizer = CudaDefaultAvoidMaxOccupancyConcretizer, bool Async = false>
+template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, bool Async = false>
 using cuda_exec_occ_avoid_max_explicit = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
-    CudaAvoidDeviceMaxThreadOccupancyConcretizer<AvoidMaxOccupancyConcretizer>, BLOCKS_PER_SM, Async>;
+    CudaAvoidDeviceMaxThreadOccupancyConcretizer, BLOCKS_PER_SM, Async>;
 
-template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, typename AvoidMaxOccupancyConcretizer = CudaDefaultAvoidMaxOccupancyConcretizer>
+template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM>
 using cuda_exec_occ_avoid_max_explicit_async = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
-    CudaAvoidDeviceMaxThreadOccupancyConcretizer<AvoidMaxOccupancyConcretizer>, BLOCKS_PER_SM, true>;
+    CudaAvoidDeviceMaxThreadOccupancyConcretizer, BLOCKS_PER_SM, true>;
 
-template <size_t BLOCK_SIZE, typename AvoidMaxOccupancyConcretizer = CudaDefaultAvoidMaxOccupancyConcretizer, bool Async = false>
+template <size_t BLOCK_SIZE, bool Async = false>
 using cuda_exec_occ_avoid_max = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
-    CudaAvoidDeviceMaxThreadOccupancyConcretizer<AvoidMaxOccupancyConcretizer>, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
+    CudaAvoidDeviceMaxThreadOccupancyConcretizer, policy::cuda::MIN_BLOCKS_PER_SM, Async>;
 
-template <size_t BLOCK_SIZE, typename AvoidMaxOccupancyConcretizer = CudaDefaultAvoidMaxOccupancyConcretizer>
+template <size_t BLOCK_SIZE>
 using cuda_exec_occ_avoid_max_async = policy::cuda::cuda_exec_explicit<
     iteration_mapping::StridedLoop<named_usage::unspecified>, cuda::global_x<BLOCK_SIZE>,
-    CudaAvoidDeviceMaxThreadOccupancyConcretizer<AvoidMaxOccupancyConcretizer>, policy::cuda::MIN_BLOCKS_PER_SM, true>;
+    CudaAvoidDeviceMaxThreadOccupancyConcretizer, policy::cuda::MIN_BLOCKS_PER_SM, true>;
 
 template <size_t BLOCK_SIZE, size_t BLOCKS_PER_SM, bool Async = false>
 using cuda_exec_rec_for_reduce_explicit = policy::cuda::cuda_exec_explicit<

--- a/include/RAJA/policy/cuda/scan.hpp
+++ b/include/RAJA/policy/cuda/scan.hpp
@@ -44,6 +44,7 @@ namespace scan
 */
 template <typename IterationMapping,
           typename IterationGetter,
+          typename Concretizer,
           size_t BLOCKS_PER_SM,
           bool Async,
           typename InputIter,
@@ -52,7 +53,7 @@ RAJA_INLINE
 resources::EventProxy<resources::Cuda>
 inclusive_inplace(
     resources::Cuda cuda_res,
-    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async>,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async>,
     InputIter begin,
     InputIter end,
     Function binary_op)
@@ -96,6 +97,7 @@ inclusive_inplace(
 */
 template <typename IterationMapping,
           typename IterationGetter,
+          typename Concretizer,
           size_t BLOCKS_PER_SM,
           bool Async,
           typename InputIter,
@@ -105,7 +107,7 @@ RAJA_INLINE
 resources::EventProxy<resources::Cuda>
 exclusive_inplace(
     resources::Cuda cuda_res,
-    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async>,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async>,
     InputIter begin,
     InputIter end,
     Function binary_op,
@@ -152,6 +154,7 @@ exclusive_inplace(
 */
 template <typename IterationMapping,
           typename IterationGetter,
+          typename Concretizer,
           size_t BLOCKS_PER_SM,
           bool Async,
           typename InputIter,
@@ -161,7 +164,7 @@ RAJA_INLINE
 resources::EventProxy<resources::Cuda>
 inclusive(
     resources::Cuda cuda_res,
-    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async>,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async>,
     InputIter begin,
     InputIter end,
     OutputIter out,
@@ -206,6 +209,7 @@ inclusive(
 */
 template <typename IterationMapping,
           typename IterationGetter,
+          typename Concretizer,
           size_t BLOCKS_PER_SM,
           bool Async,
           typename InputIter,
@@ -216,7 +220,7 @@ RAJA_INLINE
 resources::EventProxy<resources::Cuda>
 exclusive(
     resources::Cuda cuda_res,
-    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async>,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async>,
     InputIter begin,
     InputIter end,
     OutputIter out,

--- a/include/RAJA/policy/cuda/sort.hpp
+++ b/include/RAJA/policy/cuda/sort.hpp
@@ -44,7 +44,9 @@ namespace sort
 /*!
         \brief static assert unimplemented stable sort
 */
-template <typename IterationMapping, typename IterationGetter, size_t BLOCKS_PER_SM, bool Async, typename Iter, typename Compare>
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, size_t BLOCKS_PER_SM, bool Async,
+          typename Iter, typename Compare>
 concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                       concepts::negate<concepts::all_of<
                         type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
@@ -54,7 +56,7 @@ concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                           camp::is_same<Compare, operators::greater<RAJA::detail::IterVal<Iter>>>>>>>
 stable(
     resources::Cuda cuda_res,
-    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async>,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async>,
     Iter,
     Iter,
     Compare)
@@ -75,13 +77,15 @@ stable(
 /*!
         \brief stable sort given range in ascending order
 */
-template <typename IterationMapping, typename IterationGetter, size_t BLOCKS_PER_SM, bool Async, typename Iter>
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, size_t BLOCKS_PER_SM, bool Async,
+          typename Iter>
 concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                       type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
                       std::is_pointer<Iter>>
 stable(
     resources::Cuda cuda_res,
-    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async>,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async>,
     Iter begin,
     Iter end,
     operators::less<RAJA::detail::IterVal<Iter>>)
@@ -143,13 +147,15 @@ stable(
 /*!
         \brief stable sort given range in descending order
 */
-template <typename IterationMapping, typename IterationGetter, size_t BLOCKS_PER_SM, bool Async, typename Iter>
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, size_t BLOCKS_PER_SM, bool Async,
+          typename Iter>
 concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                       type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
                       std::is_pointer<Iter>>
 stable(
     resources::Cuda cuda_res,
-    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async>,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async>,
     Iter begin,
     Iter end,
     operators::greater<RAJA::detail::IterVal<Iter>>)
@@ -212,7 +218,9 @@ stable(
 /*!
         \brief static assert unimplemented sort
 */
-template <typename IterationMapping, typename IterationGetter, size_t BLOCKS_PER_SM, bool Async, typename Iter, typename Compare>
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, size_t BLOCKS_PER_SM, bool Async,
+          typename Iter, typename Compare>
 concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                       concepts::negate<concepts::all_of<
                         type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
@@ -222,7 +230,7 @@ concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                           camp::is_same<Compare, operators::greater<RAJA::detail::IterVal<Iter>>>>>>>
 unstable(
     resources::Cuda cuda_res,
-    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async>,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async>,
     Iter,
     Iter,
     Compare)
@@ -243,13 +251,15 @@ unstable(
 /*!
         \brief sort given range in ascending order
 */
-template <typename IterationMapping, typename IterationGetter, size_t BLOCKS_PER_SM, bool Async, typename Iter>
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, size_t BLOCKS_PER_SM, bool Async,
+          typename Iter>
 concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                       type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
                       std::is_pointer<Iter>>
 unstable(
     resources::Cuda cuda_res,
-    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async> p,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async> p,
     Iter begin,
     Iter end,
     operators::less<RAJA::detail::IterVal<Iter>> comp)
@@ -260,13 +270,15 @@ unstable(
 /*!
         \brief sort given range in descending order
 */
-template <typename IterationMapping, typename IterationGetter, size_t BLOCKS_PER_SM, bool Async, typename Iter>
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, size_t BLOCKS_PER_SM, bool Async,
+          typename Iter>
 concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                       type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
                       std::is_pointer<Iter>>
 unstable(
     resources::Cuda cuda_res,
-    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async> p,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async> p,
     Iter begin,
     Iter end,
     operators::greater<RAJA::detail::IterVal<Iter>> comp)
@@ -278,7 +290,8 @@ unstable(
 /*!
         \brief static assert unimplemented stable sort pairs
 */
-template <typename IterationMapping, typename IterationGetter, size_t BLOCKS_PER_SM, bool Async,
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, size_t BLOCKS_PER_SM, bool Async,
           typename KeyIter, typename ValIter, typename Compare>
 concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                       concepts::negate<concepts::all_of<
@@ -290,7 +303,7 @@ concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                           camp::is_same<Compare, operators::greater<RAJA::detail::IterVal<KeyIter>>>>>>>
 stable_pairs(
     resources::Cuda cuda_res,
-    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async>,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async>,
     KeyIter,
     KeyIter,
     ValIter,
@@ -314,7 +327,8 @@ stable_pairs(
 /*!
         \brief stable sort given range of pairs in ascending order of keys
 */
-template <typename IterationMapping, typename IterationGetter, size_t BLOCKS_PER_SM, bool Async,
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, size_t BLOCKS_PER_SM, bool Async,
           typename KeyIter, typename ValIter>
 concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                       type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
@@ -322,7 +336,7 @@ concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                       std::is_pointer<ValIter>>
 stable_pairs(
     resources::Cuda cuda_res,
-    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async>,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async>,
     KeyIter keys_begin,
     KeyIter keys_end,
     ValIter vals_begin,
@@ -396,7 +410,8 @@ stable_pairs(
 /*!
         \brief stable sort given range of pairs in descending order of keys
 */
-template <typename IterationMapping, typename IterationGetter, size_t BLOCKS_PER_SM, bool Async,
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, size_t BLOCKS_PER_SM, bool Async,
           typename KeyIter, typename ValIter>
 concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                       type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
@@ -404,7 +419,7 @@ concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                       std::is_pointer<ValIter>>
 stable_pairs(
     resources::Cuda cuda_res,
-    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async>,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async>,
     KeyIter keys_begin,
     KeyIter keys_end,
     ValIter vals_begin,
@@ -479,7 +494,8 @@ stable_pairs(
 /*!
         \brief static assert unimplemented sort pairs
 */
-template <typename IterationMapping, typename IterationGetter, size_t BLOCKS_PER_SM, bool Async,
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, size_t BLOCKS_PER_SM, bool Async,
           typename KeyIter, typename ValIter, typename Compare>
 concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                       concepts::negate<concepts::all_of<
@@ -491,7 +507,7 @@ concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                           camp::is_same<Compare, operators::greater<RAJA::detail::IterVal<KeyIter>>>>>>>
 unstable_pairs(
     resources::Cuda cuda_res,
-    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async>,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async>,
     KeyIter,
     KeyIter,
     ValIter,
@@ -515,7 +531,8 @@ unstable_pairs(
 /*!
         \brief stable sort given range of pairs in ascending order of keys
 */
-template <typename IterationMapping, typename IterationGetter, size_t BLOCKS_PER_SM, bool Async,
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, size_t BLOCKS_PER_SM, bool Async,
           typename KeyIter, typename ValIter>
 concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                       type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
@@ -523,7 +540,7 @@ concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                       std::is_pointer<ValIter>>
 unstable_pairs(
     resources::Cuda cuda_res,
-    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async> p,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async> p,
     KeyIter keys_begin,
     KeyIter keys_end,
     ValIter vals_begin,
@@ -535,7 +552,8 @@ unstable_pairs(
 /*!
         \brief stable sort given range of pairs in descending order of keys
 */
-template <typename IterationMapping, typename IterationGetter, size_t BLOCKS_PER_SM, bool Async,
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, size_t BLOCKS_PER_SM, bool Async,
           typename KeyIter, typename ValIter>
 concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                       type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
@@ -543,7 +561,7 @@ concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
                       std::is_pointer<ValIter>>
 unstable_pairs(
     resources::Cuda cuda_res,
-    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async> p,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async> p,
     KeyIter keys_begin,
     KeyIter keys_end,
     ValIter vals_begin,

--- a/include/RAJA/policy/hip/MemUtils_HIP.hpp
+++ b/include/RAJA/policy/hip/MemUtils_HIP.hpp
@@ -292,7 +292,7 @@ hipDeviceProp_t get_device_prop()
   return prop;
 }
 
-//! Get a cached copy of the device properties
+//! Get a copy of the device properties, this copy is cached on first use to speedup later calls
 RAJA_INLINE
 hipDeviceProp_t& device_prop()
 {
@@ -437,7 +437,7 @@ HipOccMaxBlocksData hip_occupancy_max_blocks(const void* func,
  ******************************************************************************
  *
  * \brief  Concretizer Implementation that chooses block size and/or grid
- *         size when they has not been specified at compile time.
+ *         size when one or both has not been specified at compile time.
  *
  * \tparam IdxT Index type to use for integer calculations.
  * \tparam Concretizer Class that determines the max number of blocks to use

--- a/include/RAJA/policy/hip/MemUtils_HIP.hpp
+++ b/include/RAJA/policy/hip/MemUtils_HIP.hpp
@@ -301,203 +301,227 @@ hipDeviceProp_t& device_prop()
 
 struct HipFixedMaxBlocksData
 {
-  int multiProcessorCount;
-  int maxThreadsPerMultiProcessor;
+  int device_sm_per_device;
+  int device_max_threads_per_sm;
 };
 
 RAJA_INLINE
-int hip_max_blocks(int block_size)
+HipFixedMaxBlocksData hip_max_blocks()
 {
-  static HipFixedMaxBlocksData data = []() {
-    hipDeviceProp_t& prop = hip::device_prop();
-    return HipFixedMaxBlocksData{prop.multiProcessorCount,
-                                 prop.maxThreadsPerMultiProcessor};
-  }();
+  static thread_local HipFixedMaxBlocksData data {
+      hip::device_prop().multiProcessorCount,
+      hip::device_prop().maxThreadsPerMultiProcessor };
 
-  int max_blocks = data.multiProcessorCount *
-                  (data.maxThreadsPerMultiProcessor / block_size);
-
-  return max_blocks;
+  return data;
 }
 
 struct HipOccMaxBlocksThreadsData
 {
-  size_t prev_shmem_size;
-  int max_blocks;
-  int max_threads;
+  size_t func_dynamic_shmem_per_block;
+  int func_max_blocks_per_device;
+  int func_max_threads_per_block;
 };
 
-template < typename RAJA_UNUSED_ARG(UniqueMarker), typename Func >
+template < typename RAJA_UNUSED_ARG(UniqueMarker) >
 RAJA_INLINE
-void hip_occupancy_max_blocks_threads(Func&& func, size_t shmem_size,
-                                       int &max_blocks, int &max_threads)
+HipOccMaxBlocksThreadsData hip_occupancy_max_blocks_threads(const void* func,
+    size_t func_dynamic_shmem_per_block)
 {
-  static constexpr int uninitialized = -1;
-  static constexpr size_t uninitialized_size_t = std::numeric_limits<size_t>::max();
-  static thread_local HipOccMaxBlocksThreadsData data = {
-      uninitialized_size_t, uninitialized, uninitialized};
+  static thread_local HipOccMaxBlocksThreadsData data {
+      std::numeric_limits<size_t>::max(),
+      -1,
+      -1 };
 
-  if (data.prev_shmem_size != shmem_size) {
+  if (data.func_dynamic_shmem_per_block != func_dynamic_shmem_per_block) {
 
 #ifdef RAJA_ENABLE_HIP_OCCUPANCY_CALCULATOR
     hipErrchk(hipOccupancyMaxPotentialBlockSize(
-        &data.max_blocks, &data.max_threads, func, shmem_size));
+        &data.func_max_blocks_per_device, &data.func_max_threads_per_block, func, func_dynamic_shmem_per_block));
 #else
     RAJA_UNUSED_VAR(func);
     hipDeviceProp_t& prop = hip::device_prop();
-    data.max_blocks = prop.multiProcessorCount;
-    data.max_threads = 1024;
+    data.func_max_blocks_per_device = prop.multiProcessorCount;
+    data.func_max_threads_per_block = 1024;
 #endif
 
-    data.prev_shmem_size = shmem_size;
+    data.func_dynamic_shmem_per_block = func_dynamic_shmem_per_block;
 
   }
 
-  max_blocks  = data.max_blocks;
-  max_threads = data.max_threads;
-
+  return data;
 }
 
-struct HipOccMaxBlocksFixedThreadsData
+struct HipOccMaxBlocksData
 {
-  size_t prev_shmem_size;
-  int max_blocks;
-  int multiProcessorCount;
+  size_t func_dynamic_shmem_per_block;
+  int func_threads_per_block;
+  int device_sm_per_device;
+  int device_max_threads_per_sm;
+  int func_max_blocks_per_sm;
 };
 
-template < typename RAJA_UNUSED_ARG(UniqueMarker), int num_threads, typename Func >
+template < typename RAJA_UNUSED_ARG(UniqueMarker), int func_threads_per_block >
 RAJA_INLINE
-void hip_occupancy_max_blocks(Func&& func, size_t shmem_size,
-                               int &max_blocks)
+HipOccMaxBlocksData hip_occupancy_max_blocks(const void* func,
+    size_t func_dynamic_shmem_per_block)
 {
-  static constexpr int uninitialized = -1;
-  static constexpr size_t uninitialized_size_t = std::numeric_limits<size_t>::max();
-  static thread_local HipOccMaxBlocksFixedThreadsData data = {
-      uninitialized_size_t, uninitialized, uninitialized};
+  static thread_local HipOccMaxBlocksData data {
+      std::numeric_limits<size_t>::max(),
+      func_threads_per_block,
+      hip::device_prop().multiProcessorCount,
+      hip::device_prop().maxThreadsPerMultiProcessor,
+      -1 };
 
-  if (data.prev_shmem_size != shmem_size) {
+  if (data.func_dynamic_shmem_per_block != func_dynamic_shmem_per_block) {
+
+    data.func_dynamic_shmem_per_block = func_dynamic_shmem_per_block;
 
 #ifdef RAJA_ENABLE_HIP_OCCUPANCY_CALCULATOR
     hipErrchk(hipOccupancyMaxActiveBlocksPerMultiprocessor(
-        &data.max_blocks, func, num_threads, shmem_size));
+        &data.func_max_blocks_per_sm, func, func_threads_per_block, func_dynamic_shmem_per_block));
 #else
     RAJA_UNUSED_VAR(func);
-    data.max_blocks = hip::device_prop().maxThreadsPerMultiProcessor/1024;
-    if (data.max_blocks <= 0) { data.max_blocks = 1 }
+    data.func_max_blocks_per_sm = hip::device_prop().maxThreadsPerMultiProcessor/1024;
+    if (data.func_max_blocks_per_sm <= 0) { data.func_max_blocks_per_sm = 1 }
 #endif
 
-    if (data.multiProcessorCount == uninitialized) {
-
-      data.multiProcessorCount = hip::device_prop().multiProcessorCount;
-
-    }
-
-    data.max_blocks *= data.multiProcessorCount;
-
-    data.prev_shmem_size = shmem_size;
 
   }
 
-  max_blocks = data.max_blocks;
-
+  return data;
 }
 
-struct HipOccMaxBlocksVariableThreadsData
-{
-  size_t prev_shmem_size;
-  int prev_num_threads;
-  int max_blocks;
-  int multiProcessorCount;
-};
-
-template < typename RAJA_UNUSED_ARG(UniqueMarker), typename Func >
+template < typename RAJA_UNUSED_ARG(UniqueMarker) >
 RAJA_INLINE
-void hip_occupancy_max_blocks(Func&& func, size_t shmem_size,
-                               int &max_blocks, int num_threads)
+HipOccMaxBlocksData hip_occupancy_max_blocks(const void* func,
+    size_t func_dynamic_shmem_per_block, int func_threads_per_block)
 {
-  static constexpr int uninitialized = 0;
-  static constexpr size_t uninitialized_size_t = std::numeric_limits<size_t>::max();
-  static thread_local HipOccMaxBlocksVariableThreadsData data = {
-      uninitialized_size_t, uninitialized, uninitialized, uninitialized};
+  static thread_local HipOccMaxBlocksData data {
+      std::numeric_limits<size_t>::max(),
+      -1,
+      hip::device_prop().multiProcessorCount,
+      hip::device_prop().maxThreadsPerMultiProcessor,
+      -1 };
 
-  if ( data.prev_shmem_size  != shmem_size ||
-       data.prev_num_threads != num_threads ) {
+  if ( data.func_dynamic_shmem_per_block != func_dynamic_shmem_per_block ||
+       data.func_threads_per_block != func_threads_per_block ) {
+
+    data.func_dynamic_shmem_per_block = func_dynamic_shmem_per_block;
+    data.func_threads_per_block = func_threads_per_block;
 
 #ifdef RAJA_ENABLE_HIP_OCCUPANCY_CALCULATOR
     hipErrchk(hipOccupancyMaxActiveBlocksPerMultiprocessor(
-        &data.max_blocks, func, num_threads, shmem_size));
+        &data.func_max_blocks_per_sm, func, func_threads_per_block, func_dynamic_shmem_per_block));
 #else
     RAJA_UNUSED_VAR(func);
-    data.max_blocks = hip::device_prop().maxThreadsPerMultiProcessor/1024;
-    if (data.max_blocks <= 0) { data.max_blocks = 1 }
+    data.func_max_blocks_per_sm = hip::device_prop().maxThreadsPerMultiProcessor/1024;
+    if (data.func_max_blocks_per_sm <= 0) { data.func_max_blocks_per_sm = 1 }
 #endif
 
-    if (data.multiProcessorCount == uninitialized) {
-
-      data.multiProcessorCount = hip::device_prop().multiProcessorCount;
-
-    }
-
-    data.max_blocks *= data.multiProcessorCount;
-
-    data.prev_shmem_size  = shmem_size;
-    data.prev_num_threads = num_threads;
-
   }
 
-  max_blocks = data.max_blocks;
-
+  return data;
 }
 
-struct HipOccupancyDefaults
+/*!
+ ******************************************************************************
+ *
+ * \brief  Hip Concretizer Implementation.
+ *
+ * \tparam IdxT Index type to use for integer calculations.
+ * \tparam Concretizer Class the determines the max number of blocks to use when
+ *         fitting for the device.
+ * \tparam UniqueMarker A type that is unique to each global function, used to
+ *         help cache the occupancy data for that global function.
+ *
+ ******************************************************************************
+ */
+template < typename IdxT, typename Concretizer, typename UniqueMarker>
+struct ConcretizerImpl
 {
-  HipOccupancyDefaults(const void* RAJA_UNUSED_ARG(func))
-  { }
-
-  template < typename IdxT >
-  inline auto get_max_grid_size(size_t RAJA_UNUSED_ARG(dynamic_shmem_size),
-                                IdxT RAJA_UNUSED_ARG(block_size)) const
-  {
-    return std::numeric_limits<IdxT>::max();
-  }
-
-  template < typename IdxT = hip_dim_member_t >
-  inline auto get_max_block_size_and_grid_size(size_t RAJA_UNUSED_ARG(dynamic_shmem_size)) const
-  {
-    return std::make_pair(static_cast<IdxT>(::RAJA::policy::hip::MAX_BLOCK_SIZE),
-                          std::numeric_limits<IdxT>::max());
-  }
-};
-
-template < typename UniqueMarker >
-struct HipOccupancyCalculator
-{
-  HipOccupancyCalculator(const void* func)
+  ConcretizerImpl(const void* func, size_t func_dynamic_shmem_per_block, IdxT len)
     : m_func(func)
+    , m_func_dynamic_shmem_per_block(func_dynamic_shmem_per_block)
+    , m_len(len)
   { }
 
-  template < typename IdxT >
-  inline auto get_max_grid_size(size_t dynamic_shmem_size, IdxT block_size) const
+  // Get the maximum block size
+  IdxT get_max_block_size() const
   {
-    int max_grid_size = -1;
-    ::RAJA::hip::hip_occupancy_max_blocks<UniqueMarker>(
-        m_func, dynamic_shmem_size, max_grid_size, block_size);
-    return static_cast<IdxT>(max_grid_size);
+    auto data = hip_occupancy_max_blocks_threads<UniqueMarker>(
+        m_func, m_func_dynamic_shmem_per_block);
+    IdxT func_max_threads_per_block = data.func_max_threads_per_block;
+    return func_max_threads_per_block;
   }
 
-  template < typename IdxT = hip_dim_member_t >
-  inline auto get_max_block_size_and_grid_size(size_t dynamic_shmem_size) const
+  // Get a block size that combined with the given grid size is large enough
+  // to do len work, or 0 if not possible
+  IdxT get_block_size_to_fit_len(IdxT func_blocks_per_device) const
   {
-    int max_block_size = -1;
-    int max_grid_size = -1;
-    ::RAJA::hip::hip_occupancy_max_blocks_threads<UniqueMarker>(
-        m_func, dynamic_shmem_size, max_grid_size, max_block_size);
-    return std::make_pair(static_cast<IdxT>(max_block_size),
-                          static_cast<IdxT>(max_grid_size));
+    IdxT func_max_threads_per_block = this->get_max_block_size();
+    IdxT func_threads_per_block = RAJA_DIVIDE_CEILING_INT(m_len, func_blocks_per_device);
+    if (func_threads_per_block <= func_max_threads_per_block) {
+      return func_threads_per_block;
+    } else {
+      return IdxT(0);
+    }
+  }
+
+  // Get a grid size that combined with the given block size is large enough
+  // to do len work
+  IdxT get_grid_size_to_fit_len(IdxT func_threads_per_block) const
+  {
+    IdxT func_blocks_per_device = RAJA_DIVIDE_CEILING_INT(m_len, func_threads_per_block);
+    return func_blocks_per_device;
+  }
+
+  // Get a block size and grid size that combined is large enough
+  // to do len work
+  auto get_block_and_grid_size_to_fit_len() const
+  {
+    IdxT func_max_threads_per_block = this->get_max_block_size();
+    IdxT func_blocks_per_device = RAJA_DIVIDE_CEILING_INT(m_len, func_max_threads_per_block);
+    return std::make_pair(func_max_threads_per_block,
+                          func_blocks_per_device);
+  }
+
+  // Get a block size that combined with the given grid size is the smaller of
+  // the amount need to achieve maximum occupancy on the device or
+  // the amount needed to do len work
+  IdxT get_block_size_to_fit_device(IdxT func_blocks_per_device) const
+  {
+    IdxT func_max_threads_per_block = this->get_max_block_size();
+    IdxT func_threads_per_block = RAJA_DIVIDE_CEILING_INT(m_len, func_blocks_per_device);
+    return std::min(func_threads_per_block, func_max_threads_per_block);
+  }
+
+  // Get a grid size that combined with the given block size is the smaller of
+  // the amount need to achieve maximum occupancy on the device or
+  // the amount needed to do len work
+  IdxT get_grid_size_to_fit_device(IdxT func_threads_per_block) const
+  {
+    auto data = hip_occupancy_max_blocks<UniqueMarker>(
+        m_func, m_func_dynamic_shmem_per_block, func_threads_per_block);
+    IdxT func_max_blocks_per_device = Concretizer::template get_max_grid_size<IdxT>(data);
+    IdxT func_blocks_per_device = RAJA_DIVIDE_CEILING_INT(m_len, func_threads_per_block);
+    return std::min(func_blocks_per_device, func_max_blocks_per_device);
+  }
+
+  // Get a block size and grid size that combined is the smaller of
+  // the amount need to achieve maximum occupancy on the device or
+  // the amount needed to do len work
+  auto get_block_and_grid_size_to_fit_device() const
+  {
+    IdxT func_max_threads_per_block = this->get_max_block_size();
+    IdxT func_blocks_per_device = this->get_grid_size_to_fit_device(func_max_threads_per_block);
+    return std::make_pair(func_max_threads_per_block,
+                          func_blocks_per_device);
   }
 
 private:
   const void* m_func;
+  size_t m_func_dynamic_shmem_per_block;
+  IdxT m_len;
 };
 
 }  // namespace hip

--- a/include/RAJA/policy/hip/MemUtils_HIP.hpp
+++ b/include/RAJA/policy/hip/MemUtils_HIP.hpp
@@ -281,6 +281,7 @@ RAJA_INLINE typename std::remove_reference<LOOP_BODY>::type make_launch_body(
   return return_type(std::forward<LOOP_BODY>(loop_body));
 }
 
+//! Get the properties of the current device
 RAJA_INLINE
 hipDeviceProp_t get_device_prop()
 {
@@ -291,6 +292,7 @@ hipDeviceProp_t get_device_prop()
   return prop;
 }
 
+//! Get a cached copy of the device properties
 RAJA_INLINE
 hipDeviceProp_t& device_prop()
 {
@@ -299,12 +301,14 @@ hipDeviceProp_t& device_prop()
 }
 
 
+//! Struct with the maximum theoretical occupancy of the device
 struct HipFixedMaxBlocksData
 {
   int device_sm_per_device;
   int device_max_threads_per_sm;
 };
 
+//! Get the maximum theoretical occupancy of the device
 RAJA_INLINE
 HipFixedMaxBlocksData hip_max_blocks()
 {
@@ -315,6 +319,7 @@ HipFixedMaxBlocksData hip_max_blocks()
   return data;
 }
 
+//! Struct with the maximum occupancy of a kernel in simple terms
 struct HipOccMaxBlocksThreadsData
 {
   size_t func_dynamic_shmem_per_block;
@@ -322,6 +327,7 @@ struct HipOccMaxBlocksThreadsData
   int func_max_threads_per_block;
 };
 
+//! Get the maximum occupancy of a kernel with unknown threads per block
 template < typename RAJA_UNUSED_ARG(UniqueMarker) >
 RAJA_INLINE
 HipOccMaxBlocksThreadsData hip_occupancy_max_blocks_threads(const void* func,
@@ -351,6 +357,7 @@ HipOccMaxBlocksThreadsData hip_occupancy_max_blocks_threads(const void* func,
   return data;
 }
 
+//! Struct with the maximum occupancy of a kernel in specific terms
 struct HipOccMaxBlocksData
 {
   size_t func_dynamic_shmem_per_block;
@@ -360,6 +367,7 @@ struct HipOccMaxBlocksData
   int func_max_blocks_per_sm;
 };
 
+//! Get the maximum occupancy of a kernel with compile time threads per block
 template < typename RAJA_UNUSED_ARG(UniqueMarker), int func_threads_per_block >
 RAJA_INLINE
 HipOccMaxBlocksData hip_occupancy_max_blocks(const void* func,
@@ -391,6 +399,7 @@ HipOccMaxBlocksData hip_occupancy_max_blocks(const void* func,
   return data;
 }
 
+//! Get the maximum occupancy of a kernel with runtime threads per block
 template < typename RAJA_UNUSED_ARG(UniqueMarker) >
 RAJA_INLINE
 HipOccMaxBlocksData hip_occupancy_max_blocks(const void* func,
@@ -423,16 +432,30 @@ HipOccMaxBlocksData hip_occupancy_max_blocks(const void* func,
   return data;
 }
 
+
 /*!
  ******************************************************************************
  *
- * \brief  Hip Concretizer Implementation.
+ * \brief  Concretizer Implementation that chooses block size and/or grid
+ *         size when they has not been specified at compile time.
  *
  * \tparam IdxT Index type to use for integer calculations.
- * \tparam Concretizer Class the determines the max number of blocks to use when
- *         fitting for the device.
+ * \tparam Concretizer Class that determines the max number of blocks to use
+ *         when fitting for the device.
  * \tparam UniqueMarker A type that is unique to each global function, used to
  *         help cache the occupancy data for that global function.
+ *
+ * The methods come in two flavors:
+ * - The fit_len methods choose grid and block sizes that result in a total
+ *   number of threads of at least the len given in the constructor or 0 if
+ *   that is not possible.
+ * - The fit_device methods choose grid and block sizes that best fit the
+ *   occupancy of the global function according to the occupancy calculator and
+ *   the Concretizer class.
+ *
+ * Common terms:
+ * - block size - threads per block
+ * - grid size - blocks per device
  *
  ******************************************************************************
  */
@@ -445,7 +468,6 @@ struct ConcretizerImpl
     , m_len(len)
   { }
 
-  // Get the maximum block size
   IdxT get_max_block_size() const
   {
     auto data = hip_occupancy_max_blocks_threads<UniqueMarker>(
@@ -454,8 +476,7 @@ struct ConcretizerImpl
     return func_max_threads_per_block;
   }
 
-  // Get a block size that combined with the given grid size is large enough
-  // to do len work, or 0 if not possible
+  //! Get a block size when grid size is specified
   IdxT get_block_size_to_fit_len(IdxT func_blocks_per_device) const
   {
     IdxT func_max_threads_per_block = this->get_max_block_size();
@@ -467,16 +488,14 @@ struct ConcretizerImpl
     }
   }
 
-  // Get a grid size that combined with the given block size is large enough
-  // to do len work
+  //! Get a grid size when block size is specified
   IdxT get_grid_size_to_fit_len(IdxT func_threads_per_block) const
   {
     IdxT func_blocks_per_device = RAJA_DIVIDE_CEILING_INT(m_len, func_threads_per_block);
     return func_blocks_per_device;
   }
 
-  // Get a block size and grid size that combined is large enough
-  // to do len work
+  //! Get a block size and grid size when neither is specified
   auto get_block_and_grid_size_to_fit_len() const
   {
     IdxT func_max_threads_per_block = this->get_max_block_size();
@@ -485,9 +504,7 @@ struct ConcretizerImpl
                           func_blocks_per_device);
   }
 
-  // Get a block size that combined with the given grid size is the smaller of
-  // the amount need to achieve maximum occupancy on the device or
-  // the amount needed to do len work
+  //! Get a block size when grid size is specified
   IdxT get_block_size_to_fit_device(IdxT func_blocks_per_device) const
   {
     IdxT func_max_threads_per_block = this->get_max_block_size();
@@ -495,9 +512,7 @@ struct ConcretizerImpl
     return std::min(func_threads_per_block, func_max_threads_per_block);
   }
 
-  // Get a grid size that combined with the given block size is the smaller of
-  // the amount need to achieve maximum occupancy on the device or
-  // the amount needed to do len work
+  //! Get a grid size when block size is specified
   IdxT get_grid_size_to_fit_device(IdxT func_threads_per_block) const
   {
     auto data = hip_occupancy_max_blocks<UniqueMarker>(
@@ -507,9 +522,7 @@ struct ConcretizerImpl
     return std::min(func_blocks_per_device, func_max_blocks_per_device);
   }
 
-  // Get a block size and grid size that combined is the smaller of
-  // the amount need to achieve maximum occupancy on the device or
-  // the amount needed to do len work
+  //! Get a block size and grid size when neither is specified
   auto get_block_and_grid_size_to_fit_device() const
   {
     IdxT func_max_threads_per_block = this->get_max_block_size();

--- a/include/RAJA/policy/hip/forall.hpp
+++ b/include/RAJA/policy/hip/forall.hpp
@@ -59,57 +59,6 @@ namespace impl
 /*!
  ******************************************************************************
  *
- * \brief  Hip grid dimension helper for strided loops template.
- *
- * \tparam MappingModifiers Decide how many blocks to use cased on the . For example StridedLoop uses a grid
- *         stride loop to run multiple iterates in a single thread.
- *
- ******************************************************************************
- */
-template<typename IterationMapping>
-struct GridStrideHelper;
-
-/// handle direct policies with no modifiers
-template<>
-struct GridStrideHelper<::RAJA::iteration_mapping::Direct<>>
-{
-  template < typename IdxT >
-  static constexpr IdxT get_grid_size(IdxT normal_grid_size, IdxT RAJA_UNUSED_ARG(max_grid_size))
-  {
-    return normal_grid_size;
-  }
-};
-
-/// handle strided loop policies with no modifiers
-template<>
-struct GridStrideHelper<::RAJA::iteration_mapping::StridedLoop<
-    named_usage::unspecified>>
-{
-  template < typename IdxT >
-  static constexpr IdxT get_grid_size(IdxT normal_grid_size, IdxT max_grid_size)
-  {
-    return std::min(normal_grid_size, max_grid_size);
-  }
-};
-
-/// handle strided loop policies with multiplier on iterates per thread
-template<typename FractionIdxT, FractionIdxT numerator, FractionIdxT demoninator>
-struct GridStrideHelper<::RAJA::iteration_mapping::StridedLoop<
-    named_usage::unspecified, Fraction<FractionIdxT, numerator, demoninator>>>
-{
-  template < typename IdxT >
-  static constexpr IdxT get_grid_size(IdxT normal_grid_size, IdxT max_grid_size)
-  {
-    // use inverse multiplier on max grid size to affect number of threads
-    using Frac = typename Fraction<IdxT, IdxT(numerator), IdxT(demoninator)>::inverse;
-    max_grid_size = Frac::multiply(max_grid_size);
-    return std::min(normal_grid_size, max_grid_size);
-  }
-};
-
-/*!
- ******************************************************************************
- *
  * \brief  Hip kernel block and grid dimension calculator template.
  *
  * \tparam IterationMapping Way of mapping from threads in the kernel to
@@ -122,21 +71,21 @@ struct GridStrideHelper<::RAJA::iteration_mapping::StridedLoop<
  *
  ******************************************************************************
  */
-template<typename IterationMapping, typename IterationGetter, typename UniqueMarker>
+template<typename IterationMapping, typename IterationGetter, typename Concretizer, typename UniqueMarker>
 struct ForallDimensionCalculator;
 
 // The general cases handle fixed BLOCK_SIZE > 0 and/or GRID_SIZE > 0
 // there are specializations for named_usage::unspecified
 // but named_usage::ignored is not supported so no specializations are provided
 // and static_asserts in the general case catch unsupported values
-template<named_dim dim, int BLOCK_SIZE, int GRID_SIZE, typename UniqueMarker, typename ... MappingModifiers>
-struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct<MappingModifiers...>,
+template<named_dim dim, int BLOCK_SIZE, int GRID_SIZE, typename Concretizer, typename UniqueMarker>
+struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct,
                                  ::RAJA::hip::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>,
+                                 Concretizer,
                                  UniqueMarker>
 {
   static_assert(BLOCK_SIZE > 0, "block size must be > 0 or named_usage::unspecified with forall");
   static_assert(GRID_SIZE > 0, "grid size must be > 0 or named_usage::unspecified with forall");
-  static_assert(sizeof...(MappingModifiers) == 0, "MappingModifiers not supported in this configuration");
 
   using IndexGetter = ::RAJA::hip::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>;
 
@@ -144,8 +93,10 @@ struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct<MappingModifi
   static void set_dimensions(internal::HipDims& dims, IdxT len,
                              const void* RAJA_UNUSED_ARG(func), size_t RAJA_UNUSED_ARG(dynamic_shmem_size))
   {
-    if ( len > (static_cast<IdxT>(IndexGetter::block_size) *
-                static_cast<IdxT>(IndexGetter::grid_size)) ) {
+    const IdxT block_size = static_cast<IdxT>(IndexGetter::block_size);
+    const IdxT grid_size = static_cast<IdxT>(IndexGetter::grid_size);
+
+    if ( len > (block_size * grid_size) ) {
       RAJA_ABORT_OR_THROW("len exceeds the size of the directly mapped index space");
     }
 
@@ -154,160 +105,168 @@ struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct<MappingModifi
   }
 };
 
-template<named_dim dim, int GRID_SIZE, typename UniqueMarker, typename ... MappingModifiers>
-struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct<MappingModifiers...>,
+template<named_dim dim, int GRID_SIZE, typename Concretizer, typename UniqueMarker>
+struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct,
                                  ::RAJA::hip::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>,
+                                 Concretizer,
                                  UniqueMarker>
 {
   static_assert(GRID_SIZE > 0, "grid size must be > 0 or named_usage::unspecified with forall");
-  static_assert(sizeof...(MappingModifiers) == 0, "MappingModifiers not supported in this configuration");
 
   using IndexGetter = ::RAJA::hip::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>;
 
   template < typename IdxT >
   static void set_dimensions(internal::HipDims& dims, IdxT len,
-                             const void* RAJA_UNUSED_ARG(func), size_t RAJA_UNUSED_ARG(dynamic_shmem_size))
+                             const void* func, size_t dynamic_shmem_size)
   {
-    // BEWARE: if calculated block_size is too high then the kernel launch will fail
-    internal::set_hip_dim<dim>(dims.threads, RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexGetter::grid_size)));
-    internal::set_hip_dim<dim>(dims.blocks, static_cast<IdxT>(IndexGetter::grid_size));
+    ::RAJA::hip::ConcretizerImpl<IdxT, Concretizer, UniqueMarker> concretizer{func, dynamic_shmem_size, len};
+
+    const IdxT grid_size = static_cast<IdxT>(IndexGetter::grid_size);
+    const IdxT block_size = concretizer.get_block_size_to_fit_len(grid_size);
+
+    if ( block_size == IdxT(0) ) {
+      RAJA_ABORT_OR_THROW("len exceeds the size of the directly mapped index space");
+    }
+
+    internal::set_hip_dim<dim>(dims.threads, block_size);
+    internal::set_hip_dim<dim>(dims.blocks, grid_size);
   }
 };
 
-template<named_dim dim, int BLOCK_SIZE, typename UniqueMarker, typename ... MappingModifiers>
-struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct<MappingModifiers...>,
+template<named_dim dim, int BLOCK_SIZE, typename Concretizer, typename UniqueMarker>
+struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct,
                                  ::RAJA::hip::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>,
+                                 Concretizer,
                                  UniqueMarker>
 {
   static_assert(BLOCK_SIZE > 0, "block size must be > 0 or named_usage::unspecified with forall");
-  static_assert(sizeof...(MappingModifiers) == 0, "MappingModifiers not supported in this configuration");
 
   using IndexGetter = ::RAJA::hip::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>;
 
   template < typename IdxT >
   static void set_dimensions(internal::HipDims& dims, IdxT len,
-                             const void* RAJA_UNUSED_ARG(func), size_t RAJA_UNUSED_ARG(dynamic_shmem_size))
+                             const void* func, size_t dynamic_shmem_size)
   {
-    internal::set_hip_dim<dim>(dims.threads, static_cast<IdxT>(IndexGetter::block_size));
-    internal::set_hip_dim<dim>(dims.blocks, RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexGetter::block_size)));
+    ::RAJA::hip::ConcretizerImpl<IdxT, Concretizer, UniqueMarker> concretizer{func, dynamic_shmem_size, len};
+
+    const IdxT block_size = static_cast<IdxT>(IndexGetter::block_size);
+    const IdxT grid_size = concretizer.get_grid_size_to_fit_len(block_size);
+
+    internal::set_hip_dim<dim>(dims.threads, block_size);
+    internal::set_hip_dim<dim>(dims.blocks, grid_size);
   }
 };
 
-template<named_dim dim, typename UniqueMarker, typename ... MappingModifiers>
-struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct<MappingModifiers...>,
+template<named_dim dim, typename Concretizer, typename UniqueMarker>
+struct ForallDimensionCalculator<::RAJA::iteration_mapping::Direct,
                                  ::RAJA::hip::IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>,
+                                 Concretizer,
                                  UniqueMarker>
 {
-  static_assert(sizeof...(MappingModifiers) == 0, "MappingModifiers not supported in this configuration");
-
   using IndexGetter = ::RAJA::hip::IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>;
 
   template < typename IdxT >
   static void set_dimensions(internal::HipDims& dims, IdxT len,
                              const void* func, size_t dynamic_shmem_size)
   {
-    ::RAJA::hip::HipOccupancyCalculator<UniqueMarker> oc(func);
-    auto max_sizes = oc.get_max_block_size_and_grid_size(dynamic_shmem_size);
+    ::RAJA::hip::ConcretizerImpl<IdxT, Concretizer, UniqueMarker> concretizer{func, dynamic_shmem_size, len};
 
-    internal::set_hip_dim<dim>(dims.threads, static_cast<IdxT>(max_sizes.first));
-    internal::set_hip_dim<dim>(dims.blocks, RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(max_sizes.first)));
+    const auto sizes = concretizer.get_block_and_grid_size_to_fit_len();
+
+    internal::set_hip_dim<dim>(dims.threads, sizes.first);
+    internal::set_hip_dim<dim>(dims.blocks, sizes.second);
   }
 };
 
-template<named_dim dim, int BLOCK_SIZE, int GRID_SIZE, typename UniqueMarker, typename ... MappingModifiers>
-struct ForallDimensionCalculator<::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified, MappingModifiers...>,
+template<named_dim dim, int BLOCK_SIZE, int GRID_SIZE, typename Concretizer, typename UniqueMarker>
+struct ForallDimensionCalculator<::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                  ::RAJA::hip::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>,
+                                 Concretizer,
                                  UniqueMarker>
 {
   static_assert(BLOCK_SIZE > 0, "block size must be > 0 or named_usage::unspecified with forall");
   static_assert(GRID_SIZE > 0, "grid size must be > 0 or named_usage::unspecified with forall");
-  static_assert(sizeof...(MappingModifiers) == 0, "MappingModifiers not supported in this configuration");
 
-  using IndexMapper = ::RAJA::hip::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>;
+  using IndexGetter = ::RAJA::hip::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>;
 
   template < typename IdxT >
   static void set_dimensions(internal::HipDims& dims, IdxT RAJA_UNUSED_ARG(len),
                              const void* RAJA_UNUSED_ARG(func), size_t RAJA_UNUSED_ARG(dynamic_shmem_size))
   {
-    internal::set_hip_dim<dim>(dims.threads, static_cast<IdxT>(IndexMapper::block_size));
-    internal::set_hip_dim<dim>(dims.blocks, static_cast<IdxT>(IndexMapper::grid_size));
+    const IdxT block_size = static_cast<IdxT>(IndexGetter::block_size);
+    const IdxT grid_size = static_cast<IdxT>(IndexGetter::grid_size);
+
+    internal::set_hip_dim<dim>(dims.threads, block_size);
+    internal::set_hip_dim<dim>(dims.blocks, grid_size);
   }
 };
 
-template<named_dim dim, int GRID_SIZE, typename UniqueMarker, typename ... MappingModifiers>
-struct ForallDimensionCalculator<::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified, MappingModifiers...>,
+template<named_dim dim, int GRID_SIZE, typename Concretizer, typename UniqueMarker>
+struct ForallDimensionCalculator<::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                  ::RAJA::hip::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>,
+                                 Concretizer,
                                  UniqueMarker>
 {
   static_assert(GRID_SIZE > 0, "grid size must be > 0 or named_usage::unspecified with forall");
-  static_assert(sizeof...(MappingModifiers) == 0, "MappingModifiers not supported in this configuration");
 
-  using IndexMapper = ::RAJA::hip::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>;
+  using IndexGetter = ::RAJA::hip::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>;
 
   template < typename IdxT >
   static void set_dimensions(internal::HipDims& dims, IdxT len,
                              const void* func, size_t dynamic_shmem_size)
   {
-    ::RAJA::hip::HipOccupancyCalculator<UniqueMarker> oc(func);
-    auto max_sizes = oc.get_max_block_size_and_grid_size(dynamic_shmem_size);
+    ::RAJA::hip::ConcretizerImpl<IdxT, Concretizer, UniqueMarker> concretizer{func, dynamic_shmem_size, len};
 
-    IdxT calculated_block_size = std::min(
-        RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::grid_size)),
-        static_cast<IdxT>(max_sizes.first));
+    const IdxT grid_size = static_cast<IdxT>(IndexGetter::grid_size);
+    const IdxT block_size = concretizer.get_block_size_to_fit_device(grid_size);
 
-    internal::set_hip_dim<dim>(dims.threads, calculated_block_size);
-    internal::set_hip_dim<dim>(dims.blocks, static_cast<IdxT>(IndexMapper::grid_size));
+    internal::set_hip_dim<dim>(dims.threads, block_size);
+    internal::set_hip_dim<dim>(dims.blocks, grid_size);
   }
 };
 
-template<named_dim dim, int BLOCK_SIZE, typename UniqueMarker, typename ... MappingModifiers>
-struct ForallDimensionCalculator<::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified, MappingModifiers...>,
+template<named_dim dim, int BLOCK_SIZE, typename Concretizer, typename UniqueMarker>
+struct ForallDimensionCalculator<::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                  ::RAJA::hip::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>,
+                                 Concretizer,
                                  UniqueMarker>
 {
   static_assert(BLOCK_SIZE > 0, "block size must be > 0 or named_usage::unspecified with forall");
 
-  using IterationMapping = ::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified, MappingModifiers...>;
-  using IndexMapper = ::RAJA::hip::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>;
+  using IndexGetter = ::RAJA::hip::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>;
 
   template < typename IdxT >
   static void set_dimensions(internal::HipDims& dims, IdxT len,
                              const void* func, size_t dynamic_shmem_size)
   {
-    ::RAJA::hip::HipOccupancyCalculator<UniqueMarker> oc(func);
-    auto max_grid_size = oc.get_max_grid_size(dynamic_shmem_size,
-                                              static_cast<IdxT>(IndexMapper::block_size));
+    ::RAJA::hip::ConcretizerImpl<IdxT, Concretizer, UniqueMarker> concretizer{func, dynamic_shmem_size, len};
 
-    IdxT calculated_grid_size = GridStrideHelper<IterationMapping>::get_grid_size(
-        RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::block_size)),
-        static_cast<IdxT>(max_grid_size));
+    const IdxT block_size = static_cast<IdxT>(IndexGetter::block_size);
+    const IdxT grid_size = concretizer.get_grid_size_to_fit_device(block_size);
 
-    internal::set_hip_dim<dim>(dims.threads, static_cast<IdxT>(IndexMapper::block_size));
-    internal::set_hip_dim<dim>(dims.blocks, calculated_grid_size);
+    internal::set_hip_dim<dim>(dims.threads, block_size);
+    internal::set_hip_dim<dim>(dims.blocks, grid_size);
   }
 };
 
-template<named_dim dim, typename UniqueMarker, typename ... MappingModifiers>
-struct ForallDimensionCalculator<::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified, MappingModifiers...>,
+template<named_dim dim, typename Concretizer, typename UniqueMarker>
+struct ForallDimensionCalculator<::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                  ::RAJA::hip::IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>,
+                                 Concretizer,
                                  UniqueMarker>
 {
-  using IterationMapping = ::RAJA::iteration_mapping::StridedLoop<named_usage::unspecified, MappingModifiers...>;
-  using IndexMapper = ::RAJA::hip::IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>;
+  using IndexGetter = ::RAJA::hip::IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>;
 
   template < typename IdxT >
   static void set_dimensions(internal::HipDims& dims, IdxT len,
                              const void* func, size_t dynamic_shmem_size)
   {
-    ::RAJA::hip::HipOccupancyCalculator<UniqueMarker> oc(func);
-    auto max_sizes = oc.get_max_block_size_and_grid_size(dynamic_shmem_size);
+    ::RAJA::hip::ConcretizerImpl<IdxT, Concretizer, UniqueMarker> concretizer{func, dynamic_shmem_size, len};
 
-    IdxT calculated_grid_size = GridStrideHelper<IterationMapping>::get_grid_size(
-        RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(max_sizes.first)),
-        static_cast<IdxT>(max_sizes.second));
+    const auto sizes = concretizer.get_block_and_grid_size_to_fit_device();
 
-    internal::set_hip_dim<dim>(dims.threads, static_cast<IdxT>(max_sizes.first));
-    internal::set_hip_dim<dim>(dims.blocks, calculated_grid_size);
+    internal::set_hip_dim<dim>(dims.threads, sizes.first);
+    internal::set_hip_dim<dim>(dims.blocks, sizes.second);
   }
 };
 
@@ -551,7 +510,7 @@ void forallp_hip_kernel(LOOP_BODY loop_body,
 
 template <typename Iterable, typename LoopBody,
           typename IterationMapping, typename IterationGetter,
-          bool Async,
+          typename Concretizer, bool Async,
           typename ForallParam>
 RAJA_INLINE 
 concepts::enable_if_t<
@@ -559,7 +518,7 @@ concepts::enable_if_t<
   RAJA::expt::type_traits::is_ForallParamPack<ForallParam>,
   RAJA::expt::type_traits::is_ForallParamPack_empty<ForallParam>>
 forall_impl(resources::Hip hip_res,
-            ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>const&,
+            ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>const&,
             Iterable&& iter,
             LoopBody&& loop_body,
             ForallParam)
@@ -567,9 +526,9 @@ forall_impl(resources::Hip hip_res,
   using Iterator  = camp::decay<decltype(std::begin(iter))>;
   using LOOP_BODY = camp::decay<LoopBody>;
   using IndexType = camp::decay<decltype(std::distance(std::begin(iter), std::end(iter)))>;
-  using EXEC_POL = ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>;
+  using EXEC_POL = ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>;
   using UniqueMarker = ::camp::list<IterationMapping, IterationGetter, LOOP_BODY, Iterator, ForallParam>;
-  using DimensionCalculator = impl::ForallDimensionCalculator<IterationMapping, IterationGetter, UniqueMarker>;
+  using DimensionCalculator = impl::ForallDimensionCalculator<IterationMapping, IterationGetter, Concretizer, UniqueMarker>;
 
   //
   // Compute the requested iteration space size
@@ -620,7 +579,7 @@ forall_impl(resources::Hip hip_res,
 
 template <typename Iterable, typename LoopBody,
           typename IterationMapping, typename IterationGetter,
-          bool Async,
+          typename Concretizer, bool Async,
           typename ForallParam>
 RAJA_INLINE 
 concepts::enable_if_t<
@@ -628,7 +587,7 @@ concepts::enable_if_t<
   RAJA::expt::type_traits::is_ForallParamPack<ForallParam>,
   concepts::negate< RAJA::expt::type_traits::is_ForallParamPack_empty<ForallParam>> >
 forall_impl(resources::Hip hip_res,
-            ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async> const&,
+            ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async> const&,
             Iterable&& iter,
             LoopBody&& loop_body,
             ForallParam f_params)
@@ -636,9 +595,9 @@ forall_impl(resources::Hip hip_res,
   using Iterator  = camp::decay<decltype(std::begin(iter))>;
   using LOOP_BODY = camp::decay<LoopBody>;
   using IndexType = camp::decay<decltype(std::distance(std::begin(iter), std::end(iter)))>;
-  using EXEC_POL = ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>;
+  using EXEC_POL = ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>;
   using UniqueMarker = ::camp::list<IterationMapping, IterationGetter, LOOP_BODY, Iterator, ForallParam>;
-  using DimensionCalculator = impl::ForallDimensionCalculator<IterationMapping, IterationGetter, UniqueMarker>;
+  using DimensionCalculator = impl::ForallDimensionCalculator<IterationMapping, IterationGetter, Concretizer, UniqueMarker>;
 
   //
   // Compute the requested iteration space size
@@ -716,11 +675,11 @@ forall_impl(resources::Hip hip_res,
  */
 template <typename LoopBody,
           typename IterationMapping, typename IterationGetter,
-          bool Async,
+          typename Concretizer, bool Async,
           typename... SegmentTypes>
 RAJA_INLINE resources::EventProxy<resources::Hip>
 forall_impl(resources::Hip r,
-            ExecPolicy<seq_segit, ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>>,
+            ExecPolicy<seq_segit, ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>>,
             const TypedIndexSet<SegmentTypes...>& iset,
             LoopBody&& loop_body)
 {
@@ -729,7 +688,7 @@ forall_impl(resources::Hip r,
     iset.segmentCall(r,
                      isi,
                      detail::CallForall(),
-                     ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, true>(),
+                     ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, true>(),
                      loop_body);
   }  // iterate over segments of index set
 

--- a/include/RAJA/policy/hip/kernel.hpp
+++ b/include/RAJA/policy/hip/kernel.hpp
@@ -4,7 +4,7 @@
  * \file
  *
  * \brief   RAJA header file containing constructs used to run kernel::forall
- *          traversals on GPU with CUDA.
+ *          traversals on GPU with HIP.
  *
  ******************************************************************************
  */

--- a/include/RAJA/policy/hip/kernel/For.hpp
+++ b/include/RAJA/policy/hip/kernel/For.hpp
@@ -45,7 +45,7 @@ template <typename Data,
 struct HipStatementExecutor<
     Data,
     statement::For<ArgumentId,
-                   RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
+                   RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>,
                    EnclosedStmts...>,
     Types> {
 
@@ -60,7 +60,7 @@ struct HipStatementExecutor<
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
   using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<
-      RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>>;
+      RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>>;
 
   static inline RAJA_DEVICE
   void exec(Data &data, bool thread_active)

--- a/include/RAJA/policy/hip/kernel/For.hpp
+++ b/include/RAJA/policy/hip/kernel/For.hpp
@@ -45,7 +45,7 @@ template <typename Data,
 struct HipStatementExecutor<
     Data,
     statement::For<ArgumentId,
-                   RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>,
+                   RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
                    EnclosedStmts...>,
     Types> {
 
@@ -60,7 +60,7 @@ struct HipStatementExecutor<
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
   using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<
-      RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>>;
+      RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>>;
 
   static inline RAJA_DEVICE
   void exec(Data &data, bool thread_active)
@@ -108,7 +108,7 @@ template <typename Data,
 struct HipStatementExecutor<
     Data,
     statement::For<ArgumentId,
-                   RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>,
+                   RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>,
                    EnclosedStmts...>,
     Types> {
 
@@ -123,7 +123,7 @@ struct HipStatementExecutor<
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
   using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<
-      RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>>;
+      RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>>;
 
 
   static inline RAJA_DEVICE
@@ -180,7 +180,7 @@ template <typename Data,
 struct HipStatementExecutor<
     Data,
     statement::For<ArgumentId,
-                   RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>,
+                   RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>,
                    EnclosedStmts...>,
     Types> {
 
@@ -195,7 +195,7 @@ struct HipStatementExecutor<
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
   using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<
-      RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>>;
+      RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>>;
 
 
   static inline RAJA_DEVICE
@@ -246,7 +246,7 @@ struct HipStatementExecutor<
     statement::For<ArgumentId, seq_exec, EnclosedStmts...>,
     Types>
 : HipStatementExecutor<Data, statement::For<ArgumentId,
-      RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop,
+      RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                      kernel_sync_requirement::none,
                                      hip::IndexGlobal<named_dim::x, named_usage::ignored, named_usage::ignored>>,
       EnclosedStmts...>, Types>

--- a/include/RAJA/policy/hip/kernel/ForICount.hpp
+++ b/include/RAJA/policy/hip/kernel/ForICount.hpp
@@ -47,20 +47,20 @@ template <typename Data,
 struct HipStatementExecutor<
     Data,
     statement::ForICount<ArgumentId, ParamId,
-                         RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
+                         RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>,
                          EnclosedStmts...>,
     Types>
     : HipStatementExecutor<
         Data,
         statement::For<ArgumentId,
-                       RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
+                       RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>,
                        EnclosedStmts...>,
         Types> {
 
   using Base = HipStatementExecutor<
       Data,
       statement::For<ArgumentId,
-                     RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
+                     RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>,
                      EnclosedStmts...>,
       Types>;
 

--- a/include/RAJA/policy/hip/kernel/ForICount.hpp
+++ b/include/RAJA/policy/hip/kernel/ForICount.hpp
@@ -47,20 +47,20 @@ template <typename Data,
 struct HipStatementExecutor<
     Data,
     statement::ForICount<ArgumentId, ParamId,
-                         RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>,
+                         RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
                          EnclosedStmts...>,
     Types>
     : HipStatementExecutor<
         Data,
         statement::For<ArgumentId,
-                       RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>,
+                       RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
                        EnclosedStmts...>,
         Types> {
 
   using Base = HipStatementExecutor<
       Data,
       statement::For<ArgumentId,
-                     RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>,
+                     RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
                      EnclosedStmts...>,
       Types>;
 
@@ -103,20 +103,20 @@ template <typename Data,
 struct HipStatementExecutor<
     Data,
     statement::ForICount<ArgumentId, ParamId,
-                         RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>,
+                         RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>,
                          EnclosedStmts...>,
     Types>
     : public HipStatementExecutor<
         Data,
         statement::For<ArgumentId,
-                       RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>,
+                       RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>,
                        EnclosedStmts...>,
         Types> {
 
   using Base = HipStatementExecutor<
       Data,
       statement::For<ArgumentId,
-                     RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>,
+                     RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>,
                      EnclosedStmts...>,
       Types>;
 
@@ -166,20 +166,20 @@ template <typename Data,
 struct HipStatementExecutor<
     Data,
     statement::ForICount<ArgumentId, ParamId,
-                         RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>,
+                         RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>,
                          EnclosedStmts...>,
     Types>
     : public HipStatementExecutor<
         Data,
         statement::For<ArgumentId,
-                       RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>,
+                       RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>,
                        EnclosedStmts...>,
         Types> {
 
   using Base = HipStatementExecutor<
       Data,
       statement::For<ArgumentId,
-                     RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>,
+                     RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>,
                      EnclosedStmts...>,
       Types>;
 
@@ -226,7 +226,7 @@ struct HipStatementExecutor<
     statement::ForICount<ArgumentId, ParamId, seq_exec, EnclosedStmts...>,
     Types>
 : HipStatementExecutor<Data, statement::ForICount<ArgumentId,
-      RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop,
+      RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                      kernel_sync_requirement::none,
                                      hip::IndexGlobal<named_dim::x, named_usage::ignored, named_usage::ignored>>,
       EnclosedStmts...>, Types>

--- a/include/RAJA/policy/hip/kernel/Tile.hpp
+++ b/include/RAJA/policy/hip/kernel/Tile.hpp
@@ -58,7 +58,7 @@ struct HipStatementExecutor<
     Data,
     statement::Tile<ArgumentId,
                     RAJA::tile_fixed<chunk_size>,
-                    RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
+                    RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>,
                     EnclosedStmts...>,
                     Types>
   {
@@ -69,7 +69,7 @@ struct HipStatementExecutor<
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
-  using DimensionCalculator = KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>>;
+  using DimensionCalculator = KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>>;
 
   static inline RAJA_DEVICE
   void exec(Data &data, bool thread_active)

--- a/include/RAJA/policy/hip/kernel/Tile.hpp
+++ b/include/RAJA/policy/hip/kernel/Tile.hpp
@@ -58,7 +58,7 @@ struct HipStatementExecutor<
     Data,
     statement::Tile<ArgumentId,
                     RAJA::tile_fixed<chunk_size>,
-                    RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>,
+                    RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
                     EnclosedStmts...>,
                     Types>
   {
@@ -69,7 +69,7 @@ struct HipStatementExecutor<
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
-  using DimensionCalculator = KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>>;
+  using DimensionCalculator = KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>>;
 
   static inline RAJA_DEVICE
   void exec(Data &data, bool thread_active)
@@ -143,7 +143,7 @@ struct HipStatementExecutor<
     Data,
     statement::Tile<ArgumentId,
                     RAJA::tile_fixed<chunk_size>,
-                    RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>,
+                    RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>,
                     EnclosedStmts...>, Types>
   {
 
@@ -153,7 +153,7 @@ struct HipStatementExecutor<
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
-  using DimensionCalculator = KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>>;
+  using DimensionCalculator = KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>>;
 
   static inline RAJA_DEVICE
   void exec(Data &data, bool thread_active)
@@ -233,7 +233,7 @@ struct HipStatementExecutor<
     Data,
     statement::Tile<ArgumentId,
                     RAJA::tile_fixed<chunk_size>,
-                    RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>,
+                    RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>,
                     EnclosedStmts...>, Types>
   {
 
@@ -243,7 +243,7 @@ struct HipStatementExecutor<
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
-  using DimensionCalculator = KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>>;
+  using DimensionCalculator = KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>>;
 
   static inline RAJA_DEVICE
   void exec(Data &data, bool thread_active)
@@ -318,7 +318,7 @@ struct HipStatementExecutor<
     Data,
     statement::Tile<ArgumentId, TPol, seq_exec, EnclosedStmts...>, Types>
 : HipStatementExecutor<Data, statement::Tile<ArgumentId, TPol,
-    RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop,
+    RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                    kernel_sync_requirement::none,
                                    hip::IndexGlobal<named_dim::x, named_usage::ignored, named_usage::ignored>>,
     EnclosedStmts...>, Types>

--- a/include/RAJA/policy/hip/kernel/TileTCount.hpp
+++ b/include/RAJA/policy/hip/kernel/TileTCount.hpp
@@ -60,14 +60,14 @@ struct HipStatementExecutor<
     Data,
     statement::TileTCount<ArgumentId, ParamId,
                     RAJA::tile_fixed<chunk_size>,
-                    RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>,
+                    RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
                     EnclosedStmts...>,
                     Types>
     : public HipStatementExecutor<
         Data,
         statement::Tile<ArgumentId,
                         RAJA::tile_fixed<chunk_size>,
-                        RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>,
+                        RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
                         EnclosedStmts...>,
                         Types> {
 
@@ -75,7 +75,7 @@ struct HipStatementExecutor<
       Data,
       statement::Tile<ArgumentId,
                       RAJA::tile_fixed<chunk_size>,
-                      RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>,
+                      RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
                       EnclosedStmts...>,
                       Types>;
 
@@ -131,14 +131,14 @@ struct HipStatementExecutor<
     Data,
     statement::TileTCount<ArgumentId, ParamId,
                     RAJA::tile_fixed<chunk_size>,
-                    RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>,
+                    RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>,
                     EnclosedStmts...>,
                     Types>
     : public HipStatementExecutor<
         Data,
         statement::Tile<ArgumentId,
                         RAJA::tile_fixed<chunk_size>,
-                        RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>,
+                        RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>,
                         EnclosedStmts...>,
                         Types> {
 
@@ -146,7 +146,7 @@ struct HipStatementExecutor<
       Data,
       statement::Tile<ArgumentId,
                       RAJA::tile_fixed<chunk_size>,
-                      RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::sync, IndexMapper>,
+                      RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::sync, IndexMapper>,
                       EnclosedStmts...>,
                       Types>;
 
@@ -209,14 +209,14 @@ struct HipStatementExecutor<
     Data,
     statement::TileTCount<ArgumentId, ParamId,
                     RAJA::tile_fixed<chunk_size>,
-                    RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>,
+                    RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>,
                     EnclosedStmts...>,
                     Types>
     : public HipStatementExecutor<
         Data,
         statement::Tile<ArgumentId,
                         RAJA::tile_fixed<chunk_size>,
-                        RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>,
+                        RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>,
                         EnclosedStmts...>,
                         Types> {
 
@@ -224,7 +224,7 @@ struct HipStatementExecutor<
       Data,
       statement::Tile<ArgumentId,
                       RAJA::tile_fixed<chunk_size>,
-                      RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop, kernel_sync_requirement::none, IndexMapper>,
+                      RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>, kernel_sync_requirement::none, IndexMapper>,
                       EnclosedStmts...>,
                       Types>;
 
@@ -281,7 +281,7 @@ struct HipStatementExecutor<
     Data,
     statement::TileTCount<ArgumentId, ParamId, TPol, seq_exec, EnclosedStmts...>, Types>
 : HipStatementExecutor<Data, statement::TileTCount<ArgumentId, ParamId, TPol,
-    RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop,
+    RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                    kernel_sync_requirement::none,
                                    hip::IndexGlobal<named_dim::x, named_usage::ignored, named_usage::ignored>>,
     EnclosedStmts...>, Types>

--- a/include/RAJA/policy/hip/kernel/TileTCount.hpp
+++ b/include/RAJA/policy/hip/kernel/TileTCount.hpp
@@ -60,14 +60,14 @@ struct HipStatementExecutor<
     Data,
     statement::TileTCount<ArgumentId, ParamId,
                     RAJA::tile_fixed<chunk_size>,
-                    RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
+                    RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>,
                     EnclosedStmts...>,
                     Types>
     : public HipStatementExecutor<
         Data,
         statement::Tile<ArgumentId,
                         RAJA::tile_fixed<chunk_size>,
-                        RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
+                        RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>,
                         EnclosedStmts...>,
                         Types> {
 
@@ -75,7 +75,7 @@ struct HipStatementExecutor<
       Data,
       statement::Tile<ArgumentId,
                       RAJA::tile_fixed<chunk_size>,
-                      RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>, sync, IndexMapper>,
+                      RAJA::policy::hip::hip_indexer<iteration_mapping::Direct, sync, IndexMapper>,
                       EnclosedStmts...>,
                       Types>;
 

--- a/include/RAJA/policy/hip/kernel/internal.hpp
+++ b/include/RAJA/policy/hip/kernel/internal.hpp
@@ -217,7 +217,7 @@ struct KernelDimensionCalculator;
 
 // specialization for direct sequential policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::ignored, named_usage::ignored>>>
 {
@@ -234,7 +234,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 
 // specialization for direct thread policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::unspecified, named_usage::ignored>>>
 {
@@ -250,7 +250,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     hip::IndexGlobal<dim, BLOCK_SIZE, named_usage::ignored>>>
 {
@@ -271,7 +271,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 
 // specialization for direct block policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::ignored, named_usage::unspecified>>>
 {
@@ -286,7 +286,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 };
 ///
 template<named_dim dim, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::ignored, GRID_SIZE>>>
 {
@@ -307,7 +307,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 
 // specialization for direct global policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>>>
 {
@@ -323,7 +323,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 };
 ///
 template<named_dim dim, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>>>
 {
@@ -343,7 +343,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     hip::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>>>
 {
@@ -362,7 +362,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
                                                     sync,
                                                     hip::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>>>
 {

--- a/include/RAJA/policy/hip/kernel/internal.hpp
+++ b/include/RAJA/policy/hip/kernel/internal.hpp
@@ -217,7 +217,7 @@ struct KernelDimensionCalculator;
 
 // specialization for direct sequential policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::ignored, named_usage::ignored>>>
 {
@@ -234,7 +234,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 
 // specialization for direct thread policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::unspecified, named_usage::ignored>>>
 {
@@ -250,7 +250,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     hip::IndexGlobal<dim, BLOCK_SIZE, named_usage::ignored>>>
 {
@@ -271,7 +271,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 
 // specialization for direct block policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::ignored, named_usage::unspecified>>>
 {
@@ -286,7 +286,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 };
 ///
 template<named_dim dim, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::ignored, GRID_SIZE>>>
 {
@@ -307,7 +307,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 
 // specialization for direct global policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>>>
 {
@@ -323,7 +323,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 };
 ///
 template<named_dim dim, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>>>
 {
@@ -343,7 +343,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     hip::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>>>
 {
@@ -362,7 +362,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::Direct<>,
                                                     sync,
                                                     hip::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>>>
 {
@@ -388,7 +388,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 
 // specialization for strided loop sequential policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::ignored, named_usage::ignored>>>
 {
@@ -402,7 +402,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 
 // specialization for strided loop thread policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::unspecified, named_usage::ignored>>>
 {
@@ -418,7 +418,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     hip::IndexGlobal<dim, BLOCK_SIZE, named_usage::ignored>>>
 {
@@ -436,7 +436,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 
 // specialization for strided loop block policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::ignored, named_usage::unspecified>>>
 {
@@ -451,7 +451,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 };
 ///
 template<named_dim dim, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::ignored, GRID_SIZE>>>
 {
@@ -469,7 +469,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 
 // specialization for strided loop global policies
 template<named_dim dim, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>>>
 {
@@ -488,7 +488,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 };
 ///
 template<named_dim dim, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     hip::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>>>
 {
@@ -508,7 +508,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     hip::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>>>
 {
@@ -527,7 +527,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mappin
 };
 ///
 template<named_dim dim, int BLOCK_SIZE, int GRID_SIZE, kernel_sync_requirement sync>
-struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop,
+struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                     sync,
                                                     hip::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>>>
 {

--- a/include/RAJA/policy/hip/launch.hpp
+++ b/include/RAJA/policy/hip/launch.hpp
@@ -348,7 +348,7 @@ struct LaunchExecute<RAJA::policy::hip::hip_launch_t<async, nthreads>> {
    HIP generic loop implementations
 */
 template <typename SEGMENT, typename IndexMapper>
-struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper>,
                    SEGMENT> {
@@ -371,7 +371,7 @@ struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direc
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper0,
                                                   IndexMapper1>,
@@ -399,7 +399,7 @@ struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direc
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper0,
                                                   IndexMapper1,
@@ -538,7 +538,7 @@ struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Strid
 };
 
 template <typename SEGMENT, typename IndexMapper>
-struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper>,
                          SEGMENT> {
@@ -560,7 +560,7 @@ struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping:
   }
 };
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper0,
                                                         IndexMapper1>,
@@ -590,7 +590,7 @@ struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping:
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper0,
                                                         IndexMapper1,
@@ -736,18 +736,18 @@ struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping:
    HIP generic flattened loop implementations
 */
 template<typename SEGMENT, kernel_sync_requirement sync, typename IndexMapper0>
-struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::Direct,
                                                           sync,
                                                           IndexMapper0>,
                    SEGMENT>
-    :  LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
+    :  LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
                                                   sync,
                                                   IndexMapper0>,
                    SEGMENT>
 {};
 
 template<typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::Direct,
                                                           kernel_sync_requirement::none,
                                                           IndexMapper0,
                                                           IndexMapper1>,
@@ -777,7 +777,7 @@ struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mappin
 };
 
 template<typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::Direct<>,
+struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::Direct,
                                                           kernel_sync_requirement::none,
                                                           IndexMapper0,
                                                           IndexMapper1,
@@ -890,7 +890,7 @@ struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mappin
    HIP generic tile implementations
 */
 template <typename SEGMENT, typename IndexMapper>
-struct TileExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
+struct TileExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper>,
                    SEGMENT> {
@@ -939,7 +939,7 @@ struct TileExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Strid
 };
 
 template <typename SEGMENT, typename IndexMapper>
-struct TileTCountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
+struct TileTCountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper>,
                          SEGMENT> {

--- a/include/RAJA/policy/hip/launch.hpp
+++ b/include/RAJA/policy/hip/launch.hpp
@@ -348,7 +348,7 @@ struct LaunchExecute<RAJA::policy::hip::hip_launch_t<async, nthreads>> {
    HIP generic loop implementations
 */
 template <typename SEGMENT, typename IndexMapper>
-struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
+struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper>,
                    SEGMENT> {
@@ -371,7 +371,7 @@ struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direc
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
+struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper0,
                                                   IndexMapper1>,
@@ -399,7 +399,7 @@ struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direc
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
+struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper0,
                                                   IndexMapper1,
@@ -433,7 +433,7 @@ struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direc
 };
 
 template <typename SEGMENT, typename IndexMapper>
-struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper>,
                    SEGMENT> {
@@ -457,7 +457,7 @@ struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Strid
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper0,
                                                   IndexMapper1>,
@@ -493,7 +493,7 @@ struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Strid
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper0,
                                                   IndexMapper1,
@@ -538,7 +538,7 @@ struct LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Strid
 };
 
 template <typename SEGMENT, typename IndexMapper>
-struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
+struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper>,
                          SEGMENT> {
@@ -560,7 +560,7 @@ struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping:
   }
 };
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
+struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper0,
                                                         IndexMapper1>,
@@ -590,7 +590,7 @@ struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping:
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
+struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper0,
                                                         IndexMapper1,
@@ -625,7 +625,7 @@ struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping:
 };
 
 template <typename SEGMENT, typename IndexMapper>
-struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper>,
                          SEGMENT> {
@@ -649,7 +649,7 @@ struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping:
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper0,
                                                         IndexMapper1>,
@@ -686,7 +686,7 @@ struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping:
 };
 
 template <typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper0,
                                                         IndexMapper1,
@@ -736,18 +736,18 @@ struct LoopICountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping:
    HIP generic flattened loop implementations
 */
 template<typename SEGMENT, kernel_sync_requirement sync, typename IndexMapper0>
-struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::Direct,
+struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::Direct<>,
                                                           sync,
                                                           IndexMapper0>,
                    SEGMENT>
-    :  LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
+    :  LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
                                                   sync,
                                                   IndexMapper0>,
                    SEGMENT>
 {};
 
 template<typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::Direct,
+struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::Direct<>,
                                                           kernel_sync_requirement::none,
                                                           IndexMapper0,
                                                           IndexMapper1>,
@@ -777,7 +777,7 @@ struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mappin
 };
 
 template<typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::Direct,
+struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::Direct<>,
                                                           kernel_sync_requirement::none,
                                                           IndexMapper0,
                                                           IndexMapper1,
@@ -810,18 +810,18 @@ struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mappin
 };
 
 template<typename SEGMENT, kernel_sync_requirement sync, typename IndexMapper0>
-struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                           sync,
                                                           IndexMapper0>,
                    SEGMENT>
-    :  LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop,
+    :  LoopExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                   sync,
                                                   IndexMapper0>,
                    SEGMENT>
 {};
 
 template<typename SEGMENT, typename IndexMapper0, typename IndexMapper1>
-struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                           kernel_sync_requirement::none,
                                                           IndexMapper0,
                                                           IndexMapper1>,
@@ -852,7 +852,7 @@ struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mappin
 };
 
 template<typename SEGMENT, typename IndexMapper0, typename IndexMapper1, typename IndexMapper2>
-struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::StridedLoop,
+struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                           kernel_sync_requirement::none,
                                                           IndexMapper0,
                                                           IndexMapper1,
@@ -890,7 +890,7 @@ struct LoopExecute<RAJA::policy::hip::hip_flatten_indexer<RAJA::iteration_mappin
    HIP generic tile implementations
 */
 template <typename SEGMENT, typename IndexMapper>
-struct TileExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
+struct TileExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper>,
                    SEGMENT> {
@@ -914,7 +914,7 @@ struct TileExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direc
 };
 
 template <typename SEGMENT, typename IndexMapper>
-struct TileExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop,
+struct TileExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                   kernel_sync_requirement::none,
                                                   IndexMapper>,
                    SEGMENT> {
@@ -939,7 +939,7 @@ struct TileExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Strid
 };
 
 template <typename SEGMENT, typename IndexMapper>
-struct TileTCountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct,
+struct TileTCountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::Direct<>,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper>,
                          SEGMENT> {
@@ -964,7 +964,7 @@ struct TileTCountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping:
 };
 
 template <typename SEGMENT, typename IndexMapper>
-struct TileTCountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop,
+struct TileTCountExecute<RAJA::policy::hip::hip_indexer<RAJA::iteration_mapping::StridedLoop<named_usage::unspecified>,
                                                         kernel_sync_requirement::none,
                                                         IndexMapper>,
                          SEGMENT> {

--- a/include/RAJA/policy/hip/policy.hpp
+++ b/include/RAJA/policy/hip/policy.hpp
@@ -961,19 +961,16 @@ using global_z = IndexGlobal<named_dim::z, BLOCK_SIZE, GRID_SIZE>;
 
 // contretizers used in forall, scan, and sort policies
 
-using HipDefaultAvoidMaxOccupancyConcretizer = hip::FractionOffsetOccupancyConcretizer<Fraction<size_t, 1, 1>, -1>;
-
-template < typename AvoidMaxOccupancyConcretizer >
-using HipAvoidDeviceMaxThreadOccupancyConcretizer = hip::AvoidDeviceMaxThreadOccupancyConcretizer<AvoidMaxOccupancyConcretizer>;
+using HipAvoidDeviceMaxThreadOccupancyConcretizer = hip::AvoidDeviceMaxThreadOccupancyConcretizer<hip::FractionOffsetOccupancyConcretizer<Fraction<size_t, 1, 1>, -1>>;
 
 template < typename Fraction, std::ptrdiff_t BLOCKS_PER_SM_OFFSET >
 using HipFractionOffsetOccupancyConcretizer = hip::FractionOffsetOccupancyConcretizer<Fraction, BLOCKS_PER_SM_OFFSET>;
 
 using HipMaxOccupancyConcretizer = hip::MaxOccupancyConcretizer;
 
-using HipRecForReduceConcretizer = hip::AvoidDeviceMaxThreadOccupancyConcretizer<HipDefaultAvoidMaxOccupancyConcretizer>;
+using HipRecForReduceConcretizer = HipAvoidDeviceMaxThreadOccupancyConcretizer;
 
-using HipDefaultConcretizer = hip::MaxOccupancyConcretizer;
+using HipDefaultConcretizer = HipAvoidDeviceMaxThreadOccupancyConcretizer;
 
 // policies usable with forall, scan, and sort
 
@@ -1017,15 +1014,15 @@ using hip_exec_occ_fraction_async = policy::hip::hip_exec<
     iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
     HipFractionOffsetOccupancyConcretizer<Fraction, 0>, true>;
 
-template <size_t BLOCK_SIZE, typename AvoidMaxOccupancyConcretizer = HipDefaultAvoidMaxOccupancyConcretizer, bool Async = false>
+template <size_t BLOCK_SIZE, bool Async = false>
 using hip_exec_occ_avoid_max = policy::hip::hip_exec<
     iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
-    HipAvoidDeviceMaxThreadOccupancyConcretizer<AvoidMaxOccupancyConcretizer>, Async>;
+    HipAvoidDeviceMaxThreadOccupancyConcretizer, Async>;
 
-template <size_t BLOCK_SIZE, typename AvoidMaxOccupancyConcretizer = HipDefaultAvoidMaxOccupancyConcretizer>
+template <size_t BLOCK_SIZE>
 using hip_exec_occ_avoid_max_async = policy::hip::hip_exec<
     iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
-    HipAvoidDeviceMaxThreadOccupancyConcretizer<AvoidMaxOccupancyConcretizer>, true>;
+    HipAvoidDeviceMaxThreadOccupancyConcretizer, true>;
 
 template <size_t BLOCK_SIZE, bool Async = false>
 using hip_exec_rec_for_reduce = policy::hip::hip_exec<

--- a/include/RAJA/policy/hip/policy.hpp
+++ b/include/RAJA/policy/hip/policy.hpp
@@ -909,6 +909,14 @@ template <size_t BLOCK_SIZE, typename Fraction>
 using hip_exec_occ_calc_fraction_async = policy::hip::hip_exec<
     iteration_mapping::StridedLoop<named_usage::unspecified, typename Fraction::inverse>, hip::global_x<BLOCK_SIZE>, true>;
 
+template <size_t BLOCK_SIZE, bool Async = false>
+using hip_exec_occ_calc_recommended = policy::hip::hip_exec<
+    iteration_mapping::StridedLoop<named_usage::unspecified, Fraction<size_t, 2, 1>>, hip::global_x<BLOCK_SIZE>, Async>;
+
+template <size_t BLOCK_SIZE>
+using hip_exec_occ_calc_recommended_async = policy::hip::hip_exec<
+    iteration_mapping::StridedLoop<named_usage::unspecified, Fraction<size_t, 2, 1>>, hip::global_x<BLOCK_SIZE>, true>;
+
 // policies usable with WorkGroup
 using policy::hip::hip_work;
 

--- a/include/RAJA/policy/hip/policy.hpp
+++ b/include/RAJA/policy/hip/policy.hpp
@@ -968,7 +968,7 @@ using HipFractionOffsetOccupancyConcretizer = hip::FractionOffsetOccupancyConcre
 
 using HipMaxOccupancyConcretizer = hip::MaxOccupancyConcretizer;
 
-using HipRecForReduceConcretizer = HipAvoidDeviceMaxThreadOccupancyConcretizer;
+using HipRecForReduceConcretizer = HipFractionOffsetOccupancyConcretizer<Fraction<size_t, 1, 2>, 0>;
 
 using HipDefaultConcretizer = HipAvoidDeviceMaxThreadOccupancyConcretizer;
 

--- a/include/RAJA/policy/hip/policy.hpp
+++ b/include/RAJA/policy/hip/policy.hpp
@@ -997,10 +997,20 @@ using hip_exec_async = policy::hip::hip_exec<
 template <size_t BLOCK_SIZE, bool Async = false>
 using hip_exec_occ_calc = policy::hip::hip_exec<
     iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
-    HipMaxOccupancyConcretizer, Async>;
+    HipDefaultConcretizer, Async>;
 
 template <size_t BLOCK_SIZE>
 using hip_exec_occ_calc_async = policy::hip::hip_exec<
+    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
+    HipDefaultConcretizer, true>;
+
+template <size_t BLOCK_SIZE, bool Async = false>
+using hip_exec_occ_max = policy::hip::hip_exec<
+    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
+    HipMaxOccupancyConcretizer, Async>;
+
+template <size_t BLOCK_SIZE>
+using hip_exec_occ_max_async = policy::hip::hip_exec<
     iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
     HipMaxOccupancyConcretizer, true>;
 
@@ -1014,15 +1024,15 @@ using hip_exec_occ_fraction_async = policy::hip::hip_exec<
     iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
     HipFractionOffsetOccupancyConcretizer<Fraction, 0>, true>;
 
-template <size_t BLOCK_SIZE, bool Async = false>
-using hip_exec_occ_avoid_max = policy::hip::hip_exec<
+template <size_t BLOCK_SIZE, typename Concretizer, bool Async = false>
+using hip_exec_occ_custom = policy::hip::hip_exec<
     iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
-    HipAvoidDeviceMaxThreadOccupancyConcretizer, Async>;
+    Concretizer, Async>;
 
-template <size_t BLOCK_SIZE>
-using hip_exec_occ_avoid_max_async = policy::hip::hip_exec<
+template <size_t BLOCK_SIZE, typename Concretizer>
+using hip_exec_occ_custom_async = policy::hip::hip_exec<
     iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
-    HipAvoidDeviceMaxThreadOccupancyConcretizer, true>;
+    Concretizer, true>;
 
 template <size_t BLOCK_SIZE, bool Async = false>
 using hip_exec_rec_for_reduce = policy::hip::hip_exec<

--- a/include/RAJA/policy/hip/policy.hpp
+++ b/include/RAJA/policy/hip/policy.hpp
@@ -910,12 +910,10 @@ using hip_exec_occ_calc_fraction_async = policy::hip::hip_exec<
     iteration_mapping::StridedLoop<named_usage::unspecified, typename Fraction::inverse>, hip::global_x<BLOCK_SIZE>, true>;
 
 template <size_t BLOCK_SIZE, bool Async = false>
-using hip_exec_occ_calc_recommended = policy::hip::hip_exec<
-    iteration_mapping::StridedLoop<named_usage::unspecified, Fraction<size_t, 2, 1>>, hip::global_x<BLOCK_SIZE>, Async>;
+using hip_exec_rec_for_reduce = hip_exec_occ_calc_fraction<BLOCK_SIZE, Fraction<size_t, 1, 2>, Async>;
 
 template <size_t BLOCK_SIZE>
-using hip_exec_occ_calc_recommended_async = policy::hip::hip_exec<
-    iteration_mapping::StridedLoop<named_usage::unspecified, Fraction<size_t, 2, 1>>, hip::global_x<BLOCK_SIZE>, true>;
+using hip_exec_rec_for_reduce_async = hip_exec_occ_calc_fraction_async<BLOCK_SIZE, Fraction<size_t, 1, 2>>;
 
 // policies usable with WorkGroup
 using policy::hip::hip_work;

--- a/include/RAJA/policy/hip/policy.hpp
+++ b/include/RAJA/policy/hip/policy.hpp
@@ -879,27 +879,35 @@ using global_z = IndexGlobal<named_dim::z, BLOCK_SIZE, GRID_SIZE>;
 // policies usable with forall, scan, and sort
 template <size_t BLOCK_SIZE, size_t GRID_SIZE, bool Async = false>
 using hip_exec_grid = policy::hip::hip_exec<
-    iteration_mapping::StridedLoop, hip::global_x<BLOCK_SIZE, GRID_SIZE>, Async>;
+    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE, GRID_SIZE>, Async>;
 
 template <size_t BLOCK_SIZE, size_t GRID_SIZE>
 using hip_exec_grid_async = policy::hip::hip_exec<
-    iteration_mapping::StridedLoop, hip::global_x<BLOCK_SIZE, GRID_SIZE>, true>;
+    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE, GRID_SIZE>, true>;
 
 template <size_t BLOCK_SIZE, bool Async = false>
 using hip_exec = policy::hip::hip_exec<
-    iteration_mapping::Direct, hip::global_x<BLOCK_SIZE>, Async>;
+    iteration_mapping::Direct<>, hip::global_x<BLOCK_SIZE>, Async>;
 
 template <size_t BLOCK_SIZE>
 using hip_exec_async = policy::hip::hip_exec<
-    iteration_mapping::Direct, hip::global_x<BLOCK_SIZE>, true>;
+    iteration_mapping::Direct<>, hip::global_x<BLOCK_SIZE>, true>;
 
 template <size_t BLOCK_SIZE, bool Async = false>
 using hip_exec_occ_calc = policy::hip::hip_exec<
-    iteration_mapping::StridedLoop, hip::global_x<BLOCK_SIZE>, Async>;
+    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>, Async>;
 
 template <size_t BLOCK_SIZE>
 using hip_exec_occ_calc_async = policy::hip::hip_exec<
-    iteration_mapping::StridedLoop, hip::global_x<BLOCK_SIZE>, true>;
+    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>, true>;
+
+template <size_t BLOCK_SIZE, typename Fraction, bool Async = false>
+using hip_exec_occ_calc_fraction = policy::hip::hip_exec<
+    iteration_mapping::StridedLoop<named_usage::unspecified, typename Fraction::inverse>, hip::global_x<BLOCK_SIZE>, Async>;
+
+template <size_t BLOCK_SIZE, typename Fraction>
+using hip_exec_occ_calc_fraction_async = policy::hip::hip_exec<
+    iteration_mapping::StridedLoop<named_usage::unspecified, typename Fraction::inverse>, hip::global_x<BLOCK_SIZE>, true>;
 
 // policies usable with WorkGroup
 using policy::hip::hip_work;
@@ -923,11 +931,11 @@ using policy::hip::hip_block_reduce;
 using policy::hip::hip_warp_reduce;
 
 using hip_warp_direct = RAJA::policy::hip::hip_indexer<
-    iteration_mapping::Direct,
+    iteration_mapping::Direct<>,
     kernel_sync_requirement::none,
     hip::thread_x<RAJA::policy::hip::WARP_SIZE>>;
 using hip_warp_loop = RAJA::policy::hip::hip_indexer<
-    iteration_mapping::StridedLoop,
+    iteration_mapping::StridedLoop<named_usage::unspecified>,
     kernel_sync_requirement::none,
     hip::thread_x<RAJA::policy::hip::WARP_SIZE>>;
 
@@ -947,31 +955,31 @@ using policy::hip::hip_launch_t;
 // policies usable with kernel and launch
 template < typename ... indexers >
 using hip_indexer_direct = policy::hip::hip_indexer<
-    iteration_mapping::Direct,
+    iteration_mapping::Direct<>,
     kernel_sync_requirement::none,
     indexers...>;
 
 template < typename ... indexers >
 using hip_indexer_loop = policy::hip::hip_indexer<
-    iteration_mapping::StridedLoop,
+    iteration_mapping::StridedLoop<named_usage::unspecified>,
     kernel_sync_requirement::none,
     indexers...>;
 
 template < typename ... indexers >
 using hip_indexer_syncable_loop = policy::hip::hip_indexer<
-    iteration_mapping::StridedLoop,
+    iteration_mapping::StridedLoop<named_usage::unspecified>,
     kernel_sync_requirement::sync,
     indexers...>;
 
 template < typename ... indexers >
 using hip_flatten_indexer_direct = policy::hip::hip_flatten_indexer<
-    iteration_mapping::Direct,
+    iteration_mapping::Direct<>,
     kernel_sync_requirement::none,
     indexers...>;
 
 template < typename ... indexers >
 using hip_flatten_indexer_loop = policy::hip::hip_flatten_indexer<
-    iteration_mapping::StridedLoop,
+    iteration_mapping::StridedLoop<named_usage::unspecified>,
     kernel_sync_requirement::none,
     indexers...>;
 

--- a/include/RAJA/policy/hip/policy.hpp
+++ b/include/RAJA/policy/hip/policy.hpp
@@ -74,6 +74,86 @@ struct IndexGlobal;
 template<typename ...indexers>
 struct IndexFlatten;
 
+/*!
+ * Use the max occupancy of a kernel on the current device when launch
+ * parameters are not fully determined.
+ * Note that the maximum occupancy of the kernel may be less than the maximum
+ * occupancy of the device in terms of total threads.
+ */
+struct MaxOccupancyConcretizer
+{
+  template < typename IdxT, typename Data >
+  static IdxT get_max_grid_size(Data const& data)
+  {
+    IdxT device_sm_per_device = data.device_sm_per_device;
+    IdxT func_max_blocks_per_sm = data.func_max_blocks_per_sm;
+
+    IdxT func_max_blocks_per_device = func_max_blocks_per_sm * device_sm_per_device;
+
+    return func_max_blocks_per_device;
+  }
+};
+
+/*!
+ * Use a fraction and an offset of the max occupancy of a kernel on the current
+ * device when launch parameters are not fully determined.
+ * The following formula is used, with care to avoid zero, to determine the
+ * maximum grid size:
+ * (Fraction * kernel_max_blocks_per_sm + BLOCKS_PER_SM_OFFSET) * device_sm
+ */
+template < typename t_Fraction, std::ptrdiff_t BLOCKS_PER_SM_OFFSET >
+struct FractionOffsetOccupancyConcretizer
+{
+  template < typename IdxT, typename Data >
+  static IdxT get_max_grid_size(Data const& data)
+  {
+    using Fraction = typename t_Fraction::template rebind<IdxT>;
+
+    IdxT device_sm_per_device = data.device_sm_per_device;
+    IdxT func_max_blocks_per_sm = data.func_max_blocks_per_sm;
+
+    if (Fraction::multiply(func_max_blocks_per_sm) > IdxT(0)) {
+      func_max_blocks_per_sm = Fraction::multiply(func_max_blocks_per_sm);
+    }
+
+    if (IdxT(std::ptrdiff_t(func_max_blocks_per_sm) + BLOCKS_PER_SM_OFFSET) > IdxT(0)) {
+      func_max_blocks_per_sm = IdxT(std::ptrdiff_t(func_max_blocks_per_sm) + BLOCKS_PER_SM_OFFSET);
+    }
+
+    IdxT func_max_blocks_per_device = func_max_blocks_per_sm * device_sm_per_device;
+
+    return func_max_blocks_per_device;
+  }
+};
+
+/*!
+ * Use an occupancy that is less than the max occupancy of the device when
+ * launch parameters are not fully determined.
+ * Use the MaxOccupancyConcretizer if the maximum occupancy of the kernel is
+ * below the maximum occupancy of the device.
+ * Otherwise use the given AvoidMaxOccupancyCalculator to determine the
+ * maximum grid size.
+ */
+template < typename AvoidMaxOccupancyConcretizer >
+struct AvoidDeviceMaxThreadOccupancyConcretizer
+{
+  template < typename IdxT, typename Data >
+  static IdxT get_max_grid_size(Data const& data)
+  {
+    IdxT device_max_threads_per_sm = data.device_max_threads_per_sm;
+    IdxT func_max_blocks_per_sm = data.func_max_blocks_per_sm;
+    IdxT func_threads_per_block = data.func_threads_per_block;
+
+    IdxT func_max_threads_per_sm = func_threads_per_block * func_max_blocks_per_sm;
+
+    if (func_max_threads_per_sm < device_max_threads_per_sm) {
+      return MaxOccupancyConcretizer::template get_max_grid_size<IdxT>(data);
+    } else {
+      return AvoidMaxOccupancyConcretizer::template get_max_grid_size<IdxT>(data);
+    }
+  }
+};
+
 }  // namespace hip
 
 namespace policy
@@ -93,7 +173,8 @@ struct hip_flatten_indexer : public RAJA::make_policy_pattern_launch_platform_t<
   using IterationGetter = RAJA::hip::IndexFlatten<_IterationGetters...>;
 };
 
-template <typename _IterationMapping, typename _IterationGetter, bool Async = false>
+template <typename _IterationMapping, typename _IterationGetter, typename _LaunchConcretizer,
+          bool Async = false>
 struct hip_exec : public RAJA::make_policy_pattern_launch_platform_t<
                        RAJA::Policy::hip,
                        RAJA::Pattern::forall,
@@ -101,6 +182,7 @@ struct hip_exec : public RAJA::make_policy_pattern_launch_platform_t<
                        RAJA::Platform::hip> {
   using IterationMapping = _IterationMapping;
   using IterationGetter = _IterationGetter;
+  using LaunchConcretizer = _LaunchConcretizer;
 };
 
 template <bool Async, int num_threads = named_usage::unspecified>
@@ -816,6 +898,7 @@ struct IndexFlatten<x_index, y_index, z_index>
 
 };
 
+
 // helper to get just the thread indexing part of IndexGlobal
 template < typename index_global >
 struct get_index_thread;
@@ -876,44 +959,83 @@ using global_z = IndexGlobal<named_dim::z, BLOCK_SIZE, GRID_SIZE>;
 
 } // namespace hip
 
+// contretizers used in forall, scan, and sort policies
+
+using HipDefaultAvoidMaxOccupancyConcretizer = hip::FractionOffsetOccupancyConcretizer<Fraction<size_t, 1, 1>, -1>;
+
+template < typename AvoidMaxOccupancyConcretizer >
+using HipAvoidDeviceMaxThreadOccupancyConcretizer = hip::AvoidDeviceMaxThreadOccupancyConcretizer<AvoidMaxOccupancyConcretizer>;
+
+template < typename Fraction, std::ptrdiff_t BLOCKS_PER_SM_OFFSET >
+using HipFractionOffsetOccupancyConcretizer = hip::FractionOffsetOccupancyConcretizer<Fraction, BLOCKS_PER_SM_OFFSET>;
+
+using HipMaxOccupancyConcretizer = hip::MaxOccupancyConcretizer;
+
+using HipRecForReduceConcretizer = hip::AvoidDeviceMaxThreadOccupancyConcretizer<HipDefaultAvoidMaxOccupancyConcretizer>;
+
+using HipDefaultConcretizer = hip::MaxOccupancyConcretizer;
+
 // policies usable with forall, scan, and sort
+
 template <size_t BLOCK_SIZE, size_t GRID_SIZE, bool Async = false>
 using hip_exec_grid = policy::hip::hip_exec<
-    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE, GRID_SIZE>, Async>;
+    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE, GRID_SIZE>,
+    HipDefaultConcretizer, Async>;
 
 template <size_t BLOCK_SIZE, size_t GRID_SIZE>
 using hip_exec_grid_async = policy::hip::hip_exec<
-    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE, GRID_SIZE>, true>;
+    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE, GRID_SIZE>,
+    HipDefaultConcretizer, true>;
 
 template <size_t BLOCK_SIZE, bool Async = false>
 using hip_exec = policy::hip::hip_exec<
-    iteration_mapping::Direct<>, hip::global_x<BLOCK_SIZE>, Async>;
+    iteration_mapping::Direct, hip::global_x<BLOCK_SIZE>,
+    HipDefaultConcretizer, Async>;
 
 template <size_t BLOCK_SIZE>
 using hip_exec_async = policy::hip::hip_exec<
-    iteration_mapping::Direct<>, hip::global_x<BLOCK_SIZE>, true>;
+    iteration_mapping::Direct, hip::global_x<BLOCK_SIZE>,
+    HipDefaultConcretizer, true>;
 
 template <size_t BLOCK_SIZE, bool Async = false>
 using hip_exec_occ_calc = policy::hip::hip_exec<
-    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>, Async>;
+    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
+    HipMaxOccupancyConcretizer, Async>;
 
 template <size_t BLOCK_SIZE>
 using hip_exec_occ_calc_async = policy::hip::hip_exec<
-    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>, true>;
+    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
+    HipMaxOccupancyConcretizer, true>;
 
 template <size_t BLOCK_SIZE, typename Fraction, bool Async = false>
-using hip_exec_occ_calc_fraction = policy::hip::hip_exec<
-    iteration_mapping::StridedLoop<named_usage::unspecified, typename Fraction::inverse>, hip::global_x<BLOCK_SIZE>, Async>;
+using hip_exec_occ_fraction = policy::hip::hip_exec<
+    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
+    HipFractionOffsetOccupancyConcretizer<Fraction, 0>, Async>;
 
 template <size_t BLOCK_SIZE, typename Fraction>
-using hip_exec_occ_calc_fraction_async = policy::hip::hip_exec<
-    iteration_mapping::StridedLoop<named_usage::unspecified, typename Fraction::inverse>, hip::global_x<BLOCK_SIZE>, true>;
+using hip_exec_occ_fraction_async = policy::hip::hip_exec<
+    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
+    HipFractionOffsetOccupancyConcretizer<Fraction, 0>, true>;
+
+template <size_t BLOCK_SIZE, typename AvoidMaxOccupancyConcretizer = HipDefaultAvoidMaxOccupancyConcretizer, bool Async = false>
+using hip_exec_occ_avoid_max = policy::hip::hip_exec<
+    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
+    HipAvoidDeviceMaxThreadOccupancyConcretizer<AvoidMaxOccupancyConcretizer>, Async>;
+
+template <size_t BLOCK_SIZE, typename AvoidMaxOccupancyConcretizer = HipDefaultAvoidMaxOccupancyConcretizer>
+using hip_exec_occ_avoid_max_async = policy::hip::hip_exec<
+    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
+    HipAvoidDeviceMaxThreadOccupancyConcretizer<AvoidMaxOccupancyConcretizer>, true>;
 
 template <size_t BLOCK_SIZE, bool Async = false>
-using hip_exec_rec_for_reduce = hip_exec_occ_calc_fraction<BLOCK_SIZE, Fraction<size_t, 1, 2>, Async>;
+using hip_exec_rec_for_reduce = policy::hip::hip_exec<
+    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
+    HipRecForReduceConcretizer, Async>;
 
 template <size_t BLOCK_SIZE>
-using hip_exec_rec_for_reduce_async = hip_exec_occ_calc_fraction_async<BLOCK_SIZE, Fraction<size_t, 1, 2>>;
+using hip_exec_rec_for_reduce_async = policy::hip::hip_exec<
+    iteration_mapping::StridedLoop<named_usage::unspecified>, hip::global_x<BLOCK_SIZE>,
+    HipRecForReduceConcretizer, true>;
 
 // policies usable with WorkGroup
 using policy::hip::hip_work;
@@ -937,7 +1059,7 @@ using policy::hip::hip_block_reduce;
 using policy::hip::hip_warp_reduce;
 
 using hip_warp_direct = RAJA::policy::hip::hip_indexer<
-    iteration_mapping::Direct<>,
+    iteration_mapping::Direct,
     kernel_sync_requirement::none,
     hip::thread_x<RAJA::policy::hip::WARP_SIZE>>;
 using hip_warp_loop = RAJA::policy::hip::hip_indexer<
@@ -961,7 +1083,7 @@ using policy::hip::hip_launch_t;
 // policies usable with kernel and launch
 template < typename ... indexers >
 using hip_indexer_direct = policy::hip::hip_indexer<
-    iteration_mapping::Direct<>,
+    iteration_mapping::Direct,
     kernel_sync_requirement::none,
     indexers...>;
 
@@ -979,7 +1101,7 @@ using hip_indexer_syncable_loop = policy::hip::hip_indexer<
 
 template < typename ... indexers >
 using hip_flatten_indexer_direct = policy::hip::hip_flatten_indexer<
-    iteration_mapping::Direct<>,
+    iteration_mapping::Direct,
     kernel_sync_requirement::none,
     indexers...>;
 

--- a/include/RAJA/policy/hip/scan.hpp
+++ b/include/RAJA/policy/hip/scan.hpp
@@ -49,6 +49,7 @@ namespace scan
 */
 template <typename IterationMapping,
           typename IterationGetter,
+          typename Concretizer,
           bool Async,
           typename InputIter,
           typename Function>
@@ -56,7 +57,7 @@ RAJA_INLINE
 resources::EventProxy<resources::Hip>
 inclusive_inplace(
     resources::Hip hip_res,
-    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>,
+    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
     InputIter begin,
     InputIter end,
     Function binary_op)
@@ -121,6 +122,7 @@ inclusive_inplace(
 */
 template <typename IterationMapping,
           typename IterationGetter,
+          typename Concretizer,
           bool Async,
           typename InputIter,
           typename Function,
@@ -129,7 +131,7 @@ RAJA_INLINE
 resources::EventProxy<resources::Hip>
 exclusive_inplace(
     resources::Hip hip_res,
-    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>,
+    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
     InputIter begin,
     InputIter end,
     Function binary_op,
@@ -198,6 +200,7 @@ exclusive_inplace(
 */
 template <typename IterationMapping,
           typename IterationGetter,
+          typename Concretizer,
           bool Async,
           typename InputIter,
           typename OutputIter,
@@ -206,7 +209,7 @@ RAJA_INLINE
 resources::EventProxy<resources::Hip>
 inclusive(
     resources::Hip hip_res,
-    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>,
+    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
     InputIter begin,
     InputIter end,
     OutputIter out,
@@ -271,6 +274,7 @@ inclusive(
 */
 template <typename IterationMapping,
           typename IterationGetter,
+          typename Concretizer,
           bool Async,
           typename InputIter,
           typename OutputIter,
@@ -280,7 +284,7 @@ RAJA_INLINE
 resources::EventProxy<resources::Hip>
 exclusive(
     resources::Hip hip_res,
-    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>,
+    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
     InputIter begin,
     InputIter end,
     OutputIter out,

--- a/include/RAJA/policy/hip/sort.hpp
+++ b/include/RAJA/policy/hip/sort.hpp
@@ -73,7 +73,9 @@ namespace detail
 /*!
         \brief static assert unimplemented stable sort
 */
-template <typename IterationMapping, typename IterationGetter, bool Async, typename Iter, typename Compare>
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, bool Async,
+          typename Iter, typename Compare>
 concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                       concepts::negate<concepts::all_of<
                         type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
@@ -83,7 +85,7 @@ concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                           camp::is_same<Compare, operators::greater<RAJA::detail::IterVal<Iter>>>>>>>
 stable(
     resources::Hip hip_res,
-    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>,
+    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
     Iter,
     Iter,
     Compare)
@@ -102,13 +104,15 @@ stable(
 /*!
         \brief stable sort given range in ascending order
 */
-template <typename IterationMapping, typename IterationGetter, bool Async, typename Iter>
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, bool Async,
+          typename Iter>
 concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                       type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
                       std::is_pointer<Iter>>
 stable(
     resources::Hip hip_res,
-    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>,
+    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
     Iter begin,
     Iter end,
     operators::less<RAJA::detail::IterVal<Iter>>)
@@ -190,13 +194,15 @@ stable(
 /*!
         \brief stable sort given range in descending order
 */
-template <typename IterationMapping, typename IterationGetter, bool Async, typename Iter>
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, bool Async,
+          typename Iter>
 concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                       type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
                       std::is_pointer<Iter>>
 stable(
     resources::Hip hip_res,
-    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>,
+    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
     Iter begin,
     Iter end,
     operators::greater<RAJA::detail::IterVal<Iter>>)
@@ -279,7 +285,9 @@ stable(
 /*!
         \brief static assert unimplemented sort
 */
-template <typename IterationMapping, typename IterationGetter, bool Async, typename Iter, typename Compare>
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, bool Async,
+          typename Iter, typename Compare>
 concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                       concepts::negate<concepts::all_of<
                         type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
@@ -289,7 +297,7 @@ concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                           camp::is_same<Compare, operators::greater<RAJA::detail::IterVal<Iter>>>>>>>
 unstable(
     resources::Hip hip_res,
-    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>,
+    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
     Iter,
     Iter,
     Compare)
@@ -308,13 +316,15 @@ unstable(
 /*!
         \brief sort given range in ascending order
 */
-template <typename IterationMapping, typename IterationGetter, bool Async, typename Iter>
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, bool Async,
+          typename Iter>
 concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                       type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
                       std::is_pointer<Iter>>
 unstable(
     resources::Hip hip_res,
-    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async> p,
+    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async> p,
     Iter begin,
     Iter end,
     operators::less<RAJA::detail::IterVal<Iter>> comp)
@@ -325,13 +335,15 @@ unstable(
 /*!
         \brief sort given range in descending order
 */
-template <typename IterationMapping, typename IterationGetter, bool Async, typename Iter>
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, bool Async,
+          typename Iter>
 concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                       type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
                       std::is_pointer<Iter>>
 unstable(
     resources::Hip hip_res,
-    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async> p,
+    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async> p,
     Iter begin,
     Iter end,
     operators::greater<RAJA::detail::IterVal<Iter>> comp)
@@ -343,7 +355,8 @@ unstable(
 /*!
         \brief static assert unimplemented stable sort pairs
 */
-template <typename IterationMapping, typename IterationGetter, bool Async,
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, bool Async,
           typename KeyIter, typename ValIter, typename Compare>
 concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                       concepts::negate<concepts::all_of<
@@ -355,7 +368,7 @@ concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                           camp::is_same<Compare, operators::greater<RAJA::detail::IterVal<KeyIter>>>>>>>
 stable_pairs(
     resources::Hip hip_res,
-    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>,
+    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
     KeyIter,
     KeyIter,
     ValIter,
@@ -379,7 +392,8 @@ stable_pairs(
 /*!
         \brief stable sort given range of pairs in ascending order of keys
 */
-template <typename IterationMapping, typename IterationGetter, bool Async,
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, bool Async,
           typename KeyIter, typename ValIter>
 concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                       type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
@@ -387,7 +401,7 @@ concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                       std::is_pointer<ValIter>>
 stable_pairs(
     resources::Hip hip_res,
-    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>,
+    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
     KeyIter keys_begin,
     KeyIter keys_end,
     ValIter vals_begin,
@@ -483,7 +497,8 @@ stable_pairs(
 /*!
         \brief stable sort given range of pairs in descending order of keys
 */
-template <typename IterationMapping, typename IterationGetter, bool Async,
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, bool Async,
           typename KeyIter, typename ValIter>
 concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                       type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
@@ -491,7 +506,7 @@ concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                       std::is_pointer<ValIter>>
 stable_pairs(
     resources::Hip hip_res,
-    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>,
+    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
     KeyIter keys_begin,
     KeyIter keys_end,
     ValIter vals_begin,
@@ -588,7 +603,8 @@ stable_pairs(
 /*!
         \brief static assert unimplemented sort pairs
 */
-template <typename IterationMapping, typename IterationGetter, bool Async,
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, bool Async,
           typename KeyIter, typename ValIter, typename Compare>
 concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                       concepts::negate<concepts::all_of<
@@ -600,7 +616,7 @@ concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                           camp::is_same<Compare, operators::greater<RAJA::detail::IterVal<KeyIter>>>>>>>
 unstable_pairs(
     resources::Hip hip_res,
-    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>,
+    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
     KeyIter,
     KeyIter,
     ValIter,
@@ -624,7 +640,8 @@ unstable_pairs(
 /*!
         \brief stable sort given range of pairs in ascending order of keys
 */
-template <typename IterationMapping, typename IterationGetter, bool Async,
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, bool Async,
           typename KeyIter, typename ValIter>
 concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                       type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
@@ -632,7 +649,7 @@ concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                       std::is_pointer<ValIter>>
 unstable_pairs(
     resources::Hip hip_res,
-    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async> p,
+    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async> p,
     KeyIter keys_begin,
     KeyIter keys_end,
     ValIter vals_begin,
@@ -644,7 +661,8 @@ unstable_pairs(
 /*!
         \brief stable sort given range of pairs in descending order of keys
 */
-template <typename IterationMapping, typename IterationGetter, bool Async,
+template <typename IterationMapping, typename IterationGetter,
+          typename Concretizer, bool Async,
           typename KeyIter, typename ValIter>
 concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                       type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
@@ -652,7 +670,7 @@ concepts::enable_if_t<resources::EventProxy<resources::Hip>,
                       std::is_pointer<ValIter>>
 unstable_pairs(
     resources::Hip hip_res,
-    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async> p,
+    ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async> p,
     KeyIter keys_begin,
     KeyIter keys_end,
     ValIter vals_begin,

--- a/include/RAJA/util/basic_mempool.hpp
+++ b/include/RAJA/util/basic_mempool.hpp
@@ -309,6 +309,7 @@ public:
   }
 
 
+  /// Free all backing allocations, even if they are currently in use
   void free_chunks()
   {
 #if defined(RAJA_ENABLE_OPENMP)

--- a/include/RAJA/util/resource.hpp
+++ b/include/RAJA/util/resource.hpp
@@ -65,8 +65,9 @@ namespace RAJA
     using type = camp::resources::Cuda;
   };
 
-  template<typename IterationMapping, typename IterationGetter, size_t BLOCKS_PER_SM, bool Async>
-  struct get_resource<::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async>>{
+  template<typename IterationMapping, typename IterationGetter,
+           typename Concretizer, size_t BLOCKS_PER_SM, bool Async>
+  struct get_resource<::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async>>{
     using type = camp::resources::Cuda;
   };
 
@@ -75,8 +76,9 @@ namespace RAJA
     using type = camp::resources::Cuda;
   };
 
-  template<typename ISetIter, typename IterationMapping, typename IterationGetter, size_t BLOCKS_PER_SM, bool Async>
-  struct get_resource<ExecPolicy<ISetIter, ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, BLOCKS_PER_SM, Async>>>{
+  template<typename ISetIter, typename IterationMapping, typename IterationGetter,
+           typename Concretizer, size_t BLOCKS_PER_SM, bool Async>
+  struct get_resource<ExecPolicy<ISetIter, ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM, Async>>>{
     using type = camp::resources::Cuda;
   };
 #endif
@@ -87,8 +89,9 @@ namespace RAJA
     using type = camp::resources::Hip;
   };
 
-  template<typename IterationMapping, typename IterationGetter, bool Async>
-  struct get_resource<::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>>{
+  template<typename IterationMapping, typename IterationGetter,
+           typename Concretizer, bool Async>
+  struct get_resource<::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>>{
     using type = camp::resources::Hip;
   };
 
@@ -97,8 +100,9 @@ namespace RAJA
     using type = camp::resources::Hip;
   };
 
-  template<typename ISetIter, typename IterationMapping, typename IterationGetter, bool Async>
-  struct get_resource<ExecPolicy<ISetIter, ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Async>>>{
+  template<typename ISetIter, typename IterationMapping, typename IterationGetter,
+           typename Concretizer, bool Async>
+  struct get_resource<ExecPolicy<ISetIter, ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, Async>>>{
     using type = camp::resources::Hip;
   };
 #endif

--- a/include/RAJA/util/types.hpp
+++ b/include/RAJA/util/types.hpp
@@ -196,7 +196,7 @@ struct SizeList {
 template <typename int_t, int_t numerator, int_t denominator>
 struct Fraction
 {
-  static_assert(denominator != int_t(0), "denominator may not be zero");
+  static_assert(denominator != int_t(0), "denominator must not be zero");
 
   using inverse = Fraction<int_t, denominator, numerator>;
 

--- a/include/RAJA/util/types.hpp
+++ b/include/RAJA/util/types.hpp
@@ -172,6 +172,25 @@ struct SizeList {
 };
 
 
+///
+/// Compile time fraction for use with integral types
+///
+template <typename int_t, int_t numerator, int_t denominator>
+struct Fraction
+{
+  static_assert(denominator != int_t(0), "denominator may not be zero");
+
+  using inverse = Fraction<int_t, denominator, numerator>;
+
+  static constexpr int_t multiply(int_t val) noexcept
+  {
+    return (val / denominator) * numerator +
+           (val % denominator) * numerator / denominator;
+  }
+
+};
+
+
 /*!
  ******************************************************************************
  *

--- a/include/RAJA/util/types.hpp
+++ b/include/RAJA/util/types.hpp
@@ -100,7 +100,6 @@ struct SizedLoopSpecifyingBase : SizedLoopBase
 ///   // 3 -> {3}
 ///   // 4 -> {}
 ///
-template < typename ... Modifiers >
 struct Direct : DirectBase {};
 
 ///
@@ -128,7 +127,7 @@ struct Direct : DirectBase {};
 ///   // 1 -> {3, 4, 5}
 ///   // 2 -> {6, 7}
 ///
-template < size_t max_iterations, typename ... Modifiers >
+template < size_t max_iterations >
 struct Contiguousloop : ContiguousLoopBase,
     std::conditional_t<(max_iterations != named_usage::unspecified),
                        SizedLoopSpecifyingBase<max_iterations>, UnsizedLoopBase> {};
@@ -158,7 +157,7 @@ struct Contiguousloop : ContiguousLoopBase,
 ///   // 1 -> {1, 4, 7}
 ///   // 2 -> {2, 5}
 ///
-template < size_t max_iterations, typename ... Modifiers >
+template < size_t max_iterations >
 struct StridedLoop : StridedLoopBase,
     std::conditional_t<(max_iterations != named_usage::unspecified),
                        SizedLoopSpecifyingBase<max_iterations>, UnsizedLoopBase> {};
@@ -200,6 +199,9 @@ struct Fraction
   static_assert(denominator != int_t(0), "denominator may not be zero");
 
   using inverse = Fraction<int_t, denominator, numerator>;
+
+  template < typename new_int_t >
+  using rebind = Fraction<new_int_t, new_int_t(numerator), new_int_t(denominator)>;
 
   static constexpr int_t multiply(int_t val) noexcept
   {

--- a/test/include/RAJA_test-forall-execpol.hpp
+++ b/test/include/RAJA_test-forall-execpol.hpp
@@ -108,7 +108,8 @@ using OpenMPTargetForallAtomicExecPols = OpenMPTargetForallExecPols;
 using CudaForallExecPols = camp::list< RAJA::cuda_exec<128>,
                                        RAJA::cuda_exec_occ_calc<256>,
                                        RAJA::cuda_exec_grid<256, 64>,
-                                       RAJA::cuda_exec_explicit<256,2> >;
+                                       RAJA::cuda_exec_explicit<256,2>,
+                                       RAJA::cuda_exec_occ_calc_fraction<256, RAJA::Fraction<int,1,2>> >;
 
 using CudaForallReduceExecPols = CudaForallExecPols;
 
@@ -119,7 +120,8 @@ using CudaForallAtomicExecPols = CudaForallExecPols;
 #if defined(RAJA_ENABLE_HIP)
 using HipForallExecPols = camp::list< RAJA::hip_exec<128>,
                                       RAJA::hip_exec_occ_calc<256>,
-                                      RAJA::hip_exec_grid<256, 64>  >;
+                                      RAJA::hip_exec_grid<256, 64>,
+                                      RAJA::hip_exec_occ_calc_fraction<256, RAJA::Fraction<int,1,2>> >;
 
 using HipForallReduceExecPols = HipForallExecPols;
 

--- a/test/include/RAJA_test-forall-execpol.hpp
+++ b/test/include/RAJA_test-forall-execpol.hpp
@@ -109,7 +109,8 @@ using CudaForallExecPols = camp::list< RAJA::cuda_exec<128>,
                                        RAJA::cuda_exec_occ_calc<256>,
                                        RAJA::cuda_exec_grid<256, 64>,
                                        RAJA::cuda_exec_explicit<256,2>,
-                                       RAJA::cuda_exec_occ_calc_fraction<256, RAJA::Fraction<size_t,1,2>> >;
+                                       RAJA::cuda_exec_occ_fraction<256, RAJA::Fraction<size_t,1,2>>,
+                                       RAJA::cuda_exec_occ_avoid_max<256> >;
 
 using CudaForallReduceExecPols = CudaForallExecPols;
 
@@ -121,7 +122,8 @@ using CudaForallAtomicExecPols = CudaForallExecPols;
 using HipForallExecPols = camp::list< RAJA::hip_exec<128>,
                                       RAJA::hip_exec_occ_calc<256>,
                                       RAJA::hip_exec_grid<256, 64>,
-                                      RAJA::hip_exec_occ_calc_fraction<256, RAJA::Fraction<size_t,1,2>> >;
+                                      RAJA::hip_exec_occ_fraction<256, RAJA::Fraction<size_t,1,2>>,
+                                      RAJA::hip_exec_occ_avoid_max<256> >;
 
 using HipForallReduceExecPols = HipForallExecPols;
 

--- a/test/include/RAJA_test-forall-execpol.hpp
+++ b/test/include/RAJA_test-forall-execpol.hpp
@@ -110,7 +110,7 @@ using CudaForallExecPols = camp::list< RAJA::cuda_exec<128>,
                                        RAJA::cuda_exec_grid<256, 64>,
                                        RAJA::cuda_exec_explicit<256,2>,
                                        RAJA::cuda_exec_occ_fraction<256, RAJA::Fraction<size_t,1,2>>,
-                                       RAJA::cuda_exec_occ_avoid_max<256> >;
+                                       RAJA::cuda_exec_occ_custom<256, RAJA::CudaAvoidDeviceMaxThreadOccupancyConcretizer> >;
 
 using CudaForallReduceExecPols = CudaForallExecPols;
 
@@ -123,7 +123,7 @@ using HipForallExecPols = camp::list< RAJA::hip_exec<128>,
                                       RAJA::hip_exec_occ_calc<256>,
                                       RAJA::hip_exec_grid<256, 64>,
                                       RAJA::hip_exec_occ_fraction<256, RAJA::Fraction<size_t,1,2>>,
-                                      RAJA::hip_exec_occ_avoid_max<256> >;
+                                      RAJA::hip_exec_occ_custom<256, RAJA::HipAvoidDeviceMaxThreadOccupancyConcretizer> >;
 
 using HipForallReduceExecPols = HipForallExecPols;
 

--- a/test/include/RAJA_test-forall-execpol.hpp
+++ b/test/include/RAJA_test-forall-execpol.hpp
@@ -109,7 +109,7 @@ using CudaForallExecPols = camp::list< RAJA::cuda_exec<128>,
                                        RAJA::cuda_exec_occ_calc<256>,
                                        RAJA::cuda_exec_grid<256, 64>,
                                        RAJA::cuda_exec_explicit<256,2>,
-                                       RAJA::cuda_exec_occ_calc_fraction<256, RAJA::Fraction<int,1,2>> >;
+                                       RAJA::cuda_exec_occ_calc_fraction<256, RAJA::Fraction<size_t,1,2>> >;
 
 using CudaForallReduceExecPols = CudaForallExecPols;
 
@@ -121,7 +121,7 @@ using CudaForallAtomicExecPols = CudaForallExecPols;
 using HipForallExecPols = camp::list< RAJA::hip_exec<128>,
                                       RAJA::hip_exec_occ_calc<256>,
                                       RAJA::hip_exec_grid<256, 64>,
-                                      RAJA::hip_exec_occ_calc_fraction<256, RAJA::Fraction<int,1,2>> >;
+                                      RAJA::hip_exec_occ_calc_fraction<256, RAJA::Fraction<size_t,1,2>> >;
 
 using HipForallReduceExecPols = HipForallExecPols;
 

--- a/test/unit/util/CMakeLists.txt
+++ b/test/unit/util/CMakeLists.txt
@@ -21,4 +21,8 @@ raja_add_test(
   NAME test-span
   SOURCES test-span.cpp)
 
+raja_add_test(
+  NAME test-fraction
+  SOURCES test-fraction.cpp)
+
 add_subdirectory(operator)

--- a/test/unit/util/test-fraction.cpp
+++ b/test/unit/util/test-fraction.cpp
@@ -1,0 +1,64 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-24, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Source file containing tests for Fraction
+///
+
+#include <RAJA/RAJA.hpp>
+#include "RAJA_gtest.hpp"
+#include <type_traits>
+
+template <typename IntegerType, IntegerType numerator, IntegerType denominator>
+void testFractionMultiplyTypesValues()
+{
+  using Frac = RAJA::Fraction<IntegerType, numerator, denominator>;
+
+  ASSERT_EQ(Frac::multiply(IntegerType(0)), IntegerType(0));
+
+  ASSERT_EQ(Frac::multiply(IntegerType(1)),
+            IntegerType(double(numerator) / double(denominator)));
+
+  ASSERT_EQ(Frac::multiply(IntegerType(100)),
+            IntegerType(double(numerator) / double(denominator) * double(100)));
+
+  ASSERT_EQ(Frac::multiply(IntegerType(101)),
+            IntegerType(double(numerator) / double(denominator) * double(101)));
+
+  // Test where naive algorithm causes overflow, when within precision of double
+  if /*constexpr*/ (sizeof(IntegerType) < sizeof(double)) {
+
+    static constexpr IntegerType max = std::numeric_limits<IntegerType>::max();
+    static constexpr IntegerType val = (numerator > denominator) ?
+        (max / numerator * denominator) : max;
+
+    ASSERT_EQ(Frac::multiply(IntegerType(val)),
+              IntegerType(double(numerator) / double(denominator) * double(val)));
+  }
+
+}
+
+template <typename IntegerType>
+void testFractionMultiplyTypes()
+{
+  testFractionMultiplyTypesValues<IntegerType, 1, 1>();
+  testFractionMultiplyTypesValues<IntegerType, 1, 2>();
+  testFractionMultiplyTypesValues<IntegerType, 1, 3>();
+  testFractionMultiplyTypesValues<IntegerType, 2, 3>();
+  testFractionMultiplyTypesValues<IntegerType, 12, 7>();
+  testFractionMultiplyTypesValues<IntegerType, 0, 100>();
+}
+
+
+#define RAJA_FRACTION_RUN_TEST(test) \
+  test<int>(); \
+  test<size_t>();
+
+TEST(Fraction, basic_multiply_Fraction)
+{
+  RAJA_FRACTION_RUN_TEST(testFractionMultiplyTypes)
+}


### PR DESCRIPTION
# Add GPU Max Occupancy Fraction Option

Add an option to change the max grid size in for_all policies that use the occupancy calculator.

The most important thing to be aware of is which policy gets the best performance with reducers, so an alias `RAJA::hip_exec_rec_for_reduce<BLOCKS_SIZE>` now exists which is the policy that performed best with reducers in our testing.

Another thing to note is that the meaning of the default occupancy calculator policy is changing, `(hip|cuda)_exec_occ_calc<BLOCKS_SIZE>`, is now the policy using the occupancy calculator that performed best in our testing for non-reducer loops.

More occupancy calculator policies exist now as well. `(hip|cuda)_exec_occ_max<BLOCKS_SIZE>` policy lets you run with the max occupancy. `(hip|cuda)_exec_occ_fraction<BLOCKS_SIZE, Fraction<size_t, numerator, denominator>>` policy lets you run with a fraction of the max occupancy. `(hip|cuda)_exec_occ_custom<BLOCKS_SIZE, Concretizer>` policy lets you use any concretizer.

This is implemented by adding a concretizer class to the exec policies used with for_all. When grid size of block size is not specified this class is used to pick the value. For example `RAJA::CudaMaxOccupancyConcretizer` uses the occupancy calculator to get the highest occupancy possible with each kernel. Another example 'RAJA::CudaFractionOffsetOccupancyConcretizer<Fraction, BLOCKS_PER_SM_OFFSET>` lets you use a fraction of and/or offset the max occupancy.

- This PR is a feature
- It does the following:
  - Adds `hip_exec_rec_for_reduce` at the request of people using reducers

