### PR TITLE
Add OpenMP 5.1 implementations for atomics

### DIFF
--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -212,18 +212,8 @@ template <typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T atomicCAS(omp_atomic, T volatile *acc, T compare, T value)
 {
-#if _OPENMP >= 202011
-  T old;
-  #pragma omp atomic capture compare
-  {
-    old = *acc;
-    *acc = *acc == compare ? value : *acc;
-  }
-  return old;
-#else
   // OpenMP doesn't define atomic ternary operators so use builtin atomics
   return RAJA::atomicCAS(builtin_atomic{}, acc, compare, value);
-#endif
 }
 
 #endif // not defined RAJA_COMPILER_MSVC

--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -68,8 +68,18 @@ template <typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T atomicMin(omp_atomic, T volatile *acc, T value)
 {
+#if _OPENMP >= 202011
+  T ret;
+  #pragma omp atomic capture compare
+  {
+    ret = *acc;
+    *acc = value < *acc ? value : *acc;
+  }
+  return ret;
+#else
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
   return atomicMin(builtin_atomic{}, acc, value);
+#endif
 }
 
 RAJA_SUPPRESS_HD_WARN
@@ -77,8 +87,18 @@ template <typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T atomicMax(omp_atomic, T volatile *acc, T value)
 {
+#if _OPENMP >= 202011
+  T ret;
+  #pragma omp atomic capture compare
+  {
+    ret = *acc;
+    *acc = *acc < value ? value : *acc;
+  }
+  return ret;
+#else
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
   return atomicMax(builtin_atomic{}, acc, value);
+#endif
 }
 
 

--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -73,7 +73,7 @@ RAJA_INLINE T atomicMin(omp_atomic, T volatile *acc, T value)
   #pragma omp atomic capture compare
   {
     old = *acc;
-    *acc = value < old ? value : old;
+    *acc = value < *acc ? value : *acc;
   }
   return old;
 #else
@@ -92,7 +92,7 @@ RAJA_INLINE T atomicMax(omp_atomic, T volatile *acc, T value)
   #pragma omp atomic capture compare
   {
     old = *acc;
-    *acc = old < value ? value : old;
+    *acc = *acc < value ? value : *acc;
   }
   return old;
 #else
@@ -122,18 +122,8 @@ template <typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T atomicInc(omp_atomic, T volatile *acc, T value)
 {
-#if _OPENMP >= 202011
-  T old;
-  #pragma omp atomic capture compare
-  {
-    old = *acc;
-    *acc = value <= old ? T(0) : (old + T(1));
-  }
-  return old;
-#else
-  // OpenMP doesn't define atomic ternary operators so use builtin atomics
+  // OpenMP doesn't define needed operations, so use builtin atomics
   return RAJA::atomicInc(builtin_atomic{}, acc, value);
-#endif
 }
 
 
@@ -157,18 +147,8 @@ template <typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T atomicDec(omp_atomic, T volatile *acc, T value)
 {
-#if _OPENMP >= 202011
-  T old;
-  #pragma omp atomic capture compare
-  {
-    old = *acc;
-    *acc = old == T(0) || value < old ? value : old - T(1);
-  }
-  return old;
-#else
-  // OpenMP doesn't define atomic ternary operators so use builtin atomics
+  // OpenMP doesn't define needed operations, so use builtin atomics
   return RAJA::atomicDec(builtin_atomic{}, acc, value);
-#endif
 }
 
 RAJA_SUPPRESS_HD_WARN
@@ -237,7 +217,7 @@ RAJA_INLINE T atomicCAS(omp_atomic, T volatile *acc, T compare, T value)
   #pragma omp atomic capture compare
   {
     old = *acc;
-    *acc = old == compare ? value : old;
+    *acc = *acc == compare ? value : *acc;
   }
   return old;
 #else

--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -38,13 +38,13 @@ template <typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T atomicAdd(omp_atomic, T volatile *acc, T value)
 {
-  T ret;
+  T old;
 #pragma omp atomic capture
   {
-    ret = *acc;  // capture old for return value
+    old = *acc;  // capture old for return value
     *acc += value;
   }
-  return ret;
+  return old;
 }
 
 
