### PR TITLE
Support for sycl reducers in RAJA launch

### DIFF
--- a/examples/launch-param-reductions.cpp
+++ b/examples/launch-param-reductions.cpp
@@ -38,8 +38,8 @@ constexpr int HIP_BLOCK_SIZE = 256;
 #endif
 
 #if defined(RAJA_ENABLE_SYCL)
-constexpr int SYCL_BLOCK_SIZE = 151; //reductions have a limit of 151
-//constexpr int SYCL_BLOCK_SIZE = 256;
+//LC testing hardware has a limit of 151
+constexpr int SYCL_BLOCK_SIZE = 151;
 #endif
 
 int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))

--- a/examples/launch-param-reductions.cpp
+++ b/examples/launch-param-reductions.cpp
@@ -39,7 +39,7 @@ constexpr int HIP_BLOCK_SIZE = 256;
 
 #if defined(RAJA_ENABLE_SYCL)
 //LC testing hardware has a limit of 151
-constexpr int SYCL_BLOCK_SIZE = 151;
+constexpr int SYCL_BLOCK_SIZE = 128;
 #endif
 
 int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))

--- a/include/RAJA/policy/sycl/launch.hpp
+++ b/include/RAJA/policy/sycl/launch.hpp
@@ -99,7 +99,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>> {
                                  RAJA::expt::type_traits::is_ForallParamPack<ReduceParams>,
                                  concepts::negate<RAJA::expt::type_traits::is_ForallParamPack_empty<ReduceParams>>>
   exec(RAJA::resources::Resource res, const LaunchParams &launch_params, const char *kernel_name,
-       BODY_IN &&body_in, ReduceParams &&launch_reducers)
+       BODY_IN &&body_in, ReduceParams launch_reducers)
   {
 
    RAJA_ABORT_OR_THROW("SYCL trivially copyable lambda with param pack currently not supported in RAJA launch");
@@ -185,14 +185,89 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>> {
                                  RAJA::expt::type_traits::is_ForallParamPack<ReduceParams>,
                                  concepts::negate<RAJA::expt::type_traits::is_ForallParamPack_empty<ReduceParams>>>
     exec(RAJA::resources::Resource res, const LaunchParams &launch_params, const char *kernel_name,
-         BODY_IN &&body_in, ReduceParams &&launch_reducers)
+         BODY_IN &&body_in, ReduceParams launch_reducers)
   {
 
-   RAJA_ABORT_OR_THROW("SYCL non-trivially copyable lambda with param pack currently not supported in RAJA launch");
+    /*Get the queue from concrete resource */
+    ::sycl::queue* q = res.get<camp::resources::Sycl>().get_queue();
+
+    using EXEC_POL = RAJA::sycl_launch_t<async, 0>;
+    RAJA::expt::ParamMultiplexer::init<EXEC_POL>(launch_reducers);
+
+    //
+    // Compute the number of blocks and threads
+    //
+    const ::sycl::range<3> blockSize(launch_params.threads.value[2],
+				     launch_params.threads.value[1],
+				     launch_params.threads.value[0]);
+
+    const ::sycl::range<3> gridSize(launch_params.threads.value[2] * launch_params.teams.value[2],
+				    launch_params.threads.value[1] * launch_params.teams.value[1],
+				    launch_params.threads.value[0] * launch_params.teams.value[0]);
+
+    // Only launch kernel if we have something to iterate over
+    constexpr size_t zero = 0;
+    if ( launch_params.threads.value[0]  > zero && launch_params.threads.value[1]  > zero && launch_params.threads.value[2] > zero &&
+         launch_params.teams.value[0] > zero && launch_params.teams.value[1] > zero && launch_params.teams.value[2]> zero ) {
+
+
+      auto combiner = []( ReduceParams x, ReduceParams y ) {
+        RAJA::expt::ParamMultiplexer::combine<EXEC_POL>( x, y );
+        return x;
+       };
+
+      RAJA_FT_BEGIN;
+
+      //
+      // Kernel body is nontrivially copyable, create space on device and copy to
+      // Workaround until "is_device_copyable" is supported
+      //
+      using LOOP_BODY = camp::decay<BODY_IN>;
+      LOOP_BODY* lbody;
+      lbody = (LOOP_BODY*) cl::sycl::malloc_device(sizeof(LOOP_BODY), *q);
+      q->memcpy(lbody, &body_in, sizeof(LOOP_BODY)).wait();
+
+      ReduceParams* res = ::sycl::malloc_shared<ReduceParams>(1,*q);
+      RAJA::expt::ParamMultiplexer::init<EXEC_POL>(*res);
+      auto reduction = ::sycl::reduction(res, launch_reducers, combiner);
+
+      q->submit([&](cl::sycl::handler& h) {
+
+       auto s_vec = ::sycl::local_accessor<char, 1> (launch_params.shared_mem_size, h);
+
+        h.parallel_for
+          (cl::sycl::nd_range<3>(gridSize, blockSize),
+           reduction,
+           [=] (cl::sycl::nd_item<3> itm, auto & red) {
+
+            LaunchContext ctx;
+            ctx.itm = &itm;
+
+            //Point to shared memory
+            ctx.shared_mem_ptr = s_vec.get_multi_ptr<::sycl::access::decorated::yes>().get();
+
+            ReduceParams fp;
+            RAJA::expt::ParamMultiplexer::init<EXEC_POL>(fp);
+
+            RAJA::expt::invoke_body(fp, *lbody, ctx);
+
+            red.combine(fp);
+
+           });
+
+      }).wait(); // Need to wait for completion to free memory
+
+      RAJA::expt::ParamMultiplexer::combine<EXEC_POL>( launch_reducers, *res );
+      ::sycl::free(res, *q);
+      cl::sycl::free(lbody, *q);
+
+      RAJA_FT_END;
+    }
+
+    RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(launch_reducers);
 
    return resources::EventProxy<resources::Resource>(res);
   }
-
 
 };
 

