### PR TITLE
Fix ub in multireduce tests

### DIFF
--- a/test/functional/forall/multi-reduce-basic/tests/test-forall-basic-MultiReduce.hpp
+++ b/test/functional/forall/multi-reduce-basic/tests/test-forall-basic-MultiReduce.hpp
@@ -73,13 +73,15 @@ ForallMultiReduceBasicTestImpl(const SEG_TYPE& seg,
     test_range[i] = ~IDX_TYPE(0);
   }
 
-  std::uniform_int_distribution<IDX_TYPE> work_per_iterate_distribution(0, num_bins);
+  {
+    std::uniform_int_distribution<IDX_TYPE> work_per_iterate_distribution(0, num_bins);
 
-  for (IDX_TYPE i = 0; i < idx_len; ++i) {
-    IDX_TYPE idx = seg_idx[i];
-    test_range[idx] = data_len;
-    data_len += work_per_iterate_distribution(rngen);
-    test_range[idx+1] = data_len;
+    for (IDX_TYPE i = 0; i < idx_len; ++i) {
+      IDX_TYPE idx = seg_idx[i];
+      test_range[idx] = data_len;
+      data_len += work_per_iterate_distribution(rngen);
+      test_range[idx+1] = data_len;
+    }
   }
 
   allocateForallTestData(data_len,
@@ -94,16 +96,19 @@ ForallMultiReduceBasicTestImpl(const SEG_TYPE& seg,
                          &check_bins,
                          &test_bins);
 
-  // use ints to initialize array here to avoid floating point precision issues
-  std::uniform_int_distribution<int> array_int_distribution(0, modval-1);
-  std::uniform_int_distribution<IDX_TYPE> bin_distribution(0, num_bins-1);
+  if (data_len > IDX_TYPE(0)) {
+
+    // use ints to initialize array here to avoid floating point precision issues
+    std::uniform_int_distribution<int> array_int_distribution(0, modval-1);
+    std::uniform_int_distribution<IDX_TYPE> bin_distribution(0, num_bins-1);
 
 
-  for (IDX_TYPE i = 0; i < data_len; ++i) {
-    test_array[i] = DATA_TYPE(array_int_distribution(rngen));
+    for (IDX_TYPE i = 0; i < data_len; ++i) {
+      test_array[i] = DATA_TYPE(array_int_distribution(rngen));
 
-    // this may use the same bin multiple times per iterate
-    test_bins[i] = bin_distribution(rngen);
+      // this may use the same bin multiple times per iterate
+      test_bins[i] = bin_distribution(rngen);
+    }
   }
 
   working_res.memcpy(working_range, test_range, sizeof(IDX_TYPE) * (idx_range+1));

--- a/test/functional/kernel/multi-reduce-nested/tests/test-kernel-nested-MultiReduce.hpp
+++ b/test/functional/kernel/multi-reduce-nested/tests/test-kernel-nested-MultiReduce.hpp
@@ -83,15 +83,17 @@ KernelMultiReduceNestedTestImpl(const SEGMENTS_TYPE& segments,
     test_range[i] = ~IDX_TYPE(0);
   }
 
-  std::uniform_int_distribution<IDX_TYPE> work_per_iterate_distribution(0, num_bins);
+  {
+    std::uniform_int_distribution<IDX_TYPE> work_per_iterate_distribution(0, num_bins);
 
-  for (IDX_TYPE k : sk) {
-    for (IDX_TYPE j : sj) {
-      for (IDX_TYPE i : si) {
-        IDX_TYPE ii = (dimi * dimj * k) + (dimi * j) + i;
-        test_range[ii] = data_len;
-        data_len += work_per_iterate_distribution(rngen);
-        test_range[ii+1] = data_len;
+    for (IDX_TYPE k : sk) {
+      for (IDX_TYPE j : sj) {
+        for (IDX_TYPE i : si) {
+          IDX_TYPE ii = (dimi * dimj * k) + (dimi * j) + i;
+          test_range[ii] = data_len;
+          data_len += work_per_iterate_distribution(rngen);
+          test_range[ii+1] = data_len;
+        }
       }
     }
   }
@@ -108,16 +110,19 @@ KernelMultiReduceNestedTestImpl(const SEGMENTS_TYPE& segments,
                          &check_bins,
                          &test_bins);
 
-  // use ints to initialize array here to avoid floating point precision issues
-  std::uniform_int_distribution<int> array_int_distribution(0, modval-1);
-  std::uniform_int_distribution<IDX_TYPE> bin_distribution(0, num_bins-1);
+  if (data_len > IDX_TYPE(0)) {
+
+    // use ints to initialize array here to avoid floating point precision issues
+    std::uniform_int_distribution<int> array_int_distribution(0, modval-1);
+    std::uniform_int_distribution<IDX_TYPE> bin_distribution(0, num_bins-1);
 
 
-  for (IDX_TYPE i = 0; i < data_len; ++i) {
-    test_array[i] = DATA_TYPE(array_int_distribution(rngen));
+    for (IDX_TYPE i = 0; i < data_len; ++i) {
+      test_array[i] = DATA_TYPE(array_int_distribution(rngen));
 
-    // this may use the same bin multiple times per iterate
-    test_bins[i] = bin_distribution(rngen);
+      // this may use the same bin multiple times per iterate
+      test_bins[i] = bin_distribution(rngen);
+    }
   }
 
   working_res.memcpy(working_range, test_range, sizeof(IDX_TYPE) * (idx_range+1));

--- a/test/functional/launch/multi-reduce-nested/tests/test-launch-nested-MultiReduce.hpp
+++ b/test/functional/launch/multi-reduce-nested/tests/test-launch-nested-MultiReduce.hpp
@@ -154,15 +154,17 @@ LaunchMultiReduceNestedTestImpl(const SEGMENTS_TYPE& segments,
     test_range[i] = ~IDX_TYPE(0);
   }
 
-  std::uniform_int_distribution<IDX_TYPE> work_per_iterate_distribution(0, num_bins);
+  {
+    std::uniform_int_distribution<IDX_TYPE> work_per_iterate_distribution(0, num_bins);
 
-  for (IDX_TYPE k : sk) {
-    for (IDX_TYPE j : sj) {
-      for (IDX_TYPE i : si) {
-        IDX_TYPE ii = (dimi * dimj * k) + (dimi * j) + i;
-        test_range[ii] = data_len;
-        data_len += work_per_iterate_distribution(rngen);
-        test_range[ii+1] = data_len;
+    for (IDX_TYPE k : sk) {
+      for (IDX_TYPE j : sj) {
+        for (IDX_TYPE i : si) {
+          IDX_TYPE ii = (dimi * dimj * k) + (dimi * j) + i;
+          test_range[ii] = data_len;
+          data_len += work_per_iterate_distribution(rngen);
+          test_range[ii+1] = data_len;
+        }
       }
     }
   }
@@ -179,16 +181,19 @@ LaunchMultiReduceNestedTestImpl(const SEGMENTS_TYPE& segments,
                          &check_bins,
                          &test_bins);
 
-  // use ints to initialize array here to avoid floating point precision issues
-  std::uniform_int_distribution<int> array_int_distribution(0, modval-1);
-  std::uniform_int_distribution<IDX_TYPE> bin_distribution(0, num_bins-1);
+  if (data_len > IDX_TYPE(0)) {
+
+    // use ints to initialize array here to avoid floating point precision issues
+    std::uniform_int_distribution<int> array_int_distribution(0, modval-1);
+    std::uniform_int_distribution<IDX_TYPE> bin_distribution(0, num_bins-1);
 
 
-  for (IDX_TYPE i = 0; i < data_len; ++i) {
-    test_array[i] = DATA_TYPE(array_int_distribution(rngen));
+    for (IDX_TYPE i = 0; i < data_len; ++i) {
+      test_array[i] = DATA_TYPE(array_int_distribution(rngen));
 
-    // this may use the same bin multiple times per iterate
-    test_bins[i] = bin_distribution(rngen);
+      // this may use the same bin multiple times per iterate
+      test_bins[i] = bin_distribution(rngen);
+    }
   }
 
   working_res.memcpy(working_range, test_range, sizeof(IDX_TYPE) * (idx_range+1));


### PR DESCRIPTION
# Fix ub in multireduce tests

This was causing tests on windows to fail.
It is undefined behavior to construct a uniform_int_distribution with min > max

- This PR is a bugfix,
- It does the following (modify list as needed):
  - Fixes ub in multireduce tests