@@ -53,13 +53,13 @@ template <typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T atomicSub(omp_atomic, T volatile *acc, T value)
 {
-  T ret;
+  T old;
 #pragma omp atomic capture
   {
-    ret = *acc;  // capture old for return value
+    old = *acc;  // capture old for return value
     *acc -= value;
   }
-  return ret;
+  return old;
 }
 
 
@@ -69,13 +69,13 @@ RAJA_HOST_DEVICE
 RAJA_INLINE T atomicMin(omp_atomic, T volatile *acc, T value)
 {
 #if _OPENMP >= 202011
-  T ret;
+  T old;
   #pragma omp atomic capture compare
   {
-    ret = *acc;
-    *acc = ret < value ? ret : value;
+    old = *acc;
+    *acc = old < value ? old : value;
   }
-  return ret;
+  return old;
 #else
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
   return atomicMin(builtin_atomic{}, acc, value);
@@ -88,13 +88,13 @@ RAJA_HOST_DEVICE
 RAJA_INLINE T atomicMax(omp_atomic, T volatile *acc, T value)
 {
 #if _OPENMP >= 202011
-  T ret;
+  T old;
   #pragma omp atomic capture compare
   {
-    ret = *acc;
-    *acc = value < ret ? ret : value;
+    old = *acc;
+    *acc = value < old ? old : value;
   }
-  return ret;
+  return old;
 #else
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
   return atomicMax(builtin_atomic{}, acc, value);
@@ -107,13 +107,13 @@ template <typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T atomicInc(omp_atomic, T volatile *acc)
 {
-  T ret;
+  T old;
 #pragma omp atomic capture
   {
-    ret = *acc;  // capture old for return value
+    old = *acc;  // capture old for return value
     *acc += T(1);
   }
-  return ret;
+  return old;
 }
 
 
@@ -123,13 +123,13 @@ RAJA_HOST_DEVICE
 RAJA_INLINE T atomicInc(omp_atomic, T volatile *acc, T value)
 {
 #if _OPENMP >= 202011
-  T ret;
+  T old;
   #pragma omp atomic capture compare
   {
-    ret = *acc;
-    *acc = value <= ret ? T(0) : (ret + T(1));
+    old = *acc;
+    *acc = value <= old ? T(0) : (old + T(1));
   }
-  return ret;
+  return old;
 #else
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
   return RAJA::atomicInc(builtin_atomic{}, acc, value);
@@ -142,13 +142,13 @@ template <typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T atomicDec(omp_atomic, T volatile *acc)
 {
-  T ret;
+  T old;
 #pragma omp atomic capture
   {
-    ret = *acc;  // capture old for return value
+    old = *acc;  // capture old for return value
     *acc -= T(1);
   }
-  return ret;
+  return old;
 }
 
 
@@ -158,13 +158,13 @@ RAJA_HOST_DEVICE
 RAJA_INLINE T atomicDec(omp_atomic, T volatile *acc, T value)
 {
 #if _OPENMP >= 202011
-  T ret;
+  T old;
   #pragma omp atomic capture compare
   {
-    ret = *acc;
-    *acc = ret == T(0) || value < ret ? value : ret - T(1);
+    old = *acc;
+    *acc = old == T(0) || value < old ? value : old - T(1);
   }
-  return ret;
+  return old;
 #else
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
   return RAJA::atomicDec(builtin_atomic{}, acc, value);
@@ -176,13 +176,13 @@ template <typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T atomicAnd(omp_atomic, T volatile *acc, T value)
 {
-  T ret;
+  T old;
 #pragma omp atomic capture
   {
-    ret = *acc;  // capture old for return value
+    old = *acc;  // capture old for return value
     *acc &= value;
   }
-  return ret;
+  return old;
 }
 
 RAJA_SUPPRESS_HD_WARN
@@ -190,13 +190,13 @@ template <typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T atomicOr(omp_atomic, T volatile *acc, T value)
 {
-  T ret;
+  T old;
 #pragma omp atomic capture
   {
-    ret = *acc;  // capture old for return value
+    old = *acc;  // capture old for return value
     *acc |= value;
   }
-  return ret;
+  return old;
 }
 
 RAJA_SUPPRESS_HD_WARN
@@ -204,13 +204,13 @@ template <typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T atomicXor(omp_atomic, T volatile *acc, T value)
 {
-  T ret;
+  T old;
 #pragma omp atomic capture
   {
-    ret = *acc;  // capture old for return value
+    old = *acc;  // capture old for return value
     *acc ^= value;
   }
-  return ret;
+  return old;
 }
 
 RAJA_SUPPRESS_HD_WARN
@@ -218,13 +218,13 @@ template <typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T atomicExchange(omp_atomic, T volatile *acc, T value)
 {
-  T ret;
+  T old;
 #pragma omp atomic capture
   {
-    ret = *acc;  // capture old for return value
+    old = *acc;  // capture old for return value
     *acc = value;
   }
-  return ret;
+  return old;
 }
 
 RAJA_SUPPRESS_HD_WARN
@@ -233,13 +233,13 @@ RAJA_HOST_DEVICE
 RAJA_INLINE T atomicCAS(omp_atomic, T volatile *acc, T compare, T value)
 {
 #if _OPENMP >= 202011
-  T ret;
+  T old;
   #pragma omp atomic capture compare
   {
-    ret = *acc;
-    *acc = ret == compare ? value : ret;
+    old = *acc;
+    *acc = old == compare ? value : old;
   }
-  return ret;
+  return old;
 #else
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
   return RAJA::atomicCAS(builtin_atomic{}, acc, compare, value);

--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -73,7 +73,7 @@ RAJA_INLINE T atomicMin(omp_atomic, T volatile *acc, T value)
   #pragma omp atomic capture compare
   {
     old = *acc;
-    *acc = old < value ? old : value;
+    *acc = value < old ? value : old;
   }
   return old;
 #else
@@ -92,7 +92,7 @@ RAJA_INLINE T atomicMax(omp_atomic, T volatile *acc, T value)
   #pragma omp atomic capture compare
   {
     old = *acc;
-    *acc = value < old ? old : value;
+    *acc = old < value ? value : old;
   }
   return old;
 #else

--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -77,7 +77,7 @@ RAJA_INLINE T atomicMin(omp_atomic, T volatile *acc, T value)
   }
   return old;
 #else
-  // OpenMP doesn't define atomic trinary operators so use builtin atomics
+  // OpenMP doesn't define atomic ternary operators so use builtin atomics
   return atomicMin(builtin_atomic{}, acc, value);
 #endif
 }
@@ -96,7 +96,7 @@ RAJA_INLINE T atomicMax(omp_atomic, T volatile *acc, T value)
   }
   return old;
 #else
-  // OpenMP doesn't define atomic trinary operators so use builtin atomics
+  // OpenMP doesn't define atomic ternary operators so use builtin atomics
   return atomicMax(builtin_atomic{}, acc, value);
 #endif
 }
@@ -131,7 +131,7 @@ RAJA_INLINE T atomicInc(omp_atomic, T volatile *acc, T value)
   }
   return old;
 #else