--- a/test/functional/launch/reduce-params/CMakeLists.txt
+++ b/test/functional/launch/reduce-params/CMakeLists.txt
@@ -20,7 +20,6 @@ set(DATATYPES CoreReductionDataTypeList)
 # Note: LAUNCH_BACKENDS is defined in ../CMakeLists.txt
 #
 foreach( BACKEND ${LAUNCH_BACKENDS} )
-  if( NOT (BACKEND STREQUAL "Sycl"))
   foreach( REDUCETYPE ${REDUCETYPES} )
     configure_file( test-launch-basic-param-expt-reduce.cpp.in
                     test-launch-basic-param-expt-${REDUCETYPE}-${BACKEND}.cpp)
@@ -30,7 +29,6 @@ foreach( BACKEND ${LAUNCH_BACKENDS} )
     target_include_directories(test-launch-basic-param-expt-${REDUCETYPE}-${BACKEND}.exe
                                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
   endforeach()
-  endif()
 endforeach()
 
 unset( DATATYPES )
@@ -52,7 +50,6 @@ set(DATATYPES BitwiseReductionDataTypeList)
 # Note: LAUNCH_BACKENDS is defined in ../CMakeLists.txt
 #
 foreach( BACKEND ${LAUNCH_BACKENDS} )
-  if( NOT (BACKEND STREQUAL "Sycl"))
   foreach( REDUCETYPE ${REDUCETYPES} )
     configure_file( test-launch-basic-param-expt-reduce.cpp.in
                     test-launch-basic-param-expt-${REDUCETYPE}-${BACKEND}.cpp )
@@ -62,7 +59,6 @@ foreach( BACKEND ${LAUNCH_BACKENDS} )
     target_include_directories(test-launch-basic-param-expt-${REDUCETYPE}-${BACKEND}.exe
                                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
   endforeach()
-  endif()
 endforeach()
 
 unset( DATATYPES )


### PR DESCRIPTION
This PR adds sycl reducer support to RAJA::launch 

Interesting error when using more than 151 work-items: 
terminate called after throwing an instance of 'sycl::_V1::exception'
  what():  The implementation handling parallel_for with reduction requires work group size not bigger than 151

