### PR TITLE
Bug fixes for the bump style allocator

### DIFF
--- a/include/RAJA/pattern/launch/launch_core.hpp
+++ b/include/RAJA/pattern/launch/launch_core.hpp
@@ -174,10 +174,14 @@ public:
   template<typename T>
   RAJA_HOST_DEVICE T* getSharedMemory(size_t bytes)
   {
-    T * mem_ptr = &((T*) shared_mem_ptr)[shared_mem_offset];
+
+    //Calculate offset in bytes with a char pointer
+    char* mem_ptr = (char*) shared_mem_ptr + shared_mem_offset;
 
     shared_mem_offset += bytes*sizeof(T);
-    return mem_ptr;
+
+    //convert to desired type
+    return (T *) mem_ptr;
   }
 
   /*


### PR DESCRIPTION
Fixed a bug with the bump style allocator we have in RAJA launch. The bump was being calculated incorrectly. 
This PR should fix the count and includes tests. 