### PR TITLE
Fix compilation issue with intel-2024

### DIFF
--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -101,7 +101,10 @@ RAJA_INLINE T atomicMin(omp_atomic, T *acc, T value)
   #pragma omp atomic capture compare
   {
     old = *acc;
-    *acc = value < *acc ? value : *acc;
+    if ( value < *acc )
+    {
+      *acc = value;
+    }
   }
   return old;
 #else
@@ -120,7 +123,10 @@ RAJA_INLINE T atomicMax(omp_atomic, T *acc, T value)
   #pragma omp atomic capture compare
   {
     old = *acc;
-    *acc = *acc < value ? value : *acc;
+    if ( value > *acc )
+    {
+      *acc = value;
+    }
   }
   return old;
 #else


### PR DESCRIPTION
# Summary

- This PR is a bugfix.

While working to switch our Azure CI testing over to GitHub Actions and move to newer compiler images, I found that the Intel 2024 compiler does not like the ternary operator with some OpenMP clauses. This fixes the compilation error. Interestingly, intel 2022 and intel 2023 on LC systems don't have the issue.

@adayton1 whether to merge this is mainly your call.