### PR TITLE
Remove volatile from atomics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /install-*/
 /Debug/
 *.swp
+*.orig

--- a/include/RAJA/pattern/atomic.hpp
+++ b/include/RAJA/pattern/atomic.hpp
@@ -88,7 +88,7 @@ namespace RAJA
  */
 RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicAdd(T volatile *acc, T value)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicAdd(T *acc, T value)
 {
   return RAJA::atomicAdd(Policy{}, acc, value);
 }
@@ -102,7 +102,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicAdd(T volatile *acc, T value)
  */
 RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicSub(T volatile *acc, T value)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicSub(T *acc, T value)
 {
   return RAJA::atomicSub(Policy{}, acc, value);
 }
@@ -116,7 +116,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicSub(T volatile *acc, T value)
  */
 RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicMin(T volatile *acc, T value)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicMin(T *acc, T value)
 {
   return RAJA::atomicMin(Policy{}, acc, value);
 }
@@ -130,7 +130,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicMin(T volatile *acc, T value)
  */
 RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicMax(T volatile *acc, T value)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicMax(T *acc, T value)
 {
   return RAJA::atomicMax(Policy{}, acc, value);
 }
@@ -143,7 +143,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicMax(T volatile *acc, T value)
  */
 RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicInc(T volatile *acc)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicInc(T *acc)
 {
   return RAJA::atomicInc(Policy{}, acc);
 }
@@ -159,7 +159,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicInc(T volatile *acc)
  */
 RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicInc(T volatile *acc, T compare)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicInc(T *acc, T compare)
 {
   return RAJA::atomicInc(Policy{}, acc, compare);
 }
@@ -172,7 +172,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicInc(T volatile *acc, T compare)
  */
 RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicDec(T volatile *acc)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicDec(T *acc)
 {
   return RAJA::atomicDec(Policy{}, acc);
 }
@@ -188,7 +188,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicDec(T volatile *acc)
  */
 RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicDec(T volatile *acc, T compare)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicDec(T *acc, T compare)
 {
   return RAJA::atomicDec(Policy{}, acc, compare);
 }
