### PR TITLE
Fix OpenMP Launch Mem Leak and Add Clang Sanitizer Build

### DIFF
--- a/host-configs/lc-builds/toss4/clang_X_asan.cmake
+++ b/host-configs/lc-builds/toss4/clang_X_asan.cmake
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2016-24, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+set(RAJA_COMPILER "RAJA_COMPILER_CLANG" CACHE STRING "")
+
+set(CMAKE_CXX_FLAGS_RELEASE "--gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1 -O3 -march=native -funroll-loops -finline-functions" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "--gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1 -O3 -g -march=native -funroll-loops -finline-functions" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_DEBUG "--gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1 -O0 -g -fsanitize=address -fno-omit-frame-pointer" CACHE STRING "")
+
+set(RAJA_HOST_CONFIG_LOADED On CACHE BOOL "")

--- a/host-configs/lc-builds/toss4/clang_X_asan.cmake
+++ b/host-configs/lc-builds/toss4/clang_X_asan.cmake
@@ -7,8 +7,8 @@
 
 set(RAJA_COMPILER "RAJA_COMPILER_CLANG" CACHE STRING "")
 
-set(CMAKE_CXX_FLAGS_RELEASE "--gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1 -O3 -march=native -funroll-loops -finline-functions" CACHE STRING "")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "--gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1 -O3 -g -march=native -funroll-loops -finline-functions" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELEASE "--gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1 -O3 -march=native -funroll-loops -finline-functions -fsanitize=address -fno-omit-frame-pointer" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "--gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1 -O3 -g -march=native -funroll-loops -finline-functions -fsanitize=address -fno-omit-frame-pointer" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_DEBUG "--gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1 -O0 -g -fsanitize=address -fno-omit-frame-pointer" CACHE STRING "")
 
 set(RAJA_HOST_CONFIG_LOADED On CACHE BOOL "")

--- a/host-configs/lc-builds/toss4/clang_X_ubsan.cmake
+++ b/host-configs/lc-builds/toss4/clang_X_ubsan.cmake
@@ -7,8 +7,8 @@
 
 set(RAJA_COMPILER "RAJA_COMPILER_CLANG" CACHE STRING "")
 
-set(CMAKE_CXX_FLAGS_RELEASE "--gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1 -O3 -march=native -funroll-loops -finline-functions" CACHE STRING "")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "--gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1 -O3 -g -march=native -funroll-loops -finline-functions" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELEASE "--gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1 -O3 -march=native -funroll-loops -finline-functions -fsanitize=undefined -fno-omit-frame-pointer -fsanitize=integer" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "--gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1 -O3 -g -march=native -funroll-loops -finline-functions -fsanitize=undefined -fno-omit-frame-pointer -fsanitize=integer" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_DEBUG "--gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1 -O0 -g -fsanitize=undefined -fno-omit-frame-pointer -fsanitize=integer" CACHE STRING "")
 
 set(RAJA_HOST_CONFIG_LOADED On CACHE BOOL "")

--- a/host-configs/lc-builds/toss4/clang_X_ubsan.cmake
+++ b/host-configs/lc-builds/toss4/clang_X_ubsan.cmake
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2016-24, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+set(RAJA_COMPILER "RAJA_COMPILER_CLANG" CACHE STRING "")
+
+set(CMAKE_CXX_FLAGS_RELEASE "--gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1 -O3 -march=native -funroll-loops -finline-functions" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "--gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1 -O3 -g -march=native -funroll-loops -finline-functions" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_DEBUG "--gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1 -O0 -g -fsanitize=undefined -fno-omit-frame-pointer -fsanitize=integer" CACHE STRING "")
+
+set(RAJA_HOST_CONFIG_LOADED On CACHE BOOL "")

--- a/include/RAJA/policy/openmp/launch.hpp
+++ b/include/RAJA/policy/openmp/launch.hpp
@@ -77,6 +77,9 @@ struct LaunchExecute<RAJA::omp_launch_t> {
       ctx.shared_mem_ptr = (char*) malloc(launch_params.shared_mem_size);
 
       expt::invoke_body(f_params, loop_body.get_priv(), ctx);
+
+      free(ctx.shared_mem_ptr);
+      ctx.shared_mem_ptr = nullptr;
     }
 
     expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
