### PR TITLE
fix unused variable warning

### DIFF
--- a/include/RAJA/policy/cuda/params/kernel_name.hpp
+++ b/include/RAJA/policy/cuda/params/kernel_name.hpp
@@ -1,8 +1,6 @@
 #ifndef CUDA_KERNELNAME_HPP
 #define CUDA_KERNELNAME_HPP
 
-//#include "../util/policy.hpp"
-
 #if defined(RAJA_CUDA_ACTIVE)
 
 #include <cuda.h>
@@ -19,6 +17,8 @@ namespace detail {
   {
 #if defined(RAJA_ENABLE_NV_TOOLS_EXT)
     nvtxRangePush(kn.name);
+#else
+    RAJA_UNUSED_VAR(kn);
 #endif
   }
 

--- a/include/RAJA/policy/hip/params/kernel_name.hpp
+++ b/include/RAJA/policy/hip/params/kernel_name.hpp
@@ -21,6 +21,8 @@ namespace detail {
   {
 #if defined(RAJA_ENABLE_ROCTX)
     roctxRangePush(kn.name);
+#else
+    RAJA_UNUSED_VAR(kn);
 #endif
   }
 


### PR DESCRIPTION
When not using ROCTX or NVTX we have to guard for an unused variable. 