### PR TITLE
Swap ordering of thread configuration in Sycl

### DIFF
--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -541,7 +541,7 @@ GPU Policies for SYCL
 	  When using RAJA launch thread and team configuration
 	  follows CUDA and HIP programming models and is always
 	  configured in three-dimensions. This means that dimension
-	  2 always exist and should be used as one would the
+	  2 always exists and should be used as one would use the
 	  x dimension for CUDA and HIP.
 
  ======================================== ============= ==============================

--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -525,8 +525,23 @@ write more explicit policies.
             unspecified so a runtime number of threads is used, but grid_size is
             ignored so blocks are ignored when getting indices.
 
+	    
 GPU Policies for SYCL
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. note:: SYCL uses C++-style ordering in which the right
+	  most index corresponds to having unit stride.
+	  In a three-dimensional compute grid this means
+	  that dimension 2 has the unit stride while
+	  dimension 0 has the longest stride. This is
+	  important to note as the ordering is reverse
+	  compared to the CUDA and HIP programming models.   
+
+	  When using RAJA launch thread and team configuration
+	  follows CUDA and HIP programming models and is always
+	  configured in three-dimensions. This means that dimension
+	  2 always exist and should be used as one would the
+	  x dimension for CUDA and HIP.
 
  ======================================== ============= ==============================
  SYCL Execution Policies                  Works with    Brief description

--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -524,7 +524,6 @@ write more explicit policies.
             ignored. For example in cuda_thread_x_direct block_size is
             unspecified so a runtime number of threads is used, but grid_size is
             ignored so blocks are ignored when getting indices.
-
 	    
 GPU Policies for SYCL
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -535,7 +534,9 @@ GPU Policies for SYCL
 	  that dimension 2 has the unit stride while
 	  dimension 0 has the longest stride. This is
 	  important to note as the ordering is reverse
-	  compared to the CUDA and HIP programming models.   
+	  compared to the CUDA and HIP programming models.
+	  CUDA and HIP employ a x/y/z ordering in which
+	  dimension x has the unit stride.
 
 	  When using RAJA launch thread and team configuration
 	  follows CUDA and HIP programming models and is always

--- a/docs/sphinx/user_guide/feature/policies.rst
+++ b/docs/sphinx/user_guide/feature/policies.rst
@@ -538,7 +538,7 @@ GPU Policies for SYCL
 	  CUDA and HIP employ a x/y/z ordering in which
 	  dimension x has the unit stride.
 
-	  When using RAJA launch thread and team configuration
+	  When using RAJA::launch, thread and team configuration
 	  follows CUDA and HIP programming models and is always
 	  configured in three-dimensions. This means that dimension
 	  2 always exists and should be used as one would use the

