### PR TITLE
Remove dependences on RAJA internal set/getQueue methods

### DIFF
--- a/include/RAJA/pattern/kernel/For.hpp
+++ b/include/RAJA/pattern/kernel/For.hpp
@@ -145,4 +145,4 @@ struct StatementExecutor<
 }  // end namespace RAJA
 
 
-#endif /* RAJA_pattern_nested_HPP */
+#endif /* RAJA_pattern_kernel_For_HPP */

--- a/include/RAJA/pattern/kernel/internal/LoopData.hpp
+++ b/include/RAJA/pattern/kernel/internal/LoopData.hpp
@@ -214,7 +214,7 @@ struct GenericWrapper : GenericWrapperBase {
 
 
 /*!
- * Convenience object used to create thread-private a LoopData object.
+ * Convenience object used to create a thread-private LoopData object.
  */
 template <typename T>
 struct NestedPrivatizer {

--- a/include/RAJA/pattern/kernel/internal/LoopTypes.hpp
+++ b/include/RAJA/pattern/kernel/internal/LoopTypes.hpp
@@ -93,4 +93,4 @@ using setSegmentTypeFromData =
 }  // end namespace RAJA
 
 
-#endif /* RAJA_pattern_kernel_internal_LoopData_HPP */
+#endif /* RAJA_pattern_kernel_internal_LoopTypes_HPP */

--- a/include/RAJA/pattern/kernel/internal/LoopTypes.hpp
+++ b/include/RAJA/pattern/kernel/internal/LoopTypes.hpp
@@ -3,8 +3,7 @@
  *
  * \file
  *
- * \brief   Header file for loop kernel internals: LoopData structure and
- *          related helper functions.
+ * \brief   Header file for loop kernel internals and related helper functions.
  *
  ******************************************************************************
  */

--- a/include/RAJA/pattern/kernel/internal/Template.hpp
+++ b/include/RAJA/pattern/kernel/internal/Template.hpp
@@ -3,8 +3,7 @@
  *
  * \file
  *
- * \brief   Header file for loop kernel internals: LoopData structure and
- *          related helper functions.
+ * \brief   Header file for loop kernel internals and helper functions.
  *
  ******************************************************************************
  */
@@ -83,4 +82,4 @@ using tuple_of_n = typename detail::TupleOfNHelper<T, camp::make_idx_seq_t<N>>::
 }  // end namespace RAJA
 
 
-#endif /* RAJA_pattern_kernel_internal_LoopData_HPP */
+#endif /* RAJA_pattern_kernel_internal_Template_HPP */

