### PR TITLE
Add another math method and test

### DIFF
--- a/include/RAJA/util/math.hpp
+++ b/include/RAJA/util/math.hpp
@@ -91,6 +91,16 @@ constexpr T prev_pow2(T n) noexcept
   return n - (n >> 1);
 }
 
+/*!
+    \brief compute lhs mod rhs where lhs is non-negative and rhs is a power of 2
+*/
+template < typename L, typename R,
+           std::enable_if_t<std::is_integral<L>::value && std::is_integral<R>::value>* = nullptr >
+constexpr auto power_of_2_mod(L lhs, R rhs) noexcept
+{
+  return lhs & (rhs-R(1));
+}
+
 }  // namespace RAJA
 
 #endif

--- a/include/RAJA/util/math.hpp
+++ b/include/RAJA/util/math.hpp
@@ -74,10 +74,10 @@ constexpr T next_pow2(T n) noexcept
     \brief "round down" to the largest power of 2 that is less than or equal to n
 
     For an integer n,
-      if n is non-negative,
-        if n is a power of 2, return n
-        if n is not a power of 2, return the next smaller power of 2
       if n is negative, return 0
+      else
+        if n is a power of 2, return n
+        else return the largest power of 2 that is less than n
 */
 template < typename T,
            std::enable_if_t<std::is_integral<T>::value>* = nullptr >

--- a/include/RAJA/util/math.hpp
+++ b/include/RAJA/util/math.hpp
@@ -71,9 +71,9 @@ constexpr T next_pow2(T n) noexcept
 }
 
 /*!
-    \brief "round down" to the next smallest power of 2
+    \brief "round down" to the largest power of 2 that is less than or equal to n
 
-    For a integer n,
+    For an integer n,
       if n is non-negative,
         if n is a power of 2, return n
         if n is not a power of 2, return the next smaller power of 2

--- a/include/RAJA/util/math.hpp
+++ b/include/RAJA/util/math.hpp
@@ -70,6 +70,27 @@ constexpr T next_pow2(T n) noexcept
   return n;
 }
 
+/*!
+    \brief "round down" to the next smallest power of 2
+
+    For a integer n,
+      if n is non-negative,
+        if n is a power of 2, return n
+        if n is not a power of 2, return the next smaller power of 2
+      if n is negative, return 0
+*/
+template < typename T,
+           std::enable_if_t<std::is_integral<T>::value>* = nullptr >
+RAJA_HOST_DEVICE
+constexpr T prev_pow2(T n) noexcept
+{
+  if ( n < 0 ) return 0;
+  for (size_t s = 1; s < CHAR_BIT*sizeof(T); s *= 2) {
+    n |= n >> s;
+  }
+  return n - (n >> 1);
+}
+
 }  // namespace RAJA
 
 #endif

--- a/test/unit/util/CMakeLists.txt
+++ b/test/unit/util/CMakeLists.txt
@@ -25,4 +25,8 @@ raja_add_test(
   NAME test-fraction
   SOURCES test-fraction.cpp)
 
+raja_add_test(
+  NAME test-math
+  SOURCES test-math.cpp)
+
 add_subdirectory(operator)