@@ -97,6 +100,7 @@ struct LoopExecute<omp_parallel_for_exec, SEGMENT> {
       BODY const &body)
   {
 
+    printf( "RCC omp_parallel_for_exec 1\n" );
     int len = segment.end() - segment.begin();
     RAJA::region<RAJA::omp_parallel_region>([&]() {
       using RAJA::internal::thread_privatize;
@@ -116,6 +120,7 @@ struct LoopExecute<omp_parallel_for_exec, SEGMENT> {
       BODY const &body)
   {
 
+    printf( "RCC omp_parallel_for_exec 2\n" );
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
 
@@ -143,6 +148,7 @@ struct LoopExecute<omp_parallel_for_exec, SEGMENT> {
       BODY const &body)
   {
 
+    printf( "RCC omp_parallel_for_exec 3\n" );
     const int len2 = segment2.end() - segment2.begin();
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
@@ -175,6 +181,7 @@ struct LoopExecute<omp_for_exec, SEGMENT> {
       BODY const &body)
   {
 
+    //printf( "RCC omp_for_exec 1\n" );
     int len = segment.end() - segment.begin();
 #pragma omp for
     for (int i = 0; i < len; i++) {
@@ -191,6 +198,7 @@ struct LoopExecute<omp_for_exec, SEGMENT> {
       BODY const &body)
   {
 
+    printf( "RCC omp_for_exec 2\n" );
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
 
@@ -212,6 +220,7 @@ struct LoopExecute<omp_for_exec, SEGMENT> {
       BODY const &body)
   {
 
+    printf( "RCC omp_for_exec 3\n" );
     const int len2 = segment2.end() - segment2.begin();
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
@@ -242,6 +251,7 @@ struct LoopICountExecute<omp_for_exec, SEGMENT> {
       BODY const &body)
   {
 
+    printf( "RCC omp_for_exec icount 1\n" );
     int len = segment.end() - segment.begin();
 
 #pragma omp for
@@ -258,6 +268,7 @@ struct LoopICountExecute<omp_for_exec, SEGMENT> {
       BODY const &body)
   {
 
+    printf( "RCC omp_for_exec icount 2\n" );
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
 
@@ -282,6 +293,7 @@ struct LoopICountExecute<omp_for_exec, SEGMENT> {
       BODY const &body)
   {
 
+    printf( "RCC omp_for_exec icount 3\n" );
     const int len2 = segment2.end() - segment2.begin();
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
@@ -316,6 +328,7 @@ struct LoopExecute<omp_parallel_nested_for_exec, SEGMENT> {
       BODY const &body)
   {
 
+    printf( "RCC omp_parallel_nested_for_exec 1\n" );
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
 
@@ -343,6 +356,7 @@ struct LoopExecute<omp_parallel_nested_for_exec, SEGMENT> {
       BODY const &body)
   {
 
+    printf( "RCC omp_parallel_nested_for_exec 2\n" );
     const int len2 = segment2.end() - segment2.begin();
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
@@ -377,6 +391,7 @@ struct LoopICountExecute<omp_parallel_nested_for_exec, SEGMENT> {
       BODY const &body)
   {
 
+    printf( "RCC omp_parallel_nested_for_exec icount 1\n" );
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
 
@@ -406,6 +421,7 @@ struct LoopICountExecute<omp_parallel_nested_for_exec, SEGMENT> {
       BODY const &body)
   {
 
+    printf( "RCC omp_parallel_nested_for_exec icount 2\n" );
     const int len2 = segment2.end() - segment2.begin();
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
@@ -443,6 +459,7 @@ struct TileExecute<omp_parallel_for_exec, SEGMENT> {
       BODY const &body)
   {
 
+    printf( "RCC omp_parallel_for_exec tile 1\n" );
     int len = segment.end() - segment.begin();
 
     RAJA::region<RAJA::omp_parallel_region>([&]() {
@@ -468,6 +485,7 @@ struct TileTCountExecute<omp_parallel_for_exec, SEGMENT> {
       BODY const &body)
   {
 
+    printf( "RCC omp_parallel_for_exec tile 2\n" );
     const int len = segment.end() - segment.begin();
     const int numTiles = (len - 1) / tile_size + 1;
 
@@ -495,6 +513,7 @@ struct TileExecute<omp_for_exec, SEGMENT> {
       BODY const &body)
   {
 
+    printf( "RCC omp_for_exec tile seg 1\n" );
     int len = segment.end() - segment.begin();
 #pragma omp for
     for (int i = 0; i < len; i += tile_size) {
@@ -514,6 +533,7 @@ struct TileTCountExecute<omp_for_exec, SEGMENT> {
       BODY const &body)
   {
 
+    printf( "RCC omp_for_exec tile tcount seg 1\n" );
     const int len = segment.end() - segment.begin();
     const int numTiles = (len - 1) / tile_size + 1;
 

--- a/include/RAJA/policy/openmp/launch.hpp
+++ b/include/RAJA/policy/openmp/launch.hpp
@@ -100,7 +100,6 @@ struct LoopExecute<omp_parallel_for_exec, SEGMENT> {
       BODY const &body)
   {
 
-    printf( "RCC omp_parallel_for_exec 1\n" );
     int len = segment.end() - segment.begin();
     RAJA::region<RAJA::omp_parallel_region>([&]() {
       using RAJA::internal::thread_privatize;
@@ -120,7 +119,6 @@ struct LoopExecute<omp_parallel_for_exec, SEGMENT> {
       BODY const &body)
   {
 
-    printf( "RCC omp_parallel_for_exec 2\n" );
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
 
@@ -148,7 +146,6 @@ struct LoopExecute<omp_parallel_for_exec, SEGMENT> {
       BODY const &body)
   {
 
-    printf( "RCC omp_parallel_for_exec 3\n" );
     const int len2 = segment2.end() - segment2.begin();
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
@@ -181,7 +178,6 @@ struct LoopExecute<omp_for_exec, SEGMENT> {
       BODY const &body)
   {
 
-    //printf( "RCC omp_for_exec 1\n" );
     int len = segment.end() - segment.begin();
 #pragma omp for
     for (int i = 0; i < len; i++) {
@@ -198,7 +194,6 @@ struct LoopExecute<omp_for_exec, SEGMENT> {
       BODY const &body)
   {
 
-    printf( "RCC omp_for_exec 2\n" );
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
 
@@ -220,7 +215,6 @@ struct LoopExecute<omp_for_exec, SEGMENT> {
       BODY const &body)
   {
 
-    printf( "RCC omp_for_exec 3\n" );
     const int len2 = segment2.end() - segment2.begin();
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
@@ -251,7 +245,6 @@ struct LoopICountExecute<omp_for_exec, SEGMENT> {
       BODY const &body)
   {
 
-    printf( "RCC omp_for_exec icount 1\n" );
     int len = segment.end() - segment.begin();
 
 #pragma omp for
@@ -268,7 +261,6 @@ struct LoopICountExecute<omp_for_exec, SEGMENT> {
       BODY const &body)
   {
 
-    printf( "RCC omp_for_exec icount 2\n" );
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
 
@@ -293,7 +285,6 @@ struct LoopICountExecute<omp_for_exec, SEGMENT> {
       BODY const &body)
   {
 
-    printf( "RCC omp_for_exec icount 3\n" );
     const int len2 = segment2.end() - segment2.begin();
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
@@ -328,7 +319,6 @@ struct LoopExecute<omp_parallel_nested_for_exec, SEGMENT> {
       BODY const &body)
   {
 
-    printf( "RCC omp_parallel_nested_for_exec 1\n" );
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
 
@@ -356,7 +346,6 @@ struct LoopExecute<omp_parallel_nested_for_exec, SEGMENT> {
       BODY const &body)
   {
 
-    printf( "RCC omp_parallel_nested_for_exec 2\n" );
     const int len2 = segment2.end() - segment2.begin();
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
@@ -391,7 +380,6 @@ struct LoopICountExecute<omp_parallel_nested_for_exec, SEGMENT> {
       BODY const &body)
   {
 
-    printf( "RCC omp_parallel_nested_for_exec icount 1\n" );
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
 
@@ -421,7 +409,6 @@ struct LoopICountExecute<omp_parallel_nested_for_exec, SEGMENT> {
       BODY const &body)
   {
 
-    printf( "RCC omp_parallel_nested_for_exec icount 2\n" );
     const int len2 = segment2.end() - segment2.begin();
     const int len1 = segment1.end() - segment1.begin();
     const int len0 = segment0.end() - segment0.begin();
@@ -459,7 +446,6 @@ struct TileExecute<omp_parallel_for_exec, SEGMENT> {
       BODY const &body)
   {
 
-    printf( "RCC omp_parallel_for_exec tile 1\n" );
     int len = segment.end() - segment.begin();
 
     RAJA::region<RAJA::omp_parallel_region>([&]() {
@@ -485,7 +471,6 @@ struct TileTCountExecute<omp_parallel_for_exec, SEGMENT> {
       BODY const &body)
   {
 
-    printf( "RCC omp_parallel_for_exec tile 2\n" );
     const int len = segment.end() - segment.begin();
     const int numTiles = (len - 1) / tile_size + 1;
 
@@ -513,7 +498,6 @@ struct TileExecute<omp_for_exec, SEGMENT> {
       BODY const &body)
   {
 
-    printf( "RCC omp_for_exec tile seg 1\n" );
     int len = segment.end() - segment.begin();
 #pragma omp for
     for (int i = 0; i < len; i += tile_size) {
@@ -533,7 +517,6 @@ struct TileTCountExecute<omp_for_exec, SEGMENT> {
       BODY const &body)
   {
 
-    printf( "RCC omp_for_exec tile tcount seg 1\n" );
     const int len = segment.end() - segment.begin();
     const int numTiles = (len - 1) / tile_size + 1;
 

--- a/scripts/lc-builds/toss4_clang_san.sh
+++ b/scripts/lc-builds/toss4_clang_san.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2016-24, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+if [ "$1" == "" ]; then
+  echo
+  echo "You must pass 2 arguments to the script (in this order): "
+  echo "    1) compiler version number for clang"
+  echo "    2) sanitizer version (one of 2 options: asan, or ubsan)"
+  echo
+  echo "For example: "
+  echo "    toss4_clang.sh 14.0.6-magic asan"
+  exit
+fi
+
+COMP_VER=$1
+SAN_VER=$2
+shift 2
+
+if [[ ( ${SAN_VER} != "asan" ) && ( ${SAN_VER} != "ubsan" ) ]] ; then
+  echo "Sanitizer version must be \"asan\" or \"ubsan\". Exiting!" ; exit
+fi
+
+BUILD_SUFFIX=lc_toss4-clang-${COMP_VER}-${SAN_VER}
+
+echo
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
+echo
+
+rm -rf build_${BUILD_SUFFIX} 2>/dev/null
+mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
+
+module load cmake/3.23.1
+
+cmake \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DCMAKE_CXX_COMPILER=/usr/tce/packages/clang/clang-${COMP_VER}/bin/clang++ \
+  -DBLT_CXX_STD=c++14 \
+  -C ../host-configs/lc-builds/toss4/clang_X_${SAN_VER}.cmake \
+  -DENABLE_OPENMP=On \
+  -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
+  "$@" \
+  ..
+
+if [[ ( ${SAN_VER} = "ubsan" ) ]] ; then
+  echo "To view ubsan output, set the following environment variable: "
+  echo "    UBSAN_OPTIONS=log_path=/path/to/ubsan_log_prefix"
+  echo
+  echo "Each test will create a ubsan output file with the prefix \"ubsan_log_prefix\"."
+fi

--- a/scripts/lc-builds/toss4_icpc-classic.sh
+++ b/scripts/lc-builds/toss4_icpc-classic.sh
@@ -55,6 +55,6 @@ echo
 echo "  Please note that you may need to add some intel openmp libraries to your"
 echo "  LD_LIBRARY_PATH to run with openmp."
 echo
-echo "    LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/tce/packages/intel/intel-${COMP_VER}/compiler/lib/intel64_lin"
+echo "    LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/tce/packages/intel-classic/intel-classic-${COMP_VER}/compiler/lib/intel64_lin"
 echo
 echo "***********************************************************************"

--- a/scripts/lc-builds/toss4_icpx.sh
+++ b/scripts/lc-builds/toss4_icpx.sh
@@ -39,8 +39,8 @@ source /usr/tce/packages/intel/intel-${COMP_VER}/setvars.sh
 
 cmake \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CXX_COMPILER=/usr/tce/packages/intel/intel-${COMP_VER}/compiler/${COMP_VER}/linux/bin/icpx \
-  -DCMAKE_C_COMPILER=/usr/tce/packages/intel/intel-${COMP_VER}/compiler/${COMP_VER}/linux/bin/icx \
+  -DCMAKE_CXX_COMPILER=/usr/tce/packages/intel/intel-${COMP_VER}/bin/icpx \
+  -DCMAKE_C_COMPILER=/usr/tce/packages/intel/intel-${COMP_VER}/bin/icx \
   -DBLT_CXX_STD=c++14 \
   -C ../host-configs/lc-builds/toss4/icpx_X.cmake \
   -DRAJA_ENABLE_FORCEINLINE_RECURSIVE=Off \


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Fixes memory leak in the Launch OpenMP backend. Memory leak was found via clang ASAN.
  - Updates some Intel build scripts.
  - Adds build script for clang's ASAN and UBSAN sanitizers on TOSS4. 

- Note: Does _not_ fix the OpenMP Launch reduction tests. Will iterate with LC on those.