-  // OpenMP doesn't define atomic trinary operators so use builtin atomics
+  // OpenMP doesn't define atomic ternary operators so use builtin atomics
   return RAJA::atomicInc(builtin_atomic{}, acc, value);
 #endif
 }
@@ -166,7 +166,7 @@ RAJA_INLINE T atomicDec(omp_atomic, T volatile *acc, T value)
   }
   return old;
 #else
-  // OpenMP doesn't define atomic trinary operators so use builtin atomics
+  // OpenMP doesn't define atomic ternary operators so use builtin atomics
   return RAJA::atomicDec(builtin_atomic{}, acc, value);
 #endif
 }
@@ -241,7 +241,7 @@ RAJA_INLINE T atomicCAS(omp_atomic, T volatile *acc, T compare, T value)
   }
   return old;
 #else
-  // OpenMP doesn't define atomic trinary operators so use builtin atomics
+  // OpenMP doesn't define atomic ternary operators so use builtin atomics
   return RAJA::atomicCAS(builtin_atomic{}, acc, compare, value);
 #endif
 }

--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -111,7 +111,7 @@ RAJA_INLINE T atomicInc(omp_atomic, T volatile *acc)
 #pragma omp atomic capture
   {
     ret = *acc;  // capture old for return value
-    *acc += (T)1;
+    *acc += T(1);
   }
   return ret;
 }