--- a/test/unit/util/test-math.cpp
+++ b/test/unit/util/test-math.cpp
@@ -1,0 +1,85 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-24, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Source file containing tests for Fraction
+///
+
+#include <RAJA/RAJA.hpp>
+#include "RAJA_gtest.hpp"
+#include <type_traits>
+
+template < typename T >
+void test_log2()
+{
+  ASSERT_EQ(RAJA::log2(T(257)), T(8));
+  ASSERT_EQ(RAJA::log2(T(256)), T(8));
+  ASSERT_EQ(RAJA::log2(T(255)), T(7));
+  ASSERT_EQ(RAJA::log2(T(4)), T(2));
+  ASSERT_EQ(RAJA::log2(T(3)), T(1));
+  ASSERT_EQ(RAJA::log2(T(2)), T(1));
+  ASSERT_EQ(RAJA::log2(T(1)), T(0));
+  ASSERT_EQ(RAJA::log2(T(0)), T(0));
+  if (std::is_signed<T>::value) {
+    ASSERT_EQ(RAJA::log2(T(-1)), T(0));
+    ASSERT_EQ(RAJA::log2(T(-100)), T(0));
+  }
+}
+
+TEST(math, log2)
+{
+  test_log2<int>();
+  test_log2<size_t>();
+}
+
+
+template < typename T >
+void test_next_pow2()
+{
+  ASSERT_EQ(RAJA::next_pow2(T(257)), T(512));
+  ASSERT_EQ(RAJA::next_pow2(T(256)), T(256));
+  ASSERT_EQ(RAJA::next_pow2(T(255)), T(256));
+  ASSERT_EQ(RAJA::next_pow2(T(4)), T(4));
+  ASSERT_EQ(RAJA::next_pow2(T(3)), T(4));
+  ASSERT_EQ(RAJA::next_pow2(T(2)), T(2));
+  ASSERT_EQ(RAJA::next_pow2(T(1)), T(1));
+  ASSERT_EQ(RAJA::next_pow2(T(0)), T(0));
+  if (std::is_signed<T>::value) {
+    ASSERT_EQ(RAJA::next_pow2(T(-1)), T(0));
+    ASSERT_EQ(RAJA::next_pow2(T(-100)), T(0));
+  }
+}
+
+TEST(math, next_pow2)
+{
+  test_next_pow2<int>();
+  test_next_pow2<size_t>();
+}
+
+
+template < typename T >
+void test_prev_pow2()
+{
+  ASSERT_EQ(RAJA::prev_pow2(T(257)), T(256));
+  ASSERT_EQ(RAJA::prev_pow2(T(256)), T(256));
+  ASSERT_EQ(RAJA::prev_pow2(T(255)), T(128));
+  ASSERT_EQ(RAJA::prev_pow2(T(4)), T(4));
+  ASSERT_EQ(RAJA::prev_pow2(T(3)), T(2));
+  ASSERT_EQ(RAJA::prev_pow2(T(2)), T(2));
+  ASSERT_EQ(RAJA::prev_pow2(T(1)), T(1));
+  ASSERT_EQ(RAJA::prev_pow2(T(0)), T(0));
+  if (std::is_signed<T>::value) {
+    ASSERT_EQ(RAJA::prev_pow2(T(-1)), T(0));
+    ASSERT_EQ(RAJA::prev_pow2(T(-100)), T(0));
+  }
+}
+
+TEST(math, prev_pow2)
+{
+  test_prev_pow2<int>();
+  test_prev_pow2<size_t>();
+}

--- a/test/unit/util/test-math.cpp
+++ b/test/unit/util/test-math.cpp
@@ -83,3 +83,37 @@ TEST(math, prev_pow2)
   test_prev_pow2<int>();
   test_prev_pow2<size_t>();
 }
+
+
+template < typename T >
+void test_power_of_2_mod()
+{
+  ASSERT_EQ(RAJA::power_of_2_mod(T(257), T(256)), T(1));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(256), T(256)), T(0));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(255), T(256)), T(255));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(128), T(256)), T(128));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(256), T(4)), T(0));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(95), T(4)), T(3));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(94), T(4)), T(2));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(93), T(4)), T(1));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(92), T(4)), T(0));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(7), T(4)), T(3));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(6), T(4)), T(2));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(5), T(4)), T(1));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(4), T(4)), T(0));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(3), T(4)), T(3));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(2), T(4)), T(2));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(1), T(4)), T(1));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(0), T(4)), T(0));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(3), T(2)), T(1));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(2), T(2)), T(0));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(1), T(2)), T(1));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(0), T(2)), T(0));
+  ASSERT_EQ(RAJA::power_of_2_mod(T(1), T(1)), T(0));
+}
+
+TEST(math, power_of_2_mod)
+{
+  test_power_of_2_mod<int>();
+  test_power_of_2_mod<size_t>();
+}


### PR DESCRIPTION
# Add prev_pow2 and tests for functions in util/math.hpp

- This PR is a bugfix, feature
- It does the following:
  - Fixes missing math tests
  - Adds prev_pow2 at the request of me