### PR TITLE
Switch GitLab CI to use id_tokens

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,9 @@
 # We define the following GitLab pipeline variables:
 variables:
 ##### LC GITLAB CONFIGURATION
+include:
+  - project: 'lc-templates/id_tokens'
+    file: 'id_tokens.yml'
 # Use an LLNL service user to run CI. This prevents from running pipelines as an
 # actual user.
   LLNL_SERVICE_USER: rajasa


### PR DESCRIPTION
LC memo: https://hpc.llnl.gov/technical-bulletins/bulletin-568

# Summary

- This PR changes LC GItLab CI to use id_tokens at the request of LC. See link above.

All LC GitLab projects must do this due to the GitLab update in May 2024.