### PR TITLE
add sphinx jquery extension to fix read-the-docs search

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,8 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.mathjax'
+    'sphinx.ext.mathjax',
+    'sphinxcontrib.jquery'
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
# Summary

I noticed the RAJA's read the docs search was not returning results. 

This PR adds `sphinxcontrib.jquery` to heal search, and approach that has worked on other projects. 
