### PR TITLE
Missing GPU Info Headers in KernelName

### DIFF
--- a/include/RAJA/policy/cuda/params/kernel_name.hpp
+++ b/include/RAJA/policy/cuda/params/kernel_name.hpp
@@ -4,6 +4,7 @@
 #if defined(RAJA_CUDA_ACTIVE)
 
 #include <cuda.h>
+#include "RAJA/policy/cuda/MemUtils_CUDA.hpp"
 #include "RAJA/pattern/params/kernel_name.hpp"
 
 namespace RAJA {

--- a/include/RAJA/policy/hip/params/kernel_name.hpp
+++ b/include/RAJA/policy/hip/params/kernel_name.hpp
@@ -3,6 +3,7 @@
 
 #if defined(RAJA_HIP_ACTIVE)
 
+#include "RAJA/policy/hip/MemUtils_HIP.hpp"
 #include "RAJA/pattern/params/kernel_name.hpp"
 
 #if defined(RAJA_ENABLE_ROCTX)


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Adds missing GPU info headers.