@@ -203,7 +203,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicDec(T volatile *acc, T compare)
  */
 RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicAnd(T volatile *acc, T value)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicAnd(T *acc, T value)
 {
   static_assert(std::is_integral<T>::value,
                 "atomicAnd can only be used on integral types");
@@ -220,7 +220,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicAnd(T volatile *acc, T value)
  */
 RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicOr(T volatile *acc, T value)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicOr(T *acc, T value)
 {
   static_assert(std::is_integral<T>::value,
                 "atomicOr can only be used on integral types");
@@ -237,7 +237,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicOr(T volatile *acc, T value)
  */
 RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicXor(T volatile *acc, T value)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicXor(T *acc, T value)
 {
   static_assert(std::is_integral<T>::value,
                 "atomicXor can only be used on integral types");
@@ -253,7 +253,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicXor(T volatile *acc, T value)
  */
 RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicExchange(T volatile *acc, T value)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicExchange(T *acc, T value)
 {
   return RAJA::atomicExchange(Policy{}, acc, value);
 }
@@ -269,7 +269,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicExchange(T volatile *acc, T value)
 
 RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicCAS(T volatile *acc, T compare, T value)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicCAS(T *acc, T compare, T value)
 {
   return RAJA::atomicCAS(Policy{}, acc, compare, value);
 }
@@ -303,7 +303,7 @@ public:
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
-  value_type volatile * getPointer() const { return m_value_ptr; }
+  value_type * getPointer() const { return m_value_ptr; }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
@@ -498,7 +498,7 @@ public:
   }
 
 private:
-  value_type volatile *m_value_ptr;
+  value_type *m_value_ptr;
 };
 
 

--- a/include/RAJA/pattern/atomic.hpp
+++ b/include/RAJA/pattern/atomic.hpp
@@ -318,31 +318,34 @@ public:
   RAJA_INLINE
   RAJA_HOST_DEVICE
   constexpr explicit AtomicRef(value_type *value_ptr)
-      : m_value_ptr(value_ptr){};
+      : m_value_ptr(value_ptr) {}
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
-  constexpr AtomicRef(AtomicRef const&c)
-      : m_value_ptr(c.m_value_ptr){};
+  constexpr AtomicRef(AtomicRef const &c)
+      : m_value_ptr(c.m_value_ptr) {}
 
   AtomicRef& operator=(AtomicRef const&) = delete;
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
-  value_type * getPointer() const { return m_value_ptr; }
+  value_type * getPointer() const
+  {
+    return m_value_ptr;
+  }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   void store(value_type rhs) const
   {
-    *m_value_ptr = rhs;
+    RAJA::atomicStore<Policy>(m_value_ptr, rhs);
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   value_type operator=(value_type rhs) const
   {
-    *m_value_ptr = rhs;
+    RAJA::atomicStore<Policy>(m_value_ptr, rhs);
     return rhs;
   }
 
@@ -350,14 +353,14 @@ public:
   RAJA_HOST_DEVICE
   value_type load() const
   {
-    return *m_value_ptr;
+    return RAJA::atomicLoad<Policy>(m_value_ptr);
   }
 
   RAJA_INLINE
   RAJA_HOST_DEVICE
   operator value_type() const
   {
-    return *m_value_ptr;
+    return RAJA::atomicLoad<Policy>(m_value_ptr);
   }
 
   RAJA_INLINE

--- a/include/RAJA/pattern/atomic.hpp
+++ b/include/RAJA/pattern/atomic.hpp
@@ -87,7 +87,7 @@ namespace RAJA
  */
 RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicLoad(T volatile *acc)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicLoad(T *acc)
 {
   return RAJA::atomicLoad(Policy{}, acc);
 }
@@ -100,7 +100,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicLoad(T volatile *acc)
  */
 RAJA_SUPPRESS_HD_WARN
 template <typename Policy, typename T>
-RAJA_INLINE RAJA_HOST_DEVICE void atomicStore(T volatile *acc, T value)
+RAJA_INLINE RAJA_HOST_DEVICE void atomicStore(T *acc, T value)
 {
   RAJA::atomicStore(Policy{}, acc, value);
 }

--- a/include/RAJA/policy/atomic_auto.hpp
+++ b/include/RAJA/policy/atomic_auto.hpp
@@ -65,79 +65,79 @@ struct auto_atomic {
 
 
 template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicAdd(auto_atomic, T volatile *acc, T value)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicAdd(auto_atomic, T *acc, T value)
 {
   return atomicAdd(RAJA_AUTO_ATOMIC, acc, value);
 }
 
 
 template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicSub(auto_atomic, T volatile *acc, T value)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicSub(auto_atomic, T *acc, T value)
 {
   return atomicSub(RAJA_AUTO_ATOMIC, acc, value);
 }
 
 template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicMin(auto_atomic, T volatile *acc, T value)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicMin(auto_atomic, T *acc, T value)
 {
   return atomicMin(RAJA_AUTO_ATOMIC, acc, value);
 }
 
 template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicMax(auto_atomic, T volatile *acc, T value)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicMax(auto_atomic, T *acc, T value)
 {
   return atomicMax(RAJA_AUTO_ATOMIC, acc, value);
 }
 
 template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicInc(auto_atomic, T volatile *acc)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicInc(auto_atomic, T *acc)
 {
   return atomicInc(RAJA_AUTO_ATOMIC, acc);
 }
 
 template <typename T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicInc(auto_atomic,
-                                         T volatile *acc,
+                                         T *acc,
                                          T compare)
 {
   return atomicInc(RAJA_AUTO_ATOMIC, acc, compare);
 }
 
 template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicDec(auto_atomic, T volatile *acc)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicDec(auto_atomic, T *acc)
 {
   return atomicDec(RAJA_AUTO_ATOMIC, acc);
 }
 
 template <typename T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicDec(auto_atomic,
-                                         T volatile *acc,
+                                         T *acc,
                                          T compare)
 {
   return atomicDec(RAJA_AUTO_ATOMIC, acc, compare);
 }
 
 template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicAnd(auto_atomic, T volatile *acc, T value)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicAnd(auto_atomic, T *acc, T value)
 {
   return atomicAnd(RAJA_AUTO_ATOMIC, acc, value);
 }
 
 template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicOr(auto_atomic, T volatile *acc, T value)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicOr(auto_atomic, T *acc, T value)
 {
   return atomicOr(RAJA_AUTO_ATOMIC, acc, value);
 }
 
 template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicXor(auto_atomic, T volatile *acc, T value)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicXor(auto_atomic, T *acc, T value)
 {
   return atomicXor(RAJA_AUTO_ATOMIC, acc, value);
 }
 
 template <typename T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicExchange(auto_atomic,
-                                              T volatile *acc,
+                                              T *acc,
                                               T value)
 {
   return atomicExchange(RAJA_AUTO_ATOMIC, acc, value);
@@ -145,7 +145,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicExchange(auto_atomic,
 
 template <typename T>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicCAS(auto_atomic, T volatile *acc, T compare, T value)
+atomicCAS(auto_atomic, T *acc, T compare, T value)
 {
   return atomicCAS(RAJA_AUTO_ATOMIC, acc, compare, value);
 }

--- a/include/RAJA/policy/atomic_auto.hpp
+++ b/include/RAJA/policy/atomic_auto.hpp
@@ -64,13 +64,13 @@ struct auto_atomic {
 };
 
 template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicLoad(auto_atomic, T volatile *acc)
+RAJA_INLINE RAJA_HOST_DEVICE T atomicLoad(auto_atomic, T *acc)
 {
   return atomicLoad(RAJA_AUTO_ATOMIC, acc);
 }
 
 template <typename T>
-RAJA_INLINE RAJA_HOST_DEVICE void atomicStore(auto_atomic, T volatile *acc, T value)
+RAJA_INLINE RAJA_HOST_DEVICE void atomicStore(auto_atomic, T *acc, T value)
 {
   atomicStore(RAJA_AUTO_ATOMIC, acc, value);
 }

--- a/include/RAJA/policy/atomic_builtin.hpp
+++ b/include/RAJA/policy/atomic_builtin.hpp
@@ -79,7 +79,7 @@ RAJA_INLINE unsigned long long builtin_atomic_load(
   return RAJA::util::reinterp_A_as_B<long long, unsigned long long>(_InterlockedOr64((long long *)acc, 0));
 }
 
-RAJA_INLINE void builtin_atomic_store(unsigned volatile *acc, unsigned value)
+RAJA_INLINE void builtin_atomic_store(unsigned *acc, unsigned value)
 {
   static_assert(sizeof(unsigned) == sizeof(long),
                 "builtin atomic store assumes unsigned and long are the same size");
@@ -88,7 +88,7 @@ RAJA_INLINE void builtin_atomic_store(unsigned volatile *acc, unsigned value)
 }
 
 RAJA_INLINE void builtin_atomic_store(
-    unsigned long long volatile *acc,
+    unsigned long long *acc,
     unsigned long long value)
 {
   static_assert(sizeof(unsigned long long) == sizeof(long long),
@@ -97,7 +97,7 @@ RAJA_INLINE void builtin_atomic_store(
   _InterlockedExchange64((long long *)acc, RAJA::util::reinterp_A_as_B<unsigned long long, long long>(value));
 }
 
-RAJA_INLINE unsigned builtin_atomic_CAS(unsigned volatile *acc,
+RAJA_INLINE unsigned builtin_atomic_CAS(unsigned *acc,
                                         unsigned compare,
                                         unsigned value)
 {
@@ -144,7 +144,7 @@ RAJA_INLINE unsigned long long builtin_atomic_load(
 }
 
 RAJA_DEVICE_HIP
-RAJA_INLINE void builtin_atomic_store(unsigned volatile *acc,
+RAJA_INLINE void builtin_atomic_store(unsigned *acc,
                                       unsigned value)
 {
   __atomic_store_n(acc, value, __ATOMIC_RELAXED);
@@ -152,14 +152,14 @@ RAJA_INLINE void builtin_atomic_store(unsigned volatile *acc,
 
 RAJA_DEVICE_HIP
 RAJA_INLINE void builtin_atomic_store(
-    unsigned long long volatile *acc,
+    unsigned long long *acc,
     unsigned long long value)
 {
   __atomic_store_n(acc, value, __ATOMIC_RELAXED);
 }
 
 RAJA_DEVICE_HIP
-RAJA_INLINE unsigned builtin_atomic_CAS(unsigned volatile *acc,
+RAJA_INLINE unsigned builtin_atomic_CAS(unsigned *acc,
                                         unsigned compare,
                                         unsigned value)
 {
@@ -204,17 +204,17 @@ RAJA_DEVICE_HIP RAJA_INLINE
 template <typename T>
 RAJA_DEVICE_HIP RAJA_INLINE
     typename std::enable_if<sizeof(T) == sizeof(unsigned), void>::type
-    builtin_atomic_store(T volatile *acc, T value)
+    builtin_atomic_store(T *acc, T value)
 {
-  builtin_atomic_store((unsigned volatile*)acc, RAJA::util::reinterp_A_as_B<T, unsigned>(value));
+  builtin_atomic_store((unsigned *)acc, RAJA::util::reinterp_A_as_B<T, unsigned>(value));
 }
 
 template <typename T>
 RAJA_DEVICE_HIP RAJA_INLINE
     typename std::enable_if<sizeof(T) == sizeof(unsigned long long), void>::type
-    builtin_atomic_store(T volatile *acc, T value)
+    builtin_atomic_store(T *acc, T value)
 {
-  builtin_atomic_store((unsigned long long volatile*)acc, RAJA::util::reinterp_A_as_B<T, unsigned long long>(value));
+  builtin_atomic_store((unsigned long long *)acc, RAJA::util::reinterp_A_as_B<T, unsigned long long>(value));
 }
 
 template <typename T>
@@ -294,14 +294,14 @@ RAJA_DEVICE_HIP RAJA_INLINE T builtin_atomic_CAS_oper_sc(T *acc,
 
 template <typename T>
 RAJA_DEVICE_HIP RAJA_INLINE T atomicLoad(builtin_atomic,
-                                         T volatile *acc)
+                                         T *acc)
 {
   return detail::builtin_atomic_load(acc);
 }
 
 template <typename T>
 RAJA_DEVICE_HIP RAJA_INLINE void atomicStore(builtin_atomic,
-                                             T volatile *acc,
+                                             T *acc,
                                              T value)
 {
   detail::builtin_atomic_store(acc, value);

--- a/include/RAJA/policy/atomic_builtin.hpp
+++ b/include/RAJA/policy/atomic_builtin.hpp
@@ -333,7 +333,7 @@ RAJA_DEVICE_HIP RAJA_INLINE T atomicMin(builtin_atomic,
                                               return a < value ? a : value;
                                             },
                                             [=](T current) {
-                                              return current < value;
+                                              return current <= value;
                                             });
 }
 
@@ -347,7 +347,7 @@ RAJA_DEVICE_HIP RAJA_INLINE T atomicMax(builtin_atomic,
                                               return a > value ? a : value;
                                             },
                                             [=](T current) {
-                                              return current > value;
+                                              return value <= current;
                                             });
 }
 

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -411,7 +411,7 @@ RAJA_INLINE __device__ T cuda_atomicMin(T *acc, T value)
                           return value < old ? value : old;
                         },
                         [value] (T current) {
-                          return current < value;
+                          return current <= value;
                         });
 }
 
@@ -435,7 +435,7 @@ RAJA_INLINE __device__ T cuda_atomicMax(T *acc, T value)
                           return old < value ? value : old;
                         },
                         [value] (T current) {
-                          return value < current;
+                          return value <= current;
                         });
 }
 

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -312,7 +312,7 @@ template <typename T,
           enable_if_is_none_of<T, cuda_atomicAdd_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicAdd(T *acc, T value)
 {
-  return cuda_atomicCAS(acc, [value] __device__(T old) {
+  return cuda_atomicCAS(acc, [value] (T old) {
     return old + value;
   });
 }
@@ -347,7 +347,7 @@ template <typename T,
           enable_if_is_none_of<T, cuda_atomicSub_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicSub(T *acc, T value)
 {
-  return cuda_atomicCAS(acc, [value] __device__(T old) {
+  return cuda_atomicCAS(acc, [value] (T old) {
     return old - value;
   });
 }
@@ -387,7 +387,7 @@ template <typename T,
           enable_if_is_none_of<T, cuda_atomicMinMax_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicMin(T *acc, T value)
 {
-  return cuda_atomicCAS(acc, [value] __device__(T old) {
+  return cuda_atomicCAS(acc, [value] (T old) {
     return value < old ? value : old;
   });
 }
@@ -407,7 +407,7 @@ template <typename T,
           enable_if_is_none_of<T, cuda_atomicMinMax_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicMax(T *acc, T value)
 {
-  return cuda_atomicCAS(acc, [value] __device__(T old) {
+  return cuda_atomicCAS(acc, [value] (T old) {
     return old < value ? value : old;
   });
 }
@@ -437,7 +437,7 @@ RAJA_INLINE __device__ T cuda_atomicInc(T *acc, T value)
 {
   // See:
   // http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomicinc
-  return cuda_atomicCAS(acc, [value] __device__(T old) {
+  return cuda_atomicCAS(acc, [value] (T old) {
     return value <= old ? static_cast<T>(0) : old + static_cast<T>(1);
   });
 }
@@ -469,7 +469,7 @@ RAJA_INLINE __device__ T cuda_atomicDec(T *acc, T value)
 {
   // See:
   // http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomicdec
-  return cuda_atomicCAS(acc, [value] __device__(T old) {
+  return cuda_atomicCAS(acc, [value] (T old) {
     return old == static_cast<T>(0) || value < old ? value : old - static_cast<T>(1);
   });
 }
@@ -509,7 +509,7 @@ template <typename T,
           enable_if_is_none_of<T, cuda_atomicBit_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicAnd(T *acc, T value)
 {
-  return cuda_atomicCAS(acc, [value] __device__(T old) {
+  return cuda_atomicCAS(acc, [value] (T old) {
     return old & value;
   });
 }
@@ -529,7 +529,7 @@ template <typename T,
           enable_if_is_none_of<T, cuda_atomicBit_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicOr(T *acc, T value)
 {
-  return cuda_atomicCAS(acc, [value] __device__(T old) {
+  return cuda_atomicCAS(acc, [value] (T old) {
     return old | value;
   });
 }
@@ -549,7 +549,7 @@ template <typename T,
           enable_if_is_none_of<T, cuda_atomicBit_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicXor(T *acc, T value)
 {
-  return cuda_atomicCAS(acc, [value] __device__(T old) {
+  return cuda_atomicCAS(acc, [value] (T old) {
     return old ^ value;
   });
 }

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -26,6 +26,10 @@
 #include <type_traits>
 
 #if __CUDA__ARCH__ >= 600 && __CUDACC_VER_MAJOR__ >= 11 && __CUDACC_VER_MINOR__ >= 6
+#define RAJA_ENABLE_CUDA_ATOMIC_REF
+#endif
+
+#if defined(RAJA_ENABLE_CUDA_ATOMIC_REF)
 #include <cuda/atomic>
 #endif
 
@@ -106,7 +110,7 @@ RAJA_INLINE __device__ T cuda_atomicExchange(T *acc, T value)
 /*!
  * Atomic load and store
  */
-#if __CUDA__ARCH__ >= 600 && __CUDACC_VER_MAJOR__ >= 11 && __CUDACC_VER_MINOR__ >= 6
+#if defined(RAJA_ENABLE_CUDA_ATOMIC_REF)
 
 template <typename T>
 RAJA_INLINE __device__ T cuda_atomicLoad(T *acc)

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -39,10 +39,14 @@
 #include "RAJA/policy/openmp/atomic.hpp"
 #endif
 
+#include "RAJA/util/camp_aliases.hpp"
 #include "RAJA/util/EnableIf.hpp"
 #include "RAJA/util/Operators.hpp"
 #include "RAJA/util/TypeConvert.hpp"
 #include "RAJA/util/macros.hpp"
+
+
+// TODO: When we can use if constexpr in C++17, this file can be cleaned up
 
 
 namespace RAJA

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -90,7 +90,7 @@ RAJA_INLINE __device__ T cuda_atomicExchange(T *acc, T value)
 {
   return RAJA::util::reinterp_A_as_B<unsigned int, T>(
     cuda_atomicExchange(reinterpret_cast<unsigned int*>(acc),
-                        reinterpret_cast<unsigned int&>(value)));
+                        RAJA::util::reinterp_A_as_B<T, unsigned int>(value)));
 }
 
 template <typename T,
@@ -103,7 +103,7 @@ RAJA_INLINE __device__ T cuda_atomicExchange(T *acc, T value)
 {
   return RAJA::util::reinterp_A_as_B<unsigned long long int, T>(
     cuda_atomicExchange(reinterpret_cast<unsigned long long int*>(acc),
-                        reinterpret_cast<unsigned long long int&>(value)));
+                        RAJA::util::reinterp_A_as_B<T, unsigned long long int>(value)));
 }
 
 
@@ -197,8 +197,8 @@ RAJA_INLINE __device__ T cuda_atomicCAS(T *acc, T compare, T value)
 {
   return RAJA::util::reinterp_A_as_B<unsigned short int, T>(
     cuda_atomicCAS(reinterpret_cast<unsigned short int*>(acc),
-                   reinterpret_cast<unsigned short int&>(compare),
-                   reinterpret_cast<unsigned short int&>(value)));
+                   RAJA::util::reinterp_A_as_B<T, unsigned short int>(compare),
+                   RAJA::util::reinterp_A_as_B<T, unsigned short int>(value)));
 }
 #endif
 
@@ -215,8 +215,8 @@ RAJA_INLINE __device__ T cuda_atomicCAS(T *acc, T compare, T value)
 {
   return RAJA::util::reinterp_A_as_B<unsigned int, T>(
     cuda_atomicCAS(reinterpret_cast<unsigned int*>(acc),
-                   reinterpret_cast<unsigned int&>(compare),
-                   reinterpret_cast<unsigned int&>(value)));
+                   RAJA::util::reinterp_A_as_B<T, unsigned int>(compare),
+                   RAJA::util::reinterp_A_as_B<T, unsigned int>(value)));
 }
 
 template <typename T,
@@ -232,8 +232,8 @@ RAJA_INLINE __device__ T cuda_atomicCAS(T *acc, T compare, T value)
 {
   return RAJA::util::reinterp_A_as_B<unsigned long long int, T>(
     cuda_atomicCAS(reinterpret_cast<unsigned long long int*>(acc),
-                   reinterpret_cast<unsigned long long int&>(compare),
-                   reinterpret_cast<unsigned long long int&>(value)));
+                   RAJA::util::reinterp_A_as_B<T, unsigned long long int>(compare),
+                   RAJA::util::reinterp_A_as_B<T, unsigned long long int>(value)));
 }
 
 
@@ -258,8 +258,8 @@ template <typename T,
                            sizeof(T) == sizeof(unsigned int), bool> = true>
 RAJA_INLINE __device__ bool cuda_atomicCAS_equal(const T& a, const T& b)
 {
-  return reinterpret_cast<const unsigned int&>(a) ==
-         reinterpret_cast<const unsigned int&>(b);
+  return RAJA::util::reinterp_A_as_B<T, unsigned int>(a) ==
+         RAJA::util::reinterp_A_as_B<T, unsigned int>(b);
 }
 
 template <typename T,
@@ -269,8 +269,8 @@ template <typename T,
                            sizeof(T) == sizeof(unsigned long long int), bool> = true>
 RAJA_INLINE __device__ bool cuda_atomicCAS_equal(const T& a, const T& b)
 {
-  return reinterpret_cast<const unsigned long long int&>(a) ==
-         reinterpret_cast<const unsigned long long int&>(b);
+  return RAJA::util::reinterp_A_as_B<T, unsigned long long int>(a) ==
+         RAJA::util::reinterp_A_as_B<T, unsigned long long int>(b);
 }
 
 

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -314,14 +314,15 @@ RAJA_INLINE __device__ T cuda_atomicCAS(T *acc, Oper&& oper, ShortCircuit&& sc)
  * Atomic addition
  */
 using cuda_atomicAdd_builtin_types = list<
-      int
-     ,unsigned int
-     ,unsigned long long int
-     ,float
+  int,
+  unsigned int,
+  unsigned long long int,
+  float
 #if __CUDA_ARCH__ >= 600
-     ,double
+  ,
+  double
 #endif
-    >;
+>;
 
 template <typename T,
           RAJA::util::enable_if_is_none_of<T, cuda_atomicAdd_builtin_types>* = nullptr>
@@ -346,17 +347,18 @@ RAJA_INLINE __device__ T cuda_atomicAdd(T *acc, T value)
 using cuda_atomicSub_builtin_types = cuda_atomicAdd_builtin_types;
 
 using cuda_atomicSub_via_Sub_builtin_types = list<
-      int
-     ,unsigned int
-    >;
+  int,
+  unsigned int
+>;
 
 using cuda_atomicSub_via_Add_builtin_types = list<
-      unsigned long long int
-     ,float
+  unsigned long long int,
+  float
 #if __CUDA_ARCH__ >= 600
-     ,double
+  ,
+  double
 #endif
-    >;
+>;
 
 template <typename T,
           RAJA::util::enable_if_is_none_of<T, cuda_atomicSub_builtin_types>* = nullptr>
@@ -386,13 +388,14 @@ RAJA_INLINE __device__ T cuda_atomicSub(T *acc, T value)
  * Atomic min/max
  */
 using cuda_atomicMinMax_builtin_types = list<
-      int
-     ,unsigned int
+  int,
+  unsigned int
 #if __CUDA_ARCH__ >= 500
-     ,long long int
-     ,unsigned long long int
+  ,
+  long long int,
+  unsigned long long int
 #endif
-    >;
+>;
 
 
 /*!
@@ -447,8 +450,8 @@ RAJA_INLINE __device__ T cuda_atomicMax(T *acc, T value)
  * Atomic increment/decrement with reset
  */
 using cuda_atomicIncDecReset_builtin_types = list<
-      unsigned int
-    >;
+  unsigned int
+>;
 
 
 /*!
@@ -519,10 +522,10 @@ RAJA_INLINE __device__ T cuda_atomicDec(T *acc)
  * Atomic bitwise functions (and, or, xor)
  */
 using cuda_atomicBit_builtin_types = list<
-      int
-     ,unsigned int
-     ,unsigned long long int
-    >;
+  int,
+  unsigned int,
+  unsigned long long int
+>;
 
 
 /*!

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -39,6 +39,7 @@
 #include "RAJA/policy/openmp/atomic.hpp"
 #endif
 
+#include "RAJA/util/EnableIf.hpp"
 #include "RAJA/util/Operators.hpp"
 #include "RAJA/util/TypeConvert.hpp"
 #include "RAJA/util/macros.hpp"
@@ -50,21 +51,6 @@ namespace RAJA
 
 namespace detail
 {
-
-
-template < typename T, typename TypeList >
-struct is_any_of;
-
-template < typename T, typename... Types >
-struct is_any_of<T, list<Types...>>
-  : concepts::any_of<camp::is_same<T, Types>...>
-{};
-
-template < typename T, typename TypeList >
-using enable_if_is_any_of = std::enable_if_t<is_any_of<T, TypeList>::value, T>;
-
-template < typename T, typename TypeList >
-using enable_if_is_none_of = std::enable_if_t<concepts::negate<is_any_of<T, TypeList>>::value, T>;
 
 
 /*!
@@ -334,7 +320,7 @@ using cuda_atomicAdd_builtin_types = list<
     >;
 
 template <typename T,
-          enable_if_is_none_of<T, cuda_atomicAdd_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_none_of<T, cuda_atomicAdd_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicAdd(T *acc, T value)
 {
   return cuda_atomicCAS(acc, [value] (T old) {
@@ -343,7 +329,7 @@ RAJA_INLINE __device__ T cuda_atomicAdd(T *acc, T value)
 }
 
 template <typename T,
-          enable_if_is_any_of<T, cuda_atomicAdd_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, cuda_atomicAdd_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicAdd(T *acc, T value)
 {
   return ::atomicAdd(acc, value);
@@ -369,7 +355,7 @@ using cuda_atomicSub_via_Add_builtin_types = list<
     >;
 
 template <typename T,
-          enable_if_is_none_of<T, cuda_atomicSub_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_none_of<T, cuda_atomicSub_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicSub(T *acc, T value)
 {
   return cuda_atomicCAS(acc, [value] (T old) {
@@ -378,14 +364,14 @@ RAJA_INLINE __device__ T cuda_atomicSub(T *acc, T value)
 }
 
 template <typename T,
-          enable_if_is_any_of<T, cuda_atomicSub_via_Sub_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, cuda_atomicSub_via_Sub_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicSub(T *acc, T value)
 {
   return ::atomicSub(acc, value);
 }
 
 template <typename T,
-          enable_if_is_any_of<T, cuda_atomicSub_via_Add_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, cuda_atomicSub_via_Add_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicSub(T *acc, T value)
 {
   return ::atomicAdd(acc, -value);
@@ -409,7 +395,7 @@ using cuda_atomicMinMax_builtin_types = list<
  * Atomic min
  */
 template <typename T,
-          enable_if_is_none_of<T, cuda_atomicMinMax_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_none_of<T, cuda_atomicMinMax_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicMin(T *acc, T value)
 {
   return cuda_atomicCAS(acc,
@@ -422,7 +408,7 @@ RAJA_INLINE __device__ T cuda_atomicMin(T *acc, T value)
 }
 
 template <typename T,
-          enable_if_is_any_of<T, cuda_atomicMinMax_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, cuda_atomicMinMax_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicMin(T *acc, T value)
 {
   return ::atomicMin(acc, value);
@@ -433,7 +419,7 @@ RAJA_INLINE __device__ T cuda_atomicMin(T *acc, T value)
  * Atomic max
  */
 template <typename T,
-          enable_if_is_none_of<T, cuda_atomicMinMax_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_none_of<T, cuda_atomicMinMax_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicMax(T *acc, T value)
 {
   return cuda_atomicCAS(acc,
@@ -446,7 +432,7 @@ RAJA_INLINE __device__ T cuda_atomicMax(T *acc, T value)
 }
 
 template <typename T,
-          enable_if_is_any_of<T, cuda_atomicMinMax_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, cuda_atomicMinMax_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicMax(T *acc, T value)
 {
   return ::atomicMax(acc, value);
@@ -465,7 +451,7 @@ using cuda_atomicIncDecReset_builtin_types = list<
  * Atomic increment with reset
  */
 template <typename T,
-          enable_if_is_none_of<T, cuda_atomicIncDecReset_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_none_of<T, cuda_atomicIncDecReset_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicInc(T *acc, T value)
 {
   // See:
@@ -476,7 +462,7 @@ RAJA_INLINE __device__ T cuda_atomicInc(T *acc, T value)
 }
 
 template <typename T,
-          enable_if_is_any_of<T, cuda_atomicIncDecReset_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, cuda_atomicIncDecReset_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicInc(T *acc, T value)
 {
   return ::atomicInc(acc, value);
@@ -497,7 +483,7 @@ RAJA_INLINE __device__ T cuda_atomicInc(T *acc)
  * Atomic decrement with reset
  */
 template <typename T,
-          enable_if_is_none_of<T, cuda_atomicIncDecReset_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_none_of<T, cuda_atomicIncDecReset_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicDec(T *acc, T value)
 {
   // See:
@@ -508,7 +494,7 @@ RAJA_INLINE __device__ T cuda_atomicDec(T *acc, T value)
 }
 
 template <typename T,
-          enable_if_is_any_of<T, cuda_atomicIncDecReset_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, cuda_atomicIncDecReset_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicDec(T *acc, T value)
 {
   return ::atomicDec(acc, value);
@@ -539,7 +525,7 @@ using cuda_atomicBit_builtin_types = list<
  * Atomic and
  */
 template <typename T,
-          enable_if_is_none_of<T, cuda_atomicBit_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_none_of<T, cuda_atomicBit_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicAnd(T *acc, T value)
 {
   return cuda_atomicCAS(acc, [value] (T old) {
@@ -548,7 +534,7 @@ RAJA_INLINE __device__ T cuda_atomicAnd(T *acc, T value)
 }
 
 template <typename T,
-          enable_if_is_any_of<T, cuda_atomicBit_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, cuda_atomicBit_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicAnd(T *acc, T value)
 {
   return ::atomicAnd(acc, value);
@@ -559,7 +545,7 @@ RAJA_INLINE __device__ T cuda_atomicAnd(T *acc, T value)
  * Atomic or
  */
 template <typename T,
-          enable_if_is_none_of<T, cuda_atomicBit_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_none_of<T, cuda_atomicBit_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicOr(T *acc, T value)
 {
   return cuda_atomicCAS(acc, [value] (T old) {
@@ -568,7 +554,7 @@ RAJA_INLINE __device__ T cuda_atomicOr(T *acc, T value)
 }
 
 template <typename T,
-          enable_if_is_any_of<T, cuda_atomicBit_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, cuda_atomicBit_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicOr(T *acc, T value)
 {
   return ::atomicOr(acc, value);
@@ -579,7 +565,7 @@ RAJA_INLINE __device__ T cuda_atomicOr(T *acc, T value)
  * Atomic xor
  */
 template <typename T,
-          enable_if_is_none_of<T, cuda_atomicBit_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_none_of<T, cuda_atomicBit_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicXor(T *acc, T value)
 {
   return cuda_atomicCAS(acc, [value] (T old) {
@@ -588,7 +574,7 @@ RAJA_INLINE __device__ T cuda_atomicXor(T *acc, T value)
 }
 
 template <typename T,
-          enable_if_is_any_of<T, cuda_atomicBit_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, cuda_atomicBit_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T cuda_atomicXor(T *acc, T value)
 {
   return ::atomicXor(acc, value);

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -33,13 +33,14 @@
 #include <cuda/atomic>
 #endif
 
+#include "camp/list.hpp"
+
 #include "RAJA/policy/sequential/atomic.hpp"
 #include "RAJA/policy/atomic_builtin.hpp"
 #if defined(RAJA_ENABLE_OPENMP)
 #include "RAJA/policy/openmp/atomic.hpp"
 #endif
 
-#include "RAJA/util/camp_aliases.hpp"
 #include "RAJA/util/EnableIf.hpp"
 #include "RAJA/util/Operators.hpp"
 #include "RAJA/util/TypeConvert.hpp"
@@ -313,7 +314,7 @@ RAJA_INLINE __device__ T cuda_atomicCAS(T *acc, Oper&& oper, ShortCircuit&& sc)
 /*!
  * Atomic addition
  */
-using cuda_atomicAdd_builtin_types = list<
+using cuda_atomicAdd_builtin_types = ::camp::list<
   int,
   unsigned int,
   unsigned long long int,
@@ -346,12 +347,12 @@ RAJA_INLINE __device__ T cuda_atomicAdd(T *acc, T value)
  */
 using cuda_atomicSub_builtin_types = cuda_atomicAdd_builtin_types;
 
-using cuda_atomicSub_via_Sub_builtin_types = list<
+using cuda_atomicSub_via_Sub_builtin_types = ::camp::list<
   int,
   unsigned int
 >;
 
-using cuda_atomicSub_via_Add_builtin_types = list<
+using cuda_atomicSub_via_Add_builtin_types = ::camp::list<
   unsigned long long int,
   float
 #if __CUDA_ARCH__ >= 600
@@ -387,7 +388,7 @@ RAJA_INLINE __device__ T cuda_atomicSub(T *acc, T value)
 /*!
  * Atomic min/max
  */
-using cuda_atomicMinMax_builtin_types = list<
+using cuda_atomicMinMax_builtin_types = ::camp::list<
   int,
   unsigned int
 #if __CUDA_ARCH__ >= 500
@@ -449,7 +450,7 @@ RAJA_INLINE __device__ T cuda_atomicMax(T *acc, T value)
 /*!
  * Atomic increment/decrement with reset
  */
-using cuda_atomicIncDecReset_builtin_types = list<
+using cuda_atomicIncDecReset_builtin_types = ::camp::list<
   unsigned int
 >;
 
@@ -521,7 +522,7 @@ RAJA_INLINE __device__ T cuda_atomicDec(T *acc)
 /*!
  * Atomic bitwise functions (and, or, xor)
  */
-using cuda_atomicBit_builtin_types = list<
+using cuda_atomicBit_builtin_types = ::camp::list<
   int,
   unsigned int,
   unsigned long long int

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -648,10 +648,10 @@ RAJA_INLINE __device__ unsigned long long cuda_atomicCAS<unsigned long long>(
 RAJA_SUPPRESS_HD_WARN
 template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicLoad(cuda_atomic_explicit<host_policy>, T volatile *acc)
+atomicLoad(cuda_atomic_explicit<host_policy>, T *acc)
 {
 #ifdef __CUDA_ARCH__
-  return detail::cuda_atomicAdd(acc, (T)0);
+  return detail::cuda_atomicAdd(acc, static_cast<T>(0));
 #else
   return RAJA::atomicLoad(host_policy{}, acc);
 #endif
@@ -660,7 +660,7 @@ atomicLoad(cuda_atomic_explicit<host_policy>, T volatile *acc)
 RAJA_SUPPRESS_HD_WARN
 template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE void
-atomicStore(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
+atomicStore(cuda_atomic_explicit<host_policy>, T *acc, T value)
 {
 #ifdef __CUDA_ARCH__
   detail::cuda_atomicExchange(acc, value);
@@ -672,7 +672,7 @@ atomicStore(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicAdd(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
+atomicAdd(cuda_atomic_explicit<host_policy>, T *acc, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicAdd(acc, value);
@@ -684,7 +684,7 @@ atomicAdd(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicSub(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
+atomicSub(cuda_atomic_explicit<host_policy>, T *acc, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicSub(acc, value);
@@ -696,7 +696,7 @@ atomicSub(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicMin(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
+atomicMin(cuda_atomic_explicit<host_policy>, T *acc, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicMin(acc, value);
@@ -708,7 +708,7 @@ atomicMin(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicMax(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
+atomicMax(cuda_atomic_explicit<host_policy>, T *acc, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicMax(acc, value);
@@ -720,7 +720,7 @@ atomicMax(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicInc(cuda_atomic_explicit<host_policy>, T volatile *acc, T val)
+atomicInc(cuda_atomic_explicit<host_policy>, T *acc, T val)
 {
 #ifdef __CUDA_ARCH__
   // See:
@@ -734,7 +734,7 @@ atomicInc(cuda_atomic_explicit<host_policy>, T volatile *acc, T val)
 RAJA_SUPPRESS_HD_WARN
 template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicInc(cuda_atomic_explicit<host_policy>, T volatile *acc)
+atomicInc(cuda_atomic_explicit<host_policy>, T *acc)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicInc(acc);
@@ -746,7 +746,7 @@ atomicInc(cuda_atomic_explicit<host_policy>, T volatile *acc)
 RAJA_SUPPRESS_HD_WARN
 template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicDec(cuda_atomic_explicit<host_policy>, T volatile *acc, T val)
+atomicDec(cuda_atomic_explicit<host_policy>, T *acc, T val)
 {
 #ifdef __CUDA_ARCH__
   // See:
@@ -760,7 +760,7 @@ atomicDec(cuda_atomic_explicit<host_policy>, T volatile *acc, T val)
 RAJA_SUPPRESS_HD_WARN
 template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicDec(cuda_atomic_explicit<host_policy>, T volatile *acc)
+atomicDec(cuda_atomic_explicit<host_policy>, T *acc)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicDec(acc);
@@ -772,7 +772,7 @@ atomicDec(cuda_atomic_explicit<host_policy>, T volatile *acc)
 RAJA_SUPPRESS_HD_WARN
 template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicAnd(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
+atomicAnd(cuda_atomic_explicit<host_policy>, T *acc, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicAnd(acc, value);
@@ -784,7 +784,7 @@ atomicAnd(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicOr(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
+atomicOr(cuda_atomic_explicit<host_policy>, T *acc, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicOr(acc, value);
@@ -796,7 +796,7 @@ atomicOr(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicXor(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
+atomicXor(cuda_atomic_explicit<host_policy>, T *acc, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicXor(acc, value);
@@ -808,7 +808,7 @@ atomicXor(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicExchange(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
+atomicExchange(cuda_atomic_explicit<host_policy>, T *acc, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicExchange(acc, value);
@@ -820,7 +820,7 @@ atomicExchange(cuda_atomic_explicit<host_policy>, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicCAS(cuda_atomic_explicit<host_policy>, T volatile *acc, T compare, T value)
+atomicCAS(cuda_atomic_explicit<host_policy>, T *acc, T compare, T value)
 {
 #ifdef __CUDA_ARCH__
   return detail::cuda_atomicCAS(acc, compare, value);

--- a/include/RAJA/policy/desul/atomic.hpp
+++ b/include/RAJA/policy/desul/atomic.hpp
@@ -30,9 +30,9 @@ RAJA_SUPPRESS_HD_WARN
 template <typename AtomicPolicy, typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T
-atomicLoad(AtomicPolicy, T volatile *acc)
+atomicLoad(AtomicPolicy, T *acc)
 {
-  return desul::atomic_load(const_cast<T*>(acc),
+  return desul::atomic_load(acc,
                             raja_default_desul_order{},
                             raja_default_desul_scope{});
 }
@@ -41,9 +41,9 @@ RAJA_SUPPRESS_HD_WARN
 template <typename AtomicPolicy, typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE void
-atomicStore(AtomicPolicy, T volatile *acc, T value)
+atomicStore(AtomicPolicy, T *acc, T value)
 {
-  desul::atomic_store(const_cast<T*>(acc),
+  desul::atomic_store(acc,
                       value,
                       raja_default_desul_order{},
                       raja_default_desul_scope{});
@@ -53,9 +53,9 @@ RAJA_SUPPRESS_HD_WARN
 template <typename AtomicPolicy, typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T
-atomicAdd(AtomicPolicy, T volatile *acc, T value)
+atomicAdd(AtomicPolicy, T *acc, T value)
 {
-  return desul::atomic_fetch_add(const_cast<T*>(acc),
+  return desul::atomic_fetch_add(acc,
                                  value,
                                  raja_default_desul_order{},
                                  raja_default_desul_scope{});
@@ -65,9 +65,9 @@ RAJA_SUPPRESS_HD_WARN
 template <typename AtomicPolicy, typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T
-atomicSub(AtomicPolicy, T volatile *acc, T value)
+atomicSub(AtomicPolicy, T *acc, T value)
 {
-  return desul::atomic_fetch_sub(const_cast<T*>(acc),
+  return desul::atomic_fetch_sub(acc,
                                  value,
                                  raja_default_desul_order{},
                                  raja_default_desul_scope{});

--- a/include/RAJA/policy/desul/atomic.hpp
+++ b/include/RAJA/policy/desul/atomic.hpp
@@ -30,8 +30,8 @@ RAJA_SUPPRESS_HD_WARN
 template <typename AtomicPolicy, typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T
-atomicAdd(AtomicPolicy, T volatile *acc, T value) {
-  return desul::atomic_fetch_add(const_cast<T*>(acc),
+atomicAdd(AtomicPolicy, T *acc, T value) {
+  return desul::atomic_fetch_add(acc,
                                  value,
                                  raja_default_desul_order{},
                                  raja_default_desul_scope{});
@@ -41,8 +41,8 @@ RAJA_SUPPRESS_HD_WARN
 template <typename AtomicPolicy, typename T>
 RAJA_HOST_DEVICE
 RAJA_INLINE T
-atomicSub(AtomicPolicy, T volatile *acc, T value) {
-  return desul::atomic_fetch_sub(const_cast<T*>(acc),
+atomicSub(AtomicPolicy, T *acc, T value) {
+  return desul::atomic_fetch_sub(acc,
                                  value,
                                  raja_default_desul_order{},
                                  raja_default_desul_scope{});
@@ -51,9 +51,9 @@ atomicSub(AtomicPolicy, T volatile *acc, T value) {
 RAJA_SUPPRESS_HD_WARN
 template <typename AtomicPolicy, typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicMin(AtomicPolicy, T volatile *acc, T value)
+RAJA_INLINE T atomicMin(AtomicPolicy, T *acc, T value)
 {
-  return desul::atomic_fetch_min(const_cast<T*>(acc),
+  return desul::atomic_fetch_min(acc,
                                  value,
                                  raja_default_desul_order{},
                                  raja_default_desul_scope{});
@@ -62,9 +62,9 @@ RAJA_INLINE T atomicMin(AtomicPolicy, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename AtomicPolicy, typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicMax(AtomicPolicy, T volatile *acc, T value)
+RAJA_INLINE T atomicMax(AtomicPolicy, T *acc, T value)
 {
-  return desul::atomic_fetch_max(const_cast<T*>(acc),
+  return desul::atomic_fetch_max(acc,
                                  value,
                                  raja_default_desul_order{},
                                  raja_default_desul_scope{});
@@ -73,9 +73,9 @@ RAJA_INLINE T atomicMax(AtomicPolicy, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename AtomicPolicy, typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicInc(AtomicPolicy, T volatile *acc)
+RAJA_INLINE T atomicInc(AtomicPolicy, T *acc)
 {
-  return desul::atomic_fetch_inc(const_cast<T*>(acc),
+  return desul::atomic_fetch_inc(acc,
                                  raja_default_desul_order{},
                                  raja_default_desul_scope{});
 }
@@ -83,22 +83,22 @@ RAJA_INLINE T atomicInc(AtomicPolicy, T volatile *acc)
 RAJA_SUPPRESS_HD_WARN
 template <typename AtomicPolicy, typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicInc(AtomicPolicy, T volatile *acc, T val)
+RAJA_INLINE T atomicInc(AtomicPolicy, T *acc, T val)
 {
   // See:
   // http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomicinc
-  return desul::atomic_fetch_inc_mod(const_cast<T*>(acc),
-                                          val,
-                                          raja_default_desul_order{},
-                                          raja_default_desul_scope{});
+  return desul::atomic_fetch_inc_mod(acc,
+                                     val,
+                                     raja_default_desul_order{},
+                                     raja_default_desul_scope{});
 }
 
 RAJA_SUPPRESS_HD_WARN
 template <typename AtomicPolicy, typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicDec(AtomicPolicy, T volatile *acc)
+RAJA_INLINE T atomicDec(AtomicPolicy, T *acc)
 {
-  return desul::atomic_fetch_dec(const_cast<T*>(acc),
+  return desul::atomic_fetch_dec(acc,
                                  raja_default_desul_order{},
                                  raja_default_desul_scope{});
 }
@@ -106,22 +106,22 @@ RAJA_INLINE T atomicDec(AtomicPolicy, T volatile *acc)
 RAJA_SUPPRESS_HD_WARN
 template <typename AtomicPolicy, typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicDec(AtomicPolicy, T volatile *acc, T val)
+RAJA_INLINE T atomicDec(AtomicPolicy, T *acc, T val)
 {
   // See:
   // http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomicdec
-  return desul::atomic_fetch_dec_mod(const_cast<T*>(acc),
-                                          val,
-                                          raja_default_desul_order{},
-                                          raja_default_desul_scope{});
+  return desul::atomic_fetch_dec_mod(acc,
+                                     val,
+                                     raja_default_desul_order{},
+                                     raja_default_desul_scope{});
 }
 
 RAJA_SUPPRESS_HD_WARN
 template <typename AtomicPolicy, typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicAnd(AtomicPolicy, T volatile *acc, T value)
+RAJA_INLINE T atomicAnd(AtomicPolicy, T *acc, T value)
 {
-  return desul::atomic_fetch_and(const_cast<T*>(acc),
+  return desul::atomic_fetch_and(acc,
                                  value,
                                  raja_default_desul_order{},
                                  raja_default_desul_scope{});
@@ -130,9 +130,9 @@ RAJA_INLINE T atomicAnd(AtomicPolicy, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename AtomicPolicy, typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicOr(AtomicPolicy, T volatile *acc, T value)
+RAJA_INLINE T atomicOr(AtomicPolicy, T *acc, T value)
 {
-  return desul::atomic_fetch_or(const_cast<T*>(acc),
+  return desul::atomic_fetch_or(acc,
                                 value,
                                 raja_default_desul_order{},
                                 raja_default_desul_scope{});
@@ -141,9 +141,9 @@ RAJA_INLINE T atomicOr(AtomicPolicy, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename AtomicPolicy, typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicXor(AtomicPolicy, T volatile *acc, T value)
+RAJA_INLINE T atomicXor(AtomicPolicy, T *acc, T value)
 {
-  return desul::atomic_fetch_xor(const_cast<T*>(acc),
+  return desul::atomic_fetch_xor(acc,
                                  value,
                                  raja_default_desul_order{},
                                  raja_default_desul_scope{});
@@ -152,9 +152,9 @@ RAJA_INLINE T atomicXor(AtomicPolicy, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename AtomicPolicy, typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicExchange(AtomicPolicy, T volatile *acc, T value)
+RAJA_INLINE T atomicExchange(AtomicPolicy, T *acc, T value)
 {
-  return desul::atomic_exchange(const_cast<T*>(acc),
+  return desul::atomic_exchange(acc,
                                 value,
                                 raja_default_desul_order{},
                                 raja_default_desul_scope{});
@@ -163,9 +163,9 @@ RAJA_INLINE T atomicExchange(AtomicPolicy, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename AtomicPolicy, typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicCAS(AtomicPolicy, T volatile *acc, T compare, T value)
+RAJA_INLINE T atomicCAS(AtomicPolicy, T *acc, T compare, T value)
 {
-  return desul::atomic_compare_exchange(const_cast<T*>(acc),
+  return desul::atomic_compare_exchange(acc,
                                         compare,
                                         value,
                                         raja_default_desul_order{},

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -150,7 +150,7 @@ template <class T,
                            sizeof(T) != sizeof(unsigned int) &&
                            sizeof(T) != sizeof(unsigned long long int)> = true>
 struct hip_atomicCAS_reinterpret_cast {
-  static_assert("atomicCAS is not supported for given type");
+  static_assert(false, "atomicCAS is not supported for given type");
 };
 
 /*!

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -504,7 +504,7 @@ template <typename T, enable_if_is_none_of<T, hip_atomicDecReset_builtin_types>*
 RAJA_INLINE __device__ T hip_atomicDec(T *acc, T val)
 {
   return hip_atomicCAS(acc, [=] __device__(T old) {
-    return old == static_cast<T>(0) || val < old ? val : old - static_cast<T>(1));
+    return old == static_cast<T>(0) || val < old ? val : old - static_cast<T>(1);
   });
 }
 

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -384,7 +384,7 @@ template <typename T
          >
 RAJA_INLINE __device__ void hip_atomicStore(T *acc, T val)
 {
-  hip_atomicCAS(acc, [=] __device__(T) {
+  hip_atomicCAS(acc, [val] __device__(T) {
     return val;
   });
 }
@@ -403,7 +403,7 @@ RAJA_INLINE __device__ void hip_atomicStore(T *acc, T val)
 template <typename T, enable_if_is_none_of<T, hip_atomicAdd_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicAdd(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [=] __device__(T a) {
+  return hip_atomicCAS(acc, [value] __device__(T a) {
     return a + value;
   });
 }
@@ -418,7 +418,7 @@ RAJA_INLINE __device__ T hip_atomicAdd(T *acc, T value)
 template <typename T, enable_if_is_none_of<T, hip_atomicSub_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicSub(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [=] __device__(T a) {
+  return hip_atomicCAS(acc, [value] __device__(T a) {
     return a - value;
   });
 }
@@ -445,7 +445,7 @@ RAJA_INLINE __device__ T hip_atomicSub(T *acc, T value)
 template <typename T, enable_if_is_none_of<T, hip_atomicMin_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicMin(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [=] __device__(T a) {
+  return hip_atomicCAS(acc, [value] __device__(T a) {
     return value < a ? value : a;
   });
 }
@@ -460,7 +460,7 @@ RAJA_INLINE __device__ T hip_atomicMin(T *acc, T value)
 template <typename T, enable_if_is_none_of<T, hip_atomicMax_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicMax(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [=] __device__(T a) {
+  return hip_atomicCAS(acc, [value] __device__(T a) {
     return a < value ? value : a;
   });
 }
@@ -475,7 +475,7 @@ RAJA_INLINE __device__ T hip_atomicMax(T *acc, T value)
 template <typename T, enable_if_is_none_of<T, hip_atomicIncReset_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicInc(T *acc, T val)
 {
-  return hip_atomicCAS(acc, [=] __device__(T old) {
+  return hip_atomicCAS(acc, [val] __device__(T old) {
     return val <= old ? static_cast<T>(0) : old + static_cast<T>(1);
   });
 }
@@ -503,7 +503,7 @@ RAJA_INLINE __device__ T hip_atomicInc(T *acc)
 template <typename T, enable_if_is_none_of<T, hip_atomicDecReset_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicDec(T *acc, T val)
 {
-  return hip_atomicCAS(acc, [=] __device__(T old) {
+  return hip_atomicCAS(acc, [val] __device__(T old) {
     return old == static_cast<T>(0) || val < old ? val : old - static_cast<T>(1);
   });
 }
@@ -531,7 +531,7 @@ RAJA_INLINE __device__ T hip_atomicDec(T *acc)
 template <typename T, enable_if_is_none_of<T, hip_atomicAnd_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicAnd(T *acc, T val)
 {
-  return hip_atomicCAS(acc, [=] __device__(T a) {
+  return hip_atomicCAS(acc, [val] __device__(T a) {
     return a & val;
   });
 }
@@ -546,7 +546,7 @@ RAJA_INLINE __device__ T hip_atomicAnd(T *acc, T val)
 template <typename T, enable_if_is_none_of<T, hip_atomicOr_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicOr(T *acc, T val)
 {
-  return hip_atomicCAS(acc, [=] __device__(T a) {
+  return hip_atomicCAS(acc, [val] __device__(T a) {
     return a | val;
   });
 }
@@ -561,7 +561,7 @@ RAJA_INLINE __device__ T hip_atomicOr(T *acc, T val)
 template <typename T, enable_if_is_none_of<T, hip_atomicXor_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicXor(T *acc, T val)
 {
-  return hip_atomicCAS(acc, [=] __device__(T a) {
+  return hip_atomicCAS(acc, [val] __device__(T a) {
     return a ^ val;
   });
 }
@@ -576,7 +576,7 @@ RAJA_INLINE __device__ T hip_atomicXor(T *acc, T val)
 template <typename T, enable_if_is_none_of<T, hip_atomicExch_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicExchange(T *acc, T val)
 {
-  return hip_atomicCAS(acc, [=] __device__(T) {
+  return hip_atomicCAS(acc, [val] __device__(T) {
     return val;
   });
 }

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -507,7 +507,7 @@ template <typename T,
           enable_if_is_none_of<T, hip_atomicAdd_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicAdd(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [value] __device__(T old) {
+  return hip_atomicCAS(acc, [value] (T old) {
     return old + value;
   });
 }
@@ -566,7 +566,7 @@ template <typename T,
           enable_if_is_none_of<T, hip_atomicSub_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicSub(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [value] __device__(T old) {
+  return hip_atomicCAS(acc, [value] (T old) {
     return old - value;
   });
 }
@@ -601,7 +601,7 @@ template <typename T,
           enable_if_is_none_of<T, hip_atomicMin_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicMin(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [value] __device__(T old) {
+  return hip_atomicCAS(acc, [value] (T old) {
     return value < old ? value : old;
   });
 }
@@ -623,7 +623,7 @@ template <typename T,
           enable_if_is_none_of<T, hip_atomicMax_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicMax(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [value] __device__(T old) {
+  return hip_atomicCAS(acc, [value] (T old) {
     return old < value ? value : old;
   });
 }
@@ -642,7 +642,7 @@ RAJA_INLINE __device__ T hip_atomicMax(T *acc, T value)
 template <typename T>
 RAJA_INLINE __device__ T hip_atomicInc(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [value] __device__(T old) {
+  return hip_atomicCAS(acc, [value] (T old) {
     return value <= old ? static_cast<T>(0) : old + static_cast<T>(1);
   });
 }
@@ -664,7 +664,7 @@ RAJA_INLINE __device__ T hip_atomicInc(T *acc)
 template <typename T>
 RAJA_INLINE __device__ T hip_atomicDec(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [value] __device__(T old) {
+  return hip_atomicCAS(acc, [value] (T old) {
     return old == static_cast<T>(0) || value < old ? value : old - static_cast<T>(1);
   });
 }
@@ -689,7 +689,7 @@ template <typename T,
           enable_if_is_none_of<T, hip_atomicAnd_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicAnd(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [value] __device__(T old) {
+  return hip_atomicCAS(acc, [value] (T old) {
     return old & value;
   });
 }
@@ -711,7 +711,7 @@ template <typename T,
           enable_if_is_none_of<T, hip_atomicOr_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicOr(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [value] __device__(T old) {
+  return hip_atomicCAS(acc, [value] (T old) {
     return old | value;
   });
 }
@@ -733,7 +733,7 @@ template <typename T,
           enable_if_is_none_of<T, hip_atomicXor_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicXor(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [value] __device__(T old) {
+  return hip_atomicCAS(acc, [value] (T old) {
     return old ^ value;
   });
 }

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -159,7 +159,9 @@ struct hip_atomicCAS_reinterpret_cast {
  * passed directly.
  */
 template <class T,
-          enable_if_is_any_of<T, hip_atomicCAS_builtin_types>* = nullptr>
+          std::enable_if_t<std::is_same<T, int>::value ||
+                           std::is_same<T, unsigned int>::value ||
+                           std::is_same<T, unsigned long long int>::value> = true>
 struct hip_atomicCAS_reinterpret_cast {
   using type = T;
 };

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -339,7 +339,7 @@ RAJA_INLINE __device__ T hip_atomicLoad(T *acc)
  * Returns the old value in memory before this operation.
  */
 template <typename T>
-RAJA_INLINE __device__ T hip_atomicCAS(T *acc, T compare, T val)
+RAJA_INLINE __device__ T hip_atomicCAS(T *acc, T compare, T value)
 {
   using hip_atomicCAS_type = hip_atomicCAS_reinterpret_cast_t<T>;
 
@@ -347,7 +347,7 @@ RAJA_INLINE __device__ T hip_atomicCAS(T *acc, T compare, T val)
       ::atomicCAS(
           reinterpret_cast<hip_atomicCAS_type *>(acc),
           RAJA::util::reinterp_A_as_B<T, hip_atomicCAS_type>(compare),
-          RAJA::util::reinterp_A_as_B<T, hip_atomicCAS_type>(val)));
+          RAJA::util::reinterp_A_as_B<T, hip_atomicCAS_type>(value)));
 }
 
 /*!
@@ -382,10 +382,10 @@ template <typename T
                                std::is_enum<T>::value), bool> = true
 #endif
          >
-RAJA_INLINE __device__ void hip_atomicStore(T *acc, T val)
+RAJA_INLINE __device__ void hip_atomicStore(T *acc, T value)
 {
-  hip_atomicCAS(acc, [val] __device__(T) {
-    return val;
+  hip_atomicCAS(acc, [value] __device__(T) {
+    return value;
   });
 }
 
@@ -393,9 +393,9 @@ RAJA_INLINE __device__ void hip_atomicStore(T *acc, T val)
 template <typename T,
           std::enable_if_t<std::is_arithmetic<T>::value ||
                            std::is_enum<T>::value, bool> = true>
-RAJA_INLINE __device__ void hip_atomicStore(T *acc, T val)
+RAJA_INLINE __device__ void hip_atomicStore(T *acc, T value)
 {
-  __hip_atomic_store(acc, val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+  __hip_atomic_store(acc, value, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
 }
 #endif
 
@@ -473,17 +473,17 @@ RAJA_INLINE __device__ T hip_atomicMax(T *acc, T value)
 
 
 template <typename T, enable_if_is_none_of<T, hip_atomicIncReset_builtin_types>* = nullptr>
-RAJA_INLINE __device__ T hip_atomicInc(T *acc, T val)
+RAJA_INLINE __device__ T hip_atomicInc(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [val] __device__(T old) {
-    return val <= old ? static_cast<T>(0) : old + static_cast<T>(1);
+  return hip_atomicCAS(acc, [value] __device__(T old) {
+    return value <= old ? static_cast<T>(0) : old + static_cast<T>(1);
   });
 }
 
 template <typename T, enable_if_is_any_of<T, hip_atomicIncReset_builtin_types>* = nullptr>
-RAJA_INLINE __device__ T hip_atomicInc(T *acc, T val)
+RAJA_INLINE __device__ T hip_atomicInc(T *acc, T value)
 {
-  return ::atomicInc(acc, val);
+  return ::atomicInc(acc, value);
 }
 
 
@@ -501,17 +501,17 @@ RAJA_INLINE __device__ T hip_atomicInc(T *acc)
 
 
 template <typename T, enable_if_is_none_of<T, hip_atomicDecReset_builtin_types>* = nullptr>
-RAJA_INLINE __device__ T hip_atomicDec(T *acc, T val)
+RAJA_INLINE __device__ T hip_atomicDec(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [val] __device__(T old) {
-    return old == static_cast<T>(0) || val < old ? val : old - static_cast<T>(1);
+  return hip_atomicCAS(acc, [value] __device__(T old) {
+    return old == static_cast<T>(0) || value < old ? value : old - static_cast<T>(1);
   });
 }
 
 template <typename T, enable_if_is_any_of<T, hip_atomicDecReset_builtin_types>* = nullptr>
-RAJA_INLINE __device__ T hip_atomicDec(T *acc, T val)
+RAJA_INLINE __device__ T hip_atomicDec(T *acc, T value)
 {
-  return ::atomicDec(acc, val);
+  return ::atomicDec(acc, value);
 }
 
 
@@ -529,62 +529,62 @@ RAJA_INLINE __device__ T hip_atomicDec(T *acc)
 
 
 template <typename T, enable_if_is_none_of<T, hip_atomicAnd_builtin_types>* = nullptr>
-RAJA_INLINE __device__ T hip_atomicAnd(T *acc, T val)
+RAJA_INLINE __device__ T hip_atomicAnd(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [val] __device__(T a) {
-    return a & val;
+  return hip_atomicCAS(acc, [value] __device__(T a) {
+    return a & value;
   });
 }
 
 template <typename T, enable_if_is_any_of<T, hip_atomicAnd_builtin_types>* = nullptr>
-RAJA_INLINE __device__ T hip_atomicAnd(T *acc, T val)
+RAJA_INLINE __device__ T hip_atomicAnd(T *acc, T value)
 {
-  return ::atomicAnd(acc, val);
+  return ::atomicAnd(acc, value);
 }
 
 
 template <typename T, enable_if_is_none_of<T, hip_atomicOr_builtin_types>* = nullptr>
-RAJA_INLINE __device__ T hip_atomicOr(T *acc, T val)
+RAJA_INLINE __device__ T hip_atomicOr(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [val] __device__(T a) {
-    return a | val;
+  return hip_atomicCAS(acc, [value] __device__(T a) {
+    return a | value;
   });
 }
 
 template <typename T, enable_if_is_any_of<T, hip_atomicOr_builtin_types>* = nullptr>
-RAJA_INLINE __device__ T hip_atomicOr(T *acc, T val)
+RAJA_INLINE __device__ T hip_atomicOr(T *acc, T value)
 {
-  return ::atomicOr(acc, val);
+  return ::atomicOr(acc, value);
 }
 
 
 template <typename T, enable_if_is_none_of<T, hip_atomicXor_builtin_types>* = nullptr>
-RAJA_INLINE __device__ T hip_atomicXor(T *acc, T val)
+RAJA_INLINE __device__ T hip_atomicXor(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [val] __device__(T a) {
-    return a ^ val;
+  return hip_atomicCAS(acc, [value] __device__(T a) {
+    return a ^ value;
   });
 }
 
 template <typename T, enable_if_is_any_of<T, hip_atomicXor_builtin_types>* = nullptr>
-RAJA_INLINE __device__ T hip_atomicXor(T *acc, T val)
+RAJA_INLINE __device__ T hip_atomicXor(T *acc, T value)
 {
-  return ::atomicXor(acc, val);
+  return ::atomicXor(acc, value);
 }
 
 
 template <typename T, enable_if_is_none_of<T, hip_atomicExch_builtin_types>* = nullptr>
-RAJA_INLINE __device__ T hip_atomicExchange(T *acc, T val)
+RAJA_INLINE __device__ T hip_atomicExchange(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [val] __device__(T) {
-    return val;
+  return hip_atomicCAS(acc, [value] __device__(T) {
+    return value;
   });
 }
 
 template <typename T, enable_if_is_any_of<T, hip_atomicExch_builtin_types>* = nullptr>
-RAJA_INLINE __device__ T hip_atomicExchange(T *acc, T val)
+RAJA_INLINE __device__ T hip_atomicExchange(T *acc, T value)
 {
-  return ::atomicExch(acc, val);
+  return ::atomicExch(acc, value);
 }
 
 
@@ -675,12 +675,12 @@ atomicMax(hip_atomic_explicit<host_policy>, T *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicInc(hip_atomic_explicit<host_policy>, T *acc, T val)
+atomicInc(hip_atomic_explicit<host_policy>, T *acc, T value)
 {
 #if defined(__HIP_DEVICE_COMPILE__)
-  return detail::hip_atomicInc(acc, val);
+  return detail::hip_atomicInc(acc, value);
 #else
-  return RAJA::atomicInc(host_policy{}, acc, val);
+  return RAJA::atomicInc(host_policy{}, acc, value);
 #endif
 }
 
@@ -699,12 +699,12 @@ atomicInc(hip_atomic_explicit<host_policy>, T *acc)
 RAJA_SUPPRESS_HD_WARN
 template <typename T, typename host_policy>
 RAJA_INLINE RAJA_HOST_DEVICE T
-atomicDec(hip_atomic_explicit<host_policy>, T *acc, T val)
+atomicDec(hip_atomic_explicit<host_policy>, T *acc, T value)
 {
 #if defined(__HIP_DEVICE_COMPILE__)
-  return detail::hip_atomicDec(acc, val);
+  return detail::hip_atomicDec(acc, value);
 #else
-  return RAJA::atomicDec(host_policy{}, acc, val);
+  return RAJA::atomicDec(host_policy{}, acc, value);
 #endif
 }
 

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -471,12 +471,12 @@ RAJA_INLINE __device__ bool hip_atomicCAS_equal(const T& a, const T& b)
 
 /*!
  * Generic impementation of any atomic 32-bit or 64-bit operator.
- * Implementation uses the existing CUDA supplied unsigned 32-bit or 64-bit CAS
+ * Implementation uses the existing HIP supplied unsigned 32-bit or 64-bit CAS
  * operator. Returns the OLD value that was replaced by the result of this
  * operation.
  */
-template <typename T, typename OPER>
-RAJA_INLINE __device__ T hip_atomicCAS(T *acc, OPER&& oper)
+template <typename T, typename Oper>
+RAJA_INLINE __device__ T hip_atomicCAS(T *acc, Oper&& oper)
 {
   T old = hip_atomicLoad(acc);
   T expected;
@@ -485,6 +485,32 @@ RAJA_INLINE __device__ T hip_atomicCAS(T *acc, OPER&& oper)
     expected = old;
     old = hip_atomicCAS(acc, expected, oper(expected));
   } while (!hip_atomicCAS_equal(old, expected));
+
+  return old;
+}
+
+
+/*!
+ * Generic impementation of any atomic 32-bit or 64-bit operator with short-circuiting.
+ * Implementation uses the existing HIP supplied unsigned 32-bit or 64-bit CAS
+ * operator. Returns the OLD value that was replaced by the result of this
+ * operation.
+ */
+template <typename T, typename Oper, typename ShortCircuit>
+RAJA_INLINE __device__ T hip_atomicCAS(T *acc, Oper&& oper, ShortCircuit&& sc)
+{
+  T old = hip_atomicLoad(acc);
+
+  if (sc(old)) {
+    return old;
+  }
+
+  T expected;
+
+  do {
+    expected = old;
+    old = hip_atomicCAS(acc, expected, oper(expected));
+  } while (!hip_atomicCAS_equal(old, expected) && !sc(old));
 
   return old;
 }
@@ -601,9 +627,13 @@ template <typename T,
           enable_if_is_none_of<T, hip_atomicMin_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicMin(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [value] (T old) {
-    return value < old ? value : old;
-  });
+  return hip_atomicCAS(acc,
+                       [value] (T old) {
+                         return value < old ? value : old;
+                       },
+                       [value] (T current) {
+                         return current < value;
+                       });
 }
 
 template <typename T,
@@ -623,9 +653,13 @@ template <typename T,
           enable_if_is_none_of<T, hip_atomicMax_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicMax(T *acc, T value)
 {
-  return hip_atomicCAS(acc, [value] (T old) {
-    return old < value ? value : old;
-  });
+  return hip_atomicCAS(acc,
+                       [value] (T old) {
+                         return old < value ? value : old;
+                       },
+                       [value] (T current) {
+                         return value < current;
+                       });
 }
 
 template <typename T,

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -622,7 +622,7 @@ RAJA_INLINE __device__ T hip_atomicMin(T *acc, T value)
                          return value < old ? value : old;
                        },
                        [value] (T current) {
-                         return current < value;
+                         return current <= value;
                        });
 }
 
@@ -648,7 +648,7 @@ RAJA_INLINE __device__ T hip_atomicMax(T *acc, T value)
                          return old < value ? value : old;
                        },
                        [value] (T current) {
-                         return value < current;
+                         return value <= current;
                        });
 }
 

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -27,13 +27,14 @@
 #include <type_traits>
 #include "hip/hip_runtime.h"
 
+#include "camp/list.hpp"
+
 #include "RAJA/policy/sequential/atomic.hpp"
 #include "RAJA/policy/atomic_builtin.hpp"
 #if defined(RAJA_ENABLE_OPENMP)
 #include "RAJA/policy/openmp/atomic.hpp"
 #endif
 
-#include "RAJA/util/camp_aliases.hpp"
 #include "RAJA/util/EnableIf.hpp"
 #include "RAJA/util/Operators.hpp"
 #include "RAJA/util/TypeConvert.hpp"
@@ -48,7 +49,7 @@ namespace RAJA
 namespace detail
 {
 
-using hip_atomicCommon_builtin_types = list<
+using hip_atomicCommon_builtin_types = ::camp::list<
   int,
   unsigned int,
   unsigned long long
@@ -505,7 +506,7 @@ RAJA_INLINE __device__ T hip_atomicCAS(T *acc, Oper&& oper, ShortCircuit&& sc)
 /*!
  * Atomic addition
  */
-using hip_atomicAdd_builtin_types = list<
+using hip_atomicAdd_builtin_types = ::camp::list<
   int,
   unsigned int,
   unsigned long long,
@@ -540,7 +541,7 @@ RAJA_INLINE __device__ T hip_atomicAdd(T *acc, T value)
 /*!
  * List of types where HIP builtin atomics are used to implement atomicSub.
  */
-using hip_atomicSub_builtin_types = list<
+using hip_atomicSub_builtin_types = ::camp::list<
   int,
   unsigned int,
   unsigned long long,
@@ -557,7 +558,7 @@ using hip_atomicSub_builtin_types = list<
  * Avoid multiple definition errors by including the previous list type here
  * to ensure these lists have different types.
  */
-using hip_atomicSub_via_Sub_builtin_types = list<
+using hip_atomicSub_via_Sub_builtin_types = ::camp::list<
   int,
   unsigned int
 >;
@@ -568,7 +569,7 @@ using hip_atomicSub_via_Sub_builtin_types = list<
  * Avoid multiple definition errors by including the previous list type here
  * to ensure these lists have different types.
  */
-using hip_atomicSub_via_Add_builtin_types = list<
+using hip_atomicSub_via_Add_builtin_types = ::camp::list<
   unsigned long long,
   float
 #ifdef RAJA_ENABLE_HIP_DOUBLE_ATOMICADD

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -34,7 +34,7 @@
 #endif
 
 #include "RAJA/util/camp_aliases.hpp"
-#include "RAJA/util/concepts.hpp"
+#include "RAJA/util/EnableIf.hpp"
 #include "RAJA/util/Operators.hpp"
 #include "RAJA/util/TypeConvert.hpp"
 #include "RAJA/util/macros.hpp"
@@ -44,23 +44,9 @@
 namespace RAJA
 {
 
+
 namespace detail
 {
-
-template < typename T, typename TypeList >
-struct is_any_of;
-
-template < typename T, typename... Types >
-struct is_any_of<T, list<Types...>>
-  : concepts::any_of<camp::is_same<T, Types>...>
-{};
-
-template < typename T, typename TypeList >
-using enable_if_is_any_of = std::enable_if_t<is_any_of<T, TypeList>::value, T>;
-
-template < typename T, typename TypeList >
-using enable_if_is_none_of = std::enable_if_t<concepts::negate<is_any_of<T, TypeList>>::value, T>;
-
 
 using hip_atomicCommon_builtin_types = list<
       int
@@ -530,7 +516,7 @@ using hip_atomicAdd_builtin_types = list<
     >;
 
 template <typename T,
-          enable_if_is_none_of<T, hip_atomicAdd_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_none_of<T, hip_atomicAdd_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicAdd(T *acc, T value)
 {
   return hip_atomicCAS(acc, [value] (T old) {
@@ -539,7 +525,7 @@ RAJA_INLINE __device__ T hip_atomicAdd(T *acc, T value)
 }
 
 template <typename T,
-          enable_if_is_any_of<T, hip_atomicAdd_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, hip_atomicAdd_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicAdd(T *acc, T value)
 {
   return ::atomicAdd(acc, value);
@@ -589,7 +575,7 @@ using hip_atomicSub_via_Add_builtin_types = list<
     >;
 
 template <typename T,
-          enable_if_is_none_of<T, hip_atomicSub_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_none_of<T, hip_atomicSub_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicSub(T *acc, T value)
 {
   return hip_atomicCAS(acc, [value] (T old) {
@@ -601,7 +587,7 @@ RAJA_INLINE __device__ T hip_atomicSub(T *acc, T value)
  * HIP atomicSub builtin implementation.
  */
 template <typename T,
-          enable_if_is_any_of<T, hip_atomicSub_via_Sub_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, hip_atomicSub_via_Sub_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicSub(T *acc, T value)
 {
   return ::atomicSub(acc, value);
@@ -611,7 +597,7 @@ RAJA_INLINE __device__ T hip_atomicSub(T *acc, T value)
  * HIP atomicSub via atomicAdd builtin implementation.
  */
 template <typename T,
-          enable_if_is_any_of<T, hip_atomicSub_via_Add_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, hip_atomicSub_via_Add_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicSub(T *acc, T value)
 {
   return ::atomicAdd(acc, -value);
@@ -624,7 +610,7 @@ RAJA_INLINE __device__ T hip_atomicSub(T *acc, T value)
 using hip_atomicMin_builtin_types = hip_atomicCommon_builtin_types;
 
 template <typename T,
-          enable_if_is_none_of<T, hip_atomicMin_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_none_of<T, hip_atomicMin_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicMin(T *acc, T value)
 {
   return hip_atomicCAS(acc,
@@ -637,7 +623,7 @@ RAJA_INLINE __device__ T hip_atomicMin(T *acc, T value)
 }
 
 template <typename T,
-          enable_if_is_any_of<T, hip_atomicMin_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, hip_atomicMin_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicMin(T *acc, T value)
 {
   return ::atomicMin(acc, value);
@@ -650,7 +636,7 @@ RAJA_INLINE __device__ T hip_atomicMin(T *acc, T value)
 using hip_atomicMax_builtin_types = hip_atomicCommon_builtin_types;
 
 template <typename T,
-          enable_if_is_none_of<T, hip_atomicMax_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_none_of<T, hip_atomicMax_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicMax(T *acc, T value)
 {
   return hip_atomicCAS(acc,
@@ -663,7 +649,7 @@ RAJA_INLINE __device__ T hip_atomicMax(T *acc, T value)
 }
 
 template <typename T,
-          enable_if_is_any_of<T, hip_atomicMax_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, hip_atomicMax_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicMax(T *acc, T value)
 {
   return ::atomicMax(acc, value);
@@ -720,7 +706,7 @@ RAJA_INLINE __device__ T hip_atomicDec(T *acc)
 using hip_atomicAnd_builtin_types = hip_atomicCommon_builtin_types;
 
 template <typename T,
-          enable_if_is_none_of<T, hip_atomicAnd_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_none_of<T, hip_atomicAnd_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicAnd(T *acc, T value)
 {
   return hip_atomicCAS(acc, [value] (T old) {
@@ -729,7 +715,7 @@ RAJA_INLINE __device__ T hip_atomicAnd(T *acc, T value)
 }
 
 template <typename T,
-          enable_if_is_any_of<T, hip_atomicAnd_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, hip_atomicAnd_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicAnd(T *acc, T value)
 {
   return ::atomicAnd(acc, value);
@@ -742,7 +728,7 @@ RAJA_INLINE __device__ T hip_atomicAnd(T *acc, T value)
 using hip_atomicOr_builtin_types = hip_atomicCommon_builtin_types;
 
 template <typename T,
-          enable_if_is_none_of<T, hip_atomicOr_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_none_of<T, hip_atomicOr_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicOr(T *acc, T value)
 {
   return hip_atomicCAS(acc, [value] (T old) {
@@ -751,7 +737,7 @@ RAJA_INLINE __device__ T hip_atomicOr(T *acc, T value)
 }
 
 template <typename T,
-          enable_if_is_any_of<T, hip_atomicOr_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, hip_atomicOr_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicOr(T *acc, T value)
 {
   return ::atomicOr(acc, value);
@@ -764,7 +750,7 @@ RAJA_INLINE __device__ T hip_atomicOr(T *acc, T value)
 using hip_atomicXor_builtin_types = hip_atomicCommon_builtin_types;
 
 template <typename T,
-          enable_if_is_none_of<T, hip_atomicXor_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_none_of<T, hip_atomicXor_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicXor(T *acc, T value)
 {
   return hip_atomicCAS(acc, [value] (T old) {
@@ -773,7 +759,7 @@ RAJA_INLINE __device__ T hip_atomicXor(T *acc, T value)
 }
 
 template <typename T,
-          enable_if_is_any_of<T, hip_atomicXor_builtin_types>* = nullptr>
+          RAJA::util::enable_if_is_any_of<T, hip_atomicXor_builtin_types>* = nullptr>
 RAJA_INLINE __device__ T hip_atomicXor(T *acc, T value)
 {
   return ::atomicXor(acc, value);

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -150,7 +150,7 @@ template <class T,
                            sizeof(T) != sizeof(unsigned int) &&
                            sizeof(T) != sizeof(unsigned long long int)> = true>
 struct hip_atomicCAS_reinterpret_cast {
-  static_assert(false, "atomicCAS is not supported for given type");
+  static_assert(false, "Unsupported type for atomicCAS");
 };
 
 /*!

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -93,7 +93,7 @@ RAJA_INLINE __device__ T hip_atomicExchange(T *acc, T value)
 {
   return RAJA::util::reinterp_A_as_B<unsigned int, T>(
     hip_atomicExchange(reinterpret_cast<unsigned int*>(acc),
-                       reinterpret_cast<unsigned int&>(value)));
+                       RAJA::util::reinterp_A_as_B<T, unsigned int>(value)));
 }
 
 template <typename T,
@@ -106,7 +106,7 @@ RAJA_INLINE __device__ T hip_atomicExchange(T *acc, T value)
 {
   return RAJA::util::reinterp_A_as_B<unsigned long long int, T>(
     hip_atomicExchange(reinterpret_cast<unsigned long long int*>(acc),
-                       reinterpret_cast<unsigned long long int&>(value)));
+                       RAJA::util::reinterp_A_as_B<T, unsigned long long int>(value)));
 }
 
 
@@ -281,7 +281,7 @@ template <typename T,
 RAJA_INLINE __device__ void hip_atomicStore(T *acc, T value)
 {
   hip_atomicStore(reinterpret_cast<uint8_t*>(acc),
-                  reinterpret_cast<uint8_t&>(value));
+                  RAJA::util::reinterp_A_as_B<T, uint8_t>(value));
 }
 
 #else
@@ -294,7 +294,7 @@ template <typename T,
 RAJA_INLINE __device__ void hip_atomicStore(T *acc, T value)
 {
   hip_atomicStore(reinterpret_cast<unsigned char*>(acc),
-                  reinterpret_cast<unsigned char&>(value));
+                  RAJA::util::reinterp_A_as_B<T, unsigned char>(value));
 }
 
 #endif
@@ -308,7 +308,7 @@ template <typename T,
 RAJA_INLINE __device__ void hip_atomicStore(T *acc, T value)
 {
   hip_atomicStore(reinterpret_cast<uint16_t*>(acc),
-                  reinterpret_cast<uint16_t&>(value));
+                  RAJA::util::reinterp_A_as_B<T, uint16_t>(value));
 }
 
 #else
@@ -321,7 +321,7 @@ template <typename T,
 RAJA_INLINE __device__ void hip_atomicStore(T *acc, T value)
 {
   hip_atomicStore(reinterpret_cast<unsigned short int*>(acc),
-                  reinterpret_cast<unsigned short int&>(value));
+                  RAJA::util::reinterp_A_as_B<T, unsigned short int>(value));
 }
 
 #endif
@@ -335,7 +335,7 @@ template <typename T,
 RAJA_INLINE __device__ void hip_atomicStore(T *acc, T value)
 {
   hip_atomicStore(reinterpret_cast<uint32_t*>(acc),
-                  reinterpret_cast<uint32_t&>(value));
+                  RAJA::util::reinterp_A_as_B<T, uint32_t>(value));
 }
 
 #else
@@ -348,7 +348,7 @@ template <typename T,
 RAJA_INLINE __device__ void hip_atomicStore(T *acc, T value)
 {
   hip_atomicStore(reinterpret_cast<unsigned int*>(acc),
-                  reinterpret_cast<unsigned int&>(value));
+                  RAJA::util::reinterp_A_as_B<T, unsigned int>(value));
 }
 
 #endif
@@ -362,7 +362,7 @@ template <typename T,
 RAJA_INLINE __device__ void hip_atomicStore(T *acc, T value)
 {
   hip_atomicStore(reinterpret_cast<uint64_t*>(acc),
-                  reinterpret_cast<uint64_t&>(value));
+                  RAJA::util::reinterp_A_as_B<T, uint64_t>(value));
 }
 
 #else
@@ -375,7 +375,7 @@ template <typename T,
 RAJA_INLINE __device__ void hip_atomicStore(T *acc, T value)
 {
   hip_atomicStore(reinterpret_cast<unsigned long long int*>(acc),
-                  reinterpret_cast<unsigned long long int&>(value));
+                  RAJA::util::reinterp_A_as_B<T, unsigned long long int>(value));
 }
 
 #endif
@@ -414,8 +414,8 @@ RAJA_INLINE __device__ T hip_atomicCAS(T *acc, T compare, T value)
 {
   return RAJA::util::reinterp_A_as_B<unsigned int, T>(
     hip_atomicCAS(reinterpret_cast<unsigned int*>(acc),
-                  reinterpret_cast<unsigned int&>(compare),
-                  reinterpret_cast<unsigned int&>(value)));
+                  RAJA::util::reinterp_A_as_B<T, unsigned int>(compare),
+                  RAJA::util::reinterp_A_as_B<T, unsigned int>(value)));
 }
 
 template <typename T,
@@ -427,8 +427,8 @@ RAJA_INLINE __device__ T hip_atomicCAS(T *acc, T compare, T value)
 {
   return RAJA::util::reinterp_A_as_B<unsigned long long int, T>(
     hip_atomicCAS(reinterpret_cast<unsigned long long int*>(acc),
-                  reinterpret_cast<unsigned long long int&>(compare),
-                  reinterpret_cast<unsigned long long int&>(value)));
+                  RAJA::util::reinterp_A_as_B<T, unsigned long long int>(compare),
+                  RAJA::util::reinterp_A_as_B<T, unsigned long long int>(value)));
 }
 
 
@@ -453,8 +453,8 @@ template <typename T,
                            sizeof(T) == sizeof(unsigned int), bool> = true>
 RAJA_INLINE __device__ bool hip_atomicCAS_equal(const T& a, const T& b)
 {
-  return reinterpret_cast<const unsigned int&>(a) ==
-         reinterpret_cast<const unsigned int&>(b);
+  return RAJA::util::reinterp_A_as_B<T, unsigned int>(a) ==
+         RAJA::util::reinterp_A_as_B<T, unsigned int>(b);
 }
 
 template <typename T,
@@ -464,8 +464,8 @@ template <typename T,
                            sizeof(T) == sizeof(unsigned long long int), bool> = true>
 RAJA_INLINE __device__ bool hip_atomicCAS_equal(const T& a, const T& b)
 {
-  return reinterpret_cast<const unsigned long long int&>(a) ==
-         reinterpret_cast<const unsigned long long int&>(b);
+  return RAJA::util::reinterp_A_as_B<T, unsigned long long int>(a) ==
+         RAJA::util::reinterp_A_as_B<T, unsigned long long int>(b);
 }
 
 

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -49,10 +49,10 @@ namespace detail
 {
 
 using hip_atomicCommon_builtin_types = list<
-      int
-     ,unsigned int
-     ,unsigned long long
-    >;
+  int,
+  unsigned int,
+  unsigned long long
+>;
 
 
 /*
@@ -506,14 +506,15 @@ RAJA_INLINE __device__ T hip_atomicCAS(T *acc, Oper&& oper, ShortCircuit&& sc)
  * Atomic addition
  */
 using hip_atomicAdd_builtin_types = list<
-      int
-     ,unsigned int
-     ,unsigned long long
-     ,float
+  int,
+  unsigned int,
+  unsigned long long,
+  float
 #ifdef RAJA_ENABLE_HIP_DOUBLE_ATOMICADD
-     ,double
+  ,
+  double
 #endif
-    >;
+>;
 
 template <typename T,
           RAJA::util::enable_if_is_none_of<T, hip_atomicAdd_builtin_types>* = nullptr>
@@ -540,14 +541,15 @@ RAJA_INLINE __device__ T hip_atomicAdd(T *acc, T value)
  * List of types where HIP builtin atomics are used to implement atomicSub.
  */
 using hip_atomicSub_builtin_types = list<
-      int
-     ,unsigned int
-     ,unsigned long long
-     ,float
+  int,
+  unsigned int,
+  unsigned long long,
+  float
 #ifdef RAJA_ENABLE_HIP_DOUBLE_ATOMICADD
-     ,double
+  ,
+  double
 #endif
-    >;
+>;
 
 /*!
  * List of types where HIP builtin atomicSub is used to implement atomicSub.
@@ -556,9 +558,9 @@ using hip_atomicSub_builtin_types = list<
  * to ensure these lists have different types.
  */
 using hip_atomicSub_via_Sub_builtin_types = list<
-      int
-     ,unsigned int
-    >;
+  int,
+  unsigned int
+>;
 
 /*!
  * List of types where HIP builtin atomicAdd is used to implement atomicSub.
@@ -567,12 +569,13 @@ using hip_atomicSub_via_Sub_builtin_types = list<
  * to ensure these lists have different types.
  */
 using hip_atomicSub_via_Add_builtin_types = list<
-      unsigned long long
-     ,float
+  unsigned long long,
+  float
 #ifdef RAJA_ENABLE_HIP_DOUBLE_ATOMICADD
-     ,double
+  ,
+  double
 #endif
-    >;
+>;
 
 template <typename T,
           RAJA::util::enable_if_is_none_of<T, hip_atomicSub_builtin_types>* = nullptr>

--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -65,6 +65,7 @@ RAJA_INLINE void atomicStore(omp_atomic, T *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
+RAJA_INLINE T atomicAdd(omp_atomic, T *acc, T value)
 {
   T old;
 #pragma omp atomic capture

--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -36,7 +36,7 @@ namespace RAJA
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicLoad(omp_atomic, T volatile *acc)
+RAJA_INLINE T atomicLoad(omp_atomic, T *acc)
 {
   T ret;
 #pragma omp atomic capture
@@ -50,7 +50,7 @@ RAJA_INLINE T atomicLoad(omp_atomic, T volatile *acc)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE void atomicStore(omp_atomic, T volatile *acc, T value)
+RAJA_INLINE void atomicStore(omp_atomic, T *acc, T value)
 {
   T ret;
 #pragma omp atomic capture

--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -36,7 +36,7 @@ namespace RAJA
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicAdd(omp_atomic, T volatile *acc, T value)
+RAJA_INLINE T atomicAdd(omp_atomic, T *acc, T value)
 {
   T ret;
 #pragma omp atomic capture
@@ -51,7 +51,7 @@ RAJA_INLINE T atomicAdd(omp_atomic, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicSub(omp_atomic, T volatile *acc, T value)
+RAJA_INLINE T atomicSub(omp_atomic, T *acc, T value)
 {
   T ret;
 #pragma omp atomic capture
@@ -66,7 +66,7 @@ RAJA_INLINE T atomicSub(omp_atomic, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicMin(omp_atomic, T volatile *acc, T value)
+RAJA_INLINE T atomicMin(omp_atomic, T *acc, T value)
 {
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
   return atomicMin(builtin_atomic{}, acc, value);
@@ -75,7 +75,7 @@ RAJA_INLINE T atomicMin(omp_atomic, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicMax(omp_atomic, T volatile *acc, T value)
+RAJA_INLINE T atomicMax(omp_atomic, T *acc, T value)
 {
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
   return atomicMax(builtin_atomic{}, acc, value);
@@ -85,7 +85,7 @@ RAJA_INLINE T atomicMax(omp_atomic, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicInc(omp_atomic, T volatile *acc)
+RAJA_INLINE T atomicInc(omp_atomic, T *acc)
 {
   T ret;
 #pragma omp atomic capture
@@ -100,7 +100,7 @@ RAJA_INLINE T atomicInc(omp_atomic, T volatile *acc)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicInc(omp_atomic, T volatile *acc, T val)
+RAJA_INLINE T atomicInc(omp_atomic, T *acc, T val)
 {
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
   return RAJA::atomicInc(builtin_atomic{}, acc, val);
@@ -110,7 +110,7 @@ RAJA_INLINE T atomicInc(omp_atomic, T volatile *acc, T val)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicDec(omp_atomic, T volatile *acc)
+RAJA_INLINE T atomicDec(omp_atomic, T *acc)
 {
   T ret;
 #pragma omp atomic capture
@@ -125,7 +125,7 @@ RAJA_INLINE T atomicDec(omp_atomic, T volatile *acc)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicDec(omp_atomic, T volatile *acc, T val)
+RAJA_INLINE T atomicDec(omp_atomic, T *acc, T val)
 {
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
   return RAJA::atomicDec(builtin_atomic{}, acc, val);
@@ -134,7 +134,7 @@ RAJA_INLINE T atomicDec(omp_atomic, T volatile *acc, T val)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicAnd(omp_atomic, T volatile *acc, T value)
+RAJA_INLINE T atomicAnd(omp_atomic, T *acc, T value)
 {
   T ret;
 #pragma omp atomic capture
@@ -148,7 +148,7 @@ RAJA_INLINE T atomicAnd(omp_atomic, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicOr(omp_atomic, T volatile *acc, T value)
+RAJA_INLINE T atomicOr(omp_atomic, T *acc, T value)
 {
   T ret;
 #pragma omp atomic capture
@@ -162,7 +162,7 @@ RAJA_INLINE T atomicOr(omp_atomic, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicXor(omp_atomic, T volatile *acc, T value)
+RAJA_INLINE T atomicXor(omp_atomic, T *acc, T value)
 {
   T ret;
 #pragma omp atomic capture
@@ -176,7 +176,7 @@ RAJA_INLINE T atomicXor(omp_atomic, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicExchange(omp_atomic, T volatile *acc, T value)
+RAJA_INLINE T atomicExchange(omp_atomic, T *acc, T value)
 {
   T ret;
 #pragma omp atomic capture
@@ -190,7 +190,7 @@ RAJA_INLINE T atomicExchange(omp_atomic, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicCAS(omp_atomic, T volatile *acc, T compare, T value)
+RAJA_INLINE T atomicCAS(omp_atomic, T *acc, T compare, T value)
 {
   // OpenMP doesn't define atomic trinary operators so use builtin atomics
   return RAJA::atomicCAS(builtin_atomic{}, acc, compare, value);

--- a/include/RAJA/policy/sequential/atomic.hpp
+++ b/include/RAJA/policy/sequential/atomic.hpp
@@ -28,7 +28,7 @@ namespace RAJA
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicAdd(seq_atomic, T volatile *acc, T value)
+RAJA_INLINE T atomicAdd(seq_atomic, T *acc, T value)
 {
   T ret = *acc;
   *acc += value;
@@ -39,7 +39,7 @@ RAJA_INLINE T atomicAdd(seq_atomic, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicSub(seq_atomic, T volatile *acc, T value)
+RAJA_INLINE T atomicSub(seq_atomic, T *acc, T value)
 {
   T ret = *acc;
   *acc -= value;
@@ -50,7 +50,7 @@ RAJA_INLINE T atomicSub(seq_atomic, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicMin(seq_atomic, T volatile *acc, T value)
+RAJA_INLINE T atomicMin(seq_atomic, T *acc, T value)
 {
   T ret = *acc;
   *acc = ret < value ? ret : value;
@@ -60,7 +60,7 @@ RAJA_INLINE T atomicMin(seq_atomic, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicMax(seq_atomic, T volatile *acc, T value)
+RAJA_INLINE T atomicMax(seq_atomic, T *acc, T value)
 {
   T ret = *acc;
   *acc = ret > value ? ret : value;
@@ -71,7 +71,7 @@ RAJA_INLINE T atomicMax(seq_atomic, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicInc(seq_atomic, T volatile *acc)
+RAJA_INLINE T atomicInc(seq_atomic, T *acc)
 {
   T ret = *acc;
   (*acc) += 1;
@@ -81,7 +81,7 @@ RAJA_INLINE T atomicInc(seq_atomic, T volatile *acc)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicInc(seq_atomic, T volatile *acc, T val)
+RAJA_INLINE T atomicInc(seq_atomic, T *acc, T val)
 {
   T old = *acc;
   (*acc) = ((old >= val) ? 0 : (old + 1));
@@ -91,7 +91,7 @@ RAJA_INLINE T atomicInc(seq_atomic, T volatile *acc, T val)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicDec(seq_atomic, T volatile *acc)
+RAJA_INLINE T atomicDec(seq_atomic, T *acc)
 {
   T ret = *acc;
   (*acc) -= 1;
@@ -101,7 +101,7 @@ RAJA_INLINE T atomicDec(seq_atomic, T volatile *acc)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicDec(seq_atomic, T volatile *acc, T val)
+RAJA_INLINE T atomicDec(seq_atomic, T *acc, T val)
 {
   T old = *acc;
   (*acc) = (((old == 0) | (old > val)) ? val : (old - 1));
@@ -111,7 +111,7 @@ RAJA_INLINE T atomicDec(seq_atomic, T volatile *acc, T val)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicAnd(seq_atomic, T volatile *acc, T value)
+RAJA_INLINE T atomicAnd(seq_atomic, T *acc, T value)
 {
   T ret = *acc;
   *acc &= value;
@@ -121,7 +121,7 @@ RAJA_INLINE T atomicAnd(seq_atomic, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicOr(seq_atomic, T volatile *acc, T value)
+RAJA_INLINE T atomicOr(seq_atomic, T *acc, T value)
 {
   T ret = *acc;
   *acc |= value;
@@ -131,7 +131,7 @@ RAJA_INLINE T atomicOr(seq_atomic, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicXor(seq_atomic, T volatile *acc, T value)
+RAJA_INLINE T atomicXor(seq_atomic, T *acc, T value)
 {
   T ret = *acc;
   *acc ^= value;
@@ -141,7 +141,7 @@ RAJA_INLINE T atomicXor(seq_atomic, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicExchange(seq_atomic, T volatile *acc, T value)
+RAJA_INLINE T atomicExchange(seq_atomic, T *acc, T value)
 {
   T ret = *acc;
   *acc = value;
@@ -151,7 +151,7 @@ RAJA_INLINE T atomicExchange(seq_atomic, T volatile *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicCAS(seq_atomic, T volatile *acc, T compare, T value)
+RAJA_INLINE T atomicCAS(seq_atomic, T *acc, T compare, T value)
 {
   T ret = *acc;
   *acc = ret == compare ? value : ret;

--- a/include/RAJA/policy/sequential/atomic.hpp
+++ b/include/RAJA/policy/sequential/atomic.hpp
@@ -28,7 +28,7 @@ namespace RAJA
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE T atomicLoad(seq_atomic, T volatile *acc)
+RAJA_INLINE T atomicLoad(seq_atomic, T *acc)
 {
   return *acc;
 }
@@ -36,7 +36,7 @@ RAJA_INLINE T atomicLoad(seq_atomic, T volatile *acc)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
-RAJA_INLINE void atomicStore(seq_atomic, T volatile *acc, T value)
+RAJA_INLINE void atomicStore(seq_atomic, T *acc, T value)
 {
   *acc = value;
 }

--- a/include/RAJA/policy/sequential/atomic.hpp
+++ b/include/RAJA/policy/sequential/atomic.hpp
@@ -44,6 +44,7 @@ RAJA_INLINE void atomicStore(seq_atomic, T *acc, T value)
 RAJA_SUPPRESS_HD_WARN
 template <typename T>
 RAJA_HOST_DEVICE
+RAJA_INLINE T atomicAdd(seq_atomic, T *acc, T value)
 {
   T ret = *acc;
   *acc += value;

--- a/include/RAJA/util/EnableIf.hpp
+++ b/include/RAJA/util/EnableIf.hpp
@@ -22,10 +22,12 @@
 
 #include "RAJA/config.hpp"
 
-#include "RAJA/util/camp_aliases.hpp"
-#include "RAJA/util/concepts.hpp"
-
 #include <type_traits>
+
+#include "camp/list.hpp"
+#include "camp/type_traits.hpp"
+
+#include "RAJA/util/concepts.hpp"
 
 
 namespace RAJA
@@ -38,15 +40,15 @@ template <typename T, typename TypeList>
 struct is_any_of;
 
 template <typename T, typename... Types>
-struct is_any_of<T, list<Types...>>
-  : concepts::any_of<camp::is_same<T, Types>...>
+struct is_any_of<T, ::camp::list<Types...>>
+  : ::RAJA::concepts::any_of<::camp::is_same<T, Types>...>
 {};
 
 template <typename T, typename TypeList>
 using enable_if_is_any_of = std::enable_if_t<is_any_of<T, TypeList>::value, T>;
 
 template <typename T, typename TypeList>
-using enable_if_is_none_of = std::enable_if_t<concepts::negate<is_any_of<T, TypeList>>::value, T>;
+using enable_if_is_none_of = std::enable_if_t<::RAJA::concepts::negate<is_any_of<T, TypeList>>::value, T>;
 
 
 }  // namespace util

--- a/include/RAJA/util/EnableIf.hpp
+++ b/include/RAJA/util/EnableIf.hpp
@@ -1,0 +1,54 @@
+/*!
+ ******************************************************************************
+ *
+ * \file
+ *
+ * \brief   Header file for enable_if helpers.
+ *
+ *          These type functions are used heavily by the atomic operators.
+ *
+ ******************************************************************************
+ */
+
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2024, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef RAJA_util_EnableIf_HPP
+#define RAJA_util_EnableIf_HPP
+
+#include "RAJA/config.hpp"
+
+#include "RAJA/util/concepts.hpp"
+
+#include <type_traits>
+
+
+namespace RAJA
+{
+namespace util
+{
+
+
+template <typename T, typename TypeList>
+struct is_any_of;
+
+template <typename T, typename... Types>
+struct is_any_of<T, list<Types...>>
+  : concepts::any_of<camp::is_same<T, Types>...>
+{};
+
+template <typename T, typename TypeList>
+using enable_if_is_any_of = std::enable_if_t<is_any_of<T, TypeList>::value, T>;
+
+template <typename T, typename TypeList>
+using enable_if_is_none_of = std::enable_if_t<concepts::negate<is_any_of<T, TypeList>>::value, T>;
+
+
+}  // namespace util
+}  // namespace RAJA
+
+#endif  // closing endif for header file include guard

--- a/include/RAJA/util/EnableIf.hpp
+++ b/include/RAJA/util/EnableIf.hpp
@@ -22,6 +22,7 @@
 
 #include "RAJA/config.hpp"
 
+#include "RAJA/util/camp_aliases.hpp"
 #include "RAJA/util/concepts.hpp"
 
 #include <type_traits>

--- a/include/RAJA/util/TypeConvert.hpp
+++ b/include/RAJA/util/TypeConvert.hpp
@@ -37,17 +37,13 @@ namespace util
  * Reinterpret any datatype as another datatype of the same size
  */
 template <typename A, typename B>
-RAJA_INLINE RAJA_HOST_DEVICE constexpr B reinterp_A_as_B(A const &val)
+RAJA_INLINE RAJA_HOST_DEVICE constexpr B reinterp_A_as_B(A const &a)
 {
-  static_assert(sizeof(A) == sizeof(B), "A and B must be same size");
-  return reinterpret_cast<B const &>(val);
-}
+  static_assert(sizeof(A) == sizeof(B), "A and B must be the same size");
 
-template <typename A, typename B>
-RAJA_INLINE RAJA_HOST_DEVICE constexpr B reinterp_A_as_B(A volatile const &val)
-{
-  static_assert(sizeof(A) == sizeof(B), "A and B must be same size");
-  return reinterpret_cast<B const volatile &>(val);
+  B b;
+  std::memcpy(&b, &a, sizeof(A));
+  return b;
 }
 
 


### PR DESCRIPTION
# Summary

- This PR is a refactoring
- It does the following:
  - Modifies hip and cuda generic atomic compare and swap algorithms to use atomic loads instead of relying on volatile
  - Re-implements atomic loads in terms of builtin atomics for cuda and hip (so that the generic compare and swap functions can use it)
  - Removes volatile qualifier in atomic function signatures
  - Uses cuda::atomic_ref in newer versions of CUDA to back atomicLoad/Store
  - Uses atomicAdd as a fallback for atomicSub in CUDA
  - Refactors CUDA atomics to reduce duplicate code (now more closely matches the Hip atomic implementations)
  - Removes checks where `__CUDA_ARCH__` is less than 350 since RAJA requires that as the minimum supported architecture anyway