### PR TITLE
Use GitLab container registry as a Spack build cache

### DIFF
--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -70,3 +70,15 @@ variables:
   artifacts:
     reports:
       junit: junit.xml
+
+.reproducer_vars:
+  script:
+    - |
+      echo -e "
+      # Required variables \n
+      export MODULE_LIST=\"${MODULE_LIST}\" \n
+      export SPEC=\"${SPEC//\"/\\\"}\" \n
+      # Allow to set job script for debugging (only this differs from CI) \n
+      export DEBUG_MODE=true \n
+      # Using the CI build cache is optional and requires a token. Set it like so: \n
+      # export REGISTRY_TOKEN=\"<your token here>\" \n"

--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -8,9 +8,7 @@
 # Override reproducer section to define project specific variables.
 .corona_reproducer_vars:
   script:
-    - |
-      echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
-      echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
+    - !reference [.reproducer_vars, script]
 
 ########################
 # Overridden shared jobs

--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -8,9 +8,7 @@
 # Override reproducer section to define project specific variables.
 .lassen_reproducer_vars:
   script:
-    - |
-      echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
-      echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
+    - !reference [.reproducer_vars, script]
 
 ########################
 # Overridden shared jobs

--- a/.gitlab/jobs/poodle.yml
+++ b/.gitlab/jobs/poodle.yml
@@ -8,9 +8,7 @@
 # Override reproducer section to define projet specific variables.
 .poodle_reproducer_vars:
   script:
-    - |
-      echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
-      echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
+    - !reference [.reproducer_vars, script]
 
 ########################
 # Overridden shared jobs

--- a/.gitlab/jobs/poodle.yml
+++ b/.gitlab/jobs/poodle.yml
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ##############################################################################
 
-# Override reproducer section to define projet specific variables.
+# Override reproducer section to define project specific variables.
 .poodle_reproducer_vars:
   script:
     - !reference [.reproducer_vars, script]

--- a/.gitlab/jobs/ruby.yml
+++ b/.gitlab/jobs/ruby.yml
@@ -8,9 +8,7 @@
 # Override reproducer section to define project specific variables.
 .ruby_reproducer_vars:
   script:
-    - |
-      echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
-      echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
+    - !reference [.reproducer_vars, script]
 
 ########################
 # Overridden shared jobs

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -8,9 +8,7 @@
 # Override reproducer section to define project specific variables.
 .tioga_reproducer_vars:
   script:
-    - |
-      echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
-      echo -e "export SPEC=\"${SPEC//\"/\\\"}\""
+    - !reference [.reproducer_vars, script]
 
 ########################
 # Overridden shared jobs

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "develop-2024-05-05",
+"spack_branch": "bugfix/invalid-compiler-warning",
 "spack_activate" : {},
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "develop-2024-02-18",
+"spack_branch": "develop-2024-05-05",
 "spack_activate" : {},
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -83,7 +83,13 @@ then
     export SPACK_USER_CACHE_PATH="${spack_user_cache}"
     mkdir -p ${spack_user_cache}
 
-    ./scripts/uberenv/uberenv.py --spec="${spec}" ${prefix_opt}
+    ./scripts/uberenv/uberenv.py --setup-and-env-only --spec="${spec}" ${prefix_opt}
+
+    ${prefix}/spack/bin/spack -D ${prefix}/spack_env mirror add --unsigned --oci-username ${CI_REGISTRY_USER} --oci-password ${CI_JOB_TOKEN} gitlab_ci oci://${CI_REGISTRY_IMAGE}
+
+    ./scripts/uberenv/uberenv.py --skip-setup-and-env --spec="${spec}" ${prefix_opt}
+
+    ${prefix}/spack/bin/spack -D ${prefix}/spack_env buildcache push --only dependencies gitlab_ci
 
 fi
   echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -99,7 +99,7 @@ then
 
     if [[ -z ${spec} ]]
     then
-        echo "SPEC is undefined, aborting..."
+        echo "[Error]: SPEC is undefined, aborting..."
         exit 1
     fi
 
@@ -218,7 +218,7 @@ then
       ${project_dir}
     if ! $cmake_exe --build . -j ${core_counts[$truehostname]}
     then
-        echo "[Error]: compilation failed, building with verbose output..."
+        echo "[Error]: Compilation failed, building with verbose output..."
         echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
         echo "~~~~~ Running make VERBOSE=1"
         echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
@@ -265,7 +265,7 @@ then
 
     if grep -q "Errors while running CTest" ./tests_output.txt
     then
-        echo "[Error]: failure(s) while running CTest" && exit 1
+        echo "[Error]: Failure(s) while running CTest" && exit 1
     fi
 
     if grep -q -i "ENABLE_HIP.*ON" ${hostconfig_path}
@@ -274,17 +274,17 @@ then
     else
         if [[ ! -d ${install_dir} ]]
         then
-            echo "[Error]: install directory not found : ${install_dir}" && exit 1
+            echo "[Error]: Install directory not found : ${install_dir}" && exit 1
         fi
 
         cd ${install_dir}/examples/RAJA/using-with-cmake
         mkdir build && cd build
         if ! $cmake_exe -C ../host-config.cmake ..; then
-        echo "[Error]: running $cmake_exe for using-with-cmake test" && exit 1
+            echo "[Error]: Running $cmake_exe for using-with-cmake test" && exit 1
         fi
 
         if ! make; then
-        echo "[Error]: running make for using-with-cmake test" && exit 1
+            echo "[Error]: Running make for using-with-cmake test" && exit 1
         fi
     fi
 


### PR DESCRIPTION

In this PR, we set the GitLab CI to push Spack built binaries (RAJA dependencies) to the builtin OCI container registry.

This required an update of Spack, RADIUSS Spack Configs and Uberenv.