### PR TITLE
Handle different SYCL header include locations.

### DIFF
--- a/include/RAJA/policy/sycl.hpp
+++ b/include/RAJA/policy/sycl.hpp
@@ -24,7 +24,7 @@
 
 #if defined(RAJA_SYCL_ACTIVE)
 
-#include <CL/sycl.hpp>
+#include "RAJA/util/sycl_compat.hpp"
 
 #include "RAJA/policy/sycl/forall.hpp"
 #include "RAJA/policy/sycl/policy.hpp"

--- a/include/RAJA/policy/sycl/MemUtils_SYCL.hpp
+++ b/include/RAJA/policy/sycl/MemUtils_SYCL.hpp
@@ -23,7 +23,7 @@
 
 #if defined(RAJA_ENABLE_SYCL)
 
-#include <CL/sycl.hpp>
+#include "RAJA/util/sycl_compat.hpp"
 
 #include <cassert>
 #include <cstddef>

--- a/include/RAJA/policy/sycl/forall.hpp
+++ b/include/RAJA/policy/sycl/forall.hpp
@@ -26,9 +26,10 @@
 
 #if defined(RAJA_ENABLE_SYCL)
 
-#include <CL/sycl.hpp>
 #include <algorithm>
 #include <chrono>
+
+#include "RAJA/util/sycl_compat.hpp"
 
 #include "RAJA/pattern/forall.hpp"
 

--- a/include/RAJA/policy/sycl/policy.hpp
+++ b/include/RAJA/policy/sycl/policy.hpp
@@ -22,7 +22,7 @@
 
 #if defined(RAJA_SYCL_ACTIVE)
 
-#include <CL/sycl.hpp>
+#include "RAJA/util/sycl_compat.hpp"
 
 #include "RAJA/policy/PolicyBase.hpp"
 #include "RAJA/policy/sequential/policy.hpp"

--- a/include/RAJA/util/sycl_compat.hpp
+++ b/include/RAJA/util/sycl_compat.hpp
@@ -1,0 +1,7 @@
+#if (__INTEL_CLANG_COMPILER && __INTEL_CLANG_COMPILER < 20230000)
+// older version, use legacy header locations
+#include <CL/sycl.hpp>
+#else
+// SYCL 2020 standard header
+#include <sycl/sycl.hpp>
+#endif


### PR DESCRIPTION
# Summary

- This PR makes the code able to handle potentially different locations of the main SYCL header file.
- It was borrowed from Umpire.