--- a/include/RAJA/policy/sycl/launch.hpp
+++ b/include/RAJA/policy/sycl/launch.hpp
@@ -56,13 +56,13 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>> {
     // Compute the number of blocks and threads
     //
 
-    const ::sycl::range<3> blockSize(params.threads.value[0],
+    const ::sycl::range<3> blockSize(params.threads.value[2],
 				     params.threads.value[1],
-				     params.threads.value[2]);
+				     params.threads.value[0]);
 
-    const ::sycl::range<3> gridSize(params.threads.value[0] * params.teams.value[0],
+    const ::sycl::range<3> gridSize(params.threads.value[2] * params.teams.value[2],
 				    params.threads.value[1] * params.teams.value[1],
-				    params.threads.value[2] * params.teams.value[2]);
+				    params.threads.value[0] * params.teams.value[0]);
 
     // Only launch kernel if we have something to iterate over
     constexpr size_t zero = 0;
@@ -138,13 +138,13 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>> {
     // Compute the number of blocks and threads
     //
 
-    const ::sycl::range<3> blockSize(params.threads.value[0],
+    const ::sycl::range<3> blockSize(params.threads.value[2],
 				     params.threads.value[1],
-				     params.threads.value[2]);
+				     params.threads.value[0]);
 
-    const ::sycl::range<3> gridSize(params.threads.value[0] * params.teams.value[0],
+    const ::sycl::range<3> gridSize(params.threads.value[2] * params.teams.value[2],
 				    params.threads.value[1] * params.teams.value[1],
-				    params.threads.value[2] * params.teams.value[2]);
+				    params.threads.value[0] * params.teams.value[0]);
 
     // Only launch kernel if we have something to iterate over
     constexpr size_t zero = 0;

--- a/test/include/RAJA_test-launch-direct-teams-threads-1D-execpol.hpp
+++ b/test/include/RAJA_test-launch-direct-teams-threads-1D-execpol.hpp
@@ -81,8 +81,8 @@ using Hip_launch_policies = camp::list<hip_direct_policies>;
 using sycl_direct_policies =
   camp::list<
              RAJA::LaunchPolicy<RAJA::sycl_launch_t<true>>,
-             RAJA::LoopPolicy<RAJA::sycl_group_0_direct>,
-             RAJA::LoopPolicy<RAJA::sycl_local_0_direct>
+             RAJA::LoopPolicy<RAJA::sycl_group_2_direct>,
+             RAJA::LoopPolicy<RAJA::sycl_local_2_direct>
             >;
 
 using Sycl_launch_policies = camp::list<sycl_direct_policies>;

--- a/test/include/RAJA_test-launch-direct-teams-threads-3D-execpol.hpp
+++ b/test/include/RAJA_test-launch-direct-teams-threads-3D-execpol.hpp
@@ -100,12 +100,12 @@ using Hip_launch_policies = camp::list<hip_direct_policies>;
 using sycl_direct_policies = 
   camp::list<
              RAJA::LaunchPolicy<RAJA::sycl_launch_t<true>>,
-             RAJA::LoopPolicy<RAJA::sycl_group_2_direct>,
+             RAJA::LoopPolicy<RAJA::sycl_group_0_direct>, //slowest
              RAJA::LoopPolicy<RAJA::sycl_group_1_direct>,
-             RAJA::LoopPolicy<RAJA::sycl_group_0_direct>,
-             RAJA::LoopPolicy<RAJA::sycl_local_2_direct>,
+             RAJA::LoopPolicy<RAJA::sycl_group_2_direct>, //fastest
+             RAJA::LoopPolicy<RAJA::sycl_local_0_direct>,
              RAJA::LoopPolicy<RAJA::sycl_local_1_direct>,
-             RAJA::LoopPolicy<RAJA::sycl_local_0_direct>
+             RAJA::LoopPolicy<RAJA::sycl_local_2_direct>
             >;
 
 using Sycl_launch_policies = camp::list<sycl_direct_policies>;

--- a/test/include/RAJA_test-launch-execpol.hpp
+++ b/test/include/RAJA_test-launch-execpol.hpp
@@ -68,7 +68,7 @@ using Hip_launch_policies = camp::list<
 
 using sycl_policies = camp::list<
   RAJA::LaunchPolicy<RAJA::sycl_launch_t<true>>,
-  RAJA::LoopPolicy<RAJA::sycl_global_item_0>>;
+  RAJA::LoopPolicy<RAJA::sycl_global_item_2>>;
 
 using Sycl_launch_policies = camp::list<
       sycl_policies

--- a/test/include/RAJA_test-launch-loop-teams-threads-1D-execpol.hpp
+++ b/test/include/RAJA_test-launch-loop-teams-threads-1D-execpol.hpp
@@ -75,8 +75,8 @@ using Hip_launch_policies = camp::list<
 #if defined(RAJA_ENABLE_SYCL)
 using sycl_loop_policies = camp::list<
   RAJA::LaunchPolicy<RAJA::sycl_launch_t<true>>,
-  RAJA::LoopPolicy<RAJA::sycl_group_0_loop>,
-  RAJA::LoopPolicy<RAJA::sycl_local_0_loop>
+  RAJA::LoopPolicy<RAJA::sycl_group_2_loop>,
+  RAJA::LoopPolicy<RAJA::sycl_local_2_loop>
   >;
 
 using Sycl_launch_policies = camp::list<  

--- a/test/include/RAJA_test-launch-loop-teams-threads-3D-execpol.hpp
+++ b/test/include/RAJA_test-launch-loop-teams-threads-3D-execpol.hpp
@@ -95,12 +95,12 @@ using Hip_launch_policies = camp::list<
 #if defined(RAJA_ENABLE_SYCL)
 using sycl_loop_policies = camp::list<
   RAJA::LaunchPolicy<RAJA::sycl_launch_t<true>>,
-  RAJA::LoopPolicy<RAJA::sycl_group_2_loop>,
+  RAJA::LoopPolicy<RAJA::sycl_group_0_loop>, //slowest index
   RAJA::LoopPolicy<RAJA::sycl_group_1_loop>,
-  RAJA::LoopPolicy<RAJA::sycl_group_0_loop>,
-  RAJA::LoopPolicy<RAJA::sycl_local_2_loop>,
+  RAJA::LoopPolicy<RAJA::sycl_group_2_loop>, //fastest index
+  RAJA::LoopPolicy<RAJA::sycl_local_0_loop>,
   RAJA::LoopPolicy<RAJA::sycl_local_1_loop>,
-  RAJA::LoopPolicy<RAJA::sycl_local_0_loop>
+  RAJA::LoopPolicy<RAJA::sycl_local_2_loop>
   >;
 
 using Sycl_launch_policies = camp::list<  

--- a/test/include/RAJA_test-launch-runtime-execpol.hpp
+++ b/test/include/RAJA_test-launch-runtime-execpol.hpp
@@ -52,8 +52,8 @@ using Sequential_launch_policies = camp::list<seq_hip_policies>;
 using seq_sycl_policies =
   camp::list<
              RAJA::LaunchPolicy<RAJA::seq_launch_t,RAJA::sycl_launch_t<true>>,
-             RAJA::LoopPolicy<RAJA::seq_exec, RAJA::sycl_group_0_direct>,
-             RAJA::LoopPolicy<RAJA::seq_exec,RAJA::sycl_local_0_loop>
+             RAJA::LoopPolicy<RAJA::seq_exec, RAJA::sycl_group_2_direct>,
+             RAJA::LoopPolicy<RAJA::seq_exec,RAJA::sycl_local_2_loop>
             >;
 
 using Sequential_launch_policies = camp::list<seq_sycl_policies>;
@@ -110,8 +110,8 @@ using OpenMP_launch_policies = camp::list<omp_hip_policies>;
 using omp_sycl_policies =
   camp::list<
              RAJA::LaunchPolicy<RAJA::omp_launch_t,RAJA::sycl_launch_t<false>>,
-             RAJA::LoopPolicy<RAJA::omp_for_exec, RAJA::sycl_group_0_direct>,
-             RAJA::LoopPolicy<RAJA::seq_exec,RAJA::sycl_local_0_loop>
+             RAJA::LoopPolicy<RAJA::omp_for_exec, RAJA::sycl_group_2_direct>,
+             RAJA::LoopPolicy<RAJA::seq_exec,RAJA::sycl_local_2_loop>
             >;
 
 using OpenMP_launch_policies = camp::list<omp_sycl_policies>;


### PR DESCRIPTION
Sycl uses the outermost index as the fastest, this change enables consistency when using RAJA::launch with other device back ends.

For reference this page has a good description on thread indexing using sycl: 
https://www.intel.com/content/www/us/en/docs/dpcpp-compatibility-tool/developer-guide-reference/2023-2/cuda-and-sycl-programming-model-comparison.html

See the Thread Indexing section.   