### PR TITLE
Task/rhornung67/opm target ci

### DIFF
--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -46,10 +46,10 @@ gcc_8_3_1_cuda_11_5_0_ats_disabled:
     MODULE_LIST: "cuda/11.5.0"
     LASSEN_JOB_ALLOC: "1 --atsdisable -W 30 -q pci"
 
-clang_16_0_6_gcc_8_3_1_openmp_target:
+clang_16_0_6_ibm_gcc_8_3_1_openmp_target:
   extends: .job_on_lassen
   variables:
-    SPEC: " ~shared +openmp +tests %clang@=16.0.6.gcc.8.3.1 cuda_arch=70 cxxflags==\"-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda\" ^blt@develop"
+    SPEC: " ~shared +openmp +tests %clang@=16.0.6.ibm.gcc.8.3.1 cuda_arch=70 cxxflags==\"-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda\" ^blt@develop"
     MODULE_LIST: "cuda/11.2.0"
   allow_failure: true
 

--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -46,6 +46,13 @@ gcc_8_3_1_cuda_11_5_0_ats_disabled:
     MODULE_LIST: "cuda/11.5.0"
     LASSEN_JOB_ALLOC: "1 --atsdisable -W 30 -q pci"
 
+clang_16_0_6_gcc_8_3_1_openmp_target:
+  extends: .job_on_lassen
+  variables:
+    SPEC: " ~shared +openmp +tests %clang@=16.0.6.gcc.8.3.1 cuda_arch=70 cxxflags==\"-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda\" ^blt@develop"
+    MODULE_LIST: "cuda/11.2.0"
+  allow_failure: true
+
 ##########
 # OTHERS
 ##########

--- a/test/functional/kernel/hyperplane/CMakeLists.txt
+++ b/test/functional/kernel/hyperplane/CMakeLists.txt
@@ -13,7 +13,7 @@ set(TESTTYPES 2D 3D)
 foreach( BACKEND ${KERNEL_BACKENDS} )
   foreach( TEST_TYPE ${TESTTYPES} )
     # Removing Sycl backend, implementation of Hyperplane does not exist
-    if( NOT ((BACKEND STREQUAL "Sycl")) )
+    if( NOT ((BACKEND STREQUAL "Sycl")) AND NOT ((BACKEND STREQUAL "OpenMPTarget")) )
       configure_file( test-kernel-hyperplane-${TEST_TYPE}.cpp.in
                       test-kernel-hyperplane-${TEST_TYPE}-${BACKEND}.cpp )
       raja_add_test( NAME test-kernel-hyperplane-${TEST_TYPE}-${BACKEND}

--- a/test/functional/kernel/single-loop-tile-icount-tcount/CMakeLists.txt
+++ b/test/functional/kernel/single-loop-tile-icount-tcount/CMakeLists.txt
@@ -11,6 +11,10 @@
 set(TESTTYPES ForICount TileTCount)
 set(TILESIZES 8 32)
 
+if(RAJA_ENABLE_TARGET_OPENMP)
+  list(REMOVE_ITEM TESTTYPES ForICount)
+endif()
+
 #
 # Generate tests for each enabled RAJA back-end. 
 # 


### PR DESCRIPTION
# Summary

- This PR attempts to lunch a OpenMP target test job on lassen.
- It disables OpenMP target tests that generate internal compiler errors
- The code compiles with this compiler choice when run manually, so it should compile here.
- The new test jobs is allowed to fail when running tests.