### PR TITLE
Fix hip scan accumulation types

### DIFF
--- a/include/RAJA/policy/hip/scan.hpp
+++ b/include/RAJA/policy/hip/scan.hpp
@@ -135,9 +135,12 @@ exclusive_inplace(
     InputIter begin,
     InputIter end,
     Function binary_op,
-    T init)
+    T init_in)
 {
   hipStream_t stream = hip_res.get_stream();
+
+  using AccType = typename std::iterator_traits<InputIter>::value_type;
+  auto init = static_cast<AccType>(init_in);
 
   int len = std::distance(begin, end);
   // Determine temporary device storage requirements

--- a/include/RAJA/policy/hip/scan.hpp
+++ b/include/RAJA/policy/hip/scan.hpp
@@ -220,18 +220,27 @@ inclusive(
 {
   hipStream_t stream = hip_res.get_stream();
 
+#if defined(__HIPCC__)
+  using Config = rocprim::default_config;
+  using AccType = typename std::iterator_traits<OutputIter>::value_type;
+#endif
+
   int len = std::distance(begin, end);
   // Determine temporary device storage requirements
   void* d_temp_storage = nullptr;
   size_t temp_storage_bytes = 0;
 #if defined(__HIPCC__)
-  hipErrchk(::rocprim::inclusive_scan(d_temp_storage,
-                                      temp_storage_bytes,
-                                      begin,
-                                      out,
-                                      len,
-                                      binary_op,
-                                      stream));
+  hipErrchk(::rocprim::inclusive_scan<Config,
+                                      InputIter,
+                                      OutputIter,
+                                      Function,
+                                      AccType>(d_temp_storage,
+                                               temp_storage_bytes,
+                                               begin,
+                                               out,
+                                               len,
+                                               binary_op,
+                                               stream));
 #elif defined(__CUDACC__)
   hipErrchk(::cub::DeviceScan::InclusiveScan(d_temp_storage,
                                              temp_storage_bytes,
@@ -247,13 +256,17 @@ inclusive(
           temp_storage_bytes);
   // Run
 #if defined(__HIPCC__)
-  hipErrchk(::rocprim::inclusive_scan(d_temp_storage,
-                                      temp_storage_bytes,
-                                      begin,
-                                      out,
-                                      len,
-                                      binary_op,
-                                      stream));
+  hipErrchk(::rocprim::inclusive_scan<Config,
+                                      InputIter,
+                                      OutputIter,
+                                      Function,
+                                      AccType>(d_temp_storage,
+                                               temp_storage_bytes,
+                                               begin,
+                                               out,
+                                               len,
+                                               binary_op,
+                                               stream));
 #elif defined(__CUDACC__)
   hipErrchk(::cub::DeviceScan::InclusiveScan(d_temp_storage,
                                              temp_storage_bytes,

--- a/include/RAJA/policy/hip/scan.hpp
+++ b/include/RAJA/policy/hip/scan.hpp
@@ -230,7 +230,7 @@ inclusive(
   void* d_temp_storage = nullptr;
   size_t temp_storage_bytes = 0;
 #if defined(__HIPCC__)
-  hipErrchk(::rocprim::inclusive_scan<Config,
+  hipErrchk((::rocprim::inclusive_scan<Config,
                                       InputIter,
                                       OutputIter,
                                       Function,
@@ -240,7 +240,7 @@ inclusive(
                                                out,
                                                len,
                                                binary_op,
-                                               stream));
+                                               stream)));
 #elif defined(__CUDACC__)
   hipErrchk(::cub::DeviceScan::InclusiveScan(d_temp_storage,
                                              temp_storage_bytes,
@@ -256,7 +256,7 @@ inclusive(
           temp_storage_bytes);
   // Run
 #if defined(__HIPCC__)
-  hipErrchk(::rocprim::inclusive_scan<Config,
+  hipErrchk((::rocprim::inclusive_scan<Config,
                                       InputIter,
                                       OutputIter,
                                       Function,
@@ -266,7 +266,7 @@ inclusive(
                                                out,
                                                len,
                                                binary_op,
-                                               stream));
+                                               stream)));
 #elif defined(__CUDACC__)
   hipErrchk(::cub::DeviceScan::InclusiveScan(d_temp_storage,
                                              temp_storage_bytes,

--- a/include/RAJA/policy/hip/scan.hpp
+++ b/include/RAJA/policy/hip/scan.hpp
@@ -292,9 +292,12 @@ exclusive(
     InputIter end,
     OutputIter out,
     Function binary_op,
-    T init)
+    T init_in)
 {
   hipStream_t stream = hip_res.get_stream();
+
+  using AccType = typename std::iterator_traits<OutputIter>::value_type;
+  auto init = static_cast<AccType>(init_in);
 
   int len = std::distance(begin, end);
   // Determine temporary device storage requirements


### PR DESCRIPTION
# Fixes inconsistent scan accumulation types in hip backend compared to other backends

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes #1631 

TODO:
- [ ] test mixed types, small input types with large output types