@@ -127,7 +127,7 @@ RAJA_INLINE T atomicInc(omp_atomic, T volatile *acc, T value)
   #pragma omp atomic capture compare
   {
     ret = *acc;
-    *acc = value <= ret ? (T)0 : (ret + (T)1);
+    *acc = value <= ret ? T(0) : (ret + T(1));
   }
   return ret;
 #else
@@ -146,7 +146,7 @@ RAJA_INLINE T atomicDec(omp_atomic, T volatile *acc)
 #pragma omp atomic capture
   {
     ret = *acc;  // capture old for return value
-    *acc -= (T)1;
+    *acc -= T(1);
   }
   return ret;
 }
@@ -162,7 +162,7 @@ RAJA_INLINE T atomicDec(omp_atomic, T volatile *acc, T value)
   #pragma omp atomic capture compare
   {
     ret = *acc;
-    *acc = ret == (T)0 || value < ret ? value : ret - (T)1;
+    *acc = ret == T(0) || value < ret ? value : ret - T(1);
   }
   return ret;
 #else

--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -73,7 +73,7 @@ RAJA_INLINE T atomicMin(omp_atomic, T volatile *acc, T value)
   #pragma omp atomic capture compare
   {
     ret = *acc;
-    *acc = value < *acc ? value : *acc;
+    *acc = ret < value ? ret : value;
   }
   return ret;
 #else
@@ -92,7 +92,7 @@ RAJA_INLINE T atomicMax(omp_atomic, T volatile *acc, T value)
   #pragma omp atomic capture compare
   {
     ret = *acc;
-    *acc = *acc < value ? value : *acc;
+    *acc = value < ret ? ret : value;
   }
   return ret;
 #else
@@ -120,19 +120,19 @@ RAJA_INLINE T atomicInc(omp_atomic, T volatile *acc)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicInc(omp_atomic, T volatile *acc, T val)
+RAJA_INLINE T atomicInc(omp_atomic, T volatile *acc, T value)
 {
 #if _OPENMP >= 202011
   T ret;
   #pragma omp atomic capture compare
   {
     ret = *acc;
-    *acc = val <= ret ? (T)0 : (ret + (T)1);
+    *acc = value <= ret ? (T)0 : (ret + (T)1);
   }
   return ret;
 #else
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
-  return RAJA::atomicInc(builtin_atomic{}, acc, val);
+  return RAJA::atomicInc(builtin_atomic{}, acc, value);
 #endif
 }
 
@@ -155,19 +155,19 @@ RAJA_INLINE T atomicDec(omp_atomic, T volatile *acc)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicDec(omp_atomic, T volatile *acc, T val)
+RAJA_INLINE T atomicDec(omp_atomic, T volatile *acc, T value)
 {
 #if _OPENMP >= 202011
   T ret;
   #pragma omp atomic capture compare
   {
     ret = *acc;
-    *acc = ret == (T)0 || val < ret ? val : ret - (T)1;
+    *acc = ret == (T)0 || value < ret ? value : ret - (T)1;
   }
   return ret;
 #else
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
-  return RAJA::atomicDec(builtin_atomic{}, acc, val);
+  return RAJA::atomicDec(builtin_atomic{}, acc, value);
 #endif
 }
 
