### PR TITLE
Builtin atomics fixes

### DIFF
--- a/include/RAJA/policy/atomic_builtin.hpp
+++ b/include/RAJA/policy/atomic_builtin.hpp
@@ -43,6 +43,19 @@ namespace detail
 #if defined(RAJA_COMPILER_MSVC) || (defined(_WIN32) && defined(__INTEL_COMPILER))
 
 RAJA_DEVICE_HIP
+RAJA_INLINE unsigned builtin_atomic_load(unsigned volatile *acc)
+{
+  return RAJA::util::reinterp_A_as_B<long, unsigned>(_InterlockedOr((long volatile *)acc, 0));
+}
+
+RAJA_DEVICE_HIP
+RAJA_INLINE unsigned long long builtin_atomic_load(
+    unsigned long long volatile *acc)
+{
+  return RAJA::util::reinterp_A_as_B<long long, unsigned long long>(_InterlockedOr64((long long volatile *)acc, 0));
+}
+
+RAJA_DEVICE_HIP
 RAJA_INLINE unsigned builtin_atomic_CAS(unsigned volatile *acc,
                                         unsigned compare,
                                         unsigned value)

--- a/include/RAJA/policy/atomic_builtin.hpp
+++ b/include/RAJA/policy/atomic_builtin.hpp
@@ -198,10 +198,10 @@ struct BuiltinAtomicCAS<4> {
     if (!sc(old)) {
       T assumed;
 
-      while ((assumed = builtin_atomic_CAS(acc, old, oper(old))) != old &&
-             !sc(assumed)) {
-        old = assumed;
-      }
+      do {
+        assumed = old;
+        old = builtin_atomic_CAS(acc, assumed, oper(assumed));
+      } while (assumed != old && !sc(old));
     }
 
     return old;
@@ -232,10 +232,10 @@ struct BuiltinAtomicCAS<8> {
     if (!sc(old)) {
       T assumed;
 
-      while ((assumed = builtin_atomic_CAS(acc, old, oper(old))) != old &&
-             !sc(assumed)) {
-        old = assumed;
-      }
+      do {
+        assumed = old;
+        old = builtin_atomic_CAS(acc, assumed, oper(assumed));
+      } while (assumed != old && !sc(old));
     }
 
     return old;

--- a/include/RAJA/policy/atomic_builtin.hpp
+++ b/include/RAJA/policy/atomic_builtin.hpp
@@ -62,7 +62,7 @@ using BuiltinAtomicType = typename BuiltinAtomicTypeImpl<sizeof(T)>::type;
 
 #if defined(RAJA_COMPILER_MSVC) || (defined(_WIN32) && defined(__INTEL_COMPILER))
 
-RAJA_INLINE unsigned builtin_atomic_load(unsigned *acc)
+RAJA_INLINE unsigned builtin_atomic_load(unsigned volatile *acc)
 {
   static_assert(sizeof(unsigned) == sizeof(long),
                 "builtin atomic load assumes unsigned and long are the same size");
@@ -71,7 +71,7 @@ RAJA_INLINE unsigned builtin_atomic_load(unsigned *acc)
 }
 
 RAJA_INLINE unsigned long long builtin_atomic_load(
-    unsigned long long *acc)
+    unsigned long long volatile *acc)
 {
   static_assert(sizeof(unsigned long long) == sizeof(long long),
                 "builtin atomic load assumes unsigned long long and long long are the same size");
@@ -103,7 +103,7 @@ RAJA_INLINE unsigned long long builtin_atomic_CAS(
   long long long_compare =
       RAJA::util::reinterp_A_as_B<unsigned long long, long long>(compare);
 
-  long long old = _InterlockedCompareExchange64((long long volatile *)acc,
+  long long old = _InterlockedCompareExchange64((long long *)acc,
                                                 long_value,
                                                 long_compare);
 
@@ -113,14 +113,14 @@ RAJA_INLINE unsigned long long builtin_atomic_CAS(
 #else  // RAJA_COMPILER_MSVC
 
 RAJA_DEVICE_HIP
-RAJA_INLINE unsigned builtin_atomic_load(unsigned *acc)
+RAJA_INLINE unsigned builtin_atomic_load(unsigned volatile *acc)
 {
   return __atomic_load_n(acc, __ATOMIC_RELAXED);
 }
 
 RAJA_DEVICE_HIP
 RAJA_INLINE unsigned long long builtin_atomic_load(
-    unsigned long long *acc)
+    unsigned long long volatile *acc)
 {
   return __atomic_load_n(acc, __ATOMIC_RELAXED);
 }
@@ -152,19 +152,19 @@ RAJA_INLINE unsigned long long builtin_atomic_CAS(
 template <typename T>
 RAJA_DEVICE_HIP RAJA_INLINE
     typename std::enable_if<sizeof(T) == sizeof(unsigned), T>::type
-    builtin_atomic_load(T *acc)
+    builtin_atomic_load(T volatile *acc)
 {
   return RAJA::util::reinterp_A_as_B<unsigned, T>(
-      builtin_atomic_load((unsigned *)acc));
+      builtin_atomic_load((unsigned volatile*)acc));
 }
 
 template <typename T>
 RAJA_DEVICE_HIP RAJA_INLINE
     typename std::enable_if<sizeof(T) == sizeof(unsigned long long), T>::type
-    builtin_atomic_load(T *acc)
+    builtin_atomic_load(T volatile *acc)
 {
   return RAJA::util::reinterp_A_as_B<unsigned long long, T>(
-      builtin_atomic_load((unsigned long long *)acc));
+      builtin_atomic_load((unsigned long long volatile *)acc));
 }
 
 template <typename T>
@@ -202,7 +202,7 @@ RAJA_DEVICE_HIP RAJA_INLINE T builtin_atomic_CAS_oper(T volatile *acc,
   static_assert(sizeof(T) == 4 || sizeof(T) == 8,
                 "builtin atomic cas assumes 4 or 8 byte targets");
 
-  BuiltinAtomicType<T>* accConverted = (BuiltinAtomicType<T>*) acc;
+  BuiltinAtomicType<T> volatile * accConverted = (BuiltinAtomicType<T> volatile *) acc;
   BuiltinAtomicType<T> old = builtin_atomic_load(accConverted);
   BuiltinAtomicType<T> expected;
 
@@ -222,7 +222,7 @@ RAJA_DEVICE_HIP RAJA_INLINE T builtin_atomic_CAS_oper_sc(T volatile *acc,
   static_assert(sizeof(T) == 4 || sizeof(T) == 8,
                 "builtin atomic cas assumes 4 or 8 byte targets");
 
-  BuiltinAtomicType<T>* accConverted = (BuiltinAtomicType<T>*) acc;
+  BuiltinAtomicType<T> volatile * accConverted = (BuiltinAtomicType<T> volatile *) acc;
   BuiltinAtomicType<T> old = builtin_atomic_load(accConverted);
   BuiltinAtomicType<T> expected;
 

--- a/include/RAJA/policy/atomic_builtin.hpp
+++ b/include/RAJA/policy/atomic_builtin.hpp
@@ -216,14 +216,16 @@ RAJA_DEVICE_HIP RAJA_INLINE T builtin_atomic_CAS_oper_sc(T volatile *acc,
 #endif
   T old = builtin_atomic_load(acc);
 
-  if (!sc(old)) {
-    T assumed;
-
-    do {
-      assumed = old;
-      old = builtin_atomic_CAS(acc, assumed, oper(assumed));
-    } while (assumed != old && !sc(old));
+  if (sc(old)) {
+    return old;
   }
+
+  T assumed;
+
+  do {
+    assumed = old;
+    old = builtin_atomic_CAS(acc, assumed, oper(assumed));
+  } while (assumed != old && !sc(old));
 
   return old;
 #ifdef RAJA_COMPILER_MSVC

--- a/include/RAJA/policy/atomic_builtin.hpp
+++ b/include/RAJA/policy/atomic_builtin.hpp
@@ -43,16 +43,22 @@ namespace detail
 #if defined(RAJA_COMPILER_MSVC) || (defined(_WIN32) && defined(__INTEL_COMPILER))
 
 RAJA_DEVICE_HIP
-RAJA_INLINE unsigned builtin_atomic_load(unsigned volatile *acc)
+RAJA_INLINE unsigned builtin_atomic_load(unsigned *acc)
 {
-  return RAJA::util::reinterp_A_as_B<long, unsigned>(_InterlockedOr((long volatile *)acc, 0));
+  static_assert(sizeof(unsigned) == sizeof(long),
+                "builtin atomic load assumes unsigned and long are the same size");
+
+  return RAJA::util::reinterp_A_as_B<long, unsigned>(_InterlockedOr((long *)acc, 0));
 }
 
 RAJA_DEVICE_HIP
 RAJA_INLINE unsigned long long builtin_atomic_load(
-    unsigned long long volatile *acc)
+    unsigned long long *acc)
 {
-  return RAJA::util::reinterp_A_as_B<long long, unsigned long long>(_InterlockedOr64((long long volatile *)acc, 0));
+  static_assert(sizeof(unsigned long long) == sizeof(long long),
+                "builtin atomic load assumes unsigned long long and long long are the same size");
+
+  return RAJA::util::reinterp_A_as_B<long long, unsigned long long>(_InterlockedOr64((long long *)acc, 0));
 }
 
 RAJA_DEVICE_HIP
@@ -91,14 +97,14 @@ RAJA_INLINE unsigned long long builtin_atomic_CAS(
 #else  // RAJA_COMPILER_MSVC
 
 RAJA_DEVICE_HIP
-RAJA_INLINE unsigned builtin_atomic_load(unsigned volatile *acc)
+RAJA_INLINE unsigned builtin_atomic_load(unsigned *acc)
 {
   return __atomic_load_n(acc, __ATOMIC_RELAXED);
 }
 
 RAJA_DEVICE_HIP
 RAJA_INLINE unsigned long long builtin_atomic_load(
-    unsigned long long volatile *acc)
+    unsigned long long *acc)
 {
   return __atomic_load_n(acc, __ATOMIC_RELAXED);
 }
@@ -130,19 +136,19 @@ RAJA_INLINE unsigned long long builtin_atomic_CAS(
 template <typename T>
 RAJA_DEVICE_HIP RAJA_INLINE
     typename std::enable_if<sizeof(T) == sizeof(unsigned), T>::type
-    builtin_atomic_load(T volatile *acc)
+    builtin_atomic_load(T *acc)
 {
   return RAJA::util::reinterp_A_as_B<unsigned, T>(
-      builtin_atomic_load((unsigned volatile *)acc));
+      builtin_atomic_load((unsigned *)acc));
 }
 
 template <typename T>
 RAJA_DEVICE_HIP RAJA_INLINE
     typename std::enable_if<sizeof(T) == sizeof(unsigned long long), T>::type
-    builtin_atomic_load(T volatile *acc)
+    builtin_atomic_load(T *acc)
 {
   return RAJA::util::reinterp_A_as_B<unsigned long long, T>(
-      builtin_atomic_load((unsigned long long volatile *)acc));
+      builtin_atomic_load((unsigned long long *)acc));
 }
 
 template <typename T>

--- a/include/RAJA/policy/atomic_builtin.hpp
+++ b/include/RAJA/policy/atomic_builtin.hpp
@@ -62,7 +62,6 @@ using BuiltinAtomicType = typename BuiltinAtomicTypeImpl<sizeof(T)>::type;
 
 #if defined(RAJA_COMPILER_MSVC) || (defined(_WIN32) && defined(__INTEL_COMPILER))
 
-RAJA_DEVICE_HIP
 RAJA_INLINE unsigned builtin_atomic_load(unsigned *acc)
 {
   static_assert(sizeof(unsigned) == sizeof(long),
@@ -71,7 +70,6 @@ RAJA_INLINE unsigned builtin_atomic_load(unsigned *acc)
   return RAJA::util::reinterp_A_as_B<long, unsigned>(_InterlockedOr((long *)acc, 0));
 }
 
-RAJA_DEVICE_HIP
 RAJA_INLINE unsigned long long builtin_atomic_load(
     unsigned long long *acc)
 {
@@ -81,7 +79,6 @@ RAJA_INLINE unsigned long long builtin_atomic_load(
   return RAJA::util::reinterp_A_as_B<long long, unsigned long long>(_InterlockedOr64((long long *)acc, 0));
 }
 
-RAJA_DEVICE_HIP
 RAJA_INLINE unsigned builtin_atomic_CAS(unsigned volatile *acc,
                                         unsigned compare,
                                         unsigned value)
@@ -95,7 +92,6 @@ RAJA_INLINE unsigned builtin_atomic_CAS(unsigned volatile *acc,
   return RAJA::util::reinterp_A_as_B<long, unsigned>(old);
 }
 
-RAJA_DEVICE_HIP
 RAJA_INLINE unsigned long long builtin_atomic_CAS(
     unsigned long long volatile *acc,
     unsigned long long compare,

--- a/include/RAJA/policy/atomic_builtin.hpp
+++ b/include/RAJA/policy/atomic_builtin.hpp
@@ -216,9 +216,9 @@ RAJA_DEVICE_HIP RAJA_INLINE T builtin_atomic_CAS_oper(T volatile *acc,
   do {
     expected = old;
     old = builtin_atomic_CAS(accConverted, expected, RAJA::util::reinterp_A_as_B<T, BuiltinAtomicType<T>>(oper(RAJA::util::reinterp_A_as_B<BuiltinAtomicType<T>, T>(expected))));
-  } while (expected != old);
+  } while (old != expected);
 
-  return old;
+  return RAJA::util::reinterp_A_as_B<BuiltinAtomicType<T>, T>(old);
 #ifdef RAJA_COMPILER_MSVC
 #pragma warning( default : 4244 )  // Reenable warning
 #endif
@@ -235,20 +235,20 @@ RAJA_DEVICE_HIP RAJA_INLINE T builtin_atomic_CAS_oper_sc(T volatile *acc,
 #ifdef RAJA_COMPILER_MSVC
 #pragma warning( disable : 4244 )  // Force msvc to not emit conversion warning
 #endif
-  T old = builtin_atomic_load(acc);
+  BuiltinAtomicType<T>* accConverted = (BuiltinAtomicType<T>*) acc;
+  BuiltinAtomicType<T> old = builtin_atomic_load(accConverted);
+  BuiltinAtomicType<T> expected;
 
-  if (sc(old)) {
-    return old;
+  if (sc(RAJA::util::reinterp_A_as_B<BuiltinAtomicType<T>, T>(old))) {
+    return RAJA::util::reinterp_A_as_B<BuiltinAtomicType<T>, T>(old);
   }
 
-  T assumed;
-
   do {
-    assumed = old;
-    old = builtin_atomic_CAS(acc, assumed, oper(assumed));
-  } while (assumed != old && !sc(old));
+    expected = old;
+    old = builtin_atomic_CAS(accConverted, expected, RAJA::util::reinterp_A_as_B<T, BuiltinAtomicType<T>>(oper(RAJA::util::reinterp_A_as_B<BuiltinAtomicType<T>, T>(expected))));
+  } while (old != expected && !sc(RAJA::util::reinterp_A_as_B<BuiltinAtomicType<T>, T>(old)));
 
-  return old;
+  return RAJA::util::reinterp_A_as_B<BuiltinAtomicType<T>, T>(old);
 #ifdef RAJA_COMPILER_MSVC
 #pragma warning( default : 4244 )  // Reenable warning
 #endif

--- a/include/RAJA/policy/atomic_builtin.hpp
+++ b/include/RAJA/policy/atomic_builtin.hpp
@@ -202,9 +202,6 @@ RAJA_DEVICE_HIP RAJA_INLINE T builtin_atomic_CAS_oper(T volatile *acc,
   static_assert(sizeof(T) == 4 || sizeof(T) == 8,
                 "builtin atomic cas assumes 4 or 8 byte targets");
 
-#ifdef RAJA_COMPILER_MSVC
-#pragma warning( disable : 4244 )  // Force msvc to not emit conversion warning
-#endif
   BuiltinAtomicType<T>* accConverted = (BuiltinAtomicType<T>*) acc;
   BuiltinAtomicType<T> old = builtin_atomic_load(accConverted);
   BuiltinAtomicType<T> expected;
@@ -215,9 +212,6 @@ RAJA_DEVICE_HIP RAJA_INLINE T builtin_atomic_CAS_oper(T volatile *acc,
   } while (old != expected);
 
   return RAJA::util::reinterp_A_as_B<BuiltinAtomicType<T>, T>(old);
-#ifdef RAJA_COMPILER_MSVC
-#pragma warning( default : 4244 )  // Reenable warning
-#endif
 }
 
 template <typename T, typename OPER, typename ShortCircuit>
@@ -228,9 +222,6 @@ RAJA_DEVICE_HIP RAJA_INLINE T builtin_atomic_CAS_oper_sc(T volatile *acc,
   static_assert(sizeof(T) == 4 || sizeof(T) == 8,
                 "builtin atomic cas assumes 4 or 8 byte targets");
 
-#ifdef RAJA_COMPILER_MSVC
-#pragma warning( disable : 4244 )  // Force msvc to not emit conversion warning
-#endif
   BuiltinAtomicType<T>* accConverted = (BuiltinAtomicType<T>*) acc;
   BuiltinAtomicType<T> old = builtin_atomic_load(accConverted);
   BuiltinAtomicType<T> expected;
@@ -245,9 +236,6 @@ RAJA_DEVICE_HIP RAJA_INLINE T builtin_atomic_CAS_oper_sc(T volatile *acc,
   } while (old != expected && !sc(RAJA::util::reinterp_A_as_B<BuiltinAtomicType<T>, T>(old)));
 
   return RAJA::util::reinterp_A_as_B<BuiltinAtomicType<T>, T>(old);
-#ifdef RAJA_COMPILER_MSVC
-#pragma warning( default : 4244 )  // Reenable warning
-#endif
 }
 
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Modifies builtin atomics to use atomic loads to guarantee correctness
  - Fixes the call to the short-circuiting test by passing the original type rather than the value reinterpreted as unsigned or unsigned long
  - Refactors the atomic CAS in a loop operations for more code reuse (as well as a simpler implementation)
  - Provide a slightly faster implementation when there is no option for short-circuiting