--- a/include/RAJA/policy/sycl/forall.hpp
+++ b/include/RAJA/policy/sycl/forall.hpp
@@ -121,12 +121,16 @@ forall_impl(resources::Sycl &sycl_res,
     sycl_dim_t blockSize{BlockSize};
     sycl_dim_t gridSize = impl::getGridDim(static_cast<size_t>(len), BlockSize);
 
+#if 0 // RDH
     ::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
     // Global resource was not set, use the resource that was passed to forall
     // Determine if the default SYCL res is being used
     if (!q) { 
       q = sycl_res.get_queue();
     }
+#else
+    ::sycl::queue* q = sycl_res.get_queue();
+#endif
 
     q->submit([&](::sycl::handler& h) {
 
@@ -168,6 +172,7 @@ resources::EventProxy<resources::Sycl> forall_impl(resources::Sycl &sycl_res,
 
   // Only launch kernel if we have something to iterate over
   if (len > 0 && BlockSize > 0) {
+
     // Note: We could fix an incorrect workgroup size.
     //       It would change what was specified.
     //       For now, leave the device compiler to error with invalid WG size.
@@ -178,14 +183,20 @@ resources::EventProxy<resources::Sycl> forall_impl(resources::Sycl &sycl_res,
     sycl_dim_t blockSize{BlockSize};
     sycl_dim_t gridSize = impl::getGridDim(static_cast<size_t>(len), BlockSize);
 
+#if 0  // RDH
     ::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
     // Global resource was not set, use the resource that was passed to forall
     // Determine if the default SYCL res is being used
     if (!q) { 
       q = sycl_res.get_queue();
     }
+#else
+    ::sycl::queue* q = sycl_res.get_queue();
+#endif
+
     LOOP_BODY* lbody;
     Iterator* beg;
+
     RAJA_FT_BEGIN;
     //
     // Setup shared memory buffers
@@ -250,18 +261,23 @@ forall_impl(resources::Sycl &sycl_res,
 
   // Only launch kernel if we have something to iterate over
   if (len > 0 && BlockSize > 0) {
+
     //
     // Compute the number of blocks
     //
     sycl_dim_t blockSize{BlockSize};
     sycl_dim_t gridSize = impl::getGridDim(static_cast<size_t>(len), BlockSize);
 
+#if 0 // RDH
     ::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
     // Global resource was not set, use the resource that was passed to forall
     // Determine if the default SYCL res is being used
     if (!q) {
       q = sycl_res.get_queue();
     }
+#else
+    ::sycl::queue* q = sycl_res.get_queue();
+#endif
 
     auto combiner = []( ForallParam x, ForallParam y ) {
       RAJA::expt::ParamMultiplexer::combine<EXEC_POL>( x, y );
@@ -332,12 +348,16 @@ forall_impl(resources::Sycl &sycl_res,
     sycl_dim_t blockSize{BlockSize};
     sycl_dim_t gridSize = impl::getGridDim(static_cast<size_t>(len), BlockSize);
 
+#if 0 // RDH
     ::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
     // Global resource was not set, use the resource that was passed to forall
     // Determine if the default SYCL res is being used
     if (!q) {
       q = sycl_res.get_queue();
     }
+#else
+    ::sycl::queue* q = sycl_res.get_queue();
+#endif
 
     auto combiner = []( ForallParam x, ForallParam y ) {
       RAJA::expt::ParamMultiplexer::combine<EXEC_POL>( x, y );
@@ -418,29 +438,6 @@ template <typename LoopBody,
           size_t BlockSize,
           bool Async,
           typename... SegmentTypes>
-RAJA_INLINE void forall_impl(ExecPolicy<seq_segit, sycl_exec<BlockSize, Async>>,
-                             const TypedIndexSet<SegmentTypes...>& iset,
-                             LoopBody&& loop_body)
-{
-  int num_seg = iset.getNumSegments();
-  for (int isi = 0; isi < num_seg; ++isi) {
-    iset.segmentCall(isi,
-                     detail::CallForall(),
-                     sycl_exec<BlockSize, true>(),
-                     loop_body);
-  }  // iterate over segments of index set
-
-  if (!Async) {
-    ::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
-    q->wait();
-  };
-}
-
-
-template <typename LoopBody,
-          size_t BlockSize,
-          bool Async,
-          typename... SegmentTypes>
 RAJA_INLINE resources::EventProxy<resources::Sycl> forall_impl(resources::Sycl &r,
                                                     ExecPolicy<seq_segit, sycl_exec<BlockSize, Async>>,
                                                     const TypedIndexSet<SegmentTypes...>& iset,
@@ -455,10 +452,15 @@ RAJA_INLINE resources::EventProxy<resources::Sycl> forall_impl(resources::Sycl &
                      loop_body);
   }  // iterate over segments of index set
 
+#if 0 // RDH
   if (!Async) {
     ::sycl::queue* q = ::RAJA::sycl::detail::getQueue(); 
     q->wait();
   }
+#else
+  ::sycl::queue* q = r.get_queue();
+  q->wait(); 
+#endif
 
   return resources::EventProxy<resources::Sycl>(r);
 }

--- a/include/RAJA/policy/sycl/forall.hpp
+++ b/include/RAJA/policy/sycl/forall.hpp
@@ -121,16 +121,7 @@ forall_impl(resources::Sycl &sycl_res,
     sycl_dim_t blockSize{BlockSize};
     sycl_dim_t gridSize = impl::getGridDim(static_cast<size_t>(len), BlockSize);
 
-#if 0 // RDH
-    ::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
-    // Global resource was not set, use the resource that was passed to forall
-    // Determine if the default SYCL res is being used
-    if (!q) { 
-      q = sycl_res.get_queue();
-    }
-#else
     ::sycl::queue* q = sycl_res.get_queue();
-#endif
 
     q->submit([&](::sycl::handler& h) {
 
@@ -183,16 +174,7 @@ resources::EventProxy<resources::Sycl> forall_impl(resources::Sycl &sycl_res,
     sycl_dim_t blockSize{BlockSize};
     sycl_dim_t gridSize = impl::getGridDim(static_cast<size_t>(len), BlockSize);
 
-#if 0  // RDH
-    ::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
-    // Global resource was not set, use the resource that was passed to forall
-    // Determine if the default SYCL res is being used
-    if (!q) { 
-      q = sycl_res.get_queue();
-    }
-#else
     ::sycl::queue* q = sycl_res.get_queue();
-#endif
 
     LOOP_BODY* lbody;
     Iterator* beg;
@@ -268,16 +250,7 @@ forall_impl(resources::Sycl &sycl_res,
     sycl_dim_t blockSize{BlockSize};
     sycl_dim_t gridSize = impl::getGridDim(static_cast<size_t>(len), BlockSize);
 
-#if 0 // RDH
-    ::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
-    // Global resource was not set, use the resource that was passed to forall
-    // Determine if the default SYCL res is being used
-    if (!q) {
-      q = sycl_res.get_queue();
-    }
-#else
     ::sycl::queue* q = sycl_res.get_queue();
-#endif
 
     auto combiner = []( ForallParam x, ForallParam y ) {
       RAJA::expt::ParamMultiplexer::combine<EXEC_POL>( x, y );
@@ -348,16 +321,7 @@ forall_impl(resources::Sycl &sycl_res,
     sycl_dim_t blockSize{BlockSize};
     sycl_dim_t gridSize = impl::getGridDim(static_cast<size_t>(len), BlockSize);
 
-#if 0 // RDH
-    ::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
-    // Global resource was not set, use the resource that was passed to forall
-    // Determine if the default SYCL res is being used
-    if (!q) {
-      q = sycl_res.get_queue();
-    }
-#else
     ::sycl::queue* q = sycl_res.get_queue();
-#endif
 
     auto combiner = []( ForallParam x, ForallParam y ) {
       RAJA::expt::ParamMultiplexer::combine<EXEC_POL>( x, y );
@@ -452,15 +416,8 @@ RAJA_INLINE resources::EventProxy<resources::Sycl> forall_impl(resources::Sycl &
                      loop_body);
   }  // iterate over segments of index set
 
-#if 0 // RDH
-  if (!Async) {
-    ::sycl::queue* q = ::RAJA::sycl::detail::getQueue(); 
-    q->wait();
-  }
-#else
   ::sycl::queue* q = r.get_queue();
   q->wait(); 
-#endif
 
   return resources::EventProxy<resources::Sycl>(r);
 }

--- a/include/RAJA/policy/sycl/forall.hpp
+++ b/include/RAJA/policy/sycl/forall.hpp
@@ -416,8 +416,10 @@ RAJA_INLINE resources::EventProxy<resources::Sycl> forall_impl(resources::Sycl &
                      loop_body);
   }  // iterate over segments of index set
 
-  ::sycl::queue* q = r.get_queue();
-  q->wait(); 
+  if ( !Async ) {
+    ::sycl::queue* q = r.get_queue();
+    q->wait(); 
+  }
 
   return resources::EventProxy<resources::Sycl>(r);
 }

--- a/include/RAJA/policy/sycl/kernel/SyclKernel.hpp
+++ b/include/RAJA/policy/sycl/kernel/SyclKernel.hpp
@@ -142,7 +142,7 @@ struct SyclLaunchHelper<false,sycl_launch<async0>,StmtList,Data,Types>
 
     qu->submit([&](cl::sycl::handler& h) {
  
-      h.parallel_for(launch_dims.fit_nd_range(),
+      h.parallel_for(launch_dims.fit_nd_range(qu),
                      [=] (cl::sycl::nd_item<3> item) {
         
         SyclKernelLauncher<Data, executor_t>(*m_data, item);
@@ -178,7 +178,7 @@ struct SyclLaunchHelper<true,sycl_launch<async0>,StmtList,Data,Types>
 
     qu->submit([&](cl::sycl::handler& h) {
  
-      h.parallel_for(launch_dims.fit_nd_range(),
+      h.parallel_for(launch_dims.fit_nd_range(qu),
                      [=] (cl::sycl::nd_item<3> item) {
 
         SyclKernelLauncher<Data, executor_t>(data, item);
@@ -217,6 +217,7 @@ struct StatementExecutor<
     LaunchDims launch_dims = executor_t::calculateDimensions(data);
     
     int shmem = 0;
+#if 1  // RDH
     cl::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
 
     // Global resource was not set, use the resource that was passed to forall
@@ -225,6 +226,10 @@ struct StatementExecutor<
       camp::resources::Resource res = camp::resources::Sycl();
       q = res.get<camp::resources::Sycl>().get_queue();
     }
+#else
+    camp::resources::Sycl res = data.get_resource();
+    ::sycl::queue* q = res.get_queue();;
+#endif
 
     //
     // Launch the kernels

--- a/include/RAJA/policy/sycl/kernel/internal.hpp
+++ b/include/RAJA/policy/sycl/kernel/internal.hpp
@@ -95,16 +95,6 @@ struct LaunchDims {
     launch_local.y = std::max(launch_local.y, local.y);
     launch_local.z = std::max(launch_local.z, local.z);
 
-#if 0 // RDH
-    cl::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
-    // Global resource was not set, use the resource that was passed to forall
-    // Determine if the default SYCL res is being used
-    if (!q) {
-      camp::resources::Resource sycl_res = camp::resources::Sycl();
-      q = sycl_res.get<camp::resources::Sycl>().get_queue();
-    }
-#endif
-
     cl::sycl::device dev = q->get_device();
 
     auto max_work_group_size = dev.get_info< ::cl::sycl::info::device::max_work_group_size>();

--- a/include/RAJA/policy/sycl/kernel/internal.hpp
+++ b/include/RAJA/policy/sycl/kernel/internal.hpp
@@ -86,7 +86,7 @@ struct LaunchDims {
     return result;
   }
 
-  cl::sycl::nd_range<3> fit_nd_range() {
+  cl::sycl::nd_range<3> fit_nd_range(::sycl::queue* q) {
 
     sycl_dim_3_t launch_global;
 
@@ -95,6 +95,7 @@ struct LaunchDims {
     launch_local.y = std::max(launch_local.y, local.y);
     launch_local.z = std::max(launch_local.z, local.z);
 
+#if 0 // RDH
     cl::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
     // Global resource was not set, use the resource that was passed to forall
     // Determine if the default SYCL res is being used
@@ -102,6 +103,7 @@ struct LaunchDims {
       camp::resources::Resource sycl_res = camp::resources::Sycl();
       q = sycl_res.get<camp::resources::Sycl>().get_queue();
     }
+#endif
 
     cl::sycl::device dev = q->get_device();
 

--- a/include/RAJA/policy/sycl/launch.hpp
+++ b/include/RAJA/policy/sycl/launch.hpp
@@ -41,21 +41,8 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>> {
        BODY_IN &&body_in, ReduceParams &RAJA_UNUSED_ARG(launch_reducers))
   {
 
-#if 0 // RDH
-    cl::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
-
-    /*Get the concrete resource */
-    resources::Sycl sycl_res = res.get<RAJA::resources::Sycl>();
-
-    // Global resource was not set, use the resource that was passed to forall
-    // Determine if the default SYCL res is being used
-    if (!q) {
-      q = sycl_res.get_queue();
-    }
-#else
     /*Get the queue from concrete resource */
     ::sycl::queue* q = res.get<camp::resources::Sycl>().get_queue();
-#endif
 
     //
     // Compute the number of blocks and threads
@@ -130,21 +117,8 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>> {
        BODY_IN &&body_in, ReduceParams &RAJA_UNUSED_ARG(launch_reducers))
   {
 
-#if 0 // RDH
-    cl::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
-
-    /*Get the concrete resource */
-    resources::Sycl sycl_res = res.get<RAJA::resources::Sycl>();
-
-    // Global resource was not set, use the resource that was passed to forall
-    // Determine if the default SYCL res is being used
-    if (!q) {
-      q = sycl_res.get_queue();
-    }
-#else
     /*Get the queue from concrete resource */
     ::sycl::queue* q = res.get<camp::resources::Sycl>().get_queue();
-#endif
 
     //
     // Compute the number of blocks and threads

--- a/include/RAJA/policy/sycl/launch.hpp
+++ b/include/RAJA/policy/sycl/launch.hpp
@@ -41,6 +41,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>> {
        BODY_IN &&body_in, ReduceParams &RAJA_UNUSED_ARG(launch_reducers))
   {
 
+#if 0 // RDH
     cl::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
 
     /*Get the concrete resource */
@@ -51,6 +52,10 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>> {
     if (!q) {
       q = sycl_res.get_queue();
     }
+#else
+    /*Get the queue from concrete resource */
+    ::sycl::queue* q = res.get<camp::resources::Sycl>().get_queue();
+#endif
 
     //
     // Compute the number of blocks and threads
@@ -125,6 +130,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>> {
        BODY_IN &&body_in, ReduceParams &RAJA_UNUSED_ARG(launch_reducers))
   {
 
+#if 0 // RDH
     cl::sycl::queue* q = ::RAJA::sycl::detail::getQueue();
 
     /*Get the concrete resource */
@@ -135,6 +141,10 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>> {
     if (!q) {
       q = sycl_res.get_queue();
     }
+#else
+    /*Get the queue from concrete resource */
+    ::sycl::queue* q = res.get<camp::resources::Sycl>().get_queue();
+#endif
 
     //
     // Compute the number of blocks and threads

--- a/include/RAJA/policy/sycl/policy.hpp
+++ b/include/RAJA/policy/sycl/policy.hpp
@@ -96,7 +96,7 @@ template<typename host_policy>
 struct sycl_atomic_explicit{};
 
 //
-// Default cuda atomic policy uses cuda atomics on the device and non-atomics
+// Default sycl atomic policy uses sycl atomics on the device and non-atomics
 // on the host
 //
 using sycl_atomic = sycl_atomic_explicit<seq_atomic>;

--- a/include/RAJA/policy/sycl/reduce.hpp
+++ b/include/RAJA/policy/sycl/reduce.hpp
@@ -73,7 +73,7 @@ struct maxloc
 // Ideally, MaxNumTeams = ThreadsPerTeam in omp_target_parallel_for_exec.
 static int MaxNumTeams = 1;
 
-//! Information necessary for OpenMP offload to be considered
+//! Information necessary for SYCL offload to be considered
 struct Offload_Info 
 {
   int hostID{1};
@@ -88,7 +88,7 @@ struct Offload_Info
   }
 };
 
-//! Reduction data for OpenMP Offload -- stores value, host pointer, and device
+//! Reduction data for SYCL Offload -- stores value, host pointer, and device
 //! pointer
 template <typename T>
 struct Reduce_Data
@@ -195,7 +195,7 @@ struct Reduce_Data
 
 }  // end namespace sycl
 
-//! OpenMP Target Reduction entity -- generalize on # of teams, reduction, and
+//! SYCL Target Reduction entity -- generalize on # of teams, reduction, and
 //! type
 template <typename Reducer, typename T>
 struct TargetReduce 
@@ -285,7 +285,7 @@ private:
   T finalVal;
 };
 
-//! OpenMP Target Reduction Location entity -- generalize on # of teams,
+//! SYCL Target Reduction Location entity -- generalize on # of teams,
 //! reduction, and type
 template <typename Reducer, typename T, typename IndexType>
 struct TargetReduceLoc 

--- a/test/functional/forall/reduce-basic/CMakeLists.txt
+++ b/test/functional/forall/reduce-basic/CMakeLists.txt
@@ -22,16 +22,6 @@ if(RAJA_ENABLE_TARGET_OPENMP)
   endif()
 endif()
 
-#
-# If building SYCL tests, remove the back-end from
-# from the list of tests to generate here for the 
-# expt-reduce tests.
-#
-if(RAJA_ENABLE_SYCL)
-	list(REMOVE_ITEM REDUCETYPES ReduceMaxLoc)
-	list(REMOVE_ITEM REDUCETYPES ReduceMinLoc)
-endif()
-
 
 #
 # Generate core reduction tests for each enabled RAJA back-end


### PR DESCRIPTION
# Summary

- This PR eliminates the need to use the internal set/getQueue methods in some parts of RAJA SYCL support. 
- There is more work to be done, briefly described in https://github.com/LLNL/RAJA/issues/1658. 
- The content of this PR is required to enable correct asynchronous execution of RAJA Perf kernels that use the RAJA::kernel interface. The associated PR that adds many SYCL kernel variants to RAJA Perf is https://github.com/LLNL/RAJAPerf/pull/441.

Passing resources explicitly to kernel execution methods results in consistent SYCL resource/queue usage during execution of most kernels as a result. getQueue method calls have been removed in some places as a result. When a resource is not passed to a kernel execution method, the code can now properly acquire the default SYCL resource via execution policy type traits without relying on internal getQueue calls.

Resolves https://github.com/LLNL/RAJA/issues/1652