@@ -232,8 +232,18 @@ template <typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T atomicCAS(omp_atomic, T volatile *acc, T compare, T value)
 {
+#if _OPENMP >= 202011
+  T ret;
+  #pragma omp atomic capture compare
+  {
+    ret = *acc;
+    *acc = ret == compare ? value : ret;
+  }
+  return ret;
+#else
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
   return RAJA::atomicCAS(builtin_atomic{}, acc, compare, value);
+#endif
 }
 
 #endif // not defined RAJA_COMPILER_MSVC

--- a/include/RAJA/policy/sequential/atomic.hpp
+++ b/include/RAJA/policy/sequential/atomic.hpp
@@ -63,7 +63,7 @@ RAJA_HOST_DEVICE
 RAJA_INLINE T atomicMax(seq_atomic, T volatile *acc, T value)
 {
   T ret = *acc;
-  *acc = ret > value ? ret : value;
+  *acc = value < ret ? ret : value;
   return ret;
 }
 
@@ -74,7 +74,7 @@ RAJA_HOST_DEVICE
 RAJA_INLINE T atomicInc(seq_atomic, T volatile *acc)
 {
   T ret = *acc;
-  (*acc) += 1;
+  (*acc) += (T)1;
   return ret;
 }
 
@@ -84,7 +84,7 @@ RAJA_HOST_DEVICE
 RAJA_INLINE T atomicInc(seq_atomic, T volatile *acc, T val)
 {
   T old = *acc;
-  (*acc) = ((old >= val) ? 0 : (old + 1));
+  *acc = val <= old ? 0 : old + 1;
   return old;
 }
 
@@ -94,7 +94,7 @@ RAJA_HOST_DEVICE
 RAJA_INLINE T atomicDec(seq_atomic, T volatile *acc)
 {
   T ret = *acc;
-  (*acc) -= 1;
+  (*acc) -= (T)1;
   return ret;
 }
 
@@ -104,7 +104,7 @@ RAJA_HOST_DEVICE
 RAJA_INLINE T atomicDec(seq_atomic, T volatile *acc, T val)
 {
   T old = *acc;
-  (*acc) = (((old == 0) | (old > val)) ? val : (old - 1));
+  *acc = old == (T)0 || val < old ? val : old - (T)1;
   return old;
 }
 

--- a/include/RAJA/policy/sequential/atomic.hpp
+++ b/include/RAJA/policy/sequential/atomic.hpp
@@ -74,7 +74,7 @@ RAJA_HOST_DEVICE
 RAJA_INLINE T atomicInc(seq_atomic, T volatile *acc)
 {
   T ret = *acc;
-  (*acc) += (T)1;
+  (*acc) += T(1);
   return ret;
 }
 
@@ -94,7 +94,7 @@ RAJA_HOST_DEVICE
 RAJA_INLINE T atomicDec(seq_atomic, T volatile *acc)
 {
   T ret = *acc;
-  (*acc) -= (T)1;
+  (*acc) -= T(1);
   return ret;
 }
 
@@ -104,7 +104,7 @@ RAJA_HOST_DEVICE
 RAJA_INLINE T atomicDec(seq_atomic, T volatile *acc, T val)
 {
   T old = *acc;
-  *acc = old == (T)0 || val < old ? val : old - (T)1;
+  *acc = old == T(0) || val < old ? val : old - T(1);
   return old;
 }
 

--- a/include/RAJA/policy/sequential/atomic.hpp
+++ b/include/RAJA/policy/sequential/atomic.hpp
@@ -84,7 +84,7 @@ RAJA_HOST_DEVICE
 RAJA_INLINE T atomicInc(seq_atomic, T volatile *acc, T val)
 {
   T old = *acc;
-  *acc = val <= old ? 0 : old + 1;
+  *acc = val <= old ? T(0) : old + T(1);
   return old;
 }
 


### PR DESCRIPTION
# Summary

- This PR is a feature and bugfix
- It does the following:
  - Adds OpenMP 5.1 implementations for atomicMin and  atomicMax
  - Fixes logic error in sequential atomicDec
  - Prefer operator< instead of operator>
  - Cast literals to appropriate type