### PR TITLE
Use c version of memcpy in device code

### DIFF
--- a/include/RAJA/util/TypeConvert.hpp
+++ b/include/RAJA/util/TypeConvert.hpp
@@ -26,6 +26,8 @@
 
 #include "RAJA/util/macros.hpp"
 
+#include <string.h>
+
 
 namespace RAJA
 {
@@ -42,7 +44,7 @@ RAJA_INLINE RAJA_HOST_DEVICE constexpr B reinterp_A_as_B(A const &a)
   static_assert(sizeof(A) == sizeof(B), "A and B must be the same size");
 
   B b;
-  std::memcpy(&b, &a, sizeof(A));
+  memcpy(&b, &a, sizeof(A));
   return b;
 }
 


### PR DESCRIPTION
Only the c version of memcpy is supported
in device code.
I'm not sure why this compiles in our tests.

# Summary

- This PR is a bugfix
- It does the following:
  - Fixes hip compile
