### PR TITLE
New Reducer ValOp Interface

### DIFF
--- a/docs/sphinx/user_guide/feature/reduction.rst
+++ b/docs/sphinx/user_guide/feature/reduction.rst
@@ -374,7 +374,7 @@ data types and operators, and order of the ``ValOp`` parameters must match
 the corresponding ``RAJA::expt::Reduce`` types to get correct results and to
 compile successfully. Otherwise, a static assertion will be triggered::
 
-  LAMBDA Not invocable w/ EXPECTED_ARGS.
+  LAMBDA Not invocable w/ EXPECTED_ARGS. Ordering and types must match between RAJA::expt::Reduce() and ValOp arguments.
 
 .. note:: This static assert is only enabled when passing an undecorated C++
           lambda. Meaning, this check will not happen when passing

--- a/docs/sphinx/user_guide/feature/reduction.rst
+++ b/docs/sphinx/user_guide/feature/reduction.rst
@@ -222,8 +222,8 @@ RAJA::expt::Reduce
   on the underlying data type (``double`` for ``_rs`` and ``_rm``), and the operator
   being used. It is important to note that the parameters follow the kernel iteration
   variable, ``i`` in this case, and appear in the same order as the corresponding
-  ``RAJA::expt::Reduce`` arguments to ``RAJA::forall``. The parameter types must be
-  references to the types used in the ``RAJA::expt::Reduce`` arguments.
+  ``RAJA::expt::Reduce`` arguments to ``RAJA::forall``. The ``ValOp`` parameters must
+  be references to the objects instantiated by the ``RAJA::expt::Reduce`` arguments.
 * The local variables referred to by ``_rs`` and ``_rm`` are initialized with
   the *identity* of the reduction operation to be performed.
 * The local variables are updated in the user supplied lambda.

--- a/docs/sphinx/user_guide/feature/reduction.rst
+++ b/docs/sphinx/user_guide/feature/reduction.rst
@@ -263,7 +263,7 @@ methods to access the reduction results.
 In the kernel body lambda expression, a ``ValLoc<T,I>`` must be wrapped in a
 ``ValOp``, and passed to the lambda in the same order as the corresponding 
 ``RAJA::expt::Reduce`` arguments, e.g. ``ValOp<ValLoc<T,I>, Op>``.
-For convenience, the alias of ``RAJA::expt::ValLocOp<T,I,Op>`` can be used.
+For convenience, an alias of ``RAJA::expt::ValLocOp<T,I,Op>`` is provided.
 Within the lambda, this ``ValLocOp`` object provides ``minloc``, and ``maxloc``
 functions::
 
@@ -271,7 +271,7 @@ functions::
 
   using VALOPLOC_DOUBLE_MIN = RAJA::expt::ValOp<ValLoc<double, RAJA::Index_type>,
                                                        RAJA::operators::minimum>;
-  using VALOPLOC_DOUBLE_MAX = RAJA::expt::ValOpLoc<double, RAJA::Index_type,
+  using VALOPLOC_DOUBLE_MAX = RAJA::expt::ValLocOp<double, RAJA::Index_type,
                                                    RAJA::operators::minimum>;
 
   using VL_DOUBLE = RAJA::expt::ValLoc<double>;
@@ -302,7 +302,7 @@ the forall directly without ``getVal()`` or ``getLoc()`` functions.
 
   double* a = ...;
 
-  using VALOPLOC_DOUBLE_MIN = RAJA::expt::ValOpLoc<double, RAJA::Index_type,
+  using VALOPLOC_DOUBLE_MIN = RAJA::expt::ValLocOp<double, RAJA::Index_type,
                                                    RAJA::operators::minimum>;
 
   // No ValLoc needed from the user here.

--- a/docs/sphinx/user_guide/feature/reduction.rst
+++ b/docs/sphinx/user_guide/feature/reduction.rst
@@ -190,6 +190,9 @@ RAJA::expt::Reduce
 ..................
 ::
 
+  using VALOP_DOUBLE_SUM = RAJA::expt::ValOp<double, RAJA::operators::plus>;
+  using VALOP_DOUBLE_MIN = RAJA::expt::ValOp<double, RAJA::operators::minimum>;
+
   double* a = ...;
 
   double rs = 0.0;
@@ -198,9 +201,9 @@ RAJA::expt::Reduce
   RAJA::forall<EXEC_POL> ( Res, Seg,
   RAJA::expt::Reduce<RAJA::operators::plus>(&rs),
   RAJA::expt::Reduce<RAJA::operators::minimum>(&rm),
-  [=] (int i, double& _rs, double& _rm) {
+  [=] (int i, VALOP_DOUBLE_SUM& _rs, VALOP_DOUBLE_MIN& _rm) {
     _rs += a[i];
-    _rm = RAJA_MIN(a[i], _rm);
+    _rm.min(a[i]);
   }
   );
 
@@ -213,13 +216,14 @@ RAJA::expt::Reduce
   above. The reduction operation will include the existing value of
   the given target variable.
 * The kernel body lambda expression passed to ``RAJA::forall`` must have a
-  parameter corresponding to each ``RAJA::expt::Reduce`` argument, ``_rs`` and
-  ``_rm`` in the example code. These parameters refer to a local target for each
-  reduction operation. It is important to note that the parameters follow the
-  kernel iteration variable, ``i`` in this case, and appear in the same order
-  as the corresponding ``RAJA::expt::Reduce`` arguments to ``RAJA::forall``. The
-  parameter types must be references to the types used in the
-  ``RAJA::expt::Reduce`` arguments.
+  ``RAJA::expt::ValOp`` parameter corresponding to each ``RAJA::expt::Reduce``
+  argument, ``_rs`` and ``_rm`` in the example code. These parameters refer to a
+  local target for each reduction operation. Each ``ValOp`` needs to be templated
+  on the underlying data type (``double`` for ``_rs`` and ``_rm``), and the operator
+  being used. It is important to note that the parameters follow the kernel iteration
+  variable, ``i`` in this case, and appear in the same order as the corresponding
+  ``RAJA::expt::Reduce`` arguments to ``RAJA::forall``. The parameter types must be
+  references to the types used in the ``RAJA::expt::Reduce`` arguments.
 * The local variables referred to by ``_rs`` and ``_rm`` are initialized with
   the *identity* of the reduction operation to be performed.
 * The local variables are updated in the user supplied lambda.
@@ -236,10 +240,11 @@ RAJA::expt::Reduce
           compatible with the ``EXEC_POL``. ``Seg`` is the iteration space
           object for ``RAJA::forall``.
 
-.. important:: The order and types of the local reduction variables in the
-               kernel body lambda expression must match exactly with the
-               corresponding ``RAJA::expt::Reduce`` arguments to the
-               ``RAJA::forall`` to ensure that the correct result is obtained.
+.. important:: The order of the local reduction variables in the
+               kernel body lambda expression must be ``RAJA::expt::ValOp``s which
+               match exactly in the underlying reduction data type, and RAJA
+               operator, with the corresponding ``RAJA::expt::Reduce`` arguments
+               to the ``RAJA::forall`` to ensure that the correct result is obtained.
 
 RAJA::expt::ValLoc
 ..................
@@ -247,27 +252,61 @@ RAJA::expt::ValLoc
 As with the current RAJA reduction interface, the new interface supports *loc*
 reductions, which provide the ability to get a kernel/loop index at which the
 final reduction value was found. With this new interface, *loc* reductions
-are performed using ``ValLoc<T>`` types. Since they are strongly typed, they
-provide ``min()`` and ``max()`` operations that are equivalent to using
-``RAJA_MIN()`` or ``RAJA_MAX`` macros as demonstrated in the code example below.
-Users must use the ``getVal()`` and ``getLoc()`` methods to access the reduction
-results::
+are performed using ``ValLoc<T,I>`` types, where ``T`` is the underlying data type,
+and ``I`` is the index type. Users must use the ``getVal()`` and ``getLoc()``
+methods to access the reduction results.
+
+In the kernel body lambda expression, a ``ValLoc<T,I>`` must be wrapped in a
+``ValOp``, and passed to the lambda in the same order as the corresponding 
+``RAJA::expt::Reduce`` arguments, e.g. ``ValOp<ValLoc<T,I>, minimum>``.
+For convenience, the alias of ``RAJA::expt::ValLocOp<T,I,Op>`` can be used.
+Within the lambda, this ``ValLocOp`` object provides ``minloc``, and ``maxloc``
+functions::
 
   double* a = ...;
+
+  using VALOPLOC_DOUBLE_MIN = RAJA::expt::ValOp<ValLoc<double, RAJA::Index_type>,
+                                                       RAJA::expt::minimum>;
 
   using VL_DOUBLE = RAJA::expt::ValLoc<double>;
   VL_DOUBLE rm_loc;
 
   RAJA::forall<EXEC_POL> ( Res, Seg,
   RAJA::expt::Reduce<RAJA::operators::minimum>(&rm_loc),
-  [=] (int i, VL_DOUBLE& _rm_loc) {
-    _rm_loc = RAJA_MIN(VL_DOUBLE(a[i], i), _rm_loc);
-    //_rm_loc.min(VL_DOUBLE(a[i], i)); // Alternative to RAJA_MIN
+  [=] (int i, VALOPLOC_DOUBLE_MIN& _rm_loc) {
+    _rm_loc.minloc(a[i], i);
   }
   );
 
   std::cout << rm_loc.getVal() ...
   std::cout << rm_loc.getLoc() ...
+
+Alternatively, *loc* reductions can be performed on separate reduction data, and
+location variables without a ``ValLoc``. The change required is to pass
+a ``RAJA::expt::ReduceLoc`` argument to the forall, templated on the reduction
+operation, and passing in references to the data and location in that respective
+order. The data and location can be accessed outside for the forall directly
+without ``getVal()`` or ``getLoc()`` functions.
+:: 
+
+  double* a = ...;
+
+  using VALOPLOC_DOUBLE_MIN = RAJA::expt::ValOp<ValLoc<double, RAJA::Index_type>,
+                                                       RAJA::expt::minimum>;
+
+  double rm;
+  RAJA::Index_type loc;
+
+  RAJA::forall<EXEC_POL> ( Res, Seg,
+  RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&rm, &loc),
+  [=] (int i, VALOPLOC_DOUBLE_MIN& _rm_loc) {
+    _rm_loc.minloc(a[i], i);
+  }
+  );
+
+  std::cout << rm ...
+  std::cout << loc ...
+
 
 Lambda Arguments
 ................
@@ -276,6 +315,10 @@ This interface takes advantage of C++ parameter packs to allow users to pass
 any number of ``RAJA::expt::Reduce`` objects to the ``RAJA::forall`` method::
 
   double* a = ...;
+
+  using VALOP_DOUBLE_SUM = RAJA::expt::ValOp<double, RAJA::operators::plus>;
+  using VALOP_DOUBLE_MIN = RAJA::expt::ValOp<double, RAJA::operators::minimum>;
+  using VALOPLOC_DOUBLE_MIN = RAJA::expt::ValLocOp<double, RAJA::Index_type, RAJA::operators::minimum>;
 
   using VL_DOUBLE = RAJA::expt::ValLoc<double>;
   VL_DOUBLE rm_loc;
@@ -287,10 +330,13 @@ any number of ``RAJA::expt::Reduce`` objects to the ``RAJA::forall`` method::
     RAJA::expt::Reduce<RAJA::operators::minimum>(&rm),     // --> 1 double added
     RAJA::expt::Reduce<RAJA::operators::minimum>(&rm_loc), // --> 1 VL_DOUBLE added
     RAJA::expt::KernelName("MyFirstRAJAKernel"),           // --> NO args added
-    [=] (int i, double& _rs, double& _rm, VL_DOUBLE& _rm_loc) {
+    [=] (int i,
+         VALOP_DOUBLE_SUM& _rs,
+         VALOP_DOUBLE_MIN& _rm,
+         VALOPLOC_DOUBLE_MIN& _rm_loc) {
       _rs += a[i];
-      _rm = RAJA_MIN(a[i], _rm);
-      _rm_loc.min(VL_DOUBLE(a[i], i));
+      _rm.min(a[i]);
+      _rm_loc.minloc(a[i], i);
     }
   );
 
@@ -300,9 +346,10 @@ any number of ``RAJA::expt::Reduce`` objects to the ``RAJA::forall`` method::
   std::cout << rm_loc.getLoc() ...
 
 Again, the lambda expression parameters are in the same order as
-the ``RAJA::expt::Reduce`` arguments to ``RAJA::forall``. Both the types and
-order of the parameters must match to get correct results and to compile
-successfully. Otherwise, a static assertion will be triggered::
+the ``RAJA::expt::Reduce`` arguments to ``RAJA::forall``. The ``ValOp`` underlying
+data types and operators, and order of the ``ValOp`` parameters must match 
+the corresponding ``RAJA::expt::Reduce`` types to get correct results and to
+compile successfully. Otherwise, a static assertion will be triggered::
 
   LAMBDA Not invocable w/ EXPECTED_ARGS.
 
@@ -329,6 +376,9 @@ The usage of the experiemental reductions is similar to the forall example as il
 
   double* a = ...;
 
+  using VALOP_DOUBLE_SUM = RAJA::expt::ValOp<double, RAJA::operators::plus>;
+  using VALOP_DOUBLE_MIN = RAJA::expt::ValOp<double, RAJA::operators::minimum>;
+
   double rs = 0.0;
   double rm = 1e100;
 
@@ -336,12 +386,12 @@ The usage of the experiemental reductions is similar to the forall example as il
     RAJA::expt::Reduce<RAJA::operators::plus>(&rs),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&rm),
     "LaunchReductionKernel",
-    [=] RAJA_HOST_DEVICE (int i, double& _rs, double& _rm) {
+    [=] RAJA_HOST_DEVICE (int i, VALOP_DOUBLE_SUM& _rs, VALOP_DOUBLE_MIN& _rm) {
 
       RAJA::loop<loop_pol>(ctx, Seg, [&] (int i) {
 
         _rs += a[i];
-        _rm = RAJA_MIN(a[i], _rm);
+        _rm.min(a[i], _rm);
 
         }
       );

--- a/docs/sphinx/user_guide/feature/reduction.rst
+++ b/docs/sphinx/user_guide/feature/reduction.rst
@@ -241,7 +241,7 @@ RAJA::expt::Reduce
           object for ``RAJA::forall``.
 
 .. important:: The order of the local reduction variables in the
-               kernel body lambda expression must be ``RAJA::expt::ValOp``s which
+               kernel body lambda expression must ``RAJA::expt::ValOp`` objects which
                match exactly in the underlying reduction data type, and RAJA
                operator, with the corresponding ``RAJA::expt::Reduce`` arguments
                to the ``RAJA::forall`` to ensure that the correct result is obtained.

--- a/examples/forall-param-reductions.cpp
+++ b/examples/forall-param-reductions.cpp
@@ -129,14 +129,21 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   VALLOC_INT seq_minloc(std::numeric_limits<int>::max(), -1);
   VALLOC_INT seq_maxloc(std::numeric_limits<int>::min(), -1);
 
+  int seq_min2 = std::numeric_limits<int>::max();
+  int seq_max2 = std::numeric_limits<int>::min();
+  RAJA::Index_type seq_minloc2(-1);
+  RAJA::Index_type seq_maxloc2(-1);
+
   RAJA::forall<EXEC_POL1>(host_res, arange,
     RAJA::expt::Reduce<RAJA::operators::plus>(&seq_sum),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&seq_min),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&seq_max),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&seq_minloc),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&seq_maxloc),
+    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&seq_min2, &seq_minloc2),
+    RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&seq_max2, &seq_maxloc2),
     RAJA::expt::KernelName("RAJA Reduce Seq Kernel"),
-    [=](int i, REF_INT_SUM &_seq_sum, REF_INT_MIN &_seq_min, REF_INT_MAX &_seq_max, REFLOC_INT_MIN &_seq_minloc, REFLOC_INT_MAX &_seq_maxloc) {
+    [=](int i, REF_INT_SUM &_seq_sum, REF_INT_MIN &_seq_min, REF_INT_MAX &_seq_max, REFLOC_INT_MIN &_seq_minloc, REFLOC_INT_MAX &_seq_maxloc, REFLOC_INT_MIN &_seq_minloc2, REFLOC_INT_MAX &_seq_maxloc2) {
       _seq_sum += a[i];
 
       _seq_min.min(a[i]);
@@ -144,6 +151,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
       _seq_minloc.minloc(a[i], i);
       _seq_maxloc.maxloc(a[i], i);
+
+      _seq_minloc2.minloc(a[i], i);
+      _seq_maxloc2.maxloc(a[i], i);
     }
   );
 
@@ -154,6 +164,10 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
                                << seq_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << seq_maxloc.getVal() << " , "
                                << seq_maxloc.getLoc() << std::endl;
+  std::cout << "\tmin2, loc2 = "  << seq_min2 << " , "
+                                  << seq_minloc2 << std::endl;
+  std::cout << "\tmax2, loc2 = "  << seq_max2 << " , "
+                                  << seq_maxloc2 << std::endl;
   // _reductions_raja_seq_end
 
 
@@ -172,14 +186,21 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   VALLOC_INT omp_minloc(std::numeric_limits<int>::max(), -1);
   VALLOC_INT omp_maxloc(std::numeric_limits<int>::min(), -1);
 
+  int omp_min2 = std::numeric_limits<int>::max();
+  int omp_max2 = std::numeric_limits<int>::min();
+  RAJA::Index_type omp_minloc2(-1);
+  RAJA::Index_type omp_maxloc2(-1);
+
   RAJA::forall<EXEC_POL2>(host_res, arange,
     RAJA::expt::Reduce<RAJA::operators::plus>(&omp_sum),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&omp_min),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&omp_max),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&omp_minloc),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&omp_maxloc),
+    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&omp_min2, &omp_minloc2),
+    RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&omp_max2, &omp_maxloc2),
     RAJA::expt::KernelName("RAJA Reduce OpenMP Kernel"),
-    [=](int i, REF_INT_SUM &_omp_sum, REF_INT_MIN &_omp_min, REF_INT_MAX &_omp_max, REFLOC_INT_MIN &_omp_minloc, REFLOC_INT_MAX &_omp_maxloc) {
+    [=](int i, REF_INT_SUM &_omp_sum, REF_INT_MIN &_omp_min, REF_INT_MAX &_omp_max, REFLOC_INT_MIN &_omp_minloc, REFLOC_INT_MAX &_omp_maxloc, REFLOC_INT_MIN &_omp_minloc2, REFLOC_INT_MAX &_omp_maxloc2) {
       _omp_sum += a[i];
 
       _omp_min.min(a[i]);
@@ -187,6 +208,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
       _omp_minloc.minloc(a[i], i);
       _omp_maxloc.maxloc(a[i], i);
+
+      _omp_minloc2.minloc(a[i], i);
+      _omp_maxloc2.maxloc(a[i], i);
     }
   );
 
@@ -197,6 +221,10 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
                                << omp_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << omp_maxloc.getVal() << " , "
                                << omp_maxloc.getLoc() << std::endl;
+  std::cout << "\tmin2, loc2 = "  << omp_min2 << " , "
+                                  << omp_minloc2 << std::endl;
+  std::cout << "\tmax2, loc2 = "  << omp_max2 << " , "
+                                  << omp_maxloc2 << std::endl;
 
 #endif
 
@@ -217,14 +245,21 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   VALLOC_INT omp_t_minloc(std::numeric_limits<int>::max(), -1);
   VALLOC_INT omp_t_maxloc(std::numeric_limits<int>::min(), -1);
 
+  int omp_t_min2 = std::numeric_limits<int>::max();
+  int omp_t_max2 = std::numeric_limits<int>::min();
+  RAJA::Index_type omp_t_minloc2(-1);
+  RAJA::Index_type omp_t_maxloc2(-1);
+
   RAJA::forall<EXEC_POL3>(omp_res, arange,
     RAJA::expt::Reduce<RAJA::operators::plus>(&omp_t_sum),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&omp_t_min),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&omp_t_max),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&omp_t_minloc),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&omp_t_maxloc),
+    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&omp_t_min2, &omp_t_minloc2),
+    RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&omp_t_max2, &omp_t_maxloc2),
     RAJA::expt::KernelName("RAJA Reduce Target OpenMP Kernel"),
-    [=](int i, REF_INT_SUM &_omp_t_sum, REF_INT_MIN &_omp_t_min, REF_INT_MAX &_omp_t_max, REFLOC_INT_MIN &_omp_t_minloc, REFLOC_INT_MAX &_omp_t_maxloc) {
+    [=](int i, REF_INT_SUM &_omp_t_sum, REF_INT_MIN &_omp_t_min, REF_INT_MAX &_omp_t_max, REFLOC_INT_MIN &_omp_t_minloc, REFLOC_INT_MAX &_omp_t_maxloc, REFLOC_INT_MIN &_omp_t_minloc2, REFLOC_INT_MAX &_omp_t_maxloc2) {
       _omp_t_sum += a[i];
 
       _omp_t_min.min(a[i]);
@@ -232,6 +267,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
       _omp_t_minloc.minloc(a[i], i);
       _omp_t_maxloc.maxloc(a[i], i);
+
+      _omp_t_minloc2.minloc(a[i], i);
+      _omp_t_maxloc2.maxloc(a[i], i);
     }
   );
 
@@ -242,6 +280,10 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
                                << omp_t_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << omp_t_maxloc.getVal() << " , "
                                << omp_t_maxloc.getLoc() << std::endl;
+  std::cout << "\tmin2, loc2 = "  << omp_t_min2 << " , "
+                                  << omp_t_minloc2 << std::endl;
+  std::cout << "\tmax2, loc2 = "  << omp_t_max2 << " , "
+                                  << omp_t_maxloc2 << std::endl;
 
 #endif
 
@@ -266,14 +308,21 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   VALLOC_INT cuda_minloc(std::numeric_limits<int>::max(), -1);
   VALLOC_INT cuda_maxloc(std::numeric_limits<int>::min(), -1);
 
+  int cuda_min2 = std::numeric_limits<int>::max();
+  int cuda_max2 = std::numeric_limits<int>::min();
+  RAJA::Index_type cuda_minloc2(-1);
+  RAJA::Index_type cuda_maxloc2(-1);
+
   RAJA::forall<EXEC_POL3>(cuda_res, arange,
     RAJA::expt::Reduce<RAJA::operators::plus>(&cuda_sum),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&cuda_min),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&cuda_max),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&cuda_minloc),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&cuda_maxloc),
+    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&cuda_min2, &cuda_minloc2),
+    RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&cuda_max2, &cuda_maxloc2),
     RAJA::expt::KernelName("RAJA Reduce CUDA Kernel"),
-    [=] RAJA_DEVICE (int i, REF_INT_SUM &_cuda_sum, REF_INT_MIN &_cuda_min, REF_INT_MAX &_cuda_max, REFLOC_INT_MIN &_cuda_minloc, REFLOC_INT_MAX &_cuda_maxloc) {
+    [=] RAJA_DEVICE (int i, REF_INT_SUM &_cuda_sum, REF_INT_MIN &_cuda_min, REF_INT_MAX &_cuda_max, REFLOC_INT_MIN &_cuda_minloc, REFLOC_INT_MAX &_cuda_maxloc, REFLOC_INT_MIN &_cuda_minloc2, REFLOC_INT_MAX &_cuda_maxloc2) {
       _cuda_sum += d_a[i];
 
       _cuda_min.min(d_a[i]);
@@ -281,6 +330,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
       _cuda_minloc.minloc(a[i], i);
       _cuda_maxloc.maxloc(a[i], i);
+
+      _cuda_minloc2.minloc(a[i], i);
+      _cuda_maxloc2.maxloc(a[i], i);
     }
   );
 
@@ -291,6 +343,10 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
                                << cuda_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << cuda_maxloc.getVal() << " , "
                                << cuda_maxloc.getLoc() << std::endl;
+  std::cout << "\tmin2, loc2 = "  << cuda_min2 << " , "
+                                  << cuda_minloc2 << std::endl;
+  std::cout << "\tmax2, loc2 = "  << cuda_max2 << " , "
+                                  << cuda_maxloc2 << std::endl;
   cuda_res.deallocate(d_a);
 #endif
 
@@ -314,14 +370,21 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   VALLOC_INT hip_minloc(std::numeric_limits<int>::max(), -1);
   VALLOC_INT hip_maxloc(std::numeric_limits<int>::min(), -1);
 
+  int hip_min2 = std::numeric_limits<int>::max();
+  int hip_max2 = std::numeric_limits<int>::min();
+  RAJA::Index_type hip_minloc2(-1);
+  RAJA::Index_type hip_maxloc2(-1);
+
   RAJA::forall<EXEC_POL3>(hip_res, arange,
     RAJA::expt::Reduce<RAJA::operators::plus>(&hip_sum),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&hip_min),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&hip_max),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&hip_minloc),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&hip_maxloc),
+    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&hip_min2, &hip_minloc2),
+    RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&hip_max2, &hip_maxloc2),
     RAJA::expt::KernelName("RAJA Reduce HIP Kernel"),
-    [=] RAJA_DEVICE (int i, REF_INT_SUM &_hip_sum, REF_INT_MIN &_hip_min, REF_INT_MAX &_hip_max, REFLOC_INT_MIN &_hip_minloc, REFLOC_INT_MAX &_hip_maxloc) {
+    [=] RAJA_DEVICE (int i, REF_INT_SUM &_hip_sum, REF_INT_MIN &_hip_min, REF_INT_MAX &_hip_max, REFLOC_INT_MIN &_hip_minloc, REFLOC_INT_MAX &_hip_maxloc, REFLOC_INT_MIN &_hip_minloc2, REFLOC_INT_MAX &_hip_maxloc2) {
       _hip_sum += d_a[i];
 
       _hip_min.min(d_a[i]);
@@ -329,6 +392,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
       _hip_minloc.minloc(d_a[i], i);
       _hip_maxloc.maxloc(d_a[i], i);
+
+      _hip_minloc2.minloc(d_a[i], i);
+      _hip_maxloc2.maxloc(d_a[i], i);
     }
   );
 
@@ -339,6 +405,10 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
                                << hip_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << hip_maxloc.getVal() << " , "
                                << hip_maxloc.getLoc() << std::endl;
+  std::cout << "\tmin2, loc2 = "  << hip_min2 << " , "
+                                  << hip_minloc2 << std::endl;
+  std::cout << "\tmax2, loc2 = "  << hip_max2 << " , "
+                                  << hip_maxloc2 << std::endl;
 
   hip_res.deallocate(d_a);
 #endif
@@ -363,14 +433,21 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   VALLOC_INT sycl_minloc(std::numeric_limits<int>::max(), -1);
   VALLOC_INT sycl_maxloc(std::numeric_limits<int>::min(), -1);
 
+  int sycl_min2 = std::numeric_limits<int>::max();
+  int sycl_max2 = std::numeric_limits<int>::min();
+  RAJA::Index_type sycl_minloc2(-1);
+  RAJA::Index_type sycl_maxloc2(-1);
+
   RAJA::forall<EXEC_POL3>(sycl_res, arange,
     RAJA::expt::Reduce<RAJA::operators::plus>(&sycl_sum),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&sycl_min),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&sycl_max),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&sycl_minloc),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&sycl_maxloc),
+    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&sycl_min2, &sycl_minloc2),
+    RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&sycl_max2, &sycl_maxloc2),
     RAJA::expt::KernelName("RAJA Reduce SYCL Kernel"),
-    [=] RAJA_DEVICE (int i, REF_INT_SUM &_sycl_sum, REF_INT_MIN &_sycl_min, REF_INT_MAX &_sycl_max, REFLOC_INT_MIN &_sycl_minloc, REFLOC_INT_MAX &_sycl_maxloc) {
+    [=] RAJA_DEVICE (int i, REF_INT_SUM &_sycl_sum, REF_INT_MIN &_sycl_min, REF_INT_MAX &_sycl_max, REFLOC_INT_MIN &_sycl_minloc, REFLOC_INT_MAX &_sycl_maxloc, REFLOC_INT_MIN &_sycl_minloc2, REFLOC_INT_MAX &_sycl_maxloc2) {
       _sycl_sum += d_a[i];
 
       _sycl_min.min(d_a[i]);
@@ -378,6 +455,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
       _sycl_minloc.minloc(d_a[i], i);
       _sycl_maxloc.maxloc(d_a[i], i);
+
+      _sycl_minloc2.minloc(d_a[i], i);
+      _sycl_maxloc2.maxloc(d_a[i], i);
     }
   );
 
@@ -388,6 +468,10 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
                                << sycl_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << sycl_maxloc.getVal() << " , "
                                << sycl_maxloc.getLoc() << std::endl;
+  std::cout << "\tmin2, loc2 = "  << sycl_min2 << " , "
+                                  << sycl_minloc2 << std::endl;
+  std::cout << "\tmax2, loc2 = "  << sycl_max2 << " , "
+                                  << sycl_maxloc2 << std::endl;
 
   sycl_res.deallocate(d_a);
 #endif

--- a/examples/forall-param-reductions.cpp
+++ b/examples/forall-param-reductions.cpp
@@ -274,13 +274,13 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&omp_t_max2, &omp_t_maxloc2),
     RAJA::expt::KernelName("RAJA Reduce Target OpenMP Kernel"),
     [=](int i,
-				VALOP_INT_SUM &_omp_t_sum,
-				VALOP_INT_MIN &_omp_t_min,
-				VALOP_INT_MAX &_omp_t_max,
-				VALOPLOC_INT_MIN &_omp_t_minloc,
-				VALOPLOC_INT_MAX &_omp_t_maxloc,
-				VALOPLOC_INT_MIN &_omp_t_minloc2,
-				VALOPLOC_INT_MAX &_omp_t_maxloc2) {
+        VALOP_INT_SUM &_omp_t_sum,
+        VALOP_INT_MIN &_omp_t_min,
+        VALOP_INT_MAX &_omp_t_max,
+        VALOPLOC_INT_MIN &_omp_t_minloc,
+        VALOPLOC_INT_MAX &_omp_t_maxloc,
+        VALOPLOC_INT_MIN &_omp_t_minloc2,
+        VALOPLOC_INT_MAX &_omp_t_maxloc2) {
       _omp_t_sum += a[i];
 
       _omp_t_min.min(a[i]);
@@ -483,13 +483,13 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&sycl_max2, &sycl_maxloc2),
     RAJA::expt::KernelName("RAJA Reduce SYCL Kernel"),
     [=] RAJA_DEVICE ( int i,
-				              VALOP_INT_SUM &_sycl_sum,
-				              VALOP_INT_MIN &_sycl_min,
-				              VALOP_INT_MAX &_sycl_max,
-				              VALOPLOC_INT_MIN &_sycl_minloc,
-				              VALOPLOC_INT_MAX &_sycl_maxloc,
-				              VALOPLOC_INT_MIN &_sycl_minloc2,
-				              VALOPLOC_INT_MAX &_sycl_maxloc2) {
+                      VALOP_INT_SUM &_sycl_sum,
+                      VALOP_INT_MIN &_sycl_min,
+                      VALOP_INT_MAX &_sycl_max,
+                      VALOPLOC_INT_MIN &_sycl_minloc,
+                      VALOPLOC_INT_MAX &_sycl_maxloc,
+                      VALOPLOC_INT_MIN &_sycl_minloc2,
+                      VALOPLOC_INT_MAX &_sycl_maxloc2) {
       _sycl_sum += d_a[i];
 
       _sycl_min.min(d_a[i]);

--- a/examples/forall-param-reductions.cpp
+++ b/examples/forall-param-reductions.cpp
@@ -107,14 +107,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   using VALLOC_INT = RAJA::expt::ValLoc<int, RAJA::Index_type>;
 
 //
-// Define ValLoc Safe Type
+// Define ValOp Types
 //
 
-  using REF_INT_SUM = RAJA::expt::ValOp<int, RAJA::operators::plus>;
-  using REF_INT_MIN = RAJA::expt::ValOp<int, RAJA::operators::minimum>;
-  using REF_INT_MAX = RAJA::expt::ValOp<int, RAJA::operators::maximum>;
-  using REFLOC_INT_MIN = RAJA::expt::ValLocOp<int, RAJA::Index_type, RAJA::operators::minimum>;
-  using REFLOC_INT_MAX = RAJA::expt::ValLocOp<int, RAJA::Index_type, RAJA::operators::maximum>;
+  using VALOP_INT_SUM = RAJA::expt::ValOp<int, RAJA::operators::plus>;
+  using VALOP_INT_MIN = RAJA::expt::ValOp<int, RAJA::operators::minimum>;
+  using VALOP_INT_MAX = RAJA::expt::ValOp<int, RAJA::operators::maximum>;
+  using VALOPLOC_INT_MIN = RAJA::expt::ValLocOp<int, RAJA::Index_type, RAJA::operators::minimum>;
+  using VALOPLOC_INT_MAX = RAJA::expt::ValLocOp<int, RAJA::Index_type, RAJA::operators::maximum>;
 
 //----------------------------------------------------------------------------//
 
@@ -143,7 +143,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&seq_min2, &seq_minloc2),
     RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&seq_max2, &seq_maxloc2),
     RAJA::expt::KernelName("RAJA Reduce Seq Kernel"),
-    [=](int i, REF_INT_SUM &_seq_sum, REF_INT_MIN &_seq_min, REF_INT_MAX &_seq_max, REFLOC_INT_MIN &_seq_minloc, REFLOC_INT_MAX &_seq_maxloc, REFLOC_INT_MIN &_seq_minloc2, REFLOC_INT_MAX &_seq_maxloc2) {
+    [=](int i,
+        VALOP_INT_SUM &_seq_sum,
+        VALOP_INT_MIN &_seq_min,
+        VALOP_INT_MAX &_seq_max,
+        VALOPLOC_INT_MIN &_seq_minloc,
+        VALOPLOC_INT_MAX &_seq_maxloc,
+        VALOPLOC_INT_MIN &_seq_minloc2,
+        VALOPLOC_INT_MAX &_seq_maxloc2) {
       _seq_sum += a[i];
 
       _seq_min.min(a[i]);
@@ -200,7 +207,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&omp_min2, &omp_minloc2),
     RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&omp_max2, &omp_maxloc2),
     RAJA::expt::KernelName("RAJA Reduce OpenMP Kernel"),
-    [=](int i, REF_INT_SUM &_omp_sum, REF_INT_MIN &_omp_min, REF_INT_MAX &_omp_max, REFLOC_INT_MIN &_omp_minloc, REFLOC_INT_MAX &_omp_maxloc, REFLOC_INT_MIN &_omp_minloc2, REFLOC_INT_MAX &_omp_maxloc2) {
+    [=](int i,
+        VALOP_INT_SUM &_omp_sum,
+        VALOP_INT_MIN &_omp_min,
+        VALOP_INT_MAX &_omp_max,
+        VALOPLOC_INT_MIN &_omp_minloc,
+        VALOPLOC_INT_MAX &_omp_maxloc,
+        VALOPLOC_INT_MIN &_omp_minloc2,
+        VALOPLOC_INT_MAX &_omp_maxloc2) {
       _omp_sum += a[i];
 
       _omp_min.min(a[i]);
@@ -259,7 +273,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&omp_t_min2, &omp_t_minloc2),
     RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&omp_t_max2, &omp_t_maxloc2),
     RAJA::expt::KernelName("RAJA Reduce Target OpenMP Kernel"),
-    [=](int i, REF_INT_SUM &_omp_t_sum, REF_INT_MIN &_omp_t_min, REF_INT_MAX &_omp_t_max, REFLOC_INT_MIN &_omp_t_minloc, REFLOC_INT_MAX &_omp_t_maxloc, REFLOC_INT_MIN &_omp_t_minloc2, REFLOC_INT_MAX &_omp_t_maxloc2) {
+    [=](int i,
+				VALOP_INT_SUM &_omp_t_sum,
+				VALOP_INT_MIN &_omp_t_min,
+				VALOP_INT_MAX &_omp_t_max,
+				VALOPLOC_INT_MIN &_omp_t_minloc,
+				VALOPLOC_INT_MAX &_omp_t_maxloc,
+				VALOPLOC_INT_MIN &_omp_t_minloc2,
+				VALOPLOC_INT_MAX &_omp_t_maxloc2) {
       _omp_t_sum += a[i];
 
       _omp_t_min.min(a[i]);
@@ -322,7 +343,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&cuda_min2, &cuda_minloc2),
     RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&cuda_max2, &cuda_maxloc2),
     RAJA::expt::KernelName("RAJA Reduce CUDA Kernel"),
-    [=] RAJA_DEVICE (int i, REF_INT_SUM &_cuda_sum, REF_INT_MIN &_cuda_min, REF_INT_MAX &_cuda_max, REFLOC_INT_MIN &_cuda_minloc, REFLOC_INT_MAX &_cuda_maxloc, REFLOC_INT_MIN &_cuda_minloc2, REFLOC_INT_MAX &_cuda_maxloc2) {
+    [=] RAJA_DEVICE ( int i,
+                      VALOP_INT_SUM &_cuda_sum,
+                      VALOP_INT_MIN &_cuda_min,
+                      VALOP_INT_MAX &_cuda_max,
+                      VALOPLOC_INT_MIN &_cuda_minloc,
+                      VALOPLOC_INT_MAX &_cuda_maxloc,
+                      VALOPLOC_INT_MIN &_cuda_minloc2,
+                      VALOPLOC_INT_MAX &_cuda_maxloc2) {
       _cuda_sum += d_a[i];
 
       _cuda_min.min(d_a[i]);
@@ -384,7 +412,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&hip_min2, &hip_minloc2),
     RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&hip_max2, &hip_maxloc2),
     RAJA::expt::KernelName("RAJA Reduce HIP Kernel"),
-    [=] RAJA_DEVICE (int i, REF_INT_SUM &_hip_sum, REF_INT_MIN &_hip_min, REF_INT_MAX &_hip_max, REFLOC_INT_MIN &_hip_minloc, REFLOC_INT_MAX &_hip_maxloc, REFLOC_INT_MIN &_hip_minloc2, REFLOC_INT_MAX &_hip_maxloc2) {
+    [=] RAJA_DEVICE ( int i,
+                      VALOP_INT_SUM &_hip_sum,
+                      VALOP_INT_MIN &_hip_min,
+                      VALOP_INT_MAX &_hip_max,
+                      VALOPLOC_INT_MIN &_hip_minloc,
+                      VALOPLOC_INT_MAX &_hip_maxloc,
+                      VALOPLOC_INT_MIN &_hip_minloc2,
+                      VALOPLOC_INT_MAX &_hip_maxloc2) {
       _hip_sum += d_a[i];
 
       _hip_min.min(d_a[i]);
@@ -447,7 +482,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&sycl_min2, &sycl_minloc2),
     RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&sycl_max2, &sycl_maxloc2),
     RAJA::expt::KernelName("RAJA Reduce SYCL Kernel"),
-    [=] RAJA_DEVICE (int i, REF_INT_SUM &_sycl_sum, REF_INT_MIN &_sycl_min, REF_INT_MAX &_sycl_max, REFLOC_INT_MIN &_sycl_minloc, REFLOC_INT_MAX &_sycl_maxloc, REFLOC_INT_MIN &_sycl_minloc2, REFLOC_INT_MAX &_sycl_maxloc2) {
+    [=] RAJA_DEVICE ( int i,
+				              VALOP_INT_SUM &_sycl_sum,
+				              VALOP_INT_MIN &_sycl_min,
+				              VALOP_INT_MAX &_sycl_max,
+				              VALOPLOC_INT_MIN &_sycl_minloc,
+				              VALOPLOC_INT_MAX &_sycl_maxloc,
+				              VALOPLOC_INT_MIN &_sycl_minloc2,
+				              VALOPLOC_INT_MAX &_sycl_maxloc2) {
       _sycl_sum += d_a[i];
 
       _sycl_min.min(d_a[i]);

--- a/examples/forall-param-reductions.cpp
+++ b/examples/forall-param-reductions.cpp
@@ -85,7 +85,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 // Note: with this data initialization scheme, the following results will
 //       be observed for all reduction kernels below:
 //
-//  - the sum will be zero
+//  - the sum will be two
 //  - the min will be -100
 //  - the max will be 100
 //  - the min loc will be N/2
@@ -104,8 +104,18 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 // Define ValLoc Type
 //
 
-/*
   using VALLOC_INT = RAJA::expt::ValLoc<int, RAJA::Index_type>;
+
+//
+// Define ValLoc Safe Type
+//
+
+  using REF_INT_SUM = RAJA::expt::ValOp<int, RAJA::operators::plus>;
+  using REF_INT_MIN = RAJA::expt::ValOp<int, RAJA::operators::minimum>;
+  using REF_INT_MAX = RAJA::expt::ValOp<int, RAJA::operators::maximum>;
+  using REFLOC_INT_MIN = RAJA::expt::ValLocOp<int, RAJA::Index_type, RAJA::operators::minimum>;
+  using REFLOC_INT_MAX = RAJA::expt::ValLocOp<int, RAJA::Index_type, RAJA::operators::maximum>;
+
 //----------------------------------------------------------------------------//
 
   std::cout << "\n Running RAJA sequential reductions...\n";
@@ -126,19 +136,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     RAJA::expt::Reduce<RAJA::operators::minimum>(&seq_minloc),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&seq_maxloc),
     RAJA::expt::KernelName("RAJA Reduce Seq Kernel"),
-    [=](int i, int &_seq_sum, int &_seq_min, int &_seq_max, VALLOC_INT &_seq_minloc, VALLOC_INT &_seq_maxloc) {
+    [=](int i, REF_INT_SUM &_seq_sum, REF_INT_MIN &_seq_min, REF_INT_MAX &_seq_max, REFLOC_INT_MIN &_seq_minloc, REFLOC_INT_MAX &_seq_maxloc) {
       _seq_sum += a[i];
 
-      _seq_min = RAJA_MIN(a[i], _seq_min);
-      _seq_max = RAJA_MAX(a[i], _seq_max);
+      _seq_min.min(a[i]);
+      _seq_max.max(a[i]);
 
-      _seq_minloc = RAJA_MIN(VALLOC_INT(a[i], i), _seq_minloc);
-      _seq_maxloc = RAJA_MAX(VALLOC_INT(a[i], i), _seq_maxloc);
-      //_seq_minloc.min(a[i], i);
-      //_seq_maxloc.max(a[i], i);
-      // Note : RAJA::expt::ValLoc<T> objects provide min() and max() methods
-      //        that are equivalent to the assignments with RAJA_MIN and RAJA_MAX
-      //        above.
+      _seq_minloc.minloc(a[i], i);
+      _seq_maxloc.maxloc(a[i], i);
     }
   );
 
@@ -150,58 +155,6 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::cout << "\tmax, loc = " << seq_maxloc.getVal() << " , "
                                << seq_maxloc.getLoc() << std::endl;
   // _reductions_raja_seq_end
-*/
-
-
-//
-// Define ValLoc Safe Type
-//
-
-  using REF_INT_SUM = RAJA::expt::ValOp<int, RAJA::operators::plus>;
-  using REF_INT_MIN = RAJA::expt::ValOp<int, RAJA::operators::minimum>;
-  using REF_INT_MAX = RAJA::expt::ValOp<int, RAJA::operators::maximum>;
-  using REFLOC_INT_MIN = RAJA::expt::ValLocOp<int, RAJA::Index_type, RAJA::operators::minimum>;
-  using REFLOC_INT_MAX = RAJA::expt::ValLocOp<int, RAJA::Index_type, RAJA::operators::maximum>;
-//----------------------------------------------------------------------------//
-
-  std::cout << "\n Running RAJA sequential safe reductions...\n";
-
-  using EXEC_POL1S   = RAJA::seq_exec;
-
-  REF_INT_SUM sseq_sum(0);
-  REF_INT_MIN sseq_min(std::numeric_limits<int>::max());
-  REF_INT_MAX sseq_max(std::numeric_limits<int>::min());
-  REFLOC_INT_MIN sseq_minloc(std::numeric_limits<int>::max(), -1);
-  REFLOC_INT_MAX sseq_maxloc(std::numeric_limits<int>::min(), -1);
-
-  RAJA::forall<EXEC_POL1S>(host_res, arange,
-    RAJA::expt::Reduce<>(&sseq_sum),
-    RAJA::expt::Reduce<>(&sseq_min),
-    RAJA::expt::Reduce<>(&sseq_max),
-    RAJA::expt::Reduce<>(&sseq_minloc),
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&sseq_maxloc),
-    RAJA::expt::KernelName("RAJA Reduce Seq Safe Kernel"),
-    [=](int i, REF_INT_SUM &_sseq_sum, REF_INT_MIN &_sseq_min, REF_INT_MAX &_sseq_max, REFLOC_INT_MIN &_sseq_minloc, REFLOC_INT_MAX &_sseq_maxloc) {
-      _sseq_sum += a[i];
-
-      _sseq_min.min(a[i]);
-      _sseq_max.max(a[i]);
-
-      _sseq_minloc.minloc(a[i], i);
-      _sseq_maxloc.maxloc(a[i], i);
-      // Note : RAJA::expt::ValLoc<T> objects provide min() and max() methods
-      //        that are equivalent to the assignments with RAJA_MIN and RAJA_MAX
-      //        above.
-    }
-  );
-
-  std::cout << "\tsum = " << sseq_sum.get() << std::endl;
-  std::cout << "\tmin = " << sseq_min.get() << std::endl;
-  std::cout << "\tmax = " << sseq_max.get() << std::endl;
-  std::cout << "\tmin, loc = " << sseq_minloc.getVal() << " , "
-                               << sseq_minloc.getLoc() << std::endl;
-  std::cout << "\tmax, loc = " << sseq_maxloc.getVal() << " , "
-                               << sseq_maxloc.getLoc() << std::endl;
 
 
 //----------------------------------------------------------------------------//
@@ -213,18 +166,18 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   using EXEC_POL2   = RAJA::omp_parallel_for_exec;
   // _reductions_raja_omppolicy_end
 
-  REF_INT_SUM omp_sum(0);
-  REF_INT_MIN omp_min(std::numeric_limits<int>::max());
-  REF_INT_MAX omp_max(std::numeric_limits<int>::min());
-  REFLOC_INT_MIN omp_minloc(std::numeric_limits<int>::max(), -1);
-  REFLOC_INT_MAX omp_maxloc(std::numeric_limits<int>::min(), -1);
+  int omp_sum = 0;
+  int omp_min = std::numeric_limits<int>::max();
+  int omp_max = std::numeric_limits<int>::min();
+  VALLOC_INT omp_minloc(std::numeric_limits<int>::max(), -1);
+  VALLOC_INT omp_maxloc(std::numeric_limits<int>::min(), -1);
 
   RAJA::forall<EXEC_POL2>(host_res, arange,
-    RAJA::expt::Reduce<>(&omp_sum),
-    RAJA::expt::Reduce<>(&omp_min),
-    RAJA::expt::Reduce<>(&omp_max),
-    RAJA::expt::Reduce<>(&omp_minloc),
-    RAJA::expt::Reduce<>(&omp_maxloc),
+    RAJA::expt::Reduce<RAJA::operators::plus>(&omp_sum),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&omp_min),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&omp_max),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&omp_minloc),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&omp_maxloc),
     RAJA::expt::KernelName("RAJA Reduce OpenMP Kernel"),
     [=](int i, REF_INT_SUM &_omp_sum, REF_INT_MIN &_omp_min, REF_INT_MAX &_omp_max, REFLOC_INT_MIN &_omp_minloc, REFLOC_INT_MAX &_omp_maxloc) {
       _omp_sum += a[i];
@@ -237,9 +190,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
-  std::cout << "\tsum = " << omp_sum.get() << std::endl;
-  std::cout << "\tmin = " << omp_min.get() << std::endl;
-  std::cout << "\tmax = " << omp_max.get() << std::endl;
+  std::cout << "\tsum = " << omp_sum << std::endl;
+  std::cout << "\tmin = " << omp_min << std::endl;
+  std::cout << "\tmax = " << omp_max << std::endl;
   std::cout << "\tmin, loc = " << omp_minloc.getVal() << " , "
                                << omp_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << omp_maxloc.getVal() << " , "
@@ -258,18 +211,18 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   using EXEC_POL3   = RAJA::omp_target_parallel_for_exec_nt;
   // _reductions_raja_omppolicy_end
 
-  REF_INT_SUM omp_t_sum(0);
-  REF_INT_MIN omp_t_min(std::numeric_limits<int>::max());
-  REF_INT_MAX omp_t_max(std::numeric_limits<int>::min());
-  REFLOC_INT_MIN omp_t_minloc(std::numeric_limits<int>::max(), -1);
-  REFLOC_INT_MAX omp_t_maxloc(std::numeric_limits<int>::min(), -1);
+  int omp_t_sum = 0;
+  int omp_t_min = std::numeric_limits<int>::max();
+  int omp_t_max = std::numeric_limits<int>::min();
+  VALLOC_INT omp_t_minloc(std::numeric_limits<int>::max(), -1);
+  VALLOC_INT omp_t_maxloc(std::numeric_limits<int>::min(), -1);
 
   RAJA::forall<EXEC_POL3>(omp_res, arange,
-    RAJA::expt::Reduce<>(&omp_t_sum),
-    RAJA::expt::Reduce<>(&omp_t_min),
-    RAJA::expt::Reduce<>(&omp_t_max),
-    RAJA::expt::Reduce<>(&omp_t_minloc),
-    RAJA::expt::Reduce<>(&omp_t_maxloc),
+    RAJA::expt::Reduce<RAJA::operators::plus>(&omp_t_sum),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&omp_t_min),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&omp_t_max),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&omp_t_minloc),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&omp_t_maxloc),
     RAJA::expt::KernelName("RAJA Reduce Target OpenMP Kernel"),
     [=](int i, REF_INT_SUM &_omp_t_sum, REF_INT_MIN &_omp_t_min, REF_INT_MAX &_omp_t_max, REFLOC_INT_MIN &_omp_t_minloc, REFLOC_INT_MAX &_omp_t_maxloc) {
       _omp_t_sum += a[i];
@@ -282,9 +235,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
-  std::cout << "\tsum = " << omp_t_sum.get() << std::endl;
-  std::cout << "\tmin = " << omp_t_min.get() << std::endl;
-  std::cout << "\tmax = " << omp_t_max.get() << std::endl;
+  std::cout << "\tsum = " << omp_t_sum << std::endl;
+  std::cout << "\tmin = " << omp_t_min << std::endl;
+  std::cout << "\tmax = " << omp_t_max << std::endl;
   std::cout << "\tmin, loc = " << omp_t_minloc.getVal() << " , "
                                << omp_t_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << omp_t_maxloc.getVal() << " , "
@@ -307,18 +260,18 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   using EXEC_POL3   = RAJA::cuda_exec<CUDA_BLOCK_SIZE>;
   // _reductions_raja_cudapolicy_end
 
-  REF_INT_SUM cuda_sum(0);
-  REF_INT_MIN cuda_min(std::numeric_limits<int>::max());
-  REF_INT_MAX cuda_max(std::numeric_limits<int>::min());
-  REFLOC_INT_MIN cuda_minloc(std::numeric_limits<int>::max(), -1);
-  REFLOC_INT_MAX cuda_maxloc(std::numeric_limits<int>::min(), -1);
+  int cuda_sum = 0;
+  int cuda_min = std::numeric_limits<int>::max();
+  int cuda_max = std::numeric_limits<int>::min();
+  VALLOC_INT cuda_minloc(std::numeric_limits<int>::max(), -1);
+  VALLOC_INT cuda_maxloc(std::numeric_limits<int>::min(), -1);
 
   RAJA::forall<EXEC_POL3>(cuda_res, arange,
-    RAJA::expt::Reduce<>(&cuda_sum),
-    RAJA::expt::Reduce<>(&cuda_min),
-    RAJA::expt::Reduce<>(&cuda_max),
-    RAJA::expt::Reduce<>(&cuda_minloc),
-    RAJA::expt::Reduce<>(&cuda_maxloc),
+    RAJA::expt::Reduce<RAJA::operators::plus>(&cuda_sum),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&cuda_min),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&cuda_max),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&cuda_minloc),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&cuda_maxloc),
     RAJA::expt::KernelName("RAJA Reduce CUDA Kernel"),
     [=] RAJA_DEVICE (int i, REF_INT_SUM &_cuda_sum, REF_INT_MIN &_cuda_min, REF_INT_MAX &_cuda_max, REFLOC_INT_MIN &_cuda_minloc, REFLOC_INT_MAX &_cuda_maxloc) {
       _cuda_sum += d_a[i];
@@ -331,9 +284,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
-  std::cout << "\tsum = " << cuda_sum.get() << std::endl;
-  std::cout << "\tmin = " << cuda_min.get() << std::endl;
-  std::cout << "\tmax = " << cuda_max.get() << std::endl;
+  std::cout << "\tsum = " << cuda_sum << std::endl;
+  std::cout << "\tmin = " << cuda_min << std::endl;
+  std::cout << "\tmax = " << cuda_max << std::endl;
   std::cout << "\tmin, loc = " << cuda_minloc.getVal() << " , "
                                << cuda_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << cuda_maxloc.getVal() << " , "
@@ -355,18 +308,18 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   using EXEC_POL3   = RAJA::hip_exec<HIP_BLOCK_SIZE>;
   // _reductions_raja_hippolicy_end
 
-  REF_INT_SUM hip_sum(0);
-  REF_INT_MIN hip_min(std::numeric_limits<int>::max());
-  REF_INT_MAX hip_max(std::numeric_limits<int>::min());
-  REFLOC_INT_MIN hip_minloc(std::numeric_limits<int>::max(), -1);
-  REFLOC_INT_MAX hip_maxloc(std::numeric_limits<int>::min(), -1);
+  int hip_sum = 0;
+  int hip_min = std::numeric_limits<int>::max();
+  int hip_max = std::numeric_limits<int>::min();
+  VALLOC_INT hip_minloc(std::numeric_limits<int>::max(), -1);
+  VALLOC_INT hip_maxloc(std::numeric_limits<int>::min(), -1);
 
   RAJA::forall<EXEC_POL3>(hip_res, arange,
-    RAJA::expt::Reduce<>(&hip_sum),
-    RAJA::expt::Reduce<>(&hip_min),
-    RAJA::expt::Reduce<>(&hip_max),
-    RAJA::expt::Reduce<>(&hip_minloc),
-    RAJA::expt::Reduce<>(&hip_maxloc),
+    RAJA::expt::Reduce<RAJA::operators::plus>(&hip_sum),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&hip_min),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&hip_max),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&hip_minloc),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&hip_maxloc),
     RAJA::expt::KernelName("RAJA Reduce HIP Kernel"),
     [=] RAJA_DEVICE (int i, REF_INT_SUM &_hip_sum, REF_INT_MIN &_hip_min, REF_INT_MAX &_hip_max, REFLOC_INT_MIN &_hip_minloc, REFLOC_INT_MAX &_hip_maxloc) {
       _hip_sum += d_a[i];
@@ -379,9 +332,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
-  std::cout << "\tsum = " << hip_sum.get() << std::endl;
-  std::cout << "\tmin = " << hip_min.get() << std::endl;
-  std::cout << "\tmax = " << hip_max.get() << std::endl;
+  std::cout << "\tsum = " << hip_sum << std::endl;
+  std::cout << "\tmin = " << hip_min << std::endl;
+  std::cout << "\tmax = " << hip_max << std::endl;
   std::cout << "\tmin, loc = " << hip_minloc.getVal() << " , "
                                << hip_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << hip_maxloc.getVal() << " , "
@@ -404,18 +357,18 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   using EXEC_POL3   = RAJA::sycl_exec<SYCL_BLOCK_SIZE>;
   // _reductions_raja_syclpolicy_end
 
-  REF_INT_SUM sycl_sum(0);
-  REF_INT_MIN sycl_min(std::numeric_limits<int>::max());
-  REF_INT_MAX sycl_max(std::numeric_limits<int>::min());
-  REFLOC_INT_MIN sycl_minloc(std::numeric_limits<int>::max(), -1);
-  REFLOC_INT_MAX sycl_maxloc(std::numeric_limits<int>::min(), -1);
+  int sycl_sum = 0;
+  int sycl_min = std::numeric_limits<int>::max();
+  int sycl_max = std::numeric_limits<int>::min();
+  VALLOC_INT sycl_minloc(std::numeric_limits<int>::max(), -1);
+  VALLOC_INT sycl_maxloc(std::numeric_limits<int>::min(), -1);
 
   RAJA::forall<EXEC_POL3>(sycl_res, arange,
-    RAJA::expt::Reduce<>(&sycl_sum),
-    RAJA::expt::Reduce<>(&sycl_min),
-    RAJA::expt::Reduce<>(&sycl_max),
-    RAJA::expt::Reduce<>(&sycl_minloc),
-    RAJA::expt::Reduce<>(&sycl_maxloc),
+    RAJA::expt::Reduce<RAJA::operators::plus>(&sycl_sum),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&sycl_min),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&sycl_max),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&sycl_minloc),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&sycl_maxloc),
     RAJA::expt::KernelName("RAJA Reduce SYCL Kernel"),
     [=] RAJA_DEVICE (int i, REF_INT_SUM &_sycl_sum, REF_INT_MIN &_sycl_min, REF_INT_MAX &_sycl_max, REFLOC_INT_MIN &_sycl_minloc, REFLOC_INT_MAX &_sycl_maxloc) {
       _sycl_sum += d_a[i];
@@ -428,9 +381,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
-  std::cout << "\tsum = " << sycl_sum.get() << std::endl;
-  std::cout << "\tmin = " << sycl_min.get() << std::endl;
-  std::cout << "\tmax = " << sycl_max.get() << std::endl;
+  std::cout << "\tsum = " << sycl_sum << std::endl;
+  std::cout << "\tmin = " << sycl_min << std::endl;
+  std::cout << "\tmax = " << sycl_max << std::endl;
   std::cout << "\tmin, loc = " << sycl_minloc.getVal() << " , "
                                << sycl_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << sycl_maxloc.getVal() << " , "

--- a/examples/launch-param-reductions.cpp
+++ b/examples/launch-param-reductions.cpp
@@ -82,6 +82,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   }
 
 //
+// Set a[0] to a different value. Total sum should be 2.
+//
+  a[0] = 3;
+
+//
 // Set min and max loc values
 //
   constexpr int minloc_ref = N / 2;
@@ -114,7 +119,12 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 // Define ValLoc Type
 //
 
-  using VALLOC_INT = RAJA::expt::ValLoc<int>;
+  //using VALLOC_INT = RAJA::expt::ValLoc<int>;
+  using REF_INT_SUM = RAJA::expt::ValOp<int, RAJA::operators::plus>;
+  using REF_INT_MIN = RAJA::expt::ValOp<int, RAJA::operators::minimum>;
+  using REF_INT_MAX = RAJA::expt::ValOp<int, RAJA::operators::maximum>;
+  using REFLOC_INT_MIN = RAJA::expt::ValLocOp<int, RAJA::Index_type, RAJA::operators::minimum>;
+  using REFLOC_INT_MAX = RAJA::expt::ValLocOp<int, RAJA::Index_type, RAJA::operators::maximum>;
 //----------------------------------------------------------------------------//
 
   std::cout << "\n Running RAJA sequential reductions...\n";
@@ -123,35 +133,35 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   using LAUNCH_POL1   = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
   using LOOP_POL1     = RAJA::LoopPolicy<RAJA::seq_exec>;
 
-  int seq_sum = 0;
-  int seq_min = std::numeric_limits<int>::max();
-  int seq_max = std::numeric_limits<int>::min();
-  VALLOC_INT seq_minloc(std::numeric_limits<int>::max(), -1);
-  VALLOC_INT seq_maxloc(std::numeric_limits<int>::min(), -1);
+  REF_INT_SUM seq_sum(0);
+  REF_INT_MIN seq_min(std::numeric_limits<int>::max());
+  REF_INT_MAX seq_max(std::numeric_limits<int>::min());
+  REFLOC_INT_MIN seq_minloc(std::numeric_limits<int>::max(), -1);
+  REFLOC_INT_MAX seq_maxloc(std::numeric_limits<int>::min(), -1);
 
   RAJA::launch<LAUNCH_POL1>
     (host_res, RAJA::LaunchParams(), "SeqReductionKernel",
-    RAJA::expt::Reduce<RAJA::operators::plus>(&seq_sum),
-    RAJA::expt::Reduce<RAJA::operators::minimum>(&seq_min),
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&seq_max),
-    RAJA::expt::Reduce<RAJA::operators::minimum>(&seq_minloc),
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&seq_maxloc),
+    RAJA::expt::Reduce<>(&seq_sum),
+    RAJA::expt::Reduce<>(&seq_min),
+    RAJA::expt::Reduce<>(&seq_max),
+    RAJA::expt::Reduce<>(&seq_minloc),
+    RAJA::expt::Reduce<>(&seq_maxloc),
      [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx,
-                           int &_seq_sum, int &_seq_min,
-                           int &_seq_max, VALLOC_INT &_seq_minloc,
-                           VALLOC_INT &_seq_maxloc) {
+                           REF_INT_SUM &_seq_sum,
+                           REF_INT_MIN &_seq_min,
+                           REF_INT_MAX &_seq_max,
+                           REFLOC_INT_MIN &_seq_minloc,
+                           REFLOC_INT_MAX &_seq_maxloc) {
 
       RAJA::loop<LOOP_POL1>(ctx, arange, [&] (int i) {
 
           _seq_sum += a[i];
 
-          _seq_min = RAJA_MIN(a[i], _seq_min);
-          _seq_max = RAJA_MAX(a[i], _seq_max);
+          _seq_min.min(a[i]);
+          _seq_max.max(a[i]);
 
-          _seq_minloc = RAJA_MIN(VALLOC_INT(a[i], i), _seq_minloc);
-          _seq_maxloc = RAJA_MAX(VALLOC_INT(a[i], i), _seq_maxloc);
-          //_seq_minloc.min(a[i], i);
-          //_seq_maxloc.max(a[i], i);
+          _seq_minloc.minloc(a[i], i);
+          _seq_maxloc.maxloc(a[i], i);
           // Note : RAJA::expt::ValLoc<T> objects provide min() and max() methods
           //        that are equivalent to the assignments with RAJA_MIN and RAJA_MAX
           //        above.
@@ -161,9 +171,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
-  std::cout << "\tsum = " << seq_sum << std::endl;
-  std::cout << "\tmin = " << seq_min << std::endl;
-  std::cout << "\tmax = " << seq_max << std::endl;
+  std::cout << "\tsum = " << seq_sum.get() << std::endl;
+  std::cout << "\tmin = " << seq_min.get() << std::endl;
+  std::cout << "\tmax = " << seq_max.get() << std::endl;
   std::cout << "\tmin, loc = " << seq_minloc.getVal() << " , "
                                << seq_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << seq_maxloc.getVal() << " , "
@@ -181,44 +191,44 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   using LOOP_POL2     = RAJA::LoopPolicy<RAJA::omp_for_exec>;
   // _reductions_raja_omppolicy_end
 
-  int omp_sum = 0;
-  int omp_min = std::numeric_limits<int>::max();
-  int omp_max = std::numeric_limits<int>::min();
-  VALLOC_INT omp_minloc(std::numeric_limits<int>::max(), -1);
-  VALLOC_INT omp_maxloc(std::numeric_limits<int>::min(), -1);
+  REF_INT_SUM omp_sum(0);
+  REF_INT_MIN omp_min(std::numeric_limits<int>::max());
+  REF_INT_MAX omp_max(std::numeric_limits<int>::min());
+  REFLOC_INT_MIN omp_minloc(std::numeric_limits<int>::max(), -1);
+  REFLOC_INT_MAX omp_maxloc(std::numeric_limits<int>::min(), -1);
 
   RAJA::launch<LAUNCH_POL2>
     (host_res, RAJA::LaunchParams(), "OmpReductionKernel",
-    RAJA::expt::Reduce<RAJA::operators::plus>(&omp_sum),
-    RAJA::expt::Reduce<RAJA::operators::minimum>(&omp_min),
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&omp_max),
-    RAJA::expt::Reduce<RAJA::operators::minimum>(&omp_minloc),
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&omp_maxloc),
+    RAJA::expt::Reduce<>(&omp_sum),
+    RAJA::expt::Reduce<>(&omp_min),
+    RAJA::expt::Reduce<>(&omp_max),
+    RAJA::expt::Reduce<>(&omp_minloc),
+    RAJA::expt::Reduce<>(&omp_maxloc),
      [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx,
-                           int &_omp_sum, int &_omp_min,
-                           int &_omp_max, VALLOC_INT &_omp_minloc,
-                           VALLOC_INT &_omp_maxloc) {
+                           REF_INT_SUM &_omp_sum,
+                           REF_INT_MIN &_omp_min,
+                           REF_INT_MAX &_omp_max,
+                           REFLOC_INT_MIN &_omp_minloc,
+                           REFLOC_INT_MAX &_omp_maxloc) {
 
       RAJA::loop<LOOP_POL2>(ctx, arange, [&] (int i) {
 
           _omp_sum += a[i];
 
-          _omp_min = RAJA_MIN(a[i], _omp_min);
-          _omp_max = RAJA_MAX(a[i], _omp_max);
+          _omp_min.min(a[i]);
+          _omp_max.max(a[i]);
 
-          _omp_minloc = RAJA_MIN(VALLOC_INT(a[i], i), _omp_minloc);
-          _omp_maxloc = RAJA_MAX(VALLOC_INT(a[i], i), _omp_maxloc);
-          //_omp_minloc.min(a[i], i);
-          //_omp_maxloc.max(a[i], i);
+          _omp_minloc.minloc(a[i], i);
+          _omp_maxloc.maxloc(a[i], i);
         }
       );
 
     }
   );
 
-  std::cout << "\tsum = " << omp_sum << std::endl;
-  std::cout << "\tmin = " << omp_min << std::endl;
-  std::cout << "\tmax = " << omp_max << std::endl;
+  std::cout << "\tsum = " << omp_sum.get() << std::endl;
+  std::cout << "\tmin = " << omp_min.get() << std::endl;
+  std::cout << "\tmax = " << omp_max.get() << std::endl;
   std::cout << "\tmin, loc = " << omp_minloc.getVal() << " , "
                                << omp_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << omp_maxloc.getVal() << " , "
@@ -241,36 +251,37 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   const int NUMBER_OF_TEAMS = (N-1)/CUDA_BLOCK_SIZE + 1;
 
-  int cuda_sum = 0;
-  int cuda_min = std::numeric_limits<int>::max();
-  int cuda_max = std::numeric_limits<int>::min();
-  VALLOC_INT cuda_minloc(std::numeric_limits<int>::max(), -1);
-  VALLOC_INT cuda_maxloc(std::numeric_limits<int>::min(), -1);
+  REF_INT_SUM cuda_sum(0);
+  REF_INT_MIN cuda_min(std::numeric_limits<int>::max());
+  REF_INT_MAX cuda_max(std::numeric_limits<int>::min());
+  REFLOC_INT_MIN cuda_minloc(std::numeric_limits<int>::max(), -1);
+  REFLOC_INT_MAX cuda_maxloc(std::numeric_limits<int>::min(), -1);
 
   RAJA::launch<LAUNCH_POL3>
     (device_res, RAJA::LaunchParams(RAJA::Teams(NUMBER_OF_TEAMS), RAJA::Threads(CUDA_BLOCK_SIZE)),
      "CUDAReductionKernel",
-    RAJA::expt::Reduce<RAJA::operators::plus>(&cuda_sum),
-    RAJA::expt::Reduce<RAJA::operators::minimum>(&cuda_min),
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&cuda_max),
-    RAJA::expt::Reduce<RAJA::operators::minimum>(&cuda_minloc),
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&cuda_maxloc),
+    RAJA::expt::Reduce<>(&cuda_sum),
+    RAJA::expt::Reduce<>(&cuda_min),
+    RAJA::expt::Reduce<>(&cuda_max),
+    RAJA::expt::Reduce<>(&cuda_minloc),
+    RAJA::expt::Reduce<>(&cuda_maxloc),
      [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx,
-                           int &_cuda_sum, int &_cuda_min, int &_cuda_max,
-                           VALLOC_INT &_cuda_minloc, VALLOC_INT &_cuda_maxloc) {
+                           REF_INT_SUM &_cuda_sum,
+                           REF_INT_MIN &_cuda_min,
+                           REF_INT_MAX &_cuda_max,
+                           REFLOC_INT_MIN &_cuda_minloc,
+                           REFLOC_INT_MAX &_cuda_maxloc) {
 
 
       RAJA::loop<LOOP_POL3>(ctx, arange, [&] (int i) {
 
           _cuda_sum += d_a[i];
 
-          _cuda_min = RAJA_MIN(d_a[i], _cuda_min);
-          _cuda_max = RAJA_MAX(d_a[i], _cuda_max);
+          _cuda_min.min(d_a[i]);
+          _cuda_max.max(d_a[i]);
 
-          _cuda_minloc = RAJA_MIN(VALLOC_INT(d_a[i], i), _cuda_minloc);
-          _cuda_maxloc = RAJA_MAX(VALLOC_INT(d_a[i], i), _cuda_maxloc);
-          //_cuda_minloc.min(a[i], i);
-          //_cuda_maxloc.max(a[i], i);
+          _cuda_minloc.minloc(a[i], i);
+          _cuda_maxloc.maxloc(a[i], i);
 
         }
       );
@@ -279,9 +290,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
-  std::cout << "\tsum = " << cuda_sum << std::endl;
-  std::cout << "\tmin = " << cuda_min << std::endl;
-  std::cout << "\tmax = " << cuda_max << std::endl;
+  std::cout << "\tsum = " << cuda_sum.get() << std::endl;
+  std::cout << "\tmin = " << cuda_min.get() << std::endl;
+  std::cout << "\tmax = " << cuda_max.get() << std::endl;
   std::cout << "\tmin, loc = " << cuda_minloc.getVal() << " , "
                                << cuda_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << cuda_maxloc.getVal() << " , "
@@ -305,36 +316,36 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   const int NUMBER_OF_TEAMS = (N-1)/HIP_BLOCK_SIZE + 1;
 
-  int hip_sum = 0;
-  int hip_min = std::numeric_limits<int>::max();
-  int hip_max = std::numeric_limits<int>::min();
-  VALLOC_INT hip_minloc(std::numeric_limits<int>::max(), -1);
-  VALLOC_INT hip_maxloc(std::numeric_limits<int>::min(), -1);
+  REF_INT_SUM hip_sum(0);
+  REF_INT_MIN hip_min(std::numeric_limits<int>::max());
+  REF_INT_MAX hip_max(std::numeric_limits<int>::min());
+  REFLOC_INT_MIN hip_minloc(std::numeric_limits<int>::max(), -1);
+  REFLOC_INT_MAX hip_maxloc(std::numeric_limits<int>::min(), -1);
 
   RAJA::launch<LAUNCH_POL3>
     (device_res, RAJA::LaunchParams(RAJA::Teams(NUMBER_OF_TEAMS), RAJA::Threads(HIP_BLOCK_SIZE)),
      "HipReductionKernel",
-    RAJA::expt::Reduce<RAJA::operators::plus>(&hip_sum),
-    RAJA::expt::Reduce<RAJA::operators::minimum>(&hip_min),
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&hip_max),
-    RAJA::expt::Reduce<RAJA::operators::minimum>(&hip_minloc),
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&hip_maxloc),
+    RAJA::expt::Reduce<>(&hip_sum),
+    RAJA::expt::Reduce<>(&hip_min),
+    RAJA::expt::Reduce<>(&hip_max),
+    RAJA::expt::Reduce<>(&hip_minloc),
+    RAJA::expt::Reduce<>(&hip_maxloc),
      [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx,
-                           int &_hip_sum, int &_hip_min,
-                           int &_hip_max, VALLOC_INT &_hip_minloc,
-                           VALLOC_INT &_hip_maxloc) {
+                           REF_INT_SUM &_hip_sum,
+                           REF_INT_MIN &_hip_min,
+                           REF_INT_MAX &_hip_max,
+                           REFLOC_INT_MIN &_hip_minloc,
+                           REFLOC_INT_MAX &_hip_maxloc) {
 
       RAJA::loop<LOOP_POL3>(ctx, arange, [&] (int i) {
 
           _hip_sum += d_a[i];
 
-          _hip_min = RAJA_MIN(d_a[i], _hip_min);
-          _hip_max = RAJA_MAX(d_a[i], _hip_max);
+          _hip_min.min(d_a[i]);
+          _hip_max.max(d_a[i]);
 
-          _hip_minloc = RAJA_MIN(VALLOC_INT(d_a[i], i), _hip_minloc);
-          _hip_maxloc = RAJA_MAX(VALLOC_INT(d_a[i], i), _hip_maxloc);
-          //_hip_minloc.min(d_a[i], i);
-          //_hip_maxloc.max(d_a[i], i);
+          _hip_minloc.minloc(d_a[i], i);
+          _hip_maxloc.maxloc(d_a[i], i);
 
         }
       );
@@ -342,9 +353,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
-  std::cout << "\tsum = " << hip_sum << std::endl;
-  std::cout << "\tmin = " << hip_min << std::endl;
-  std::cout << "\tmax = " << hip_max << std::endl;
+  std::cout << "\tsum = " << hip_sum.get() << std::endl;
+  std::cout << "\tmin = " << hip_min.get() << std::endl;
+  std::cout << "\tmax = " << hip_max.get() << std::endl;
   std::cout << "\tmin, loc = " << hip_minloc.getVal() << " , "
                                << hip_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << hip_maxloc.getVal() << " , "
@@ -368,36 +379,36 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   const int NUMBER_OF_TEAMS = (N-1)/SYCL_BLOCK_SIZE + 1;
 
-  int sycl_sum = 0;
-  int sycl_min = std::numeric_limits<int>::max();
-  int sycl_max = std::numeric_limits<int>::min();
-  VALLOC_INT sycl_minloc(std::numeric_limits<int>::max(), -1);
-  VALLOC_INT sycl_maxloc(std::numeric_limits<int>::min(), -1);
+  REF_INT_SUM sycl_sum(0);
+  REF_INT_MIN sycl_min(std::numeric_limits<int>::max());
+  REF_INT_MAX sycl_max(std::numeric_limits<int>::min());
+  REFLOC_INT_MIN sycl_minloc(std::numeric_limits<int>::max(), -1);
+  REFLOC_INT_MAX sycl_maxloc(std::numeric_limits<int>::min(), -1);
 
   RAJA::launch<LAUNCH_POL4>
     (device_res, RAJA::LaunchParams(RAJA::Teams(NUMBER_OF_TEAMS), RAJA::Threads(SYCL_BLOCK_SIZE)),
      "SyclReductionKernel",
-    RAJA::expt::Reduce<RAJA::operators::plus>(&sycl_sum),
-    RAJA::expt::Reduce<RAJA::operators::minimum>(&sycl_min),
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&sycl_max),
-    RAJA::expt::Reduce<RAJA::operators::minimum>(&sycl_minloc),
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&sycl_maxloc),
+    RAJA::expt::Reduce<>(&sycl_sum),
+    RAJA::expt::Reduce<>(&sycl_min),
+    RAJA::expt::Reduce<>(&sycl_max),
+    RAJA::expt::Reduce<>(&sycl_minloc),
+    RAJA::expt::Reduce<>(&sycl_maxloc),
      [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx,
-                           int &_sycl_sum, int &_sycl_min,
-                           int &_sycl_max, VALLOC_INT &_sycl_minloc,
-                           VALLOC_INT &_sycl_maxloc) {
+                           REF_INT_SUM &_sycl_sum,
+                           REF_INT_MIN &_sycl_min,
+                           REF_INT_MAX &_sycl_max,
+                           REFLOC_INT_MIN &_sycl_minloc,
+                           REFLOC_INT_MAX &_sycl_maxloc) {
 
       RAJA::loop<LOOP_POL4>(ctx, arange, [&] (int i) {
 
           _sycl_sum += d_a[i];
 
-          _sycl_min = RAJA_MIN(d_a[i], _sycl_min);
-          _sycl_max = RAJA_MAX(d_a[i], _sycl_max);
+          _sycl_min.min(d_a[i]);
+          _sycl_max.max(d_a[i]);
 
-          _sycl_minloc = RAJA_MIN(VALLOC_INT(d_a[i], i), _sycl_minloc);
-          _sycl_maxloc = RAJA_MAX(VALLOC_INT(d_a[i], i), _sycl_maxloc);
-          //_sycl_minloc.min(d_a[i], i);
-          //_sycl_maxloc.max(d_a[i], i);
+          _sycl_minloc.minloc(d_a[i], i);
+          _sycl_maxloc.maxloc(d_a[i], i);
 
         }
       );
@@ -405,9 +416,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
-  std::cout << "\tsum = " << sycl_sum << std::endl;
-  std::cout << "\tmin = " << sycl_min << std::endl;
-  std::cout << "\tmax = " << sycl_max << std::endl;
+  std::cout << "\tsum = " << sycl_sum.get() << std::endl;
+  std::cout << "\tmin = " << sycl_min.get() << std::endl;
+  std::cout << "\tmax = " << sycl_max.get() << std::endl;
   std::cout << "\tmin, loc = " << sycl_minloc.getVal() << " , "
                                << sycl_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << sycl_maxloc.getVal() << " , "

--- a/examples/launch-param-reductions.cpp
+++ b/examples/launch-param-reductions.cpp
@@ -100,7 +100,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 // Note: with this data initialization scheme, the following results will
 //       be observed for all reduction kernels below:
 //
-//  - the sum will be zero
+//  - the sum will be two
 //  - the min will be -100
 //  - the max will be 100
 //  - the min loc will be N/2
@@ -119,7 +119,8 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 // Define ValLoc Type
 //
 
-  //using VALLOC_INT = RAJA::expt::ValLoc<int>;
+  using VALLOC_INT = RAJA::expt::ValLoc<int>;
+
   using REF_INT_SUM = RAJA::expt::ValOp<int, RAJA::operators::plus>;
   using REF_INT_MIN = RAJA::expt::ValOp<int, RAJA::operators::minimum>;
   using REF_INT_MAX = RAJA::expt::ValOp<int, RAJA::operators::maximum>;
@@ -133,19 +134,19 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   using LAUNCH_POL1   = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
   using LOOP_POL1     = RAJA::LoopPolicy<RAJA::seq_exec>;
 
-  REF_INT_SUM seq_sum(0);
-  REF_INT_MIN seq_min(std::numeric_limits<int>::max());
-  REF_INT_MAX seq_max(std::numeric_limits<int>::min());
-  REFLOC_INT_MIN seq_minloc(std::numeric_limits<int>::max(), -1);
-  REFLOC_INT_MAX seq_maxloc(std::numeric_limits<int>::min(), -1);
+  int seq_sum = 0;
+  int seq_min = std::numeric_limits<int>::max();
+  int seq_max = std::numeric_limits<int>::min();
+  VALLOC_INT seq_minloc(std::numeric_limits<int>::max(), -1);
+  VALLOC_INT seq_maxloc(std::numeric_limits<int>::min(), -1);
 
   RAJA::launch<LAUNCH_POL1>
     (host_res, RAJA::LaunchParams(), "SeqReductionKernel",
-    RAJA::expt::Reduce<>(&seq_sum),
-    RAJA::expt::Reduce<>(&seq_min),
-    RAJA::expt::Reduce<>(&seq_max),
-    RAJA::expt::Reduce<>(&seq_minloc),
-    RAJA::expt::Reduce<>(&seq_maxloc),
+    RAJA::expt::Reduce<RAJA::operators::plus   >(&seq_sum),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&seq_min),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&seq_max),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&seq_minloc),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&seq_maxloc),
      [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx,
                            REF_INT_SUM &_seq_sum,
                            REF_INT_MIN &_seq_min,
@@ -171,9 +172,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
-  std::cout << "\tsum = " << seq_sum.get() << std::endl;
-  std::cout << "\tmin = " << seq_min.get() << std::endl;
-  std::cout << "\tmax = " << seq_max.get() << std::endl;
+  std::cout << "\tsum = " << seq_sum << std::endl;
+  std::cout << "\tmin = " << seq_min << std::endl;
+  std::cout << "\tmax = " << seq_max << std::endl;
   std::cout << "\tmin, loc = " << seq_minloc.getVal() << " , "
                                << seq_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << seq_maxloc.getVal() << " , "
@@ -191,19 +192,19 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   using LOOP_POL2     = RAJA::LoopPolicy<RAJA::omp_for_exec>;
   // _reductions_raja_omppolicy_end
 
-  REF_INT_SUM omp_sum(0);
-  REF_INT_MIN omp_min(std::numeric_limits<int>::max());
-  REF_INT_MAX omp_max(std::numeric_limits<int>::min());
-  REFLOC_INT_MIN omp_minloc(std::numeric_limits<int>::max(), -1);
-  REFLOC_INT_MAX omp_maxloc(std::numeric_limits<int>::min(), -1);
+  int omp_sum = 0;
+  int omp_min = std::numeric_limits<int>::max();
+  int omp_max = std::numeric_limits<int>::min();
+  VALLOC_INT omp_minloc(std::numeric_limits<int>::max(), -1);
+  VALLOC_INT omp_maxloc(std::numeric_limits<int>::min(), -1);
 
   RAJA::launch<LAUNCH_POL2>
     (host_res, RAJA::LaunchParams(), "OmpReductionKernel",
-    RAJA::expt::Reduce<>(&omp_sum),
-    RAJA::expt::Reduce<>(&omp_min),
-    RAJA::expt::Reduce<>(&omp_max),
-    RAJA::expt::Reduce<>(&omp_minloc),
-    RAJA::expt::Reduce<>(&omp_maxloc),
+    RAJA::expt::Reduce<RAJA::operators::plus   >(&omp_sum),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&omp_min),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&omp_max),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&omp_minloc),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&omp_maxloc),
      [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx,
                            REF_INT_SUM &_omp_sum,
                            REF_INT_MIN &_omp_min,
@@ -226,9 +227,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
-  std::cout << "\tsum = " << omp_sum.get() << std::endl;
-  std::cout << "\tmin = " << omp_min.get() << std::endl;
-  std::cout << "\tmax = " << omp_max.get() << std::endl;
+  std::cout << "\tsum = " << omp_sum << std::endl;
+  std::cout << "\tmin = " << omp_min << std::endl;
+  std::cout << "\tmax = " << omp_max << std::endl;
   std::cout << "\tmin, loc = " << omp_minloc.getVal() << " , "
                                << omp_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << omp_maxloc.getVal() << " , "
@@ -251,20 +252,20 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   const int NUMBER_OF_TEAMS = (N-1)/CUDA_BLOCK_SIZE + 1;
 
-  REF_INT_SUM cuda_sum(0);
-  REF_INT_MIN cuda_min(std::numeric_limits<int>::max());
-  REF_INT_MAX cuda_max(std::numeric_limits<int>::min());
-  REFLOC_INT_MIN cuda_minloc(std::numeric_limits<int>::max(), -1);
-  REFLOC_INT_MAX cuda_maxloc(std::numeric_limits<int>::min(), -1);
+  int cuda_sum = 0;
+  int cuda_min = std::numeric_limits<int>::max();
+  int cuda_max = std::numeric_limits<int>::min();
+  VALLOC_INT cuda_minloc(std::numeric_limits<int>::max(), -1);
+  VALLOC_INT cuda_maxloc(std::numeric_limits<int>::min(), -1);
 
   RAJA::launch<LAUNCH_POL3>
     (device_res, RAJA::LaunchParams(RAJA::Teams(NUMBER_OF_TEAMS), RAJA::Threads(CUDA_BLOCK_SIZE)),
      "CUDAReductionKernel",
-    RAJA::expt::Reduce<>(&cuda_sum),
-    RAJA::expt::Reduce<>(&cuda_min),
-    RAJA::expt::Reduce<>(&cuda_max),
-    RAJA::expt::Reduce<>(&cuda_minloc),
-    RAJA::expt::Reduce<>(&cuda_maxloc),
+    RAJA::expt::Reduce<RAJA::operators::plus   >(&cuda_sum),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&cuda_min),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&cuda_max),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&cuda_minloc),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&cuda_maxloc),
      [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx,
                            REF_INT_SUM &_cuda_sum,
                            REF_INT_MIN &_cuda_min,
@@ -290,9 +291,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
-  std::cout << "\tsum = " << cuda_sum.get() << std::endl;
-  std::cout << "\tmin = " << cuda_min.get() << std::endl;
-  std::cout << "\tmax = " << cuda_max.get() << std::endl;
+  std::cout << "\tsum = " << cuda_sum << std::endl;
+  std::cout << "\tmin = " << cuda_min << std::endl;
+  std::cout << "\tmax = " << cuda_max << std::endl;
   std::cout << "\tmin, loc = " << cuda_minloc.getVal() << " , "
                                << cuda_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << cuda_maxloc.getVal() << " , "
@@ -316,20 +317,20 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   const int NUMBER_OF_TEAMS = (N-1)/HIP_BLOCK_SIZE + 1;
 
-  REF_INT_SUM hip_sum(0);
-  REF_INT_MIN hip_min(std::numeric_limits<int>::max());
-  REF_INT_MAX hip_max(std::numeric_limits<int>::min());
-  REFLOC_INT_MIN hip_minloc(std::numeric_limits<int>::max(), -1);
-  REFLOC_INT_MAX hip_maxloc(std::numeric_limits<int>::min(), -1);
+  int hip_sum = 0;
+  int hip_min = std::numeric_limits<int>::max();
+  int hip_max = std::numeric_limits<int>::min();
+  VALLOC_INT hip_minloc(std::numeric_limits<int>::max(), -1);
+  VALLOC_INT hip_maxloc(std::numeric_limits<int>::min(), -1);
 
   RAJA::launch<LAUNCH_POL3>
     (device_res, RAJA::LaunchParams(RAJA::Teams(NUMBER_OF_TEAMS), RAJA::Threads(HIP_BLOCK_SIZE)),
      "HipReductionKernel",
-    RAJA::expt::Reduce<>(&hip_sum),
-    RAJA::expt::Reduce<>(&hip_min),
-    RAJA::expt::Reduce<>(&hip_max),
-    RAJA::expt::Reduce<>(&hip_minloc),
-    RAJA::expt::Reduce<>(&hip_maxloc),
+    RAJA::expt::Reduce<RAJA::operators::plus   >(&hip_sum),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&hip_min),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&hip_max),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&hip_minloc),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&hip_maxloc),
      [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx,
                            REF_INT_SUM &_hip_sum,
                            REF_INT_MIN &_hip_min,
@@ -353,9 +354,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
-  std::cout << "\tsum = " << hip_sum.get() << std::endl;
-  std::cout << "\tmin = " << hip_min.get() << std::endl;
-  std::cout << "\tmax = " << hip_max.get() << std::endl;
+  std::cout << "\tsum = " << hip_sum << std::endl;
+  std::cout << "\tmin = " << hip_min << std::endl;
+  std::cout << "\tmax = " << hip_max << std::endl;
   std::cout << "\tmin, loc = " << hip_minloc.getVal() << " , "
                                << hip_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << hip_maxloc.getVal() << " , "
@@ -379,20 +380,20 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   const int NUMBER_OF_TEAMS = (N-1)/SYCL_BLOCK_SIZE + 1;
 
-  REF_INT_SUM sycl_sum(0);
-  REF_INT_MIN sycl_min(std::numeric_limits<int>::max());
-  REF_INT_MAX sycl_max(std::numeric_limits<int>::min());
-  REFLOC_INT_MIN sycl_minloc(std::numeric_limits<int>::max(), -1);
-  REFLOC_INT_MAX sycl_maxloc(std::numeric_limits<int>::min(), -1);
+  int sycl_sum = 0;
+  int sycl_min = std::numeric_limits<int>::max();
+  int sycl_max = std::numeric_limits<int>::min();
+  VALLOC_INT sycl_minloc(std::numeric_limits<int>::max(), -1);
+  VALLOC_INT sycl_maxloc(std::numeric_limits<int>::min(), -1);
 
   RAJA::launch<LAUNCH_POL4>
     (device_res, RAJA::LaunchParams(RAJA::Teams(NUMBER_OF_TEAMS), RAJA::Threads(SYCL_BLOCK_SIZE)),
      "SyclReductionKernel",
-    RAJA::expt::Reduce<>(&sycl_sum),
-    RAJA::expt::Reduce<>(&sycl_min),
-    RAJA::expt::Reduce<>(&sycl_max),
-    RAJA::expt::Reduce<>(&sycl_minloc),
-    RAJA::expt::Reduce<>(&sycl_maxloc),
+    RAJA::expt::Reduce<RAJA::operators::plus   >(&sycl_sum),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&sycl_min),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&sycl_max),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&sycl_minloc),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&sycl_maxloc),
      [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx,
                            REF_INT_SUM &_sycl_sum,
                            REF_INT_MIN &_sycl_min,
@@ -416,9 +417,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
-  std::cout << "\tsum = " << sycl_sum.get() << std::endl;
-  std::cout << "\tmin = " << sycl_min.get() << std::endl;
-  std::cout << "\tmax = " << sycl_max.get() << std::endl;
+  std::cout << "\tsum = " << sycl_sum << std::endl;
+  std::cout << "\tmin = " << sycl_min << std::endl;
+  std::cout << "\tmax = " << sycl_max << std::endl;
   std::cout << "\tmin, loc = " << sycl_minloc.getVal() << " , "
                                << sycl_minloc.getLoc() << std::endl;
   std::cout << "\tmax, loc = " << sycl_maxloc.getVal() << " , "

--- a/examples/launch-param-reductions.cpp
+++ b/examples/launch-param-reductions.cpp
@@ -121,11 +121,16 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   using VALLOC_INT = RAJA::expt::ValLoc<int>;
 
-  using REF_INT_SUM = RAJA::expt::ValOp<int, RAJA::operators::plus>;
-  using REF_INT_MIN = RAJA::expt::ValOp<int, RAJA::operators::minimum>;
-  using REF_INT_MAX = RAJA::expt::ValOp<int, RAJA::operators::maximum>;
-  using REFLOC_INT_MIN = RAJA::expt::ValLocOp<int, RAJA::Index_type, RAJA::operators::minimum>;
-  using REFLOC_INT_MAX = RAJA::expt::ValLocOp<int, RAJA::Index_type, RAJA::operators::maximum>;
+//
+// Define ValOp Types
+//
+
+  using VALOP_INT_SUM = RAJA::expt::ValOp<int, RAJA::operators::plus>;
+  using VALOP_INT_MIN = RAJA::expt::ValOp<int, RAJA::operators::minimum>;
+  using VALOP_INT_MAX = RAJA::expt::ValOp<int, RAJA::operators::maximum>;
+  using VALOPLOC_INT_MIN = RAJA::expt::ValLocOp<int, RAJA::Index_type, RAJA::operators::minimum>;
+  using VALOPLOC_INT_MAX = RAJA::expt::ValLocOp<int, RAJA::Index_type, RAJA::operators::maximum>;
+
 //----------------------------------------------------------------------------//
 
   std::cout << "\n Running RAJA sequential reductions...\n";
@@ -140,6 +145,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   VALLOC_INT seq_minloc(std::numeric_limits<int>::max(), -1);
   VALLOC_INT seq_maxloc(std::numeric_limits<int>::min(), -1);
 
+  int seq_min2 = std::numeric_limits<int>::max();
+  int seq_max2 = std::numeric_limits<int>::min();
+  RAJA::Index_type seq_minloc2(-1);
+  RAJA::Index_type seq_maxloc2(-1);
+
   RAJA::launch<LAUNCH_POL1>
     (host_res, RAJA::LaunchParams(), "SeqReductionKernel",
     RAJA::expt::Reduce<RAJA::operators::plus   >(&seq_sum),
@@ -147,12 +157,16 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     RAJA::expt::Reduce<RAJA::operators::maximum>(&seq_max),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&seq_minloc),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&seq_maxloc),
-     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx,
-                           REF_INT_SUM &_seq_sum,
-                           REF_INT_MIN &_seq_min,
-                           REF_INT_MAX &_seq_max,
-                           REFLOC_INT_MIN &_seq_minloc,
-                           REFLOC_INT_MAX &_seq_maxloc) {
+    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&seq_min2, &seq_minloc2),
+    RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&seq_max2, &seq_maxloc2),
+     [=] RAJA_HOST_DEVICE ( RAJA::LaunchContext ctx,
+                            VALOP_INT_SUM &_seq_sum,
+                            VALOP_INT_MIN &_seq_min,
+                            VALOP_INT_MAX &_seq_max,
+                            VALOPLOC_INT_MIN &_seq_minloc,
+                            VALOPLOC_INT_MAX &_seq_maxloc,
+                            VALOPLOC_INT_MIN &_seq_minloc2,
+                            VALOPLOC_INT_MAX &_seq_maxloc2) {
 
       RAJA::loop<LOOP_POL1>(ctx, arange, [&] (int i) {
 
@@ -163,9 +177,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
           _seq_minloc.minloc(a[i], i);
           _seq_maxloc.maxloc(a[i], i);
-          // Note : RAJA::expt::ValLoc<T> objects provide min() and max() methods
-          //        that are equivalent to the assignments with RAJA_MIN and RAJA_MAX
-          //        above.
+
+          _seq_minloc2.minloc(a[i], i);
+          _seq_maxloc2.maxloc(a[i], i);
         }
       );
 
@@ -198,6 +212,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   VALLOC_INT omp_minloc(std::numeric_limits<int>::max(), -1);
   VALLOC_INT omp_maxloc(std::numeric_limits<int>::min(), -1);
 
+  int omp_min2 = std::numeric_limits<int>::max();
+  int omp_max2 = std::numeric_limits<int>::min();
+  RAJA::Index_type omp_minloc2(-1);
+  RAJA::Index_type omp_maxloc2(-1);
+
   RAJA::launch<LAUNCH_POL2>
     (host_res, RAJA::LaunchParams(), "OmpReductionKernel",
     RAJA::expt::Reduce<RAJA::operators::plus   >(&omp_sum),
@@ -205,12 +224,16 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     RAJA::expt::Reduce<RAJA::operators::maximum>(&omp_max),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&omp_minloc),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&omp_maxloc),
+    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&omp_min2, &omp_minloc2),
+    RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&omp_max2, &omp_maxloc2),
      [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx,
-                           REF_INT_SUM &_omp_sum,
-                           REF_INT_MIN &_omp_min,
-                           REF_INT_MAX &_omp_max,
-                           REFLOC_INT_MIN &_omp_minloc,
-                           REFLOC_INT_MAX &_omp_maxloc) {
+                           VALOP_INT_SUM &_omp_sum,
+                           VALOP_INT_MIN &_omp_min,
+                           VALOP_INT_MAX &_omp_max,
+                           VALOPLOC_INT_MIN &_omp_minloc,
+                           VALOPLOC_INT_MAX &_omp_maxloc,
+                           VALOPLOC_INT_MIN &_omp_minloc2,
+                           VALOPLOC_INT_MAX &_omp_maxloc2) {
 
       RAJA::loop<LOOP_POL2>(ctx, arange, [&] (int i) {
 
@@ -221,6 +244,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
           _omp_minloc.minloc(a[i], i);
           _omp_maxloc.maxloc(a[i], i);
+
+          _omp_minloc2.minloc(a[i], i);
+          _omp_maxloc2.maxloc(a[i], i);
         }
       );
 
@@ -258,6 +284,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   VALLOC_INT cuda_minloc(std::numeric_limits<int>::max(), -1);
   VALLOC_INT cuda_maxloc(std::numeric_limits<int>::min(), -1);
 
+  int cuda_min2 = std::numeric_limits<int>::max();
+  int cuda_max2 = std::numeric_limits<int>::min();
+  RAJA::Index_type cuda_minloc2(-1);
+  RAJA::Index_type cuda_maxloc2(-1);
+
   RAJA::launch<LAUNCH_POL3>
     (device_res, RAJA::LaunchParams(RAJA::Teams(NUMBER_OF_TEAMS), RAJA::Threads(CUDA_BLOCK_SIZE)),
      "CUDAReductionKernel",
@@ -266,12 +297,16 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     RAJA::expt::Reduce<RAJA::operators::maximum>(&cuda_max),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&cuda_minloc),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&cuda_maxloc),
+    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&cuda_min2, &cuda_minloc2),
+    RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&cuda_max2, &cuda_maxloc2),
      [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx,
-                           REF_INT_SUM &_cuda_sum,
-                           REF_INT_MIN &_cuda_min,
-                           REF_INT_MAX &_cuda_max,
-                           REFLOC_INT_MIN &_cuda_minloc,
-                           REFLOC_INT_MAX &_cuda_maxloc) {
+                           VALOP_INT_SUM &_cuda_sum,
+                           VALOP_INT_MIN &_cuda_min,
+                           VALOP_INT_MAX &_cuda_max,
+                           VALOPLOC_INT_MIN &_cuda_minloc,
+                           VALOPLOC_INT_MAX &_cuda_maxloc,
+                           VALOPLOC_INT_MIN &_cuda_minloc2,
+                           VALOPLOC_INT_MAX &_cuda_maxloc2) {
 
 
       RAJA::loop<LOOP_POL3>(ctx, arange, [&] (int i) {
@@ -283,6 +318,9 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
           _cuda_minloc.minloc(a[i], i);
           _cuda_maxloc.maxloc(a[i], i);
+
+          _cuda_minloc2.minloc(a[i], i);
+          _cuda_maxloc2.maxloc(a[i], i);
 
         }
       );
@@ -323,6 +361,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   VALLOC_INT hip_minloc(std::numeric_limits<int>::max(), -1);
   VALLOC_INT hip_maxloc(std::numeric_limits<int>::min(), -1);
 
+  int hip_min2 = std::numeric_limits<int>::max();
+  int hip_max2 = std::numeric_limits<int>::min();
+  RAJA::Index_type hip_minloc2(-1);
+  RAJA::Index_type hip_maxloc2(-1);
+
   RAJA::launch<LAUNCH_POL3>
     (device_res, RAJA::LaunchParams(RAJA::Teams(NUMBER_OF_TEAMS), RAJA::Threads(HIP_BLOCK_SIZE)),
      "HipReductionKernel",
@@ -331,12 +374,16 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     RAJA::expt::Reduce<RAJA::operators::maximum>(&hip_max),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&hip_minloc),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&hip_maxloc),
+    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&hip_min2, &hip_minloc2),
+    RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&hip_max2, &hip_maxloc2),
      [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx,
-                           REF_INT_SUM &_hip_sum,
-                           REF_INT_MIN &_hip_min,
-                           REF_INT_MAX &_hip_max,
-                           REFLOC_INT_MIN &_hip_minloc,
-                           REFLOC_INT_MAX &_hip_maxloc) {
+                           VALOP_INT_SUM &_hip_sum,
+                           VALOP_INT_MIN &_hip_min,
+                           VALOP_INT_MAX &_hip_max,
+                           VALOPLOC_INT_MIN &_hip_minloc,
+                           VALOPLOC_INT_MAX &_hip_maxloc,
+                           VALOPLOC_INT_MIN &_hip_minloc2,
+                           VALOPLOC_INT_MAX &_hip_maxloc2) {
 
       RAJA::loop<LOOP_POL3>(ctx, arange, [&] (int i) {
 
@@ -348,6 +395,8 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
           _hip_minloc.minloc(d_a[i], i);
           _hip_maxloc.maxloc(d_a[i], i);
 
+          _hip_minloc2.minloc(d_a[i], i);
+          _hip_maxloc2.maxloc(d_a[i], i);
         }
       );
 
@@ -386,6 +435,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   VALLOC_INT sycl_minloc(std::numeric_limits<int>::max(), -1);
   VALLOC_INT sycl_maxloc(std::numeric_limits<int>::min(), -1);
 
+  int sycl_min2 = std::numeric_limits<int>::max();
+  int sycl_max2 = std::numeric_limits<int>::min();
+  RAJA::Index_type sycl_minloc2(-1);
+  RAJA::Index_type sycl_maxloc2(-1);
+
   RAJA::launch<LAUNCH_POL4>
     (device_res, RAJA::LaunchParams(RAJA::Teams(NUMBER_OF_TEAMS), RAJA::Threads(SYCL_BLOCK_SIZE)),
      "SyclReductionKernel",
@@ -394,12 +448,16 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     RAJA::expt::Reduce<RAJA::operators::maximum>(&sycl_max),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&sycl_minloc),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&sycl_maxloc),
+    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&sycl_min2, &sycl_minloc2),
+    RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&sycl_max2, &sycl_maxloc2),
      [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx,
-                           REF_INT_SUM &_sycl_sum,
-                           REF_INT_MIN &_sycl_min,
-                           REF_INT_MAX &_sycl_max,
-                           REFLOC_INT_MIN &_sycl_minloc,
-                           REFLOC_INT_MAX &_sycl_maxloc) {
+                           VALOP_INT_SUM &_sycl_sum,
+                           VALOP_INT_MIN &_sycl_min,
+                           VALOP_INT_MAX &_sycl_max,
+                           VALOPLOC_INT_MIN &_sycl_minloc,
+                           VALOPLOC_INT_MAX &_sycl_maxloc,
+                           VALOPLOC_INT_MIN &_sycl_minloc2,
+                           VALOPLOC_INT_MAX &_sycl_maxloc2) {
 
       RAJA::loop<LOOP_POL4>(ctx, arange, [&] (int i) {
 
@@ -411,6 +469,8 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
           _sycl_minloc.minloc(d_a[i], i);
           _sycl_maxloc.maxloc(d_a[i], i);
 
+          _sycl_minloc2.minloc(d_a[i], i);
+          _sycl_maxloc2.maxloc(d_a[i], i);
         }
       );
 

--- a/include/RAJA/pattern/params/forall.hpp
+++ b/include/RAJA/pattern/params/forall.hpp
@@ -276,7 +276,7 @@ namespace expt
     template<typename LAMBDA, typename... EXPECTED_ARGS>
     constexpr concepts::enable_if<has_empty_op<LAMBDA>> check_invocable(LAMBDA&&, const camp::list<EXPECTED_ARGS...>&) {
 #if !defined(RAJA_ENABLE_HIP)
-      static_assert(is_invocable<LAMBDA, typename get_lambda_index_type<LAMBDA>::type, EXPECTED_ARGS...>::value, "LAMBDA Not invocable w/ EXPECTED_ARGS."); 
+      static_assert(is_invocable<LAMBDA, typename get_lambda_index_type<LAMBDA>::type, EXPECTED_ARGS...>::value, "LAMBDA Not invocable w/ EXPECTED_ARGS. Ordering and types must match between RAJA::expt::Reduce() and ValOp arguments."); 
 #endif
     }
 

--- a/include/RAJA/pattern/params/params_base.hpp
+++ b/include/RAJA/pattern/params/params_base.hpp
@@ -28,6 +28,8 @@ namespace expt
     RAJA_HOST_DEVICE constexpr value_type getVal() const {return val;}
     RAJA_HOST_DEVICE constexpr index_type getLoc() const {return loc;}
 
+    RAJA_HOST_DEVICE void set(T inval, IndexType inindex) {val = inval; loc = inindex;}
+
   //private:
     value_type val;
     index_type loc = -1;
@@ -98,12 +100,12 @@ namespace expt
     RAJA_HOST_DEVICE constexpr bool operator<(const ValOp& rhs) const { return val < rhs.val; }
     RAJA_HOST_DEVICE constexpr bool operator>(const ValOp& rhs) const { return val > rhs.val; }
 
-    RAJA_HOST_DEVICE constexpr value_type get() const {return val;}
-    RAJA_HOST_DEVICE constexpr valloc_value_type getVal() const {return val.getVal();}
-    RAJA_HOST_DEVICE constexpr valloc_index_type getLoc() const {return val.getLoc();}
+    //RAJA_HOST_DEVICE constexpr value_type get() const {return val;}
+    //RAJA_HOST_DEVICE constexpr valloc_value_type getVal() const {return val.getVal();}
+    //RAJA_HOST_DEVICE constexpr valloc_index_type getLoc() const {return val.getLoc();}
 
-    RAJA_HOST_DEVICE void setVal(T inval) {val.val = inval;}
-    RAJA_HOST_DEVICE void setLoc(index_type inindex) {val.loc = inindex;}
+    //RAJA_HOST_DEVICE void setVal(T inval) {val.val = inval;}
+    //RAJA_HOST_DEVICE void setLoc(index_type inindex) {val.loc = inindex;}
 
   //private:
     value_type val = op_type::identity();

--- a/include/RAJA/pattern/params/params_base.hpp
+++ b/include/RAJA/pattern/params/params_base.hpp
@@ -78,12 +78,11 @@ namespace expt
     RAJA_HOST_DEVICE constexpr explicit ValOp(valloc_value_type v) : val(v) {}
     RAJA_HOST_DEVICE constexpr ValOp(valloc_value_type v, valloc_index_type l) : val(v, l) {}
 
-    // Normal min and max for loc reducers.
     template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::minimum<value_type,value_type,value_type>>::value> * = nullptr>
-    RAJA_HOST_DEVICE constexpr T min(T v) { if (v < val.val) { val.val = v; return val.val; } return v; }
+    RAJA_HOST_DEVICE constexpr ValOp & min(value_type v) { if (v < val) { val = v; } return *this; }
 
     template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::maximum<value_type,value_type,value_type>>::value> * = nullptr>
-    RAJA_HOST_DEVICE constexpr T max(T v) { if (v > val.val) { val.val = v; return val.val; } return v; }
+    RAJA_HOST_DEVICE constexpr ValOp & max(value_type v) { if (v > val) { val = v; } return *this; }
 
     template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::minimum<value_type,value_type,value_type>>::value> * = nullptr>
     RAJA_HOST_DEVICE constexpr ValOp & minloc(valloc_value_type v, valloc_index_type l) { return min(value_type(v,l)); }
@@ -95,14 +94,6 @@ namespace expt
     RAJA_HOST_DEVICE constexpr bool operator>(const ValOp& rhs) const { return val > rhs.val; }
 
     value_type val = op_type::identity();
-
-    private:
-    // These are called by maxloc and minloc, and should not be available to the user.
-    template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::minimum<value_type,value_type,value_type>>::value> * = nullptr>
-    RAJA_HOST_DEVICE constexpr ValOp & min(value_type v) { if (v < val) { val = v; } return *this; }
-
-    template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::maximum<value_type,value_type,value_type>>::value> * = nullptr>
-    RAJA_HOST_DEVICE constexpr ValOp & max(value_type v) { if (v > val) { val = v; } return *this; }
   };
 
   template<typename T, typename IndexType, template <typename, typename, typename> class Op>

--- a/include/RAJA/pattern/params/params_base.hpp
+++ b/include/RAJA/pattern/params/params_base.hpp
@@ -6,6 +6,108 @@ namespace RAJA
 {
 namespace expt
 {
+
+  template<typename T, typename IndexType = RAJA::Index_type>
+  struct ValLoc {
+    using index_type = IndexType;
+    using value_type = T;
+
+    RAJA_HOST_DEVICE constexpr ValLoc() {}
+    RAJA_HOST_DEVICE constexpr explicit ValLoc(value_type v) : val(v) {}
+    RAJA_HOST_DEVICE constexpr ValLoc(value_type v, index_type l) : val(v), loc(l) {}
+
+    RAJA_HOST_DEVICE constexpr void min(value_type v, index_type l) { if (v < val) { val = v; loc = l; } }
+
+    RAJA_HOST_DEVICE constexpr void max(value_type v, index_type l) { if (v > val) { val = v; loc = l; } }
+
+    RAJA_HOST_DEVICE constexpr bool operator<(const ValLoc& rhs) const { return val < rhs.val; }
+    RAJA_HOST_DEVICE constexpr bool operator>(const ValLoc& rhs) const { return val > rhs.val; }
+
+    RAJA_HOST_DEVICE constexpr explicit operator T() const { return val; }
+
+    RAJA_HOST_DEVICE constexpr value_type getVal() const {return val;}
+    RAJA_HOST_DEVICE constexpr index_type getLoc() const {return loc;}
+
+  //private:
+    value_type val;
+    index_type loc = -1;
+  };
+
+  template<typename T, template <typename, typename, typename> class Op>
+  struct ValOp {
+    using value_type = T;
+    using op_type = Op<T,T,T>;
+
+    RAJA_HOST_DEVICE constexpr ValOp() {}
+    RAJA_HOST_DEVICE constexpr explicit ValOp(value_type v) : val(v) {}
+
+    template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::minimum<T,T,T>>::value> * = nullptr>
+    RAJA_HOST_DEVICE constexpr ValOp & min(value_type v) { if (v < val) { val = v; } return *this; }
+    template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::maximum<T,T,T>>::value> * = nullptr>
+    RAJA_HOST_DEVICE constexpr ValOp & max(value_type v) { if (v > val) { val = v; } return *this; }
+
+    template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::plus<T,T,T>>::value> * = nullptr>
+    RAJA_HOST_DEVICE constexpr ValOp & operator+=(const value_type& rhs) { val += rhs; return *this; }
+
+    template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::bit_and<T,T,T>>::value> * = nullptr>
+    RAJA_HOST_DEVICE constexpr ValOp & operator&=(const value_type& rhs) { val &= rhs; return *this; }
+
+    template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::bit_or<T,T,T>>::value> * = nullptr>
+    RAJA_HOST_DEVICE constexpr ValOp & operator|=(const value_type& rhs) { val |= rhs; return *this; }
+
+    template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::bit_and<T,T,T>>::value> * = nullptr>
+    RAJA_HOST_DEVICE ValOp & operator&=(value_type& rhs) { val &= rhs; return *this; }
+
+    template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::bit_or<T,T,T>>::value> * = nullptr>
+    RAJA_HOST_DEVICE ValOp & operator|=(value_type& rhs) { val |= rhs; return *this; }
+
+    RAJA_HOST_DEVICE constexpr bool operator<(const ValOp& rhs) const { val < rhs.val; return *this; }
+    RAJA_HOST_DEVICE constexpr bool operator>(const ValOp& rhs) const { val > rhs.val; return *this; }
+
+    RAJA_HOST_DEVICE constexpr value_type get() const {return val;}
+
+  //private:
+    value_type val = op_type::identity();
+  };
+
+  template<typename T, typename IndexType, template <typename, typename, typename> class Op>
+  struct ValOp <ValLoc<T,IndexType>, Op> {
+    using index_type = IndexType;
+    using value_type = ValLoc<T,index_type>;
+    using op_type = Op<value_type,value_type,value_type>;
+    using valloc_value_type = typename value_type::value_type;
+    using valloc_index_type = typename value_type::index_type;
+
+    RAJA_HOST_DEVICE constexpr ValOp() {}
+    RAJA_HOST_DEVICE constexpr explicit ValOp(value_type v) : val(v) {}
+    RAJA_HOST_DEVICE constexpr explicit ValOp(valloc_value_type v) : val(v) {}
+    RAJA_HOST_DEVICE constexpr ValOp(valloc_value_type v, valloc_index_type l) : val(v, l) {}
+
+    template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::minimum<value_type,value_type,value_type>>::value> * = nullptr>
+    RAJA_HOST_DEVICE constexpr ValOp & min(value_type v) { if (v < val) { val = v; } return *this; }
+    template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::maximum<value_type,value_type,value_type>>::value> * = nullptr>
+    RAJA_HOST_DEVICE constexpr ValOp & max(value_type v) { if (v > val) { val = v; } return *this; }
+
+    template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::minimum<value_type,value_type,value_type>>::value> * = nullptr>
+    RAJA_HOST_DEVICE constexpr ValOp & minloc(valloc_value_type v, valloc_index_type l) { return min(value_type(v,l)); }
+
+    template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::maximum<value_type,value_type,value_type>>::value> * = nullptr>
+    RAJA_HOST_DEVICE constexpr ValOp & maxloc(valloc_value_type v, valloc_index_type l) { return max(value_type(v,l)); }
+
+    RAJA_HOST_DEVICE constexpr bool operator<(const ValOp& rhs) const { return val < rhs.val; }
+    RAJA_HOST_DEVICE constexpr bool operator>(const ValOp& rhs) const { return val > rhs.val; }
+
+    RAJA_HOST_DEVICE constexpr value_type get() const {return val;}
+    RAJA_HOST_DEVICE constexpr valloc_value_type getVal() const {return val.getVal();}
+    RAJA_HOST_DEVICE constexpr valloc_index_type getLoc() const {return val.getLoc();}
+
+  //private:
+    value_type val = op_type::identity();
+  };
+
+  template<typename T, typename IndexType, template <typename, typename, typename> class Op>
+  using ValLocOp = ValOp<ValLoc<T, IndexType>, Op>;
+
 namespace detail
 {
 

--- a/include/RAJA/pattern/params/params_base.hpp
+++ b/include/RAJA/pattern/params/params_base.hpp
@@ -102,6 +102,9 @@ namespace expt
     RAJA_HOST_DEVICE constexpr valloc_value_type getVal() const {return val.getVal();}
     RAJA_HOST_DEVICE constexpr valloc_index_type getLoc() const {return val.getLoc();}
 
+    RAJA_HOST_DEVICE void setVal(T inval) {val.val = inval;}
+    RAJA_HOST_DEVICE void setLoc(index_type inindex) {val.loc = inindex;}
+
   //private:
     value_type val = op_type::identity();
   };

--- a/include/RAJA/pattern/params/params_base.hpp
+++ b/include/RAJA/pattern/params/params_base.hpp
@@ -12,14 +12,14 @@ namespace expt
     using index_type = IndexType;
     using value_type = T;
 
-    RAJA_HOST_DEVICE constexpr ValLoc() = default;
+    ValLoc() = default;
     RAJA_HOST_DEVICE constexpr explicit ValLoc(value_type v) : val(v) {}
     RAJA_HOST_DEVICE constexpr explicit ValLoc(value_type v, index_type l) : val(v), loc(l) {}
 
-    RAJA_HOST_DEVICE constexpr ValLoc(ValLoc const &) = default;
-    RAJA_HOST_DEVICE constexpr ValLoc(ValLoc &&) = default;
-    RAJA_HOST_DEVICE ValLoc& operator=(ValLoc const &) = default;
-    RAJA_HOST_DEVICE ValLoc& operator=(ValLoc &&) = default;
+    ValLoc(ValLoc const &) = default;
+    ValLoc(ValLoc &&) = default;
+    ValLoc& operator=(ValLoc const &) = default;
+    ValLoc& operator=(ValLoc &&) = default;
 
     RAJA_HOST_DEVICE constexpr bool operator<(const ValLoc& rhs) const { return val < rhs.val; }
     RAJA_HOST_DEVICE constexpr bool operator>(const ValLoc& rhs) const { return val > rhs.val; }
@@ -38,13 +38,13 @@ namespace expt
     using value_type = T;
     using op_type = Op<T,T,T>;
 
-    RAJA_HOST_DEVICE constexpr ValOp() = default;
+    ValOp() = default;
     RAJA_HOST_DEVICE constexpr explicit ValOp(value_type v) : val(v) {}
 
-    RAJA_HOST_DEVICE constexpr ValOp(ValOp const &) = default;
-    RAJA_HOST_DEVICE constexpr ValOp(ValOp &&) = default;
-    RAJA_HOST_DEVICE ValOp& operator=(ValOp const &) = default;
-    RAJA_HOST_DEVICE ValOp& operator=(ValOp &&) = default;
+    ValOp(ValOp const &) = default;
+    ValOp(ValOp &&) = default;
+    ValOp& operator=(ValOp const &) = default;
+    ValOp& operator=(ValOp &&) = default;
 
     template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::minimum<T,T,T>>::value> * = nullptr>
     RAJA_HOST_DEVICE constexpr ValOp & min(value_type v) { if (v < val) { val = v; } return *this; }
@@ -80,14 +80,14 @@ namespace expt
     using valloc_value_type = typename value_type::value_type;
     using valloc_index_type = typename value_type::index_type;
 
-    RAJA_HOST_DEVICE constexpr ValOp() = default;
+    ValOp() = default;
     RAJA_HOST_DEVICE constexpr explicit ValOp(value_type v) : val(v) {}
     RAJA_HOST_DEVICE constexpr explicit ValOp(valloc_value_type v, valloc_index_type l) : val(v, l) {}
 
-    RAJA_HOST_DEVICE constexpr ValOp(ValOp const &) = default;
-    RAJA_HOST_DEVICE constexpr ValOp(ValOp &&) = default;
-    RAJA_HOST_DEVICE ValOp& operator=(ValOp const &) = default;
-    RAJA_HOST_DEVICE ValOp& operator=(ValOp &&) = default;
+    ValOp(ValOp const &) = default;
+    ValOp(ValOp &&) = default;
+    ValOp& operator=(ValOp const &) = default;
+    ValOp& operator=(ValOp &&) = default;
 
     template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::minimum<value_type,value_type,value_type>>::value> * = nullptr>
     RAJA_HOST_DEVICE constexpr ValOp & min(value_type v) { if (v < val) { val = v; } return *this; }

--- a/include/RAJA/pattern/params/params_base.hpp
+++ b/include/RAJA/pattern/params/params_base.hpp
@@ -14,7 +14,7 @@ namespace expt
 
     ValLoc() = default;
     RAJA_HOST_DEVICE constexpr explicit ValLoc(value_type v) : val(v) {}
-    RAJA_HOST_DEVICE constexpr explicit ValLoc(value_type v, index_type l) : val(v), loc(l) {}
+    RAJA_HOST_DEVICE constexpr ValLoc(value_type v, index_type l) : val(v), loc(l) {}
 
     ValLoc(ValLoc const &) = default;
     ValLoc(ValLoc &&) = default;
@@ -28,6 +28,8 @@ namespace expt
     RAJA_HOST_DEVICE constexpr const index_type& getLoc() const {return loc;}
 
     RAJA_HOST_DEVICE void set(T inval, IndexType inindex) {val = inval; loc = inindex;}
+    RAJA_HOST_DEVICE void setVal(T inval) {val = inval;}
+    RAJA_HOST_DEVICE void setLoc(IndexType inindex) {loc = inindex;}
 
     value_type val;
     index_type loc = -1;
@@ -82,7 +84,7 @@ namespace expt
 
     ValOp() = default;
     RAJA_HOST_DEVICE constexpr explicit ValOp(value_type v) : val(v) {}
-    RAJA_HOST_DEVICE constexpr explicit ValOp(valloc_value_type v, valloc_index_type l) : val(v, l) {}
+    RAJA_HOST_DEVICE constexpr ValOp(valloc_value_type v, valloc_index_type l) : val(v, l) {}
 
     ValOp(ValOp const &) = default;
     ValOp(ValOp &&) = default;

--- a/include/RAJA/pattern/params/params_base.hpp
+++ b/include/RAJA/pattern/params/params_base.hpp
@@ -9,16 +9,13 @@ namespace expt
 
   template<typename T, typename IndexType = RAJA::Index_type>
   struct ValLoc {
+    public:
     using index_type = IndexType;
     using value_type = T;
 
     RAJA_HOST_DEVICE constexpr ValLoc() {}
     RAJA_HOST_DEVICE constexpr explicit ValLoc(value_type v) : val(v) {}
     RAJA_HOST_DEVICE constexpr ValLoc(value_type v, index_type l) : val(v), loc(l) {}
-
-    RAJA_HOST_DEVICE constexpr void min(value_type v, index_type l) { if (v < val) { val = v; loc = l; } }
-
-    RAJA_HOST_DEVICE constexpr void max(value_type v, index_type l) { if (v > val) { val = v; loc = l; } }
 
     RAJA_HOST_DEVICE constexpr bool operator<(const ValLoc& rhs) const { return val < rhs.val; }
     RAJA_HOST_DEVICE constexpr bool operator>(const ValLoc& rhs) const { return val > rhs.val; }
@@ -28,13 +25,13 @@ namespace expt
 
     RAJA_HOST_DEVICE void set(T inval, IndexType inindex) {val = inval; loc = inindex;}
 
-  //private:
     value_type val;
     index_type loc = -1;
   };
 
   template<typename T, template <typename, typename, typename> class Op>
   struct ValOp {
+    public:
     using value_type = T;
     using op_type = Op<T,T,T>;
 
@@ -64,15 +61,12 @@ namespace expt
     RAJA_HOST_DEVICE constexpr bool operator<(const ValOp& rhs) const { val < rhs.val; return *this; }
     RAJA_HOST_DEVICE constexpr bool operator>(const ValOp& rhs) const { val > rhs.val; return *this; }
 
-    RAJA_HOST_DEVICE constexpr value_type get() const {return val;}
-    RAJA_HOST_DEVICE void set(value_type inval) {val = inval;}
-
-  //private:
     value_type val = op_type::identity();
   };
 
   template<typename T, typename IndexType, template <typename, typename, typename> class Op>
   struct ValOp <ValLoc<T,IndexType>, Op> {
+    public:
     using index_type = IndexType;
     using value_type = ValLoc<T,index_type>;
     using op_type = Op<value_type,value_type,value_type>;
@@ -84,10 +78,12 @@ namespace expt
     RAJA_HOST_DEVICE constexpr explicit ValOp(valloc_value_type v) : val(v) {}
     RAJA_HOST_DEVICE constexpr ValOp(valloc_value_type v, valloc_index_type l) : val(v, l) {}
 
+    // Normal min and max for loc reducers.
     template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::minimum<value_type,value_type,value_type>>::value> * = nullptr>
-    RAJA_HOST_DEVICE constexpr ValOp & min(value_type v) { if (v < val) { val = v; } return *this; }
+    RAJA_HOST_DEVICE constexpr T min(T v) { if (v < val.val) { val.val = v; return val.val; } return v; }
+
     template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::maximum<value_type,value_type,value_type>>::value> * = nullptr>
-    RAJA_HOST_DEVICE constexpr ValOp & max(value_type v) { if (v > val) { val = v; } return *this; }
+    RAJA_HOST_DEVICE constexpr T max(T v) { if (v > val.val) { val.val = v; return val.val; } return v; }
 
     template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::minimum<value_type,value_type,value_type>>::value> * = nullptr>
     RAJA_HOST_DEVICE constexpr ValOp & minloc(valloc_value_type v, valloc_index_type l) { return min(value_type(v,l)); }
@@ -98,15 +94,15 @@ namespace expt
     RAJA_HOST_DEVICE constexpr bool operator<(const ValOp& rhs) const { return val < rhs.val; }
     RAJA_HOST_DEVICE constexpr bool operator>(const ValOp& rhs) const { return val > rhs.val; }
 
-    //RAJA_HOST_DEVICE constexpr value_type get() const {return val;}
-    //RAJA_HOST_DEVICE constexpr valloc_value_type getVal() const {return val.getVal();}
-    //RAJA_HOST_DEVICE constexpr valloc_index_type getLoc() const {return val.getLoc();}
-
-    //RAJA_HOST_DEVICE void setVal(T inval) {val.val = inval;}
-    //RAJA_HOST_DEVICE void setLoc(index_type inindex) {val.loc = inindex;}
-
-  //private:
     value_type val = op_type::identity();
+
+    private:
+    // These are called by maxloc and minloc, and should not be available to the user.
+    template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::minimum<value_type,value_type,value_type>>::value> * = nullptr>
+    RAJA_HOST_DEVICE constexpr ValOp & min(value_type v) { if (v < val) { val = v; } return *this; }
+
+    template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::maximum<value_type,value_type,value_type>>::value> * = nullptr>
+    RAJA_HOST_DEVICE constexpr ValOp & max(value_type v) { if (v > val) { val = v; } return *this; }
   };
 
   template<typename T, typename IndexType, template <typename, typename, typename> class Op>

--- a/include/RAJA/pattern/params/params_base.hpp
+++ b/include/RAJA/pattern/params/params_base.hpp
@@ -65,6 +65,7 @@ namespace expt
     RAJA_HOST_DEVICE constexpr bool operator>(const ValOp& rhs) const { val > rhs.val; return *this; }
 
     RAJA_HOST_DEVICE constexpr value_type get() const {return val;}
+    RAJA_HOST_DEVICE void set(value_type inval) {val = inval;}
 
   //private:
     value_type val = op_type::identity();

--- a/include/RAJA/pattern/params/params_base.hpp
+++ b/include/RAJA/pattern/params/params_base.hpp
@@ -23,8 +23,6 @@ namespace expt
     RAJA_HOST_DEVICE constexpr bool operator<(const ValLoc& rhs) const { return val < rhs.val; }
     RAJA_HOST_DEVICE constexpr bool operator>(const ValLoc& rhs) const { return val > rhs.val; }
 
-    RAJA_HOST_DEVICE constexpr explicit operator T() const { return val; }
-
     RAJA_HOST_DEVICE constexpr value_type getVal() const {return val;}
     RAJA_HOST_DEVICE constexpr index_type getLoc() const {return loc;}
 

--- a/include/RAJA/pattern/params/params_base.hpp
+++ b/include/RAJA/pattern/params/params_base.hpp
@@ -9,19 +9,23 @@ namespace expt
 
   template<typename T, typename IndexType = RAJA::Index_type>
   struct ValLoc {
-    public:
     using index_type = IndexType;
     using value_type = T;
 
-    RAJA_HOST_DEVICE constexpr ValLoc() {}
+    RAJA_HOST_DEVICE constexpr ValLoc() = default;
     RAJA_HOST_DEVICE constexpr explicit ValLoc(value_type v) : val(v) {}
-    RAJA_HOST_DEVICE constexpr ValLoc(value_type v, index_type l) : val(v), loc(l) {}
+    RAJA_HOST_DEVICE constexpr explicit ValLoc(value_type v, index_type l) : val(v), loc(l) {}
+
+    RAJA_HOST_DEVICE constexpr ValLoc(ValLoc const &) = default;
+    RAJA_HOST_DEVICE constexpr ValLoc(ValLoc &&) = default;
+    RAJA_HOST_DEVICE ValLoc& operator=(ValLoc const &) = default;
+    RAJA_HOST_DEVICE ValLoc& operator=(ValLoc &&) = default;
 
     RAJA_HOST_DEVICE constexpr bool operator<(const ValLoc& rhs) const { return val < rhs.val; }
     RAJA_HOST_DEVICE constexpr bool operator>(const ValLoc& rhs) const { return val > rhs.val; }
 
-    RAJA_HOST_DEVICE constexpr value_type getVal() const {return val;}
-    RAJA_HOST_DEVICE constexpr index_type getLoc() const {return loc;}
+    RAJA_HOST_DEVICE constexpr const value_type& getVal() const {return val;}
+    RAJA_HOST_DEVICE constexpr const index_type& getLoc() const {return loc;}
 
     RAJA_HOST_DEVICE void set(T inval, IndexType inindex) {val = inval; loc = inindex;}
 
@@ -31,12 +35,16 @@ namespace expt
 
   template<typename T, template <typename, typename, typename> class Op>
   struct ValOp {
-    public:
     using value_type = T;
     using op_type = Op<T,T,T>;
 
-    RAJA_HOST_DEVICE constexpr ValOp() {}
+    RAJA_HOST_DEVICE constexpr ValOp() = default;
     RAJA_HOST_DEVICE constexpr explicit ValOp(value_type v) : val(v) {}
+
+    RAJA_HOST_DEVICE constexpr ValOp(ValOp const &) = default;
+    RAJA_HOST_DEVICE constexpr ValOp(ValOp &&) = default;
+    RAJA_HOST_DEVICE ValOp& operator=(ValOp const &) = default;
+    RAJA_HOST_DEVICE ValOp& operator=(ValOp &&) = default;
 
     template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::minimum<T,T,T>>::value> * = nullptr>
     RAJA_HOST_DEVICE constexpr ValOp & min(value_type v) { if (v < val) { val = v; } return *this; }
@@ -66,17 +74,20 @@ namespace expt
 
   template<typename T, typename IndexType, template <typename, typename, typename> class Op>
   struct ValOp <ValLoc<T,IndexType>, Op> {
-    public:
     using index_type = IndexType;
     using value_type = ValLoc<T,index_type>;
     using op_type = Op<value_type,value_type,value_type>;
     using valloc_value_type = typename value_type::value_type;
     using valloc_index_type = typename value_type::index_type;
 
-    RAJA_HOST_DEVICE constexpr ValOp() {}
+    RAJA_HOST_DEVICE constexpr ValOp() = default;
     RAJA_HOST_DEVICE constexpr explicit ValOp(value_type v) : val(v) {}
-    RAJA_HOST_DEVICE constexpr explicit ValOp(valloc_value_type v) : val(v) {}
-    RAJA_HOST_DEVICE constexpr ValOp(valloc_value_type v, valloc_index_type l) : val(v, l) {}
+    RAJA_HOST_DEVICE constexpr explicit ValOp(valloc_value_type v, valloc_index_type l) : val(v, l) {}
+
+    RAJA_HOST_DEVICE constexpr ValOp(ValOp const &) = default;
+    RAJA_HOST_DEVICE constexpr ValOp(ValOp &&) = default;
+    RAJA_HOST_DEVICE ValOp& operator=(ValOp const &) = default;
+    RAJA_HOST_DEVICE ValOp& operator=(ValOp &&) = default;
 
     template <typename U = op_type, std::enable_if_t<std::is_same<U, RAJA::operators::minimum<value_type,value_type,value_type>>::value> * = nullptr>
     RAJA_HOST_DEVICE constexpr ValOp & min(value_type v) { if (v < val) { val = v; } return *this; }

--- a/include/RAJA/pattern/params/reducer.hpp
+++ b/include/RAJA/pattern/params/reducer.hpp
@@ -61,20 +61,20 @@ namespace detail
     using value_type = T;
 
     RAJA_HOST_DEVICE Reducer() {}
-    RAJA_HOST_DEVICE Reducer(value_type *target_in) : target(target_in), val(VType{}){}
+    RAJA_HOST_DEVICE Reducer(value_type *target_in) : target(target_in), valop_m(VType{}){}
 
     value_type *target = nullptr;
-    VType val = VType{};
+    VType valop_m = VType{};
 
     template <typename U = VType, std::enable_if_t<std::is_same<U,ValOp<T,Op>>::value>* = nullptr>
     RAJA_HOST_DEVICE
     value_type &
-    getVal() { return val.val; }
+    getVal() { return valop_m.val; }
 
     template <typename U = VType, std::enable_if_t<std::is_same<U,ValOp<ValLoc<T,IndexType>,Op>>::value>* = nullptr>
     RAJA_HOST_DEVICE
     value_type &
-    getVal() { return val.val.val; }
+    getVal() { return valop_m.val.val; }
 
 #if defined(RAJA_CUDA_ACTIVE) || defined(RAJA_HIP_ACTIVE) || defined(RAJA_SYCL_ACTIVE)
     // Device related attributes.
@@ -84,7 +84,7 @@ namespace detail
 #endif
 
     using ARG_TUP_T = camp::tuple<VType*>;
-    RAJA_HOST_DEVICE ARG_TUP_T get_lambda_arg_tup() { return camp::make_tuple(&val); }
+    RAJA_HOST_DEVICE ARG_TUP_T get_lambda_arg_tup() { return camp::make_tuple(&valop_m); }
 
     using ARG_LIST_T = typename ARG_TUP_T::TList;
     static constexpr size_t num_lambda_args = camp::tuple_size<ARG_TUP_T>::value ;

--- a/include/RAJA/pattern/params/reducer.hpp
+++ b/include/RAJA/pattern/params/reducer.hpp
@@ -60,9 +60,14 @@ namespace detail
     using op = Op<T,T,T>;
     using value_type = T;
 
-    RAJA_HOST_DEVICE Reducer() {}
+    RAJA_HOST_DEVICE Reducer() = default;
     RAJA_HOST_DEVICE Reducer(value_type *target_in) : valop_m(VType{}), target(target_in){}
     RAJA_HOST_DEVICE Reducer(DataType *data_in, IndexType *index_in) : valop_m(VType(*data_in, *index_in)), target(&valop_m.val), passthruval(data_in), passthruindex(index_in) {}
+
+    RAJA_HOST_DEVICE constexpr Reducer(Reducer const &) = default;
+    RAJA_HOST_DEVICE constexpr Reducer(Reducer &&) = default;
+    RAJA_HOST_DEVICE Reducer& operator=(Reducer const &) = default;
+    RAJA_HOST_DEVICE Reducer& operator=(Reducer &&) = default;
 
     VType valop_m = VType{};
     value_type *target = nullptr;

--- a/include/RAJA/pattern/params/reducer.hpp
+++ b/include/RAJA/pattern/params/reducer.hpp
@@ -121,11 +121,11 @@ namespace detail
 
     // ValLoc constructor
     // Note that the target_ variables point to the val and loc within the user defined target ValLoc
-    RAJA_HOST_DEVICE Reducer(value_type *target_in) : m_valop(VOp(target_in->val, target_in->loc)), target_value(&target_in->val), target_index(&target_in->loc) {}
+    RAJA_HOST_DEVICE Reducer(value_type *target_in) : m_valop(VOp{}), target_value(&target_in->val), target_index(&target_in->loc) {}
 
     // Dual input constructor for ReduceLoc<>(data, index) case
     // The target_ variables point to vars defined by the user
-    RAJA_HOST_DEVICE Reducer(target_value_type *data_in, target_index_type *index_in) : m_valop(VOp(*data_in, *index_in)), target_value(data_in), target_index(index_in) {}
+    RAJA_HOST_DEVICE Reducer(target_value_type *data_in, target_index_type *index_in) : m_valop(VOp{}), target_value(data_in), target_index(index_in) {}
 
     Reducer(Reducer const &) = default;
     Reducer(Reducer &&) = default;

--- a/include/RAJA/pattern/params/reducer.hpp
+++ b/include/RAJA/pattern/params/reducer.hpp
@@ -64,16 +64,16 @@ namespace detail
     using op = Op<T,T,T>;
     using value_type = T; // Can be basic data types, or ValLoc.
 
-    RAJA_HOST_DEVICE Reducer() = default;
+    Reducer() = default;
     // Standard constructor
     RAJA_HOST_DEVICE Reducer(value_type *target_in) : valop_m(VType{}), target(target_in){}
     // Pass through constructor
     RAJA_HOST_DEVICE Reducer(DataType *data_in, IndexType *index_in) : valop_m(VType(*data_in, *index_in)), target(&valop_m.val), passthruval(data_in), passthruindex(index_in) {}
 
-    RAJA_HOST_DEVICE constexpr Reducer(Reducer const &) = default;
-    RAJA_HOST_DEVICE constexpr Reducer(Reducer &&) = default;
-    RAJA_HOST_DEVICE Reducer& operator=(Reducer const &) = default;
-    RAJA_HOST_DEVICE Reducer& operator=(Reducer &&) = default;
+    Reducer(Reducer const &) = default;
+    Reducer(Reducer &&) = default;
+    Reducer& operator=(Reducer const &) = default;
+    Reducer& operator=(Reducer &&) = default;
 
     // VType should be a ValOp, and can accept basic data types or ValLoc's for T.
     // Most internal reduction operations are performed on this.
@@ -82,6 +82,7 @@ namespace detail
 
     // Points to the actual basic data type or ValLoc.
     // This is set after valop_m has the final value.
+    // Note that in the pass through use case, target points to the ValLoc in valop_m.val, because the user did not provide a ValLoc target.
     value_type *target = nullptr;
 
     // Used when the pass through ReduceLoc(*data, *index) is called.

--- a/include/RAJA/pattern/params/reducer.hpp
+++ b/include/RAJA/pattern/params/reducer.hpp
@@ -56,50 +56,92 @@ namespace detail
   //
   //
 
-  // For the standard use case, T can be a basic data type or a ValLoc, and DataType is the same as T.
-  // For the pass through use case, T is a ValLoc, and DataType is the underlying basic data type within the ValLoc.
-  // By default, we expect the standard use case, which is why passthru is set to false.
-  template <template <typename, typename, typename> class Op, typename T, typename VType, typename DataType = T, typename IndexType = RAJA::Index_type, bool passthru = false>
+  // Basic data type Reducer
+  // T must be a basic data type
+  // IndexType not used here
+  // VType must be ValOp<T, Op>
+  template <template <typename, typename, typename> class Op, typename T, typename IndexType, typename VType>
   struct Reducer : public ForallParamBase {
     using op = Op<T,T,T>;
-    using value_type = T; // Can be basic data types, or ValLoc.
+    using value_type = T; // This is a basic data type
 
     Reducer() = default;
-    // Standard constructor
+
+    // Basic data type constructor
     RAJA_HOST_DEVICE Reducer(value_type *target_in) : valop_m(VType{}), target(target_in){}
-    // Pass through constructor
-    RAJA_HOST_DEVICE Reducer(DataType *data_in, IndexType *index_in) : valop_m(VType(*data_in, *index_in)), target(&valop_m.val), passthruval(data_in), passthruindex(index_in) {}
 
     Reducer(Reducer const &) = default;
     Reducer(Reducer &&) = default;
     Reducer& operator=(Reducer const &) = default;
     Reducer& operator=(Reducer &&) = default;
 
-    // VType should be a ValOp, and can accept basic data types or ValLoc's for T.
-    // Most internal reduction operations are performed on this.
-    // In the pass through use case, T is a ValLoc, and VType is ValOp<ValLoc>.
+    // Internal ValOp object that is used within RAJA::forall/launch
     VType valop_m = VType{};
 
-    // Points to the actual basic data type or ValLoc.
-    // This is set after valop_m has the final value.
-    // Note that in the pass through use case, target points to the ValLoc in valop_m.val, because the user did not provide a ValLoc target.
+    // Points to the user specified result variable
     value_type *target = nullptr;
 
-    // Used when the pass through ReduceLoc(*data, *index) is called.
-    // These point to the actual data and index being passed in.
-    // These are set after valop_m has the final value.
-    DataType *passthruval = nullptr;
-    IndexType *passthruindex = nullptr; 
+    // Used in the resolve() call to set target in each backend
+    RAJA_HOST_DEVICE void set(value_type in) { *target = in; }
 
-    template <typename U = VType, std::enable_if_t<std::is_same<U,ValOp<T,Op>>::value>* = nullptr>
     RAJA_HOST_DEVICE
     value_type &
     getVal() { return valop_m.val; }
 
-    template <typename U = VType, std::enable_if_t<std::is_same<U,ValOp<ValLoc<T,IndexType>,Op>>::value>* = nullptr>
+#if defined(RAJA_CUDA_ACTIVE) || defined(RAJA_HIP_ACTIVE) || defined(RAJA_SYCL_ACTIVE)
+    // Device related attributes.
+    value_type * devicetarget = nullptr;
+    RAJA::detail::SoAPtr<value_type, device_mem_pool_t> device_mem;
+    unsigned int * device_count = nullptr;
+#endif
+
+    // These are types and parameters extracted from this struct, and given to the forall.
+    using ARG_TUP_T = camp::tuple<VType*>;
+    RAJA_HOST_DEVICE ARG_TUP_T get_lambda_arg_tup() { return camp::make_tuple(&valop_m); }
+
+    using ARG_LIST_T = typename ARG_TUP_T::TList;
+    static constexpr size_t num_lambda_args = camp::tuple_size<ARG_TUP_T>::value ;
+  };
+
+  // Partial specialization of Reducer for ValLoc
+  // T must be a basic data type
+  // VType must be ValOp<ValLoc<T,IndexType>,Op>
+  template <template <typename, typename, typename> class Op, typename T, typename IndexType>
+  struct Reducer<Op, T, IndexType, ValOp<ValLoc<T,IndexType>, Op>> : public ForallParamBase {
+    using value_type = ValLoc<T,IndexType>; // Note that this struct operates on ValLoc
+    using op = Op<value_type,value_type,value_type>;
+    using VType = ValOp<ValLoc<T,IndexType>, Op>;
+
+    Reducer() = default;
+
+    // ValLoc constructor
+    // Note that the passthru variables point to the val and loc within the user defined target ValLoc
+    RAJA_HOST_DEVICE Reducer(value_type *target_in) : valop_m(VType{}), target(target_in), passthruval(&target_in->val), passthruindex(&target_in->loc) {}
+
+    // Pass through constructor for ReduceLoc<>(data, index) case
+    // The passthru variables point to vars defined by the user
+    RAJA_HOST_DEVICE Reducer(T *data_in, IndexType *index_in) : valop_m(VType(*data_in, *index_in)), target(&valop_m.val), passthruval(data_in), passthruindex(index_in) {}
+
+    Reducer(Reducer const &) = default;
+    Reducer(Reducer &&) = default;
+    Reducer& operator=(Reducer const &) = default;
+    Reducer& operator=(Reducer &&) = default;
+
+    VType valop_m = VType{};
+
+    value_type *target = nullptr;
+
+    T *passthruval = nullptr;
+    IndexType *passthruindex = nullptr;
+
+    // This single-argument set() matches the basic data type Reducer::set()'s
+    // function signature to make the init/combine/resolve backend calls easier
+    // to maintain, but operates on the passthru variables instead
+    RAJA_HOST_DEVICE void set(value_type in) { *passthruval = in.val; *passthruindex = in.loc; }
+
     RAJA_HOST_DEVICE
     value_type &
-    getVal() { return valop_m.val.val; }
+    getVal() { return valop_m.val; }
 
 #if defined(RAJA_CUDA_ACTIVE) || defined(RAJA_HIP_ACTIVE) || defined(RAJA_SYCL_ACTIVE)
     // Device related attributes.
@@ -119,18 +161,26 @@ namespace detail
 } // namespace detail
 
 // Standard use case.
-template <template <typename, typename, typename> class Op, typename T, typename VType = ValOp<T, Op>>
+template <template <typename, typename, typename> class Op, typename T, typename IndexType = RAJA::Index_type,
+          std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value> * = nullptr>
 auto constexpr Reduce(T *target)
 {
-  return detail::Reducer<Op, T, VType>(target);
+  return detail::Reducer<Op, T, IndexType, ValOp<T, Op>>(target);
 }
 
-// Pass through use case where reduction value and location are separate, non-ValLoc types.
-template <template <typename, typename, typename> class Op, typename T, typename IndexType = RAJA::Index_type, bool passingthru = true,
+// User-defined ValLoc case.
+template <template <typename, typename, typename> class Op, typename T, typename IndexType>
+auto constexpr Reduce(ValLoc<T, IndexType> *target)
+{
+  return detail::Reducer<Op, T, IndexType, ValOp<ValLoc<T, IndexType>, Op>>(target);
+}
+
+// Pass through use case where reduction value and location are separate, non-ValLoc types supplied by the user.
+template <template <typename, typename, typename> class Op, typename T, typename IndexType,
           std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value> * = nullptr>
 auto constexpr ReduceLoc(T *target, IndexType *index)
 {
-  return detail::Reducer<Op, ValLoc<T, IndexType>, ValLocOp<T, IndexType, Op>, T, IndexType, passingthru>(target, index);
+  return detail::Reducer<Op, T, IndexType, ValOp<ValLoc<T, IndexType>, Op>>(target, index);
 }
 
 } // namespace expt

--- a/include/RAJA/pattern/params/reducer.hpp
+++ b/include/RAJA/pattern/params/reducer.hpp
@@ -61,15 +61,10 @@ namespace detail
     using value_type = T;
 
     RAJA_HOST_DEVICE Reducer() {}
-    RAJA_HOST_DEVICE Reducer(VType *target_in) : target(target_in), val(VType{}){}
+    RAJA_HOST_DEVICE Reducer(value_type *target_in) : target(target_in), val(VType{}){}
 
-    VType *target = nullptr;
+    value_type *target = nullptr;
     VType val = VType{};
-
-    //template <typename U = VType, std::enable_if_t<std::is_same<U,value_type>::value>* = nullptr>
-    //RAJA_HOST_DEVICE
-    //value_type &
-    //getVal() { return val; }
 
     template <typename U = VType, std::enable_if_t<std::is_same<U,ValOp<T,Op>>::value>* = nullptr>
     RAJA_HOST_DEVICE
@@ -97,25 +92,11 @@ namespace detail
 
 } // namespace detail
 
-template <template <typename, typename, typename> class Op, typename T>
-auto constexpr Reduce(ValOp<T,Op> *target)
+template <template <typename, typename, typename> class Op, typename T, typename VType = ValOp<T, Op>>
+auto constexpr Reduce(T *target)
 {
-  return detail::Reducer<Op, T, ValOp<T,Op>>(target);
+  return detail::Reducer<Op, T, VType>(target);
 }
-
-//template <template <typename, typename, typename> class Op, typename T, typename IndexType,
-//           std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>* = nullptr >
-//auto constexpr Reduce(ValLoc<T, IndexType> *target)
-//{
-//  return detail::Reducer<Op, T, ValLoc<T, IndexType>>(target);
-//}
-
-//template <template <typename, typename, typename> class Op, typename T,
-//           std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>* = nullptr >
-//auto constexpr Reduce(T *target)
-//{
-//  return detail::Reducer<Op, T, T>(target);
-//}
 
 } // namespace expt
 

--- a/include/RAJA/pattern/params/reducer.hpp
+++ b/include/RAJA/pattern/params/reducer.hpp
@@ -15,46 +15,18 @@
 namespace RAJA
 {
 
-namespace expt
-{
-
-template<typename T>
-struct ValLoc {
-  using index_type = RAJA::Index_type;
-  using value_type = T;
-
-  RAJA_HOST_DEVICE ValLoc() {}
-  RAJA_HOST_DEVICE ValLoc(value_type v) : val(v) {}
-  RAJA_HOST_DEVICE ValLoc(value_type v, RAJA::Index_type l) : val(v), loc(l) {}
-
-  RAJA_HOST_DEVICE void min(value_type v, index_type l) { if (v < val) { val = v; loc = l; } }
-  RAJA_HOST_DEVICE void max(value_type v, index_type l) { if (v > val) { val = v; loc = l; } }
-
-  bool constexpr operator<(const ValLoc& rhs) const { return val < rhs.val; }
-  bool constexpr operator>(const ValLoc& rhs) const { return val > rhs.val; }
-
-  value_type getVal() {return val;}
-  RAJA::Index_type getLoc() {return loc;}
-
-private:
-  value_type val;
-  index_type loc = -1;
-};
-
-} //  namespace expt
-
 namespace operators
 {
 
-template <typename T>
-struct limits<RAJA::expt::ValLoc<T>> {
-  RAJA_INLINE RAJA_HOST_DEVICE static constexpr RAJA::expt::ValLoc<T> min()
+template <typename T, typename IndexType>
+struct limits<RAJA::expt::ValLoc<T, IndexType>> {
+  RAJA_INLINE RAJA_HOST_DEVICE static constexpr RAJA::expt::ValLoc<T, IndexType> min()
   {
-    return RAJA::expt::ValLoc<T>(RAJA::operators::limits<T>::min());
+    return RAJA::expt::ValLoc<T, IndexType>(RAJA::operators::limits<T>::min());
   }
-  RAJA_INLINE RAJA_HOST_DEVICE static constexpr RAJA::expt::ValLoc<T> max()
+  RAJA_INLINE RAJA_HOST_DEVICE static constexpr RAJA::expt::ValLoc<T, IndexType> max()
   {
-    return RAJA::expt::ValLoc<T>(RAJA::operators::limits<T>::max());
+    return RAJA::expt::ValLoc<T, IndexType>(RAJA::operators::limits<T>::max());
   }
 };
 
@@ -83,16 +55,31 @@ namespace detail
   // Basic Reducer
   //
   //
-  template <typename Op, typename T>
+  template <template <typename, typename, typename> class Op, typename T, typename VType, typename IndexType = RAJA::Index_type>
   struct Reducer : public ForallParamBase {
-    using op = Op;
+    using op = Op<T,T,T>;
     using value_type = T;
 
     RAJA_HOST_DEVICE Reducer() {}
-    Reducer(value_type *target_in) : target(target_in), val(op::identity()) {}
+    RAJA_HOST_DEVICE Reducer(VType *target_in) : target(target_in), val(VType{}){}
 
-    value_type *target = nullptr;
-    value_type val = op::identity();
+    VType *target = nullptr;
+    VType val = VType{};
+
+    //template <typename U = VType, std::enable_if_t<std::is_same<U,value_type>::value>* = nullptr>
+    //RAJA_HOST_DEVICE
+    //value_type &
+    //getVal() { return val; }
+
+    template <typename U = VType, std::enable_if_t<std::is_same<U,ValOp<T,Op>>::value>* = nullptr>
+    RAJA_HOST_DEVICE
+    value_type &
+    getVal() { return val.val; }
+
+    template <typename U = VType, std::enable_if_t<std::is_same<U,ValOp<ValLoc<T,IndexType>,Op>>::value>* = nullptr>
+    RAJA_HOST_DEVICE
+    value_type &
+    getVal() { return val.val.val; }
 
 #if defined(RAJA_CUDA_ACTIVE) || defined(RAJA_HIP_ACTIVE) || defined(RAJA_SYCL_ACTIVE)
     // Device related attributes.
@@ -101,7 +88,7 @@ namespace detail
     unsigned int * device_count = nullptr;
 #endif
 
-    using ARG_TUP_T = camp::tuple<value_type*>;
+    using ARG_TUP_T = camp::tuple<VType*>;
     RAJA_HOST_DEVICE ARG_TUP_T get_lambda_arg_tup() { return camp::make_tuple(&val); }
 
     using ARG_LIST_T = typename ARG_TUP_T::TList;
@@ -111,38 +98,25 @@ namespace detail
 } // namespace detail
 
 template <template <typename, typename, typename> class Op, typename T>
-auto constexpr Reduce(T *target)
+auto constexpr Reduce(ValOp<T,Op> *target)
 {
-  return detail::Reducer<Op<T, T, T>, T>(target);
+  return detail::Reducer<Op, T, ValOp<T,Op>>(target);
 }
 
+//template <template <typename, typename, typename> class Op, typename T, typename IndexType,
+//           std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>* = nullptr >
+//auto constexpr Reduce(ValLoc<T, IndexType> *target)
+//{
+//  return detail::Reducer<Op, T, ValLoc<T, IndexType>>(target);
+//}
 
+//template <template <typename, typename, typename> class Op, typename T,
+//           std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>* = nullptr >
+//auto constexpr Reduce(T *target)
+//{
+//  return detail::Reducer<Op, T, T>(target);
+//}
 
-namespace detail
-{
-
-  //
-  //
-  // Basic ReducerLoc
-  //
-  //
-  template <typename Op, typename T>
-  struct ReducerLoc : public Reducer<Op, T> {
-    using Base = Reducer<Op, T>;
-    using value_type = typename Base::value_type;
-    ReducerLoc(value_type *target_in) {
-      Base::target = target_in;
-      Base::val = value_type(Op::identity());
-    }
-  };
-
-} // namespace detail
-
-template <template <typename, typename, typename> class Op, typename T>
-auto constexpr ReduceLoc(T *target)
-{
-  return detail::ReducerLoc<Op<T, T, T>, T>(target);
-}
 } // namespace expt
 
 

--- a/include/RAJA/pattern/params/reducer.hpp
+++ b/include/RAJA/pattern/params/reducer.hpp
@@ -67,7 +67,7 @@ namespace detail
     Reducer() = default;
 
     // Basic data type constructor
-    RAJA_HOST_DEVICE Reducer(value_type *target_in) : valop_m(VType{}), target(target_in){}
+    RAJA_HOST_DEVICE Reducer(value_type *target_in) : m_valop(VType{}), target(target_in){}
 
     Reducer(Reducer const &) = default;
     Reducer(Reducer &&) = default;
@@ -75,7 +75,7 @@ namespace detail
     Reducer& operator=(Reducer &&) = default;
 
     // Internal ValOp object that is used within RAJA::forall/launch
-    VType valop_m = VType{};
+    VType m_valop = VType{};
 
     // Points to the user specified result variable
     value_type *target = nullptr;
@@ -85,7 +85,7 @@ namespace detail
 
     RAJA_HOST_DEVICE
     value_type &
-    getVal() { return valop_m.val; }
+    getVal() { return m_valop.val; }
 
 #if defined(RAJA_CUDA_ACTIVE) || defined(RAJA_HIP_ACTIVE) || defined(RAJA_SYCL_ACTIVE)
     // Device related attributes.
@@ -96,7 +96,7 @@ namespace detail
 
     // These are types and parameters extracted from this struct, and given to the forall.
     using ARG_TUP_T = camp::tuple<VType*>;
-    RAJA_HOST_DEVICE ARG_TUP_T get_lambda_arg_tup() { return camp::make_tuple(&valop_m); }
+    RAJA_HOST_DEVICE ARG_TUP_T get_lambda_arg_tup() { return camp::make_tuple(&m_valop); }
 
     using ARG_LIST_T = typename ARG_TUP_T::TList;
     static constexpr size_t num_lambda_args = camp::tuple_size<ARG_TUP_T>::value ;
@@ -115,18 +115,18 @@ namespace detail
 
     // ValLoc constructor
     // Note that the passthru variables point to the val and loc within the user defined target ValLoc
-    RAJA_HOST_DEVICE Reducer(value_type *target_in) : valop_m(VType{}), target(target_in), passthruval(&target_in->val), passthruindex(&target_in->loc) {}
+    RAJA_HOST_DEVICE Reducer(value_type *target_in) : m_valop(VType{}), target(target_in), passthruval(&target_in->val), passthruindex(&target_in->loc) {}
 
     // Pass through constructor for ReduceLoc<>(data, index) case
     // The passthru variables point to vars defined by the user
-    RAJA_HOST_DEVICE Reducer(target_value_type *data_in, target_index_type *index_in) : valop_m(VType(*data_in, *index_in)), target(&valop_m.val), passthruval(data_in), passthruindex(index_in) {}
+    RAJA_HOST_DEVICE Reducer(target_value_type *data_in, target_index_type *index_in) : m_valop(VType(*data_in, *index_in)), target(&m_valop.val), passthruval(data_in), passthruindex(index_in) {}
 
     Reducer(Reducer const &) = default;
     Reducer(Reducer &&) = default;
     Reducer& operator=(Reducer const &) = default;
     Reducer& operator=(Reducer &&) = default;
 
-    VType valop_m = VType{};
+    VType m_valop = VType{};
 
     value_type *target = nullptr;
 
@@ -140,7 +140,7 @@ namespace detail
 
     RAJA_HOST_DEVICE
     value_type &
-    getVal() { return valop_m.val; }
+    getVal() { return m_valop.val; }
 
 #if defined(RAJA_CUDA_ACTIVE) || defined(RAJA_HIP_ACTIVE) || defined(RAJA_SYCL_ACTIVE)
     // Device related attributes.
@@ -151,7 +151,7 @@ namespace detail
 
     // These are types and parameters extracted from this struct, and given to the forall.
     using ARG_TUP_T = camp::tuple<VType*>;
-    RAJA_HOST_DEVICE ARG_TUP_T get_lambda_arg_tup() { return camp::make_tuple(&valop_m); }
+    RAJA_HOST_DEVICE ARG_TUP_T get_lambda_arg_tup() { return camp::make_tuple(&m_valop); }
 
     using ARG_LIST_T = typename ARG_TUP_T::TList;
     static constexpr size_t num_lambda_args = camp::tuple_size<ARG_TUP_T>::value ;

--- a/include/RAJA/pattern/params/reducer.hpp
+++ b/include/RAJA/pattern/params/reducer.hpp
@@ -58,8 +58,8 @@ namespace detail
 
   // Basic data type Reducer
   // T must be a basic data type
-  // VType must be ValOp<T, Op>
-  template <typename Op, typename T, typename VType>
+  // VOp must be ValOp<T, Op>
+  template <typename Op, typename T, typename VOp>
   struct Reducer : public ForallParamBase {
     using op = Op;
     using value_type = T; // This is a basic data type
@@ -67,7 +67,7 @@ namespace detail
     Reducer() = default;
 
     // Basic data type constructor
-    RAJA_HOST_DEVICE Reducer(value_type *target_in) : m_valop(VType{}), target(target_in){}
+    RAJA_HOST_DEVICE Reducer(value_type *target_in) : m_valop(VOp{}), target(target_in){}
 
     Reducer(Reducer const &) = default;
     Reducer(Reducer &&) = default;
@@ -75,7 +75,7 @@ namespace detail
     Reducer& operator=(Reducer &&) = default;
 
     // Internal ValOp object that is used within RAJA::forall/launch
-    VType m_valop = VType{};
+    VOp m_valop = VOp{};
 
     // Points to the user specified result variable
     value_type *target = nullptr;
@@ -99,7 +99,7 @@ namespace detail
 #endif
 
     // These are types and parameters extracted from this struct, and given to the forall.
-    using ARG_TUP_T = camp::tuple<VType*>;
+    using ARG_TUP_T = camp::tuple<VOp*>;
     RAJA_HOST_DEVICE ARG_TUP_T get_lambda_arg_tup() { return camp::make_tuple(&m_valop); }
 
     using ARG_LIST_T = typename ARG_TUP_T::TList;
@@ -115,17 +115,17 @@ namespace detail
     using target_index_type = I;
     using value_type = ValLoc<T,I>;
     using op = Op<value_type,value_type,value_type>;
-    using VType = ValOp<ValLoc<target_value_type,target_index_type>, Op>;
+    using VOp = ValOp<ValLoc<target_value_type,target_index_type>, Op>;
 
     Reducer() = default;
 
     // ValLoc constructor
     // Note that the target_ variables point to the val and loc within the user defined target ValLoc
-    RAJA_HOST_DEVICE Reducer(value_type *target_in) : m_valop(VType(target_in->val, target_in->loc)), target_value(&target_in->val), target_index(&target_in->loc) {}
+    RAJA_HOST_DEVICE Reducer(value_type *target_in) : m_valop(VOp(target_in->val, target_in->loc)), target_value(&target_in->val), target_index(&target_in->loc) {}
 
     // Dual input constructor for ReduceLoc<>(data, index) case
     // The target_ variables point to vars defined by the user
-    RAJA_HOST_DEVICE Reducer(target_value_type *data_in, target_index_type *index_in) : m_valop(VType(*data_in, *index_in)), target_value(data_in), target_index(index_in) {}
+    RAJA_HOST_DEVICE Reducer(target_value_type *data_in, target_index_type *index_in) : m_valop(VOp(*data_in, *index_in)), target_value(data_in), target_index(index_in) {}
 
     Reducer(Reducer const &) = default;
     Reducer(Reducer &&) = default;
@@ -133,7 +133,7 @@ namespace detail
     Reducer& operator=(Reducer &&) = default;
 
     // The ValLoc within m_valop is initialized with data and location values from either a ValLoc, or dual data and location values, passed into the constructor
-    VType m_valop = VType{};
+    VOp m_valop = VOp{};
 
     // Points to either dual value and index defined by the user, or value and index within a ValLoc defined by the user
     target_value_type *target_value = nullptr;
@@ -161,7 +161,7 @@ namespace detail
 #endif
 
     // These are types and parameters extracted from this struct, and given to the forall.
-    using ARG_TUP_T = camp::tuple<VType*>;
+    using ARG_TUP_T = camp::tuple<VOp*>;
     RAJA_HOST_DEVICE ARG_TUP_T get_lambda_arg_tup() { return camp::make_tuple(&m_valop); }
 
     using ARG_LIST_T = typename ARG_TUP_T::TList;

--- a/include/RAJA/policy/cuda/params/reduce.hpp
+++ b/include/RAJA/policy/cuda/params/reduce.hpp
@@ -15,9 +15,9 @@ namespace expt {
 namespace detail {
 
   // Init
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType>& red, RAJA::cuda::detail::cudaInfo& ci)
+  init(Reducer<OP, T, VOp>& red, RAJA::cuda::detail::cudaInfo& ci)
   {
     red.devicetarget = RAJA::cuda::pinned_mempool_type::getInstance().template malloc<T>(1);
     red.device_mem.allocate(ci.gridDim.x * ci.gridDim.y * ci.gridDim.z);
@@ -25,10 +25,10 @@ namespace detail {
   }
 
   // Combine
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   RAJA_HOST_DEVICE
   camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType>& red)
+  combine(Reducer<OP, T, VOp>& red)
   {
     RAJA::cuda::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter, OP>(red.devicetarget,
                                                                             red.getVal(),
@@ -37,9 +37,9 @@ namespace detail {
   }
 
   // Resolve
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType>& red, RAJA::cuda::detail::cudaInfo& ci)
+  resolve(Reducer<OP, T, VOp>& red, RAJA::cuda::detail::cudaInfo& ci)
   {
     // complete reduction
     ci.res.wait();

--- a/include/RAJA/policy/cuda/params/reduce.hpp
+++ b/include/RAJA/policy/cuda/params/reduce.hpp
@@ -54,51 +54,6 @@ namespace detail {
     red.devicetarget = nullptr;
   }
 
-//  // Init
-//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
-//  camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-//  init(Reducer<OP, T, T>& red, RAJA::cuda::detail::cudaInfo& ci)
-//  {
-//    red.devicetarget = RAJA::cuda::pinned_mempool_type::getInstance().template malloc<T>(1);
-//    red.device_mem.allocate(ci.gridDim.x * ci.gridDim.y * ci.gridDim.z);
-//    red.device_count = RAJA::cuda::device_zeroed_mempool_type::getInstance().template malloc<unsigned int>(1);
-//  }
-//
-//  // Combine
-//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
-//  RAJA_HOST_DEVICE
-//  camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-//  combine(Reducer<OP, T, T>& red)
-//  //combine(Reducer<OP, T>& red)
-//  {
-//    RAJA::cuda::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter>(red);
-//    //RAJA::cuda::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter>(red.devicetarget,
-//    //                                                                        red.val,
-//    //                                                                        red.device_mem,
-//    //                                                                        red.device_count);
-//  }
-//
-//  // Resolve
-//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
-//  //template<typename EXEC_POL, typename OP, typename T>
-//  camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-//  resolve(Reducer<OP, T, T>& red, RAJA::cuda::detail::cudaInfo& ci)
-//  //resolve(Reducer<OP, T>& red, RAJA::cuda::detail::cudaInfo& ci)
-//  {
-//    // complete reduction
-//    ci.res.wait();
-//    *red.target = OP<T,T,T>{}(*red.target, *red.devicetarget);
-//    printf( "RCC DANGER\n" );
-//
-//    // free memory
-//    RAJA::cuda::device_zeroed_mempool_type::getInstance().free(red.device_count);
-//    red.device_count = nullptr;
-//    red.device_mem.deallocate();
-//    RAJA::cuda::pinned_mempool_type::getInstance().free(red.devicetarget);
-//    red.devicetarget = nullptr;
-//  }
-
-
 } //  namespace detail
 } //  namespace expt
 } //  namespace RAJA

--- a/include/RAJA/policy/cuda/params/reduce.hpp
+++ b/include/RAJA/policy/cuda/params/reduce.hpp
@@ -8,14 +8,16 @@
 #include "RAJA/policy/cuda/reduce.hpp"
 #include "RAJA/pattern/params/reducer.hpp"
 
+#include "RAJA/policy/cuda/policy.hpp"
+
 namespace RAJA {
 namespace expt {
 namespace detail {
 
   // Init
-  template<typename EXEC_POL, typename OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
   camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-  init(Reducer<OP, T>& red, RAJA::cuda::detail::cudaInfo& ci)
+  init(Reducer<OP, T, ValOp<T,OP>>& red, RAJA::cuda::detail::cudaInfo& ci)
   {
     red.devicetarget = RAJA::cuda::pinned_mempool_type::getInstance().template malloc<T>(1);
     red.device_mem.allocate(ci.gridDim.x * ci.gridDim.y * ci.gridDim.z);
@@ -23,22 +25,26 @@ namespace detail {
   }
 
   // Combine
-  template<typename EXEC_POL, typename OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
   RAJA_HOST_DEVICE
   camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-  combine(Reducer<OP, T>& red)
+  combine(Reducer<OP, T, ValOp<T,OP>>& red)
   {
-    RAJA::cuda::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter>(red);
+    RAJA::cuda::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter, OP, T>(red.devicetarget,
+                                                                            red.getVal(),
+                                                                            red.device_mem,
+                                                                            red.device_count);
   }
 
   // Resolve
-  template<typename EXEC_POL, typename OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
   camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-  resolve(Reducer<OP, T>& red, RAJA::cuda::detail::cudaInfo& ci)
+  resolve(Reducer<OP, T, ValOp<T,OP>>& red, RAJA::cuda::detail::cudaInfo& ci)
   {
     // complete reduction
     ci.res.wait();
-    *red.target = OP{}(*red.target, *red.devicetarget);
+
+    red.target->val = OP<T,T,T>{}(red.target->val, *red.devicetarget);
 
     // free memory
     RAJA::cuda::device_zeroed_mempool_type::getInstance().free(red.device_count);
@@ -47,6 +53,51 @@ namespace detail {
     RAJA::cuda::pinned_mempool_type::getInstance().free(red.devicetarget);
     red.devicetarget = nullptr;
   }
+
+//  // Init
+//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+//  camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
+//  init(Reducer<OP, T, T>& red, RAJA::cuda::detail::cudaInfo& ci)
+//  {
+//    red.devicetarget = RAJA::cuda::pinned_mempool_type::getInstance().template malloc<T>(1);
+//    red.device_mem.allocate(ci.gridDim.x * ci.gridDim.y * ci.gridDim.z);
+//    red.device_count = RAJA::cuda::device_zeroed_mempool_type::getInstance().template malloc<unsigned int>(1);
+//  }
+//
+//  // Combine
+//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+//  RAJA_HOST_DEVICE
+//  camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
+//  combine(Reducer<OP, T, T>& red)
+//  //combine(Reducer<OP, T>& red)
+//  {
+//    RAJA::cuda::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter>(red);
+//    //RAJA::cuda::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter>(red.devicetarget,
+//    //                                                                        red.val,
+//    //                                                                        red.device_mem,
+//    //                                                                        red.device_count);
+//  }
+//
+//  // Resolve
+//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+//  //template<typename EXEC_POL, typename OP, typename T>
+//  camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
+//  resolve(Reducer<OP, T, T>& red, RAJA::cuda::detail::cudaInfo& ci)
+//  //resolve(Reducer<OP, T>& red, RAJA::cuda::detail::cudaInfo& ci)
+//  {
+//    // complete reduction
+//    ci.res.wait();
+//    *red.target = OP<T,T,T>{}(*red.target, *red.devicetarget);
+//    printf( "RCC DANGER\n" );
+//
+//    // free memory
+//    RAJA::cuda::device_zeroed_mempool_type::getInstance().free(red.device_count);
+//    red.device_count = nullptr;
+//    red.device_mem.deallocate();
+//    RAJA::cuda::pinned_mempool_type::getInstance().free(red.devicetarget);
+//    red.devicetarget = nullptr;
+//  }
+
 
 } //  namespace detail
 } //  namespace expt

--- a/include/RAJA/policy/cuda/params/reduce.hpp
+++ b/include/RAJA/policy/cuda/params/reduce.hpp
@@ -15,9 +15,9 @@ namespace expt {
 namespace detail {
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-  init(Reducer<OP, T, ValOp<T,OP>>& red, RAJA::cuda::detail::cudaInfo& ci)
+  init(Reducer<OP, T, VType>& red, RAJA::cuda::detail::cudaInfo& ci)
   {
     red.devicetarget = RAJA::cuda::pinned_mempool_type::getInstance().template malloc<T>(1);
     red.device_mem.allocate(ci.gridDim.x * ci.gridDim.y * ci.gridDim.z);
@@ -25,10 +25,10 @@ namespace detail {
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   RAJA_HOST_DEVICE
   camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-  combine(Reducer<OP, T, ValOp<T,OP>>& red)
+  combine(Reducer<OP, T, VType>& red)
   {
     RAJA::cuda::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter, OP, T>(red.devicetarget,
                                                                             red.getVal(),
@@ -37,14 +37,14 @@ namespace detail {
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, ValOp<T,OP>>& red, RAJA::cuda::detail::cudaInfo& ci)
+  resolve(Reducer<OP, T, VType>& red, RAJA::cuda::detail::cudaInfo& ci)
   {
     // complete reduction
     ci.res.wait();
 
-    red.target->val = OP<T,T,T>{}(red.target->val, *red.devicetarget);
+    *red.target = OP<T,T,T>{}(*red.target, *red.devicetarget);
 
     // free memory
     RAJA::cuda::device_zeroed_mempool_type::getInstance().free(red.device_count);

--- a/include/RAJA/policy/cuda/params/reduce.hpp
+++ b/include/RAJA/policy/cuda/params/reduce.hpp
@@ -44,7 +44,7 @@ namespace detail {
     // complete reduction
     ci.res.wait();
 
-    red.setTarget(OP{}(*red.target, *red.devicetarget));
+    red.combineTarget(*red.devicetarget);
 
     // free memory
     RAJA::cuda::device_zeroed_mempool_type::getInstance().free(red.device_count);

--- a/include/RAJA/policy/cuda/params/reduce.hpp
+++ b/include/RAJA/policy/cuda/params/reduce.hpp
@@ -15,9 +15,9 @@ namespace expt {
 namespace detail {
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType>& red, RAJA::cuda::detail::cudaInfo& ci)
+  init(Reducer<OP, T, VType, D, I, true>& red, RAJA::cuda::detail::cudaInfo& ci)
   {
     red.devicetarget = RAJA::cuda::pinned_mempool_type::getInstance().template malloc<T>(1);
     red.device_mem.allocate(ci.gridDim.x * ci.gridDim.y * ci.gridDim.z);
@@ -25,10 +25,10 @@ namespace detail {
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   RAJA_HOST_DEVICE
   camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType>& red)
+  combine(Reducer<OP, T, VType, D, I, true>& red)
   {
     RAJA::cuda::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter, OP, T>(red.devicetarget,
                                                                             red.getVal(),
@@ -37,9 +37,52 @@ namespace detail {
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType>& red, RAJA::cuda::detail::cudaInfo& ci)
+  resolve(Reducer<OP, T, VType, D, I, true>& red, RAJA::cuda::detail::cudaInfo& ci)
+  {
+    // complete reduction
+    ci.res.wait();
+
+    *red.target = OP<T,T,T>{}(*red.target, *red.devicetarget);
+
+    *red.passthruval = red.target->val;
+    *red.passthruindex = red.target->loc;
+
+    // free memory
+    RAJA::cuda::device_zeroed_mempool_type::getInstance().free(red.device_count);
+    red.device_count = nullptr;
+    red.device_mem.deallocate();
+    RAJA::cuda::pinned_mempool_type::getInstance().free(red.devicetarget);
+    red.devicetarget = nullptr;
+  }
+
+  // Init
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
+  init(Reducer<OP, T, VType, D, I, false>& red, RAJA::cuda::detail::cudaInfo& ci)
+  {
+    red.devicetarget = RAJA::cuda::pinned_mempool_type::getInstance().template malloc<T>(1);
+    red.device_mem.allocate(ci.gridDim.x * ci.gridDim.y * ci.gridDim.z);
+    red.device_count = RAJA::cuda::device_zeroed_mempool_type::getInstance().template malloc<unsigned int>(1);
+  }
+
+  // Combine
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  RAJA_HOST_DEVICE
+  camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
+  combine(Reducer<OP, T, VType, D, I, false>& red)
+  {
+    RAJA::cuda::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter, OP, T>(red.devicetarget,
+                                                                            red.getVal(),
+                                                                            red.device_mem,
+                                                                            red.device_count);
+  }
+
+  // Resolve
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  camp::concepts::enable_if< type_traits::is_cuda_policy<EXEC_POL> >
+  resolve(Reducer<OP, T, VType, D, I, false>& red, RAJA::cuda::detail::cudaInfo& ci)
   {
     // complete reduction
     ci.res.wait();

--- a/include/RAJA/policy/cuda/reduce.hpp
+++ b/include/RAJA/policy/cuda/reduce.hpp
@@ -201,7 +201,6 @@ RAJA_DEVICE RAJA_INLINE int grid_reduce_last_block(T& val,
 namespace expt {
 
 template <typename ThreadIterationGetter, template <typename, typename, typename> class Combiner, typename T>
-//template <typename ThreadIterationGetter, typename Combiner, typename T>
 RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
 {
   const int numThreads = ThreadIterationGetter::size();

--- a/include/RAJA/policy/cuda/reduce.hpp
+++ b/include/RAJA/policy/cuda/reduce.hpp
@@ -200,7 +200,8 @@ RAJA_DEVICE RAJA_INLINE int grid_reduce_last_block(T& val,
 
 namespace expt {
 
-template <typename ThreadIterationGetter, typename Combiner, typename T>
+template <typename ThreadIterationGetter, template <typename, typename, typename> class Combiner, typename T>
+//template <typename ThreadIterationGetter, typename Combiner, typename T>
 RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
 {
   const int numThreads = ThreadIterationGetter::size();
@@ -216,7 +217,7 @@ RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
     // reduce each warp
     for (int i = 1; i < RAJA::policy::cuda::device_constants.WARP_SIZE; i *= 2) {
       T rhs = RAJA::cuda::impl::shfl_xor_sync(temp, i);
-      temp = Combiner{}(temp, rhs);
+      temp = Combiner<T,T,T>{}(temp, rhs);
     }
 
   } else {
@@ -227,7 +228,7 @@ RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
       T rhs = RAJA::cuda::impl::shfl_sync(temp, srcLane);
       // only add from threads that exist (don't double count own value)
       if (srcLane < numThreads) {
-        temp = Combiner{}(temp, rhs);
+        temp = Combiner<T,T,T>{}(temp, rhs);
       }
     }
   }
@@ -263,7 +264,7 @@ RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
 
       for (int i = 1; i < RAJA::policy::cuda::device_constants.MAX_WARPS; i *= 2) {
         T rhs = RAJA::cuda::impl::shfl_xor_sync(temp, i);
-        temp = Combiner{}(temp, rhs);
+        temp = Combiner<T,T,T>{}(temp, rhs);
       }
     }
 
@@ -274,8 +275,11 @@ RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
 }
 
 
-template <typename GlobalIterationGetter, typename OP, typename T>
-RAJA_DEVICE RAJA_INLINE void grid_reduce(RAJA::expt::detail::Reducer<OP, T>& red)
+template <typename GlobalIterationGetter, template <typename, typename, typename> class OP, typename T>
+RAJA_DEVICE RAJA_INLINE void grid_reduce( T * device_target,
+                                          T val,
+                                          RAJA::detail::SoAPtr<T,RAJA::cuda::device_mempool_type> device_mem,
+                                          unsigned int* device_count)
 {
   using BlockIterationGetter = typename get_index_block<GlobalIterationGetter>::type;
   using ThreadIterationGetter = typename get_index_thread<GlobalIterationGetter>::type;
@@ -287,7 +291,54 @@ RAJA_DEVICE RAJA_INLINE void grid_reduce(RAJA::expt::detail::Reducer<OP, T>& red
   const int blockId = BlockIterationGetter::index();
   const int threadId = ThreadIterationGetter::index();
 
-  T temp = block_reduce<ThreadIterationGetter, OP>(red.val, OP::identity());
+  T temp = block_reduce<ThreadIterationGetter, OP>(val, OP<T,T,T>::identity());
+
+  // one thread per block writes to device_mem
+  bool lastBlock = false;
+  if (threadId == 0) {
+    device_mem.set(blockId, temp);
+    // ensure write visible to all threadblocks
+    __threadfence();
+    // increment counter, (wraps back to zero if old count == wrap_around)
+    unsigned int old_count = ::atomicInc(device_count, wrap_around);
+    lastBlock = (old_count == wrap_around);
+  }
+
+  // returns non-zero value if any thread passes in a non-zero value
+  lastBlock = __syncthreads_or(lastBlock);
+
+  // last block accumulates values from device_mem
+  if (lastBlock) {
+    temp = OP<T,T,T>::identity();
+    __threadfence();
+
+    for (int i = threadId; i < numBlocks; i += numThreads) {
+      temp = OP<T,T,T>{}(temp, device_mem.get(i));
+    }
+
+    temp = block_reduce<ThreadIterationGetter, OP>(temp, OP<T,T,T>::identity());
+
+    // one thread returns value
+    if (threadId == 0) {
+      *device_target = temp;
+    }
+  }
+}
+
+template <typename GlobalIterationGetter, template <typename, typename, typename> class OP, typename T>
+RAJA_DEVICE RAJA_INLINE void grid_reduce(RAJA::expt::detail::Reducer<OP, T, T>& red)
+{
+  using BlockIterationGetter = typename get_index_block<GlobalIterationGetter>::type;
+  using ThreadIterationGetter = typename get_index_thread<GlobalIterationGetter>::type;
+
+  const int numBlocks = BlockIterationGetter::size();
+  const int numThreads = ThreadIterationGetter::size();
+  const unsigned int wrap_around = numBlocks - 1;
+
+  const int blockId = BlockIterationGetter::index();
+  const int threadId = ThreadIterationGetter::index();
+
+  T temp = block_reduce<ThreadIterationGetter, OP>(red.val, OP<T,T,T>::identity());
 
   // one thread per block writes to device_mem
   bool lastBlock = false;
@@ -305,14 +356,14 @@ RAJA_DEVICE RAJA_INLINE void grid_reduce(RAJA::expt::detail::Reducer<OP, T>& red
 
   // last block accumulates values from device_mem
   if (lastBlock) {
-    temp = OP::identity();
+    temp = OP<T,T,T>::identity();
     __threadfence();
 
     for (int i = threadId; i < numBlocks; i += numThreads) {
-      temp = OP{}(temp, red.device_mem.get(i));
+      temp = OP<T,T,T>{}(temp, red.device_mem.get(i));
     }
 
-    temp = block_reduce<ThreadIterationGetter, OP>(temp, OP::identity());
+    temp = block_reduce<ThreadIterationGetter, OP>(temp, OP<T,T,T>::identity());
 
     // one thread returns value
     if (threadId == 0) {

--- a/include/RAJA/policy/hip/params/reduce.hpp
+++ b/include/RAJA/policy/hip/params/reduce.hpp
@@ -13,77 +13,40 @@ namespace expt {
 namespace detail {
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType, D, I, true>& red, RAJA::hip::detail::hipInfo& hi)
+  init(Reducer<OP, T, I, VType>& red, RAJA::hip::detail::hipInfo& hi)
   {
-    red.devicetarget = RAJA::hip::pinned_mempool_type::getInstance().template malloc<T>(1);
+    using VT = typename Reducer<OP, T, I, VType>::value_type;
+    red.devicetarget = RAJA::hip::pinned_mempool_type::getInstance().template malloc<VT>(1);
     red.device_mem.allocate(hi.gridDim.x * hi.gridDim.y * hi.gridDim.z);
     red.device_count = RAJA::hip::device_zeroed_mempool_type::getInstance().template malloc<unsigned int>(1);
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
   RAJA_HOST_DEVICE
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType, D, I, true>& red)
+  combine(Reducer<OP, T, I, VType>& red)
   {
-    RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter,OP,T>( red.devicetarget,
+    using VT = typename Reducer<OP, T, I, VType>::value_type;
+    RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter,OP,VT>( red.devicetarget,
                                                                             red.getVal(),
                                                                             red.device_mem,
                                                                             red.device_count);
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType, D, I, true>& red, RAJA::hip::detail::hipInfo& hi)
+  resolve(Reducer<OP, T, I, VType>& red, RAJA::hip::detail::hipInfo& hi)
   {
+    using VT = typename Reducer<OP, T, I, VType>::value_type;
+
     // complete reduction
     hi.res.wait();
-    *red.target = OP<T,T,T>{}(*red.target, *red.devicetarget);
 
-    *red.passthruval = red.target->val;
-    *red.passthruindex = red.target->loc;
-
-    // free memory
-    RAJA::hip::device_zeroed_mempool_type::getInstance().free(red.device_count);
-    red.device_count = nullptr;
-    red.device_mem.deallocate();
-    RAJA::hip::pinned_mempool_type::getInstance().free(red.devicetarget);
-    red.devicetarget = nullptr;
-  }
-
-  // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
-  camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType, D, I, false>& red, RAJA::hip::detail::hipInfo& hi)
-  {
-    red.devicetarget = RAJA::hip::pinned_mempool_type::getInstance().template malloc<T>(1);
-    red.device_mem.allocate(hi.gridDim.x * hi.gridDim.y * hi.gridDim.z);
-    red.device_count = RAJA::hip::device_zeroed_mempool_type::getInstance().template malloc<unsigned int>(1);
-  }
-
-  // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
-  RAJA_HOST_DEVICE
-  camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType, D, I, false>& red)
-  {
-    RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter,OP,T>( red.devicetarget,
-                                                                            red.getVal(),
-                                                                            red.device_mem,
-                                                                            red.device_count);
-  }
-
-  // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
-  camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType, D, I, false>& red, RAJA::hip::detail::hipInfo& hi)
-  {
-    // complete reduction
-    hi.res.wait();
-    *red.target = OP<T,T,T>{}(*red.target, *red.devicetarget);
+    red.set(OP<VT,VT,VT>{}(*red.target, *red.devicetarget));
 
     // free memory
     RAJA::hip::device_zeroed_mempool_type::getInstance().free(red.device_count);

--- a/include/RAJA/policy/hip/params/reduce.hpp
+++ b/include/RAJA/policy/hip/params/reduce.hpp
@@ -42,7 +42,7 @@ namespace detail {
     // complete reduction
     hi.res.wait();
 
-    red.setTarget(OP{}(*red.target, *red.devicetarget));
+    red.combineTarget(*red.devicetarget);
 
     // free memory
     RAJA::hip::device_zeroed_mempool_type::getInstance().free(red.device_count);

--- a/include/RAJA/policy/hip/params/reduce.hpp
+++ b/include/RAJA/policy/hip/params/reduce.hpp
@@ -13,9 +13,9 @@ namespace expt {
 namespace detail {
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  init(Reducer<OP, T, ValOp<T,OP>>& red, RAJA::hip::detail::hipInfo& hi)
+  init(Reducer<OP, T, VType>& red, RAJA::hip::detail::hipInfo& hi)
   {
     red.devicetarget = RAJA::hip::pinned_mempool_type::getInstance().template malloc<T>(1);
     red.device_mem.allocate(hi.gridDim.x * hi.gridDim.y * hi.gridDim.z);
@@ -23,10 +23,10 @@ namespace detail {
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   RAJA_HOST_DEVICE
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  combine(Reducer<OP, T, ValOp<T,OP>>& red)
+  combine(Reducer<OP, T, VType>& red)
   {
     RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter,OP,T>( red.devicetarget,
                                                                             red.getVal(),
@@ -35,13 +35,13 @@ namespace detail {
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, ValOp<T,OP>>& red, RAJA::hip::detail::hipInfo& hi)
+  resolve(Reducer<OP, T, VType>& red, RAJA::hip::detail::hipInfo& hi)
   {
     // complete reduction
     hi.res.wait();
-    red.target->val = OP<T,T,T>{}(red.target->val, *red.devicetarget);
+    *red.target = OP<T,T,T>{}(*red.target, *red.devicetarget);
 
     // free memory
     RAJA::hip::device_zeroed_mempool_type::getInstance().free(red.device_count);

--- a/include/RAJA/policy/hip/params/reduce.hpp
+++ b/include/RAJA/policy/hip/params/reduce.hpp
@@ -13,9 +13,9 @@ namespace expt {
 namespace detail {
 
   // Init
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType>& red, RAJA::hip::detail::hipInfo& hi)
+  init(Reducer<OP, T, VOp>& red, RAJA::hip::detail::hipInfo& hi)
   {
     red.devicetarget = RAJA::hip::pinned_mempool_type::getInstance().template malloc<T>(1);
     red.device_mem.allocate(hi.gridDim.x * hi.gridDim.y * hi.gridDim.z);
@@ -23,10 +23,10 @@ namespace detail {
   }
 
   // Combine
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   RAJA_HOST_DEVICE
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType>& red)
+  combine(Reducer<OP, T, VOp>& red)
   {
     RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter,OP>( red.devicetarget,
                                                                             red.getVal(),
@@ -35,9 +35,9 @@ namespace detail {
   }
 
   // Resolve
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType>& red, RAJA::hip::detail::hipInfo& hi)
+  resolve(Reducer<OP, T, VOp>& red, RAJA::hip::detail::hipInfo& hi)
   {
     // complete reduction
     hi.res.wait();

--- a/include/RAJA/policy/hip/params/reduce.hpp
+++ b/include/RAJA/policy/hip/params/reduce.hpp
@@ -13,9 +13,9 @@ namespace expt {
 namespace detail {
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType>& red, RAJA::hip::detail::hipInfo& hi)
+  init(Reducer<OP, T, VType, D, I, true>& red, RAJA::hip::detail::hipInfo& hi)
   {
     red.devicetarget = RAJA::hip::pinned_mempool_type::getInstance().template malloc<T>(1);
     red.device_mem.allocate(hi.gridDim.x * hi.gridDim.y * hi.gridDim.z);
@@ -23,10 +23,10 @@ namespace detail {
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   RAJA_HOST_DEVICE
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType>& red)
+  combine(Reducer<OP, T, VType, D, I, true>& red)
   {
     RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter,OP,T>( red.devicetarget,
                                                                             red.getVal(),
@@ -35,9 +35,51 @@ namespace detail {
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType>& red, RAJA::hip::detail::hipInfo& hi)
+  resolve(Reducer<OP, T, VType, D, I, true>& red, RAJA::hip::detail::hipInfo& hi)
+  {
+    // complete reduction
+    hi.res.wait();
+    *red.target = OP<T,T,T>{}(*red.target, *red.devicetarget);
+
+    *red.passthruval = red.target->val;
+    *red.passthruindex = red.target->loc;
+
+    // free memory
+    RAJA::hip::device_zeroed_mempool_type::getInstance().free(red.device_count);
+    red.device_count = nullptr;
+    red.device_mem.deallocate();
+    RAJA::hip::pinned_mempool_type::getInstance().free(red.devicetarget);
+    red.devicetarget = nullptr;
+  }
+
+  // Init
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
+  init(Reducer<OP, T, VType, D, I, false>& red, RAJA::hip::detail::hipInfo& hi)
+  {
+    red.devicetarget = RAJA::hip::pinned_mempool_type::getInstance().template malloc<T>(1);
+    red.device_mem.allocate(hi.gridDim.x * hi.gridDim.y * hi.gridDim.z);
+    red.device_count = RAJA::hip::device_zeroed_mempool_type::getInstance().template malloc<unsigned int>(1);
+  }
+
+  // Combine
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  RAJA_HOST_DEVICE
+  camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
+  combine(Reducer<OP, T, VType, D, I, false>& red)
+  {
+    RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter,OP,T>( red.devicetarget,
+                                                                            red.getVal(),
+                                                                            red.device_mem,
+                                                                            red.device_count);
+  }
+
+  // Resolve
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
+  resolve(Reducer<OP, T, VType, D, I, false>& red, RAJA::hip::detail::hipInfo& hi)
   {
     // complete reduction
     hi.res.wait();

--- a/include/RAJA/policy/hip/params/reduce.hpp
+++ b/include/RAJA/policy/hip/params/reduce.hpp
@@ -51,45 +51,6 @@ namespace detail {
     red.devicetarget = nullptr;
   }
 
-//  // Init
-//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
-//  //template<typename EXEC_POL, typename OP, typename T>
-//  camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-//  init(Reducer<OP, T, T>& red, RAJA::hip::detail::hipInfo& hi)
-//  {
-//    red.devicetarget = RAJA::hip::pinned_mempool_type::getInstance().template malloc<T>(1);
-//    red.device_mem.allocate(hi.gridDim.x * hi.gridDim.y * hi.gridDim.z);
-//    red.device_count = RAJA::hip::device_zeroed_mempool_type::getInstance().template malloc<unsigned int>(1);
-//  }
-//
-//  // Combine
-//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
-//  //template<typename EXEC_POL, typename OP, typename T>
-//  RAJA_HOST_DEVICE
-//  camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-//  combine(Reducer<OP, T, T>& red)
-//  {
-//    RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter>(red);
-//  }
-//
-//  // Resolve
-//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
-//  //template<typename EXEC_POL, typename OP, typename T>
-//  camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-//  resolve(Reducer<OP, T, T>& red, RAJA::hip::detail::hipInfo& hi)
-//  {
-//    // complete reduction
-//    hi.res.wait();
-//    *red.target = OP<T,T,T>{}(*red.target, *red.devicetarget);
-//
-//    // free memory
-//    RAJA::hip::device_zeroed_mempool_type::getInstance().free(red.device_count);
-//    red.device_count = nullptr;
-//    red.device_mem.deallocate();
-//    RAJA::hip::pinned_mempool_type::getInstance().free(red.devicetarget);
-//    red.devicetarget = nullptr;
-//  }
-
 } //  namespace detail
 } //  namespace expt
 } //  namespace RAJA

--- a/include/RAJA/policy/hip/params/reduce.hpp
+++ b/include/RAJA/policy/hip/params/reduce.hpp
@@ -13,9 +13,9 @@ namespace expt {
 namespace detail {
 
   // Init
-  template<typename EXEC_POL, typename OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  init(Reducer<OP, T>& red, RAJA::hip::detail::hipInfo& hi)
+  init(Reducer<OP, T, ValOp<T,OP>>& red, RAJA::hip::detail::hipInfo& hi)
   {
     red.devicetarget = RAJA::hip::pinned_mempool_type::getInstance().template malloc<T>(1);
     red.device_mem.allocate(hi.gridDim.x * hi.gridDim.y * hi.gridDim.z);
@@ -23,22 +23,25 @@ namespace detail {
   }
 
   // Combine
-  template<typename EXEC_POL, typename OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
   RAJA_HOST_DEVICE
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  combine(Reducer<OP, T>& red)
+  combine(Reducer<OP, T, ValOp<T,OP>>& red)
   {
-    RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter>(red);
+    RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter,OP,T>( red.devicetarget,
+                                                                            red.getVal(),
+                                                                            red.device_mem,
+                                                                            red.device_count);
   }
 
   // Resolve
-  template<typename EXEC_POL, typename OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  resolve(Reducer<OP, T>& red, RAJA::hip::detail::hipInfo& hi)
+  resolve(Reducer<OP, T, ValOp<T,OP>>& red, RAJA::hip::detail::hipInfo& hi)
   {
     // complete reduction
     hi.res.wait();
-    *red.target = OP{}(*red.target, *red.devicetarget);
+    red.target->val = OP<T,T,T>{}(red.target->val, *red.devicetarget);
 
     // free memory
     RAJA::hip::device_zeroed_mempool_type::getInstance().free(red.device_count);
@@ -47,6 +50,45 @@ namespace detail {
     RAJA::hip::pinned_mempool_type::getInstance().free(red.devicetarget);
     red.devicetarget = nullptr;
   }
+
+//  // Init
+//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+//  //template<typename EXEC_POL, typename OP, typename T>
+//  camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
+//  init(Reducer<OP, T, T>& red, RAJA::hip::detail::hipInfo& hi)
+//  {
+//    red.devicetarget = RAJA::hip::pinned_mempool_type::getInstance().template malloc<T>(1);
+//    red.device_mem.allocate(hi.gridDim.x * hi.gridDim.y * hi.gridDim.z);
+//    red.device_count = RAJA::hip::device_zeroed_mempool_type::getInstance().template malloc<unsigned int>(1);
+//  }
+//
+//  // Combine
+//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+//  //template<typename EXEC_POL, typename OP, typename T>
+//  RAJA_HOST_DEVICE
+//  camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
+//  combine(Reducer<OP, T, T>& red)
+//  {
+//    RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter>(red);
+//  }
+//
+//  // Resolve
+//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+//  //template<typename EXEC_POL, typename OP, typename T>
+//  camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
+//  resolve(Reducer<OP, T, T>& red, RAJA::hip::detail::hipInfo& hi)
+//  {
+//    // complete reduction
+//    hi.res.wait();
+//    *red.target = OP<T,T,T>{}(*red.target, *red.devicetarget);
+//
+//    // free memory
+//    RAJA::hip::device_zeroed_mempool_type::getInstance().free(red.device_count);
+//    red.device_count = nullptr;
+//    red.device_mem.deallocate();
+//    RAJA::hip::pinned_mempool_type::getInstance().free(red.devicetarget);
+//    red.devicetarget = nullptr;
+//  }
 
 } //  namespace detail
 } //  namespace expt

--- a/include/RAJA/policy/hip/params/reduce.hpp
+++ b/include/RAJA/policy/hip/params/reduce.hpp
@@ -13,40 +13,36 @@ namespace expt {
 namespace detail {
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  init(Reducer<OP, T, I, VType>& red, RAJA::hip::detail::hipInfo& hi)
+  init(Reducer<OP, T, VType>& red, RAJA::hip::detail::hipInfo& hi)
   {
-    using VT = typename Reducer<OP, T, I, VType>::value_type;
-    red.devicetarget = RAJA::hip::pinned_mempool_type::getInstance().template malloc<VT>(1);
+    red.devicetarget = RAJA::hip::pinned_mempool_type::getInstance().template malloc<T>(1);
     red.device_mem.allocate(hi.gridDim.x * hi.gridDim.y * hi.gridDim.z);
     red.device_count = RAJA::hip::device_zeroed_mempool_type::getInstance().template malloc<unsigned int>(1);
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VType>
   RAJA_HOST_DEVICE
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  combine(Reducer<OP, T, I, VType>& red)
+  combine(Reducer<OP, T, VType>& red)
   {
-    using VT = typename Reducer<OP, T, I, VType>::value_type;
-    RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter,OP,VT>( red.devicetarget,
+    RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter,OP>( red.devicetarget,
                                                                             red.getVal(),
                                                                             red.device_mem,
                                                                             red.device_count);
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_hip_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, I, VType>& red, RAJA::hip::detail::hipInfo& hi)
+  resolve(Reducer<OP, T, VType>& red, RAJA::hip::detail::hipInfo& hi)
   {
-    using VT = typename Reducer<OP, T, I, VType>::value_type;
-
     // complete reduction
     hi.res.wait();
 
-    red.set(OP<VT,VT,VT>{}(*red.target, *red.devicetarget));
+    red.setTarget(OP{}(*red.target, *red.devicetarget));
 
     // free memory
     RAJA::hip::device_zeroed_mempool_type::getInstance().free(red.device_count);

--- a/include/RAJA/policy/hip/reduce.hpp
+++ b/include/RAJA/policy/hip/reduce.hpp
@@ -195,7 +195,6 @@ RAJA_DEVICE RAJA_INLINE int grid_reduce_last_block(T& val,
 namespace expt {
 
 template <typename ThreadIterationGetter, template <typename, typename, typename> class Combiner, typename T>
-//template <typename ThreadIterationGetter, typename Combiner, typename T>
 RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
 {
   const int numThreads = ThreadIterationGetter::size();

--- a/include/RAJA/policy/hip/reduce.hpp
+++ b/include/RAJA/policy/hip/reduce.hpp
@@ -318,54 +318,6 @@ RAJA_DEVICE RAJA_INLINE void grid_reduce( T * device_target,
   }
 }
 
-
-template <typename GlobalIterationGetter, template <typename, typename, typename> class OP, typename T>
-RAJA_DEVICE RAJA_INLINE void grid_reduce(RAJA::expt::detail::Reducer<OP, T, T>& red)
-{
-  using BlockIterationGetter = typename get_index_block<GlobalIterationGetter>::type;
-  using ThreadIterationGetter = typename get_index_thread<GlobalIterationGetter>::type;
-
-  const int numBlocks = BlockIterationGetter::size();
-  const int numThreads = ThreadIterationGetter::size();
-  const unsigned int wrap_around = numBlocks - 1;
-
-  const int blockId = BlockIterationGetter::index();
-  const int threadId = ThreadIterationGetter::index();
-
-  T temp = block_reduce<ThreadIterationGetter, OP>(red.val, OP<T,T,T>::identity());
-
-  // one thread per block writes to device_mem
-  bool lastBlock = false;
-  if (threadId == 0) {
-    red.device_mem.set(blockId, temp);
-    // ensure write visible to all threadblocks
-    __threadfence();
-    // increment counter, (wraps back to zero if old count == wrap_around)
-    unsigned int old_count = ::atomicInc(red.device_count, wrap_around);
-    lastBlock = (old_count == wrap_around);
-  }
-
-  // returns non-zero value if any thread passes in a non-zero value
-  lastBlock = __syncthreads_or(lastBlock);
-
-  // last block accumulates values from device_mem
-  if (lastBlock) {
-    temp = OP<T,T,T>::identity();
-    __threadfence();
-
-    for (int i = threadId; i < numBlocks; i += numThreads) {
-      temp = OP<T,T,T>{}(temp, red.device_mem.get(i));
-    }
-
-    temp = block_reduce<ThreadIterationGetter, OP>(temp, OP<T,T,T>::identity());
-
-    // one thread returns value
-    if (threadId == 0) {
-      *(red.devicetarget) = temp;
-    }
-  }
-}
-
 } //  namespace expt
 
 

--- a/include/RAJA/policy/hip/reduce.hpp
+++ b/include/RAJA/policy/hip/reduce.hpp
@@ -194,7 +194,7 @@ RAJA_DEVICE RAJA_INLINE int grid_reduce_last_block(T& val,
 
 namespace expt {
 
-template <typename ThreadIterationGetter, template <typename, typename, typename> class Combiner, typename T>
+template <typename ThreadIterationGetter, typename Combiner, typename T>
 RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
 {
   const int numThreads = ThreadIterationGetter::size();
@@ -210,7 +210,7 @@ RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
     // reduce each warp
     for (int i = 1; i < RAJA::policy::hip::device_constants.WARP_SIZE; i *= 2) {
       T rhs = RAJA::hip::impl::shfl_xor_sync(temp, i);
-      temp = Combiner<T,T,T>{}(temp, rhs);
+      temp = Combiner{}(temp, rhs);
     }
 
   } else {
@@ -221,7 +221,7 @@ RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
       T rhs = RAJA::hip::impl::shfl_sync(temp, srcLane);
       // only add from threads that exist (don't double count own value)
       if (srcLane < numThreads) {
-        temp = Combiner<T,T,T>{}(temp, rhs);
+        temp = Combiner{}(temp, rhs);
       }
     }
   }
@@ -257,7 +257,7 @@ RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
 
       for (int i = 1; i < RAJA::policy::hip::device_constants.MAX_WARPS; i *= 2) {
         T rhs = RAJA::hip::impl::shfl_xor_sync(temp, i);
-        temp = Combiner<T,T,T>{}(temp, rhs);
+        temp = Combiner{}(temp, rhs);
       }
     }
 
@@ -268,7 +268,7 @@ RAJA_DEVICE RAJA_INLINE T block_reduce(T val, T identity)
 }
 
 
-template <typename GlobalIterationGetter, template <typename, typename, typename> class OP, typename T>
+template <typename GlobalIterationGetter, typename OP, typename T>
 RAJA_DEVICE RAJA_INLINE void grid_reduce( T * device_target,
                                           T val,
                                           RAJA::detail::SoAPtr<T,RAJA::hip::device_mempool_type> device_mem,
@@ -284,7 +284,7 @@ RAJA_DEVICE RAJA_INLINE void grid_reduce( T * device_target,
   const int blockId = BlockIterationGetter::index();
   const int threadId = ThreadIterationGetter::index();
 
-  T temp = block_reduce<ThreadIterationGetter, OP>(val, OP<T,T,T>::identity());
+  T temp = block_reduce<ThreadIterationGetter, OP>(val, OP::identity());
 
   // one thread per block writes to device_mem
   bool lastBlock = false;
@@ -302,14 +302,14 @@ RAJA_DEVICE RAJA_INLINE void grid_reduce( T * device_target,
 
   // last block accumulates values from device_mem
   if (lastBlock) {
-    temp = OP<T,T,T>::identity();
+    temp = OP::identity();
     __threadfence();
 
     for (int i = threadId; i < numBlocks; i += numThreads) {
-      temp = OP<T,T,T>{}(temp, device_mem.get(i));
+      temp = OP{}(temp, device_mem.get(i));
     }
 
-    temp = block_reduce<ThreadIterationGetter, OP>(temp, OP<T,T,T>::identity());
+    temp = block_reduce<ThreadIterationGetter, OP>(temp, OP::identity());
 
     // one thread returns value
     if (threadId == 0) {

--- a/include/RAJA/policy/openmp/params/reduce.hpp
+++ b/include/RAJA/policy/openmp/params/reduce.hpp
@@ -10,23 +10,23 @@ namespace detail {
 #if defined(RAJA_ENABLE_OPENMP)
 
   // Init
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType>& red) {
+  init(Reducer<OP, T, VOp>& red) {
     red.m_valop.val = OP::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
+  combine(Reducer<OP, T, VOp>& out, const Reducer<OP, T, VOp>& in) {
     out.m_valop.val = OP{}(out.m_valop.val, in.m_valop.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType>& red) {
+  resolve(Reducer<OP, T, VOp>& red) {
     red.combineTarget(red.m_valop.val);
   }
 

--- a/include/RAJA/policy/openmp/params/reduce.hpp
+++ b/include/RAJA/policy/openmp/params/reduce.hpp
@@ -10,47 +10,27 @@ namespace detail {
 #if defined(RAJA_ENABLE_OPENMP)
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType, D, I, true>& red) {
-    red.valop_m.val = OP<T,T,T>::identity();
+  init(Reducer<OP, T, I, VType>& red) {
+    using VT = typename Reducer<OP, T, I, VType>::value_type;
+    red.valop_m.val = OP<VT,VT,VT>::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType, D, I, true>& out, const Reducer<OP, T, VType, D, I, true>& in) {
-    out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
+  combine(Reducer<OP, T, I, VType>& out, const Reducer<OP, T, I, VType>& in) {
+    using VT = typename Reducer<OP, T, I, VType>::value_type;
+    out.valop_m.val = OP<VT,VT,VT>{}(out.valop_m.val, in.valop_m.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType, D, I, true>& red) {
-    *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
-    *red.passthruval = red.valop_m.val.val;
-    *red.passthruindex = red.valop_m.val.loc;
-  }
-
-  // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
-  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType, D, I, false>& red) {
-    red.valop_m.val = OP<T,T,T>::identity();
-  }
-
-  // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
-  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType, D, I, false>& out, const Reducer<OP, T, VType, D, I, false>& in) {
-    out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
-  }
-
-  // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
-  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType, D, I, false>& red) {
-    *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
+  resolve(Reducer<OP, T, I, VType>& red) {
+    using VT = typename Reducer<OP, T, I, VType>::value_type;
+    red.set(OP<VT,VT,VT>{}(*red.target, red.valop_m.val));
   }
 
 #endif

--- a/include/RAJA/policy/openmp/params/reduce.hpp
+++ b/include/RAJA/policy/openmp/params/reduce.hpp
@@ -27,7 +27,7 @@ namespace detail {
   template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
   resolve(Reducer<OP, T, VType>& red) {
-    red.setTarget(OP{}(*red.target, red.m_valop.val));
+    red.combineTarget(red.m_valop.val);
   }
 
 #endif

--- a/include/RAJA/policy/openmp/params/reduce.hpp
+++ b/include/RAJA/policy/openmp/params/reduce.hpp
@@ -10,25 +10,52 @@ namespace detail {
 #if defined(RAJA_ENABLE_OPENMP)
 
   // Init
-  template<typename EXEC_POL, typename OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  init(Reducer<OP, T>& red) {
-    red.val = OP::identity();
+  init(Reducer<OP, T, ValOp<T,OP>>& red) {
+    red.val.val = OP<T,T,T>::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, typename OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  combine(Reducer<OP, T>& out, const Reducer<OP, T>& in) {
-    out.val = OP{}(out.val, in.val);
+  combine(Reducer<OP, T, ValOp<T,OP>>& out, const Reducer<OP, T, ValOp<T,OP>>& in) {
+    out.val.val = OP<T,T,T>{}(out.val.val, in.val.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, typename OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  resolve(Reducer<OP, T>& red) {
-    *red.target = OP{}(*red.target, red.val);
+  resolve(Reducer<OP, T, ValOp<T,OP>>& red) {
+    red.target->val = OP<T,T,T>{}(red.target->val, red.val.val);
   }
+
+//  // Init
+//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+//  //template<typename EXEC_POL, typename OP, typename T>
+//  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
+//  init(Reducer<OP, T, T>& red) {
+//  //init(Reducer<OP, T>& red) {
+//    red.val = OP<T,T,T>::identity();
+//  }
+//
+//  // Combine
+//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+//  //template<typename EXEC_POL, typename OP, typename T>
+//  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
+//  combine(Reducer<OP, T, T>& out, const Reducer<OP, T, T>& in) {
+//  //combine(Reducer<OP, T>& out, const Reducer<OP, T>& in) {
+//    out.val = OP<T,T,T>{}(out.val, in.val);
+//  }
+//
+//  // Resolve
+//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+//  //template<typename EXEC_POL, typename OP, typename T>
+//  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
+//  resolve(Reducer<OP, T, T>& red) {
+//  //resolve(Reducer<OP, T>& red) {
+//    *red.target = OP<T,T,T>{}(*red.target, red.val);
+//  }
 
 #endif
 

--- a/include/RAJA/policy/openmp/params/reduce.hpp
+++ b/include/RAJA/policy/openmp/params/reduce.hpp
@@ -9,82 +9,25 @@ namespace detail {
 
 #if defined(RAJA_ENABLE_OPENMP)
 
-/*
-  // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType,
-           std::enable_if_t<std::is_same<T, RAJA::expt::ValLoc<int,RAJA::Index_type>>::value>* = nullptr >
-  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType>& red) {
-    red.val.val = OP<T,T,T>::identity();
-  }
-
-  // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType,
-           std::enable_if_t<std::is_same<T, RAJA::expt::ValLoc<int,RAJA::Index_type>>::value>* = nullptr >
-  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
-    out.val.val = OP<T,T,T>{}(out.val.val, in.val.val);
-  }
-
-  // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType,
-           std::enable_if_t<std::is_same<T, RAJA::expt::ValLoc<int,RAJA::Index_type>>::value>* = nullptr >
-  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType>& red) {
-  //resolve(Reducer<OP, T, ValOp<ValLoc<T,U>,OP>>& red) {
-    *red.target = OP<T,T,T>{}(*red.target, red.val.val);
-  }
-
-  // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType,
-           std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>* = nullptr >
-  //template<typename EXEC_POL, typename OP, typename T>
-  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType>& red) {
-  //init(Reducer<OP, T>& red) {
-    red.val.val = OP<T,T,T>::identity();
-  }
-
-  // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType,
-           std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>* = nullptr >
-  //template<typename EXEC_POL, typename OP, typename T>
-  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
-  //combine(Reducer<OP, T>& out, const Reducer<OP, T>& in) {
-    out.val.val = OP<T,T,T>{}(out.val.val, in.val.val);
-  }
-
-  // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType,
-           std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>* = nullptr >
-  //template<typename EXEC_POL, typename OP, typename T>
-  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType>& red) {
-  //resolve(Reducer<OP, T>& red) {
-    *red.target = OP<T,T,T>{}(*red.target, red.val.val);
-  }
-*/
-
   // Init
   template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
   init(Reducer<OP, T, VType>& red) {
-    red.val.val = OP<T,T,T>::identity();
+    red.valop_m.val = OP<T,T,T>::identity();
   }
 
   // Combine
   template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
   combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
-    out.val.val = OP<T,T,T>{}(out.val.val, in.val.val);
+    out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
   }
 
   // Resolve
   template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
   resolve(Reducer<OP, T, VType>& red) {
-    *red.target = OP<T,T,T>{}(*red.target, red.val.val);
+    *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
   }
 
 #endif

--- a/include/RAJA/policy/openmp/params/reduce.hpp
+++ b/include/RAJA/policy/openmp/params/reduce.hpp
@@ -10,23 +10,46 @@ namespace detail {
 #if defined(RAJA_ENABLE_OPENMP)
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType>& red) {
+  init(Reducer<OP, T, VType, D, I, true>& red) {
     red.valop_m.val = OP<T,T,T>::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
+  combine(Reducer<OP, T, VType, D, I, true>& out, const Reducer<OP, T, VType, D, I, true>& in) {
     out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType>& red) {
+  resolve(Reducer<OP, T, VType, D, I, true>& red) {
+    *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
+    *red.passthruval = red.valop_m.val.val;
+    *red.passthruindex = red.valop_m.val.loc;
+  }
+
+  // Init
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
+  init(Reducer<OP, T, VType, D, I, false>& red) {
+    red.valop_m.val = OP<T,T,T>::identity();
+  }
+
+  // Combine
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
+  combine(Reducer<OP, T, VType, D, I, false>& out, const Reducer<OP, T, VType, D, I, false>& in) {
+    out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
+  }
+
+  // Resolve
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
+  resolve(Reducer<OP, T, VType, D, I, false>& red) {
     *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
   }
 

--- a/include/RAJA/policy/openmp/params/reduce.hpp
+++ b/include/RAJA/policy/openmp/params/reduce.hpp
@@ -13,21 +13,21 @@ namespace detail {
   template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
   init(Reducer<OP, T, VType>& red) {
-    red.valop_m.val = OP::identity();
+    red.m_valop.val = OP::identity();
   }
 
   // Combine
   template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
   combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
-    out.valop_m.val = OP{}(out.valop_m.val, in.valop_m.val);
+    out.m_valop.val = OP{}(out.m_valop.val, in.m_valop.val);
   }
 
   // Resolve
   template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
   resolve(Reducer<OP, T, VType>& red) {
-    red.setTarget(OP{}(*red.target, red.valop_m.val));
+    red.setTarget(OP{}(*red.target, red.m_valop.val));
   }
 
 #endif

--- a/include/RAJA/policy/openmp/params/reduce.hpp
+++ b/include/RAJA/policy/openmp/params/reduce.hpp
@@ -10,27 +10,24 @@ namespace detail {
 #if defined(RAJA_ENABLE_OPENMP)
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  init(Reducer<OP, T, I, VType>& red) {
-    using VT = typename Reducer<OP, T, I, VType>::value_type;
-    red.valop_m.val = OP<VT,VT,VT>::identity();
+  init(Reducer<OP, T, VType>& red) {
+    red.valop_m.val = OP::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  combine(Reducer<OP, T, I, VType>& out, const Reducer<OP, T, I, VType>& in) {
-    using VT = typename Reducer<OP, T, I, VType>::value_type;
-    out.valop_m.val = OP<VT,VT,VT>{}(out.valop_m.val, in.valop_m.val);
+  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
+    out.valop_m.val = OP{}(out.valop_m.val, in.valop_m.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, I, VType>& red) {
-    using VT = typename Reducer<OP, T, I, VType>::value_type;
-    red.set(OP<VT,VT,VT>{}(*red.target, red.valop_m.val));
+  resolve(Reducer<OP, T, VType>& red) {
+    red.setTarget(OP{}(*red.target, red.valop_m.val));
   }
 
 #endif

--- a/include/RAJA/policy/openmp/params/reduce.hpp
+++ b/include/RAJA/policy/openmp/params/reduce.hpp
@@ -9,53 +9,83 @@ namespace detail {
 
 #if defined(RAJA_ENABLE_OPENMP)
 
+/*
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType,
+           std::enable_if_t<std::is_same<T, RAJA::expt::ValLoc<int,RAJA::Index_type>>::value>* = nullptr >
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  init(Reducer<OP, T, ValOp<T,OP>>& red) {
+  init(Reducer<OP, T, VType>& red) {
     red.val.val = OP<T,T,T>::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType,
+           std::enable_if_t<std::is_same<T, RAJA::expt::ValLoc<int,RAJA::Index_type>>::value>* = nullptr >
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  combine(Reducer<OP, T, ValOp<T,OP>>& out, const Reducer<OP, T, ValOp<T,OP>>& in) {
+  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
     out.val.val = OP<T,T,T>{}(out.val.val, in.val.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType,
+           std::enable_if_t<std::is_same<T, RAJA::expt::ValLoc<int,RAJA::Index_type>>::value>* = nullptr >
   camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, ValOp<T,OP>>& red) {
-    red.target->val = OP<T,T,T>{}(red.target->val, red.val.val);
+  resolve(Reducer<OP, T, VType>& red) {
+  //resolve(Reducer<OP, T, ValOp<ValLoc<T,U>,OP>>& red) {
+    *red.target = OP<T,T,T>{}(*red.target, red.val.val);
   }
 
-//  // Init
-//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
-//  //template<typename EXEC_POL, typename OP, typename T>
-//  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-//  init(Reducer<OP, T, T>& red) {
-//  //init(Reducer<OP, T>& red) {
-//    red.val = OP<T,T,T>::identity();
-//  }
-//
-//  // Combine
-//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
-//  //template<typename EXEC_POL, typename OP, typename T>
-//  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-//  combine(Reducer<OP, T, T>& out, const Reducer<OP, T, T>& in) {
-//  //combine(Reducer<OP, T>& out, const Reducer<OP, T>& in) {
-//    out.val = OP<T,T,T>{}(out.val, in.val);
-//  }
-//
-//  // Resolve
-//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
-//  //template<typename EXEC_POL, typename OP, typename T>
-//  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
-//  resolve(Reducer<OP, T, T>& red) {
-//  //resolve(Reducer<OP, T>& red) {
-//    *red.target = OP<T,T,T>{}(*red.target, red.val);
-//  }
+  // Init
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType,
+           std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>* = nullptr >
+  //template<typename EXEC_POL, typename OP, typename T>
+  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
+  init(Reducer<OP, T, VType>& red) {
+  //init(Reducer<OP, T>& red) {
+    red.val.val = OP<T,T,T>::identity();
+  }
+
+  // Combine
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType,
+           std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>* = nullptr >
+  //template<typename EXEC_POL, typename OP, typename T>
+  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
+  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
+  //combine(Reducer<OP, T>& out, const Reducer<OP, T>& in) {
+    out.val.val = OP<T,T,T>{}(out.val.val, in.val.val);
+  }
+
+  // Resolve
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType,
+           std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>* = nullptr >
+  //template<typename EXEC_POL, typename OP, typename T>
+  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
+  resolve(Reducer<OP, T, VType>& red) {
+  //resolve(Reducer<OP, T>& red) {
+    *red.target = OP<T,T,T>{}(*red.target, red.val.val);
+  }
+*/
+
+  // Init
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
+  init(Reducer<OP, T, VType>& red) {
+    red.val.val = OP<T,T,T>::identity();
+  }
+
+  // Combine
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
+  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
+    out.val.val = OP<T,T,T>{}(out.val.val, in.val.val);
+  }
+
+  // Resolve
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  camp::concepts::enable_if< type_traits::is_openmp_policy<EXEC_POL> >
+  resolve(Reducer<OP, T, VType>& red) {
+    *red.target = OP<T,T,T>{}(*red.target, red.val.val);
+  }
 
 #endif
 

--- a/include/RAJA/policy/openmp_target/params/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/params/reduce.hpp
@@ -10,23 +10,23 @@ namespace detail {
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
 
   // Init
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType>& red) {
+  init(Reducer<OP, T, VOp>& red) {
     red.m_valop.val = OP::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
+  combine(Reducer<OP, T, VOp>& out, const Reducer<OP, T, VOp>& in) {
     out.m_valop.val = OP{}(out.m_valop.val, in.m_valop.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, I, VType>& red) {
+  resolve(Reducer<OP, T, I, VOp>& red) {
     red.combineTarget(red.m_valop.val);
   }
 

--- a/include/RAJA/policy/openmp_target/params/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/params/reduce.hpp
@@ -13,21 +13,21 @@ namespace detail {
   template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
   init(Reducer<OP, T, VType>& red) {
-    red.valop_m.val = OP::identity();
+    red.m_valop.val = OP::identity();
   }
 
   // Combine
   template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
   combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
-    out.valop_m.val = OP{}(out.valop_m.val, in.valop_m.val);
+    out.m_valop.val = OP{}(out.m_valop.val, in.m_valop.val);
   }
 
   // Resolve
   template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
   resolve(Reducer<OP, T, I, VType>& red) {
-    red.setTarget(OP{}(*red.target, red.valop_m.val));
+    red.setTarget(OP{}(*red.target, red.m_valop.val));
   }
 
 #endif

--- a/include/RAJA/policy/openmp_target/params/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/params/reduce.hpp
@@ -10,27 +10,24 @@ namespace detail {
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  init(Reducer<OP, T, I, VType>& red) {
-    using VT = typename Reducer<OP, T, I, VType>::value_type;
-    red.valop_m.val = OP<VT,VT,VT>::identity();
+  init(Reducer<OP, T, VType>& red) {
+    red.valop_m.val = OP::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  combine(Reducer<OP, T, I, VType>& out, const Reducer<OP, T, I, VType>& in) {
-    using VT = typename Reducer<OP, T, I, VType>::value_type;
-    out.valop_m.val = OP<VT,VT,VT>{}(out.valop_m.val, in.valop_m.val);
+  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
+    out.valop_m.val = OP{}(out.valop_m.val, in.valop_m.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
   resolve(Reducer<OP, T, I, VType>& red) {
-    using VT = typename Reducer<OP, T, I, VType>::value_type;
-    red.set(OP<VT,VT,VT>{}(*red.target, red.valop_m.val));
+    red.setTarget(OP{}(*red.target, red.valop_m.val));
   }
 
 #endif

--- a/include/RAJA/policy/openmp_target/params/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/params/reduce.hpp
@@ -10,25 +10,46 @@ namespace detail {
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
 
   // Init
-  template<typename EXEC_POL, typename OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  init(Reducer<OP, T>& red) {
-    red.val = OP::identity();
+  init(Reducer<OP, T, ValOp<T,OP>>& red) {
+    red.val.val = OP<T,T,T>::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, typename OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  combine(Reducer<OP, T>& out, const Reducer<OP, T>& in) {
-    out.val = OP{}(out.val, in.val);
+  combine(Reducer<OP, T, ValOp<T,OP>>& out, const Reducer<OP, T, ValOp<T,OP>>& in) {
+    out.val.val = OP<T,T,T>{}(out.val.val, in.val.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, typename OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  resolve(Reducer<OP, T>& red) {
-    *red.target = OP{}(*red.target, red.val);
+  resolve(Reducer<OP, T, ValOp<T,OP>>& red) {
+    red.target->val = OP<T,T,T>{}(red.target->val, red.val.val);
   }
+
+//  // Init
+//  template<typename EXEC_POL, typename OP, typename T>
+//  camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
+//  init(Reducer<OP, T>& red) {
+//    red.val = OP::identity();
+//  }
+//
+//  // Combine
+//  template<typename EXEC_POL, typename OP, typename T>
+//  camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
+//  combine(Reducer<OP, T>& out, const Reducer<OP, T>& in) {
+//    out.val = OP{}(out.val, in.val);
+//  }
+//
+//  // Resolve
+//  template<typename EXEC_POL, typename OP, typename T>
+//  camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
+//  resolve(Reducer<OP, T>& red) {
+//    *red.target = OP{}(*red.target, red.val);
+//  }
 
 #endif
 

--- a/include/RAJA/policy/openmp_target/params/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/params/reduce.hpp
@@ -13,21 +13,21 @@ namespace detail {
   template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
   init(Reducer<OP, T, VType>& red) {
-    red.val.val = OP<T,T,T>::identity();
+    red.valop_m.val = OP<T,T,T>::identity();
   }
 
   // Combine
   template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
   combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
-    out.val.val = OP<T,T,T>{}(out.val.val, in.val.val);
+    out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
   }
 
   // Resolve
   template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
   resolve(Reducer<OP, T, VType>& red) {
-    *red.target = OP<T,T,T>{}(*red.target, red.val.val);
+    *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
   }
 
 #endif

--- a/include/RAJA/policy/openmp_target/params/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/params/reduce.hpp
@@ -10,46 +10,25 @@ namespace detail {
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  init(Reducer<OP, T, ValOp<T,OP>>& red) {
+  init(Reducer<OP, T, VType>& red) {
     red.val.val = OP<T,T,T>::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  combine(Reducer<OP, T, ValOp<T,OP>>& out, const Reducer<OP, T, ValOp<T,OP>>& in) {
+  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
     out.val.val = OP<T,T,T>{}(out.val.val, in.val.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, ValOp<T,OP>>& red) {
-    red.target->val = OP<T,T,T>{}(red.target->val, red.val.val);
+  resolve(Reducer<OP, T, VType>& red) {
+    *red.target = OP<T,T,T>{}(*red.target, red.val.val);
   }
-
-//  // Init
-//  template<typename EXEC_POL, typename OP, typename T>
-//  camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-//  init(Reducer<OP, T>& red) {
-//    red.val = OP::identity();
-//  }
-//
-//  // Combine
-//  template<typename EXEC_POL, typename OP, typename T>
-//  camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-//  combine(Reducer<OP, T>& out, const Reducer<OP, T>& in) {
-//    out.val = OP{}(out.val, in.val);
-//  }
-//
-//  // Resolve
-//  template<typename EXEC_POL, typename OP, typename T>
-//  camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-//  resolve(Reducer<OP, T>& red) {
-//    *red.target = OP{}(*red.target, red.val);
-//  }
 
 #endif
 

--- a/include/RAJA/policy/openmp_target/params/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/params/reduce.hpp
@@ -10,47 +10,27 @@ namespace detail {
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType, D, I, true>& red) {
-    red.valop_m.val = OP<T,T,T>::identity();
+  init(Reducer<OP, T, I, VType>& red) {
+    using VT = typename Reducer<OP, T, I, VType>::value_type;
+    red.valop_m.val = OP<VT,VT,VT>::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType, D, I, true>& out, const Reducer<OP, T, VType, D, I, true>& in) {
-    out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
+  combine(Reducer<OP, T, I, VType>& out, const Reducer<OP, T, I, VType>& in) {
+    using VT = typename Reducer<OP, T, I, VType>::value_type;
+    out.valop_m.val = OP<VT,VT,VT>{}(out.valop_m.val, in.valop_m.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType, D, I, true>& red) {
-    *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
-    *red.passthruval = red.valop_m.val.val;
-    *red.passthruindex = red.valop_m.val.loc;
-  }
-
-  // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
-  camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType>& red) {
-    red.valop_m.val = OP<T,T,T>::identity();
-  }
-
-  // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
-  camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
-    out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
-  }
-
-  // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
-  camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType>& red) {
-    *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
+  resolve(Reducer<OP, T, I, VType>& red) {
+    using VT = typename Reducer<OP, T, I, VType>::value_type;
+    red.set(OP<VT,VT,VT>{}(*red.target, red.valop_m.val));
   }
 
 #endif

--- a/include/RAJA/policy/openmp_target/params/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/params/reduce.hpp
@@ -27,7 +27,7 @@ namespace detail {
   template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
   resolve(Reducer<OP, T, I, VType>& red) {
-    red.setTarget(OP{}(*red.target, red.m_valop.val));
+    red.combineTarget(red.m_valop.val);
   }
 
 #endif

--- a/include/RAJA/policy/openmp_target/params/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/params/reduce.hpp
@@ -10,6 +10,29 @@ namespace detail {
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
 
   // Init
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
+  init(Reducer<OP, T, VType, D, I, true>& red) {
+    red.valop_m.val = OP<T,T,T>::identity();
+  }
+
+  // Combine
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
+  combine(Reducer<OP, T, VType, D, I, true>& out, const Reducer<OP, T, VType, D, I, true>& in) {
+    out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
+  }
+
+  // Resolve
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
+  resolve(Reducer<OP, T, VType, D, I, true>& red) {
+    *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
+    *red.passthruval = red.valop_m.val.val;
+    *red.passthruindex = red.valop_m.val.loc;
+  }
+
+  // Init
   template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
   init(Reducer<OP, T, VType>& red) {

--- a/include/RAJA/policy/sequential/params/reduce.hpp
+++ b/include/RAJA/policy/sequential/params/reduce.hpp
@@ -8,23 +8,23 @@ namespace expt {
 namespace detail {
 
   // Init
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  init(Reducer<OP, T, VType>& red) {
+  init(Reducer<OP, T, VOp>& red) {
     red.m_valop.val = OP::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
+  combine(Reducer<OP, T, VOp>& out, const Reducer<OP, T, VOp>& in) {
     out.m_valop.val = OP{}(out.m_valop.val, in.m_valop.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  resolve(Reducer<OP, T, VType>& red) {
+  resolve(Reducer<OP, T, VOp>& red) {
     red.combineTarget(red.m_valop.val);
   }
 

--- a/include/RAJA/policy/sequential/params/reduce.hpp
+++ b/include/RAJA/policy/sequential/params/reduce.hpp
@@ -25,7 +25,7 @@ namespace detail {
   template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
   resolve(Reducer<OP, T, VType>& red) {
-    red.setTarget(OP{}(*red.target, red.m_valop.val));
+    red.combineTarget(red.m_valop.val);
   }
 
 } //  namespace detail

--- a/include/RAJA/policy/sequential/params/reduce.hpp
+++ b/include/RAJA/policy/sequential/params/reduce.hpp
@@ -11,21 +11,21 @@ namespace detail {
   template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
   init(Reducer<OP, T, VType>& red) {
-    red.valop_m.val = OP::identity();
+    red.m_valop.val = OP::identity();
   }
 
   // Combine
   template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
   combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
-    out.valop_m.val = OP{}(out.valop_m.val, in.valop_m.val);
+    out.m_valop.val = OP{}(out.m_valop.val, in.m_valop.val);
   }
 
   // Resolve
   template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
   resolve(Reducer<OP, T, VType>& red) {
-    red.setTarget(OP{}(*red.target, red.valop_m.val));
+    red.setTarget(OP{}(*red.target, red.m_valop.val));
   }
 
 } //  namespace detail

--- a/include/RAJA/policy/sequential/params/reduce.hpp
+++ b/include/RAJA/policy/sequential/params/reduce.hpp
@@ -8,23 +8,47 @@ namespace expt {
 namespace detail {
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  init(Reducer<OP, T, VType>& red) {
+  init(Reducer<OP, T, VType, D, I, true>& red) {
     red.valop_m.val = OP<T,T,T>::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
+  combine(Reducer<OP, T, VType, D, I, true>& out, const Reducer<OP, T, VType, D, I, true>& in) {
     out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  resolve(Reducer<OP, T, VType>& red) {
+  resolve(Reducer<OP, T, VType, D, I, true>& red) {
+    *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
+    *red.passthruval = red.valop_m.val.val;
+    *red.passthruindex = red.valop_m.val.loc;
+  }
+
+
+  // Init
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
+  init(Reducer<OP, T, VType, D, I, false>& red) {
+    red.valop_m.val = OP<T,T,T>::identity();
+  }
+
+  // Combine
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
+  combine(Reducer<OP, T, VType, D, I, false>& out, const Reducer<OP, T, VType, D, I, false>& in) {
+    out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
+  }
+
+  // Resolve
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
+  resolve(Reducer<OP, T, VType, D, I, false>& red) {
     *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
   }
 

--- a/include/RAJA/policy/sequential/params/reduce.hpp
+++ b/include/RAJA/policy/sequential/params/reduce.hpp
@@ -8,48 +8,25 @@ namespace expt {
 namespace detail {
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  init(Reducer<OP, T, ValOp<T,OP>>& red) {
+  init(Reducer<OP, T, VType>& red) {
     red.val.val = OP<T,T,T>::identity();
   }
+
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  combine(Reducer<OP, T, ValOp<T,OP>>& out, const Reducer<OP, T, ValOp<T,OP>>& in) {
+  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
     out.val.val = OP<T,T,T>{}(out.val.val, in.val.val);
   }
-  // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
-  camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  resolve(Reducer<OP, T, ValOp<T,OP>>& red) {
-    red.target->val = OP<T,T,T>{}(red.target->val, red.val.val);
-  }
 
-//  // Init
-//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
-//  //template<typename EXEC_POL, typename OP, typename T>
-//  camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-//  init(Reducer<OP, T, T>& red) {
-//  //init(Reducer<OP, T>& red) {
-//    red.val = OP<T,T,T>::identity();
-//  }
-//  // Combine
-//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
-//  //template<typename EXEC_POL, typename OP, typename T>
-//  camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-//  combine(Reducer<OP, T, T>& out, const Reducer<OP, T, T>& in) {
-//  //combine(Reducer<OP, T>& out, const Reducer<OP, T>& in) {
-//    out.val = OP<T,T,T>{}(out.val, in.val);
-//  }
-//  // Resolve
-//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
-//  //template<typename EXEC_POL, typename OP, typename T>
-//  camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-//  resolve(Reducer<OP, T, T>& red) {
-//  //resolve(Reducer<OP, T>& red) {
-//    *red.target = OP<T,T,T>{}(*red.target, red.val);
-//  }
+  // Resolve
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
+  resolve(Reducer<OP, T, VType>& red) {
+    *red.target = OP<T,T,T>{}(*red.target, red.val.val);
+  }
 
 } //  namespace detail
 } //  namespace expt

--- a/include/RAJA/policy/sequential/params/reduce.hpp
+++ b/include/RAJA/policy/sequential/params/reduce.hpp
@@ -8,48 +8,27 @@ namespace expt {
 namespace detail {
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  init(Reducer<OP, T, VType, D, I, true>& red) {
-    red.valop_m.val = OP<T,T,T>::identity();
+  init(Reducer<OP, T, I, VType>& red) {
+    using VT = typename Reducer<OP, T, I, VType>::value_type;
+    red.valop_m.val = OP<VT,VT,VT>::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  combine(Reducer<OP, T, VType, D, I, true>& out, const Reducer<OP, T, VType, D, I, true>& in) {
-    out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
+  combine(Reducer<OP, T, I, VType>& out, const Reducer<OP, T, I, VType>& in) {
+    using VT = typename Reducer<OP, T, I, VType>::value_type;
+    out.valop_m.val = OP<VT,VT,VT>{}(out.valop_m.val, in.valop_m.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  resolve(Reducer<OP, T, VType, D, I, true>& red) {
-    *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
-    *red.passthruval = red.valop_m.val.val;
-    *red.passthruindex = red.valop_m.val.loc;
-  }
-
-
-  // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
-  camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  init(Reducer<OP, T, VType, D, I, false>& red) {
-    red.valop_m.val = OP<T,T,T>::identity();
-  }
-
-  // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
-  camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  combine(Reducer<OP, T, VType, D, I, false>& out, const Reducer<OP, T, VType, D, I, false>& in) {
-    out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
-  }
-
-  // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
-  camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  resolve(Reducer<OP, T, VType, D, I, false>& red) {
-    *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
+  resolve(Reducer<OP, T, I, VType>& red) {
+    using VT = typename Reducer<OP, T, I, VType>::value_type;
+    red.set(OP<VT,VT,VT>{}(*red.target, red.valop_m.val));
   }
 
 } //  namespace detail

--- a/include/RAJA/policy/sequential/params/reduce.hpp
+++ b/include/RAJA/policy/sequential/params/reduce.hpp
@@ -8,27 +8,24 @@ namespace expt {
 namespace detail {
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  init(Reducer<OP, T, I, VType>& red) {
-    using VT = typename Reducer<OP, T, I, VType>::value_type;
-    red.valop_m.val = OP<VT,VT,VT>::identity();
+  init(Reducer<OP, T, VType>& red) {
+    red.valop_m.val = OP::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  combine(Reducer<OP, T, I, VType>& out, const Reducer<OP, T, I, VType>& in) {
-    using VT = typename Reducer<OP, T, I, VType>::value_type;
-    out.valop_m.val = OP<VT,VT,VT>{}(out.valop_m.val, in.valop_m.val);
+  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
+    out.valop_m.val = OP{}(out.valop_m.val, in.valop_m.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  resolve(Reducer<OP, T, I, VType>& red) {
-    using VT = typename Reducer<OP, T, I, VType>::value_type;
-    red.set(OP<VT,VT,VT>{}(*red.target, red.valop_m.val));
+  resolve(Reducer<OP, T, VType>& red) {
+    red.setTarget(OP{}(*red.target, red.valop_m.val));
   }
 
 } //  namespace detail

--- a/include/RAJA/policy/sequential/params/reduce.hpp
+++ b/include/RAJA/policy/sequential/params/reduce.hpp
@@ -8,23 +8,48 @@ namespace expt {
 namespace detail {
 
   // Init
-  template<typename EXEC_POL, typename OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  init(Reducer<OP, T>& red) {
-    red.val = OP::identity();
+  init(Reducer<OP, T, ValOp<T,OP>>& red) {
+    red.val.val = OP<T,T,T>::identity();
   }
   // Combine
-  template<typename EXEC_POL, typename OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  combine(Reducer<OP, T>& out, const Reducer<OP, T>& in) {
-    out.val = OP{}(out.val, in.val);
+  combine(Reducer<OP, T, ValOp<T,OP>>& out, const Reducer<OP, T, ValOp<T,OP>>& in) {
+    out.val.val = OP<T,T,T>{}(out.val.val, in.val.val);
   }
   // Resolve
-  template<typename EXEC_POL, typename OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
-  resolve(Reducer<OP, T>& red) {
-    *red.target = OP{}(*red.target, red.val);
+  resolve(Reducer<OP, T, ValOp<T,OP>>& red) {
+    red.target->val = OP<T,T,T>{}(red.target->val, red.val.val);
   }
+
+//  // Init
+//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+//  //template<typename EXEC_POL, typename OP, typename T>
+//  camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
+//  init(Reducer<OP, T, T>& red) {
+//  //init(Reducer<OP, T>& red) {
+//    red.val = OP<T,T,T>::identity();
+//  }
+//  // Combine
+//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+//  //template<typename EXEC_POL, typename OP, typename T>
+//  camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
+//  combine(Reducer<OP, T, T>& out, const Reducer<OP, T, T>& in) {
+//  //combine(Reducer<OP, T>& out, const Reducer<OP, T>& in) {
+//    out.val = OP<T,T,T>{}(out.val, in.val);
+//  }
+//  // Resolve
+//  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+//  //template<typename EXEC_POL, typename OP, typename T>
+//  camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
+//  resolve(Reducer<OP, T, T>& red) {
+//  //resolve(Reducer<OP, T>& red) {
+//    *red.target = OP<T,T,T>{}(*red.target, red.val);
+//  }
 
 } //  namespace detail
 } //  namespace expt

--- a/include/RAJA/policy/sequential/params/reduce.hpp
+++ b/include/RAJA/policy/sequential/params/reduce.hpp
@@ -11,21 +11,21 @@ namespace detail {
   template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
   init(Reducer<OP, T, VType>& red) {
-    red.val.val = OP<T,T,T>::identity();
+    red.valop_m.val = OP<T,T,T>::identity();
   }
 
   // Combine
   template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
   combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
-    out.val.val = OP<T,T,T>{}(out.val.val, in.val.val);
+    out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
   }
 
   // Resolve
   template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< std::is_same< EXEC_POL, RAJA::seq_exec> >
   resolve(Reducer<OP, T, VType>& red) {
-    *red.target = OP<T,T,T>{}(*red.target, red.val.val);
+    *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
   }
 
 } //  namespace detail

--- a/include/RAJA/policy/sycl/params/reduce.hpp
+++ b/include/RAJA/policy/sycl/params/reduce.hpp
@@ -10,26 +10,45 @@ namespace detail {
 #if defined(RAJA_ENABLE_SYCL)
 
   // Init
-  template<typename EXEC_POL, typename OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  init(Reducer<OP, T>& red) {
-    red.val = OP::identity();
+  init(Reducer<OP, T, ValOp<T,OP>>& red) {
+    red.val.val = OP<T,T,T>::identity();
   }
-
   // Combine
-  template<typename EXEC_POL, typename OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  SYCL_EXTERNAL
-  combine(Reducer<OP, T>& out, const Reducer<OP, T>& in) {
-    out.val = OP{}(out.val, in.val);
+  combine(Reducer<OP, T, ValOp<T,OP>>& out, const Reducer<OP, T, ValOp<T,OP>>& in) {
+    out.val.val = OP<T,T,T>{}(out.val.val, in.val.val);
+  }
+  // Resolve
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
+  resolve(Reducer<OP, T, ValOp<T,OP>>& red) {
+    red.target->val = OP<T,T,T>{}(red.target->val, red.val.val);
   }
 
-  // Resolve
-  template<typename EXEC_POL, typename OP, typename T>
-  camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  resolve(Reducer<OP, T>& red) {
-    *red.target = OP{}(*red.target, red.val);
-  }
+//  // Init
+//  template<typename EXEC_POL, typename OP, typename T>
+//  camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
+//  init(Reducer<OP, T>& red) {
+//    red.val = OP::identity();
+//  }
+//
+//  // Combine
+//  template<typename EXEC_POL, typename OP, typename T>
+//  camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
+//  SYCL_EXTERNAL
+//  combine(Reducer<OP, T>& out, const Reducer<OP, T>& in) {
+//    out.val = OP{}(out.val, in.val);
+//  }
+//
+//  // Resolve
+//  template<typename EXEC_POL, typename OP, typename T>
+//  camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
+//  resolve(Reducer<OP, T>& red) {
+//    *red.target = OP{}(*red.target, red.val);
+//  }
 
 #endif
 

--- a/include/RAJA/policy/sycl/params/reduce.hpp
+++ b/include/RAJA/policy/sycl/params/reduce.hpp
@@ -10,45 +10,23 @@ namespace detail {
 #if defined(RAJA_ENABLE_SYCL)
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  init(Reducer<OP, T, ValOp<T,OP>>& red) {
+  init(Reducer<OP, T, VType>& red) {
     red.val.val = OP<T,T,T>::identity();
   }
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  combine(Reducer<OP, T, ValOp<T,OP>>& out, const Reducer<OP, T, ValOp<T,OP>>& in) {
+  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
     out.val.val = OP<T,T,T>{}(out.val.val, in.val.val);
   }
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, ValOp<T,OP>>& red) {
-    red.target->val = OP<T,T,T>{}(red.target->val, red.val.val);
+  resolve(Reducer<OP, T, VType>& red) {
+    *red.target = OP<T,T,T>{}(*red.target, red.val.val);
   }
-
-//  // Init
-//  template<typename EXEC_POL, typename OP, typename T>
-//  camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-//  init(Reducer<OP, T>& red) {
-//    red.val = OP::identity();
-//  }
-//
-//  // Combine
-//  template<typename EXEC_POL, typename OP, typename T>
-//  camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-//  SYCL_EXTERNAL
-//  combine(Reducer<OP, T>& out, const Reducer<OP, T>& in) {
-//    out.val = OP{}(out.val, in.val);
-//  }
-//
-//  // Resolve
-//  template<typename EXEC_POL, typename OP, typename T>
-//  camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-//  resolve(Reducer<OP, T>& red) {
-//    *red.target = OP{}(*red.target, red.val);
-//  }
 
 #endif
 

--- a/include/RAJA/policy/sycl/params/reduce.hpp
+++ b/include/RAJA/policy/sycl/params/reduce.hpp
@@ -13,21 +13,21 @@ namespace detail {
   template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
   init(Reducer<OP, T, VType>& red) {
-    red.valop_m.val = OP::identity();
+    red.m_valop.val = OP::identity();
   }
 
   // Combine
   template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
   combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
-    out.valop_m.val = OP{}(out.valop_m.val, in.valop_m.val);
+    out.m_valop.val = OP{}(out.m_valop.val, in.m_valop.val);
   }
 
   // Resolve
   template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
   resolve(Reducer<OP, T, VType>& red) {
-    red.setTarget(OP{}(*red.target, red.valop_m.val));
+    red.setTarget(OP{}(*red.target, red.m_valop.val));
   }
 
 #endif

--- a/include/RAJA/policy/sycl/params/reduce.hpp
+++ b/include/RAJA/policy/sycl/params/reduce.hpp
@@ -10,47 +10,27 @@ namespace detail {
 #if defined(RAJA_ENABLE_SYCL)
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType, D, I, true>& red) {
-    red.valop_m.val = OP<T,T,T>::identity();
+  init(Reducer<OP, T, I, VType>& red) {
+    using VT = typename Reducer<OP, T, I, VType>::value_type;
+    red.valop_m.val = OP<VT,VT,VT>::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType, D, I, true>& out, const Reducer<OP, T, VType, D, I, true>& in) {
-    out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
+  combine(Reducer<OP, T, I, VType>& out, const Reducer<OP, T, I, VType>& in) {
+    using VT = typename Reducer<OP, T, I, VType>::value_type;
+    out.valop_m.val = OP<VT,VT,VT>{}(out.valop_m.val, in.valop_m.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType, D, I, true>& red) {
-    *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
-    *red.passthruval = red.valop_m.val.val;
-    *red.passthruindex = red.valop_m.val.loc;
-  }
-
-  // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
-  camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType, D, I, false>& red) {
-    red.valop_m.val = OP<T,T,T>::identity();
-  }
-
-  // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
-  camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType, D, I, false>& out, const Reducer<OP, T, VType, D, I, false>& in) {
-    out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
-  }
-
-  // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
-  camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType, D, I, false>& red) {
-    *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
+  resolve(Reducer<OP, T, I, VType>& red) {
+    using VT = typename Reducer<OP, T, I, VType>::value_type;
+    red.set(OP<VT,VT,VT>{}(*red.target, red.valop_m.val));
   }
 
 #endif

--- a/include/RAJA/policy/sycl/params/reduce.hpp
+++ b/include/RAJA/policy/sycl/params/reduce.hpp
@@ -10,23 +10,23 @@ namespace detail {
 #if defined(RAJA_ENABLE_SYCL)
 
   // Init
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType>& red) {
+  init(Reducer<OP, T, VOp>& red) {
     red.m_valop.val = OP::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
+  combine(Reducer<OP, T, VOp>& out, const Reducer<OP, T, VOp>& in) {
     out.m_valop.val = OP{}(out.m_valop.val, in.m_valop.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, typename OP, typename T, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VOp>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType>& red) {
+  resolve(Reducer<OP, T, VOp>& red) {
     red.combineTarget(red.m_valop.val);
   }
 

--- a/include/RAJA/policy/sycl/params/reduce.hpp
+++ b/include/RAJA/policy/sycl/params/reduce.hpp
@@ -13,19 +13,19 @@ namespace detail {
   template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
   init(Reducer<OP, T, VType>& red) {
-    red.val.val = OP<T,T,T>::identity();
+    red.valop_m.val = OP<T,T,T>::identity();
   }
   // Combine
   template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
   combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
-    out.val.val = OP<T,T,T>{}(out.val.val, in.val.val);
+    out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
   }
   // Resolve
   template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
   resolve(Reducer<OP, T, VType>& red) {
-    *red.target = OP<T,T,T>{}(*red.target, red.val.val);
+    *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
   }
 
 #endif

--- a/include/RAJA/policy/sycl/params/reduce.hpp
+++ b/include/RAJA/policy/sycl/params/reduce.hpp
@@ -10,21 +10,21 @@ namespace detail {
 #if defined(RAJA_ENABLE_SYCL)
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
   init(Reducer<OP, T, VType, D, I, true>& red) {
     red.valop_m.val = OP<T,T,T>::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
   combine(Reducer<OP, T, VType, D, I, true>& out, const Reducer<OP, T, VType, D, I, true>& in) {
     out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
   resolve(Reducer<OP, T, VType, D, I, true>& red) {
     *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
@@ -33,21 +33,21 @@ namespace detail {
   }
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
   init(Reducer<OP, T, VType, D, I, false>& red) {
     red.valop_m.val = OP<T,T,T>::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
   combine(Reducer<OP, T, VType, D, I, false>& out, const Reducer<OP, T, VType, D, I, false>& in) {
     out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
   resolve(Reducer<OP, T, VType, D, I, false>& red) {
     *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);

--- a/include/RAJA/policy/sycl/params/reduce.hpp
+++ b/include/RAJA/policy/sycl/params/reduce.hpp
@@ -10,21 +10,46 @@ namespace detail {
 #if defined(RAJA_ENABLE_SYCL)
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  init(Reducer<OP, T, VType>& red) {
+  init(Reducer<OP, T, VType, D, I, true>& red) {
     red.valop_m.val = OP<T,T,T>::identity();
   }
+
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
+  combine(Reducer<OP, T, VType, D, I, true>& out, const Reducer<OP, T, VType, D, I, true>& in) {
     out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
   }
+
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename VType>
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, VType>& red) {
+  resolve(Reducer<OP, T, VType, D, I, true>& red) {
+    *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
+    *red.passthruval = red.valop_m.val.val;
+    *red.passthruindex = red.valop_m.val.loc;
+  }
+
+  // Init
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I typename VType>
+  camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
+  init(Reducer<OP, T, VType, D, I, false>& red) {
+    red.valop_m.val = OP<T,T,T>::identity();
+  }
+
+  // Combine
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I typename VType>
+  camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
+  combine(Reducer<OP, T, VType, D, I, false>& out, const Reducer<OP, T, VType, D, I, false>& in) {
+    out.valop_m.val = OP<T,T,T>{}(out.valop_m.val, in.valop_m.val);
+  }
+
+  // Resolve
+  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename D, typename I typename VType>
+  camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
+  resolve(Reducer<OP, T, VType, D, I, false>& red) {
     *red.target = OP<T,T,T>{}(*red.target, red.valop_m.val);
   }
 

--- a/include/RAJA/policy/sycl/params/reduce.hpp
+++ b/include/RAJA/policy/sycl/params/reduce.hpp
@@ -10,27 +10,24 @@ namespace detail {
 #if defined(RAJA_ENABLE_SYCL)
 
   // Init
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  init(Reducer<OP, T, I, VType>& red) {
-    using VT = typename Reducer<OP, T, I, VType>::value_type;
-    red.valop_m.val = OP<VT,VT,VT>::identity();
+  init(Reducer<OP, T, VType>& red) {
+    red.valop_m.val = OP::identity();
   }
 
   // Combine
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  combine(Reducer<OP, T, I, VType>& out, const Reducer<OP, T, I, VType>& in) {
-    using VT = typename Reducer<OP, T, I, VType>::value_type;
-    out.valop_m.val = OP<VT,VT,VT>{}(out.valop_m.val, in.valop_m.val);
+  combine(Reducer<OP, T, VType>& out, const Reducer<OP, T, VType>& in) {
+    out.valop_m.val = OP{}(out.valop_m.val, in.valop_m.val);
   }
 
   // Resolve
-  template<typename EXEC_POL, template <typename, typename, typename> class OP, typename T, typename I, typename VType>
+  template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, I, VType>& red) {
-    using VT = typename Reducer<OP, T, I, VType>::value_type;
-    red.set(OP<VT,VT,VT>{}(*red.target, red.valop_m.val));
+  resolve(Reducer<OP, T, VType>& red) {
+    red.setTarget(OP{}(*red.target, red.valop_m.val));
   }
 
 #endif

--- a/include/RAJA/policy/sycl/params/reduce.hpp
+++ b/include/RAJA/policy/sycl/params/reduce.hpp
@@ -27,7 +27,7 @@ namespace detail {
   template<typename EXEC_POL, typename OP, typename T, typename VType>
   camp::concepts::enable_if< type_traits::is_sycl_policy<EXEC_POL> >
   resolve(Reducer<OP, T, VType>& red) {
-    red.setTarget(OP{}(*red.target, red.m_valop.val));
+    red.combineTarget(red.m_valop.val);
   }
 
 #endif

--- a/include/RAJA/util/SoAPtr.hpp
+++ b/include/RAJA/util/SoAPtr.hpp
@@ -230,7 +230,7 @@ public:
   }
   RAJA_HOST_DEVICE void set(size_t i, value_type val)
   {
-    accessor::set(mem, i, first_type(val));
+    accessor::set(mem, i, val.getVal());
     accessor::set(mem_idx, i, val.getLoc());
   }
 

--- a/include/RAJA/util/SoAPtr.hpp
+++ b/include/RAJA/util/SoAPtr.hpp
@@ -26,6 +26,9 @@
 #include "RAJA/pattern/detail/reduce.hpp"
 #include "RAJA/util/types.hpp"
 
+// for RAJA::expt::ValLoc
+#include "RAJA/pattern/params/params_base.hpp"
+
 namespace RAJA
 {
 
@@ -108,6 +111,77 @@ class SoAPtr<RAJA::reduce::detail::ValueLoc<T, IndexType, doing_min>, mempool, a
 
 public:
   using value_type = RAJA::reduce::detail::ValueLoc<T, IndexType, doing_min>;
+
+  template < typename rhs_accessor >
+  using rebind_accessor = SoAPtr<value_type, mempool, rhs_accessor>;
+
+  SoAPtr() = default;
+  SoAPtr(SoAPtr const&) = default;
+  SoAPtr(SoAPtr &&) = default;
+  SoAPtr& operator=(SoAPtr const&) = default;
+  SoAPtr& operator=(SoAPtr &&) = default;
+
+  explicit SoAPtr(size_t size)
+      : mem(mempool::getInstance().template malloc<first_type>(size)),
+        mem_idx(mempool::getInstance().template malloc<second_type>(size))
+  {
+  }
+
+  template < typename rhs_accessor,
+             std::enable_if_t<!std::is_same<accessor, rhs_accessor>::value>* = nullptr >
+  RAJA_HOST_DEVICE
+  explicit SoAPtr(SoAPtr<value_type, mempool, rhs_accessor> const& rhs)
+    : mem(rhs.mem)
+    , mem_idx(rhs.mem_idx)
+  { }
+
+  SoAPtr& allocate(size_t size)
+  {
+    mem = mempool::getInstance().template malloc<first_type>(size);
+    mem_idx = mempool::getInstance().template malloc<second_type>(size);
+    return *this;
+  }
+
+  SoAPtr& deallocate()
+  {
+    mempool::getInstance().free(mem);
+    mem = nullptr;
+    mempool::getInstance().free(mem_idx);
+    mem_idx = nullptr;
+    return *this;
+  }
+
+  RAJA_HOST_DEVICE bool allocated() const { return mem != nullptr; }
+
+  RAJA_HOST_DEVICE value_type get(size_t i) const
+  {
+    return value_type(accessor::get(mem, i), accessor::get(mem_idx, i));
+  }
+  RAJA_HOST_DEVICE void set(size_t i, value_type val)
+  {
+    accessor::set(mem, i, first_type(val));
+    accessor::set(mem_idx, i, val.getLoc());
+  }
+
+private:
+  first_type* mem = nullptr;
+  second_type* mem_idx = nullptr;
+};
+
+/*!
+ * @brief Specialization for RAJA::expt::ValLoc.
+ */
+template <typename T, typename IndexType, typename mempool, typename accessor>
+class SoAPtr<RAJA::expt::ValLoc<T, IndexType>, mempool, accessor>
+{
+  using first_type = T;
+  using second_type = IndexType;
+
+  template < typename, typename, typename >
+  friend class SoAPtr; // friend other instantiations of this class
+
+public:
+  using value_type = RAJA::expt::ValLoc<T, IndexType>;
 
   template < typename rhs_accessor >
   using rebind_accessor = SoAPtr<value_type, mempool, rhs_accessor>;

--- a/scripts/lc-builds/corona_sycl.sh
+++ b/scripts/lc-builds/corona_sycl.sh
@@ -38,7 +38,7 @@ DATE=$(printf '%(%Y-%m-%d)T\n' -1)
 export PATH=${SYCL_PATH}/bin:$PATH
 export LD_LIBRARY_PATH=${SYCL_PATH}/lib:${SYCL_PATH}/lib64:$LD_LIBRARY_PATH
 
-module load cmake/3.24.2
+module load cmake/3.23.1
 
 cmake \
   -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
@@ -69,9 +69,6 @@ echo "   1) Load the ROCm module version matching the version in the compiler pa
 echo "      you passed to this script."
 echo
 echo "   2) Prefix the LD_LIBRARY_PATH environment variable with "
-echo "        SYCL_PATH/lib:SYCL_PATH/lib64"
-echo
-echo "      where SYCL_PATH is set to the compiler installation path you passed"
-echo "      to this script (using the proper command for your shell)."
+echo "        ${SYCL_PATH}/lib:${SYCL_PATH}/lib64"
 echo
 echo "***********************************************************************"

--- a/test/functional/forall/reduce-basic/CMakeLists.txt
+++ b/test/functional/forall/reduce-basic/CMakeLists.txt
@@ -8,7 +8,7 @@
 #
 # List of experimental reduction types for generating test files.
 #
-set(REDUCETYPES ReduceSum ReduceMin ReduceMax ReduceMaxLoc ReduceMinLoc)
+set(REDUCETYPES ReduceSum ReduceMin ReduceMax ReduceMaxLoc ReduceMinLoc ReduceMaxLocAlt ReduceMinLocAlt)
 
 set(DATATYPES CoreReductionDataTypeList)
 

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceBitAnd.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceBitAnd.hpp
@@ -43,15 +43,15 @@ void ForallReduceBitAndBasicTestImpl(const SEG_TYPE& seg,
   }
   working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
-  REF_BITAND simpand(21);
+  DATA_TYPE simpand(21);
 
   RAJA::forall<EXEC_POLICY>(seg,
-    RAJA::expt::Reduce<>(&simpand),
+    RAJA::expt::Reduce<RAJA::operators::bit_and>(&simpand),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_BITAND & _simpand) {
       _simpand &= working_array[idx];
   });
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(simpand.get()), 5);
+  ASSERT_EQ(static_cast<DATA_TYPE>(simpand), 5);
 
 
   //
@@ -70,33 +70,33 @@ void ForallReduceBitAndBasicTestImpl(const SEG_TYPE& seg,
     ref_and &= test_array[ seg_idx[i] ];
   }
 
-  REF_BITAND redand(0);
-  REF_BITAND redand2(2);
+  DATA_TYPE redand(0);
+  DATA_TYPE redand2(2);
 
   RAJA::forall<EXEC_POLICY>(seg,
-    RAJA::expt::Reduce<>(&redand),
-    RAJA::expt::Reduce<>(&redand2),
+    RAJA::expt::Reduce<RAJA::operators::bit_and>(&redand),
+    RAJA::expt::Reduce<RAJA::operators::bit_and>(&redand2),
     RAJA::expt::KernelName("RAJA Reduce BitAnd"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_BITAND &r1, REF_BITAND &r2) {
       r1 &= working_array[idx];
       r2 &= working_array[idx];
   });
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(redand.get()), ref_and);
-  ASSERT_EQ(static_cast<DATA_TYPE>(redand2.get()), ref_and);
+  ASSERT_EQ(static_cast<DATA_TYPE>(redand), ref_and);
+  ASSERT_EQ(static_cast<DATA_TYPE>(redand2), ref_and);
 
-  redand.set(0);
+  redand = 0;
 
   const int nloops = 3;
   for (int j = 0; j < nloops; ++j) {
     RAJA::forall<EXEC_POLICY>(seg,
-      RAJA::expt::Reduce<>(&redand),
+      RAJA::expt::Reduce<RAJA::operators::bit_and>(&redand),
       [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_BITAND &r1) {
         r1 &= working_array[idx];
     });
   }
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(redand.get()), ref_and);
+  ASSERT_EQ(static_cast<DATA_TYPE>(redand), ref_and);
 
 
   deallocateForallTestData<DATA_TYPE>(working_res,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceBitOr.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceBitOr.hpp
@@ -43,15 +43,15 @@ void ForallReduceBitOrBasicTestImpl(const SEG_TYPE& seg,
   }
   working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
-  REF_BITOR simpor(5);
+  DATA_TYPE simpor(5);
 
   RAJA::forall<EXEC_POLICY>(seg,
-    RAJA::expt::Reduce<>(&simpor),
+    RAJA::expt::Reduce<RAJA::operators::bit_or>(&simpor),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_BITOR & _simpor) {
       _simpor |= working_array[idx];
   });
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(simpor.get()), 13);
+  ASSERT_EQ(static_cast<DATA_TYPE>(simpor), 13);
 
  
   //
@@ -70,33 +70,33 @@ void ForallReduceBitOrBasicTestImpl(const SEG_TYPE& seg,
     ref_or |= test_array[ seg_idx[i] ];
   }
 
-  REF_BITOR redor(0);
-  REF_BITOR redor2(2);
+  DATA_TYPE redor(0);
+  DATA_TYPE redor2(2);
 
   RAJA::forall<EXEC_POLICY>(seg,
-    RAJA::expt::Reduce<>(&redor),
-    RAJA::expt::Reduce<>(&redor2),
+    RAJA::expt::Reduce<RAJA::operators::bit_or>(&redor),
+    RAJA::expt::Reduce<RAJA::operators::bit_or>(&redor2),
     RAJA::expt::KernelName("RAJA Reduce BitOr"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_BITOR &r1, REF_BITOR &r2) {
       r1 |= working_array[idx];
       r2 |= working_array[idx];
   });
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(redor.get()), ref_or);
-  ASSERT_EQ(static_cast<DATA_TYPE>(redor2.get()), ref_or);
+  ASSERT_EQ(static_cast<DATA_TYPE>(redor), ref_or);
+  ASSERT_EQ(static_cast<DATA_TYPE>(redor2), ref_or);
 
-  redor.set(0);
+  redor = 0;
 
   const int nloops = 3;
   for (int j = 0; j < nloops; ++j) {
     RAJA::forall<EXEC_POLICY>(seg,
-      RAJA::expt::Reduce<>(&redor),
+      RAJA::expt::Reduce<RAJA::operators::bit_or>(&redor),
       [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_BITOR &r1) {
         r1 |= working_array[idx];
     });
   }
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(redor.get()), ref_or);
+  ASSERT_EQ(static_cast<DATA_TYPE>(redor), ref_or);
    
 
   deallocateForallTestData<DATA_TYPE>(working_res,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMax.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMax.hpp
@@ -50,39 +50,39 @@ void ForallReduceMaxBasicTestImpl(const SEG_TYPE& seg,
 
   working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
-  REF_MAX maxinit(big_max);
-  REF_MAX max(max_init);
+  DATA_TYPE maxinit(big_max);
+  DATA_TYPE max(max_init);
 
   RAJA::forall<EXEC_POLICY>(seg, 
-    RAJA::expt::Reduce<>(&maxinit),
-    RAJA::expt::Reduce<>(&max),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&maxinit),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&max),
     RAJA::expt::KernelName("RAJA Reduce Max"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_MAX &mi, REF_MAX &m) {
       mi.max(working_array[idx]);
       m.max(working_array[idx]);
   });
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(maxinit.get()), big_max);
-  ASSERT_EQ(static_cast<DATA_TYPE>(max.get()), ref_max);
+  ASSERT_EQ(static_cast<DATA_TYPE>(maxinit), big_max);
+  ASSERT_EQ(static_cast<DATA_TYPE>(max), ref_max);
 
-  max.set(max_init);
-  ASSERT_EQ(static_cast<DATA_TYPE>(max.get()), max_init);
+  max = max_init;
+  ASSERT_EQ(static_cast<DATA_TYPE>(max), max_init);
 
   DATA_TYPE factor = 2;
   RAJA::forall<EXEC_POLICY>(seg, 
-    RAJA::expt::Reduce<>(&max),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&max),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_MAX &m) {
       m.max(working_array[idx] * factor);
   });
-  ASSERT_EQ(static_cast<DATA_TYPE>(max.get()), ref_max * factor);
+  ASSERT_EQ(static_cast<DATA_TYPE>(max), ref_max * factor);
    
   factor = 3;
   RAJA::forall<EXEC_POLICY>(seg, 
-    RAJA::expt::Reduce<>(&max),
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&max),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_MAX &m) {
       m.max(working_array[idx] * factor);
   });
-  ASSERT_EQ(static_cast<DATA_TYPE>(max.get()), ref_max * factor);
+  ASSERT_EQ(static_cast<DATA_TYPE>(max), ref_max * factor);
    
 
   deallocateForallTestData<DATA_TYPE>(working_res,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMaxLoc.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMaxLoc.hpp
@@ -57,17 +57,17 @@ void ForallReduceMaxLocBasicTestImpl(const SEG_TYPE& seg,
   working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
 
-  using VL_TYPE = RAJA::expt::ValLoc<DATA_TYPE>;
+  using VL_TYPE = RAJA::expt::ValLocOp<DATA_TYPE, IDX_TYPE, RAJA::operators::maximum>;
   VL_TYPE maxinit(big_max, maxloc_init);
   VL_TYPE max(max_init, maxloc_init);
 
   RAJA::forall<EXEC_POLICY>(seg, 
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&maxinit),
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&max),
+    RAJA::expt::Reduce<>(&maxinit),
+    RAJA::expt::Reduce<>(&max),
     RAJA::expt::KernelName("RAJA Reduce MaxLoc"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_TYPE &mi, VL_TYPE &m) {
-      mi.max( working_array[idx], idx );
-      m.max( working_array[idx], idx );
+      mi.maxloc( working_array[idx], idx );
+      m.maxloc( working_array[idx], idx );
   });
 
   ASSERT_EQ(static_cast<DATA_TYPE>(maxinit.getVal()), big_max);
@@ -75,24 +75,25 @@ void ForallReduceMaxLocBasicTestImpl(const SEG_TYPE& seg,
   ASSERT_EQ(static_cast<DATA_TYPE>(max.getVal()), ref_max);
   ASSERT_EQ(static_cast<IDX_TYPE>(max.getLoc()), ref_maxloc);
 
-  max = VL_TYPE(max_init, maxloc_init);
+  max.setVal(max_init);
+  max.setLoc(maxloc_init);
   ASSERT_EQ(static_cast<DATA_TYPE>(max.getVal()), max_init);
   ASSERT_EQ(static_cast<IDX_TYPE>(max.getLoc()), maxloc_init);
 
   DATA_TYPE factor = 2;
   RAJA::forall<EXEC_POLICY>(seg,
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&max),
+    RAJA::expt::Reduce<>(&max),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_TYPE &m) {
-      m.max( working_array[idx] * factor, idx);
+      m.maxloc( working_array[idx] * factor, idx);
   });
   ASSERT_EQ(static_cast<DATA_TYPE>(max.getVal()), ref_max * factor);
   ASSERT_EQ(static_cast<IDX_TYPE>(max.getLoc()), ref_maxloc);
   
   factor = 3;
   RAJA::forall<EXEC_POLICY>(seg,
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&max),
+    RAJA::expt::Reduce<>(&max),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_TYPE &m) {
-      m.max( working_array[idx] * factor, idx);
+      m.maxloc( working_array[idx] * factor, idx);
   });
   ASSERT_EQ(static_cast<DATA_TYPE>(max.getVal()), ref_max * factor);
   ASSERT_EQ(static_cast<IDX_TYPE>(max.getLoc()), ref_maxloc);

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMaxLoc.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMaxLoc.hpp
@@ -97,7 +97,20 @@ void ForallReduceMaxLocBasicTestImpl(const SEG_TYPE& seg,
   });
   ASSERT_EQ(static_cast<DATA_TYPE>(max.getVal()), ref_max * factor);
   ASSERT_EQ(static_cast<IDX_TYPE>(max.getLoc()), ref_maxloc);
+
+  max.set(max_init, maxloc_init);
+  ASSERT_EQ(static_cast<DATA_TYPE>(max.getVal()), max_init);
+  ASSERT_EQ(static_cast<IDX_TYPE>(max.getLoc()), maxloc_init);
  
+  factor = 4;
+  RAJA::forall<EXEC_POLICY>(seg,
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&max),
+    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &m) {
+      m.max( working_array[idx] * factor);
+  });
+  ASSERT_EQ(static_cast<DATA_TYPE>(max.getVal()), ref_max * factor);
+  ASSERT_EQ(static_cast<IDX_TYPE>(max.getLoc()), maxloc_init);
+
 
   deallocateForallTestData<DATA_TYPE>(working_res,
                                       working_array,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMaxLoc.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMaxLoc.hpp
@@ -101,29 +101,33 @@ void ForallReduceMaxLocBasicTestImpl(const SEG_TYPE& seg,
   VL_TYPE max2(max_init, maxloc_init);
 
   RAJA::forall<EXEC_POLICY>(seg,
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&max),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&max2),
-    [=] RAJA_HOST_DEVICE(IDX_TYPE RAJA_UNUSED_ARG(idx), VL_LAMBDA_TYPE RAJA_UNUSED_ARG(&m), VL_LAMBDA_TYPE &m2) {
+    [=] RAJA_HOST_DEVICE(IDX_TYPE RAJA_UNUSED_ARG(idx), VL_LAMBDA_TYPE &m2) {
       m2.max( max );
   });
   ASSERT_EQ(static_cast<DATA_TYPE>(max2.getVal()), static_cast<DATA_TYPE>(max.getVal()));
   ASSERT_EQ(static_cast<IDX_TYPE>(max2.getLoc()), static_cast<IDX_TYPE>(max.getLoc()));
 
   DATA_TYPE s_max = max_init;
-  DATA_TYPE s_max2 = max_init;
   IDX_TYPE s_maxloc = maxloc_init;
-  IDX_TYPE s_maxloc2 = maxloc_init;
 
   factor = 4;
   RAJA::forall<EXEC_POLICY>(seg,
     RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&s_max, &s_maxloc),
-    RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&s_max2, &s_maxloc2),
-    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &m, VL_LAMBDA_TYPE &m2) {
+    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &m) {
       m.maxloc( working_array[idx] * factor, idx);
-      m2.max(max2);
   });
   ASSERT_EQ(static_cast<DATA_TYPE>(s_max), ref_max * factor);
   ASSERT_EQ(static_cast<IDX_TYPE>(s_maxloc), ref_maxloc);
+
+  DATA_TYPE s_max2 = max_init;
+  IDX_TYPE s_maxloc2 = maxloc_init;
+
+  RAJA::forall<EXEC_POLICY>(seg,
+    RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&s_max2, &s_maxloc2),
+    [=] RAJA_HOST_DEVICE(IDX_TYPE RAJA_UNUSED_ARG(idx), VL_LAMBDA_TYPE &m2) {
+      m2.max(max2);
+  });
   ASSERT_EQ(static_cast<DATA_TYPE>(s_max2), static_cast<DATA_TYPE>(max2.getVal()));
   ASSERT_EQ(static_cast<IDX_TYPE>(s_maxloc2), static_cast<IDX_TYPE>(max2.getLoc()));
 

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMaxLoc.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMaxLoc.hpp
@@ -109,6 +109,24 @@ void ForallReduceMaxLocBasicTestImpl(const SEG_TYPE& seg,
   ASSERT_EQ(static_cast<DATA_TYPE>(max2.getVal()), static_cast<DATA_TYPE>(max.getVal()));
   ASSERT_EQ(static_cast<IDX_TYPE>(max2.getLoc()), static_cast<IDX_TYPE>(max.getLoc()));
 
+  DATA_TYPE s_max = max_init;
+  DATA_TYPE s_max2 = max_init;
+  IDX_TYPE s_maxloc = maxloc_init;
+  IDX_TYPE s_maxloc2 = maxloc_init;
+
+  factor = 4;
+  RAJA::forall<EXEC_POLICY>(seg,
+    RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&s_max, &s_maxloc),
+    RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&s_max2, &s_maxloc2),
+    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &m, VL_LAMBDA_TYPE &m2) {
+      m.maxloc( working_array[idx] * factor, idx);
+      m2.max(max2);
+  });
+  ASSERT_EQ(static_cast<DATA_TYPE>(s_max), ref_max * factor);
+  ASSERT_EQ(static_cast<IDX_TYPE>(s_maxloc), ref_maxloc);
+  ASSERT_EQ(static_cast<DATA_TYPE>(s_max2), static_cast<DATA_TYPE>(max2.getVal()));
+  ASSERT_EQ(static_cast<IDX_TYPE>(s_maxloc2), static_cast<IDX_TYPE>(max2.getLoc()));
+
 
   deallocateForallTestData<DATA_TYPE>(working_res,
                                       working_array,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMaxLoc.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMaxLoc.hpp
@@ -98,18 +98,16 @@ void ForallReduceMaxLocBasicTestImpl(const SEG_TYPE& seg,
   ASSERT_EQ(static_cast<DATA_TYPE>(max.getVal()), ref_max * factor);
   ASSERT_EQ(static_cast<IDX_TYPE>(max.getLoc()), ref_maxloc);
 
-  max.set(max_init, maxloc_init);
-  ASSERT_EQ(static_cast<DATA_TYPE>(max.getVal()), max_init);
-  ASSERT_EQ(static_cast<IDX_TYPE>(max.getLoc()), maxloc_init);
- 
-  factor = 4;
+  VL_TYPE max2(max_init, maxloc_init);
+
   RAJA::forall<EXEC_POLICY>(seg,
     RAJA::expt::Reduce<RAJA::operators::maximum>(&max),
-    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &m) {
-      m.max( working_array[idx] * factor);
+    RAJA::expt::Reduce<RAJA::operators::maximum>(&max2),
+    [=] RAJA_HOST_DEVICE(IDX_TYPE RAJA_UNUSED_ARG(idx), VL_LAMBDA_TYPE RAJA_UNUSED_ARG(&m), VL_LAMBDA_TYPE &m2) {
+      m2.max( max );
   });
-  ASSERT_EQ(static_cast<DATA_TYPE>(max.getVal()), ref_max * factor);
-  ASSERT_EQ(static_cast<IDX_TYPE>(max.getLoc()), maxloc_init);
+  ASSERT_EQ(static_cast<DATA_TYPE>(max2.getVal()), static_cast<DATA_TYPE>(max.getVal()));
+  ASSERT_EQ(static_cast<IDX_TYPE>(max2.getLoc()), static_cast<IDX_TYPE>(max.getLoc()));
 
 
   deallocateForallTestData<DATA_TYPE>(working_res,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMin.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMin.hpp
@@ -50,39 +50,39 @@ void ForallReduceMinBasicTestImpl(const SEG_TYPE& seg,
 
   working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
-  REF_MIN mininit(small_min);
-  REF_MIN min(min_init);
+  DATA_TYPE mininit(small_min);
+  DATA_TYPE min(min_init);
 
   RAJA::forall<EXEC_POLICY>(seg, 
-    RAJA::expt::Reduce<>(&mininit),
-    RAJA::expt::Reduce<>(&min),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&mininit),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
     RAJA::expt::KernelName("RAJA Reduce Min"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_MIN &mi, REF_MIN &m) {
       mi.min(working_array[idx]);
       m.min(working_array[idx]);
   });
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(mininit.get()), small_min);
-  ASSERT_EQ(static_cast<DATA_TYPE>(min.get()), ref_min);
+  ASSERT_EQ(static_cast<DATA_TYPE>(mininit), small_min);
+  ASSERT_EQ(static_cast<DATA_TYPE>(min), ref_min);
 
-  min.set(min_init);
-  ASSERT_EQ(static_cast<DATA_TYPE>(min.get()), min_init);
+  min = min_init;
+  ASSERT_EQ(static_cast<DATA_TYPE>(min), min_init);
 
   DATA_TYPE factor = 3; 
   RAJA::forall<EXEC_POLICY>(seg, 
-    RAJA::expt::Reduce<>(&min),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_MIN &m) {
       m.min(working_array[idx] * factor);
   });
-  ASSERT_EQ(static_cast<DATA_TYPE>(min.get()), ref_min * factor);
+  ASSERT_EQ(static_cast<DATA_TYPE>(min), ref_min * factor);
 
   factor = 2;
   RAJA::forall<EXEC_POLICY>(seg, 
-    RAJA::expt::Reduce<>(&min),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_MIN &m) {
       m.min(working_array[idx] * factor);
   });
-  ASSERT_EQ(static_cast<DATA_TYPE>(min.get()), ref_min * factor);
+  ASSERT_EQ(static_cast<DATA_TYPE>(min), ref_min * factor);
 
   deallocateForallTestData<DATA_TYPE>(working_res,
                                       working_array,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLoc.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLoc.hpp
@@ -97,18 +97,16 @@ void ForallReduceMinLocBasicTestImpl(const SEG_TYPE& seg,
   ASSERT_EQ(static_cast<DATA_TYPE>(min.getVal()), ref_min * factor);
   ASSERT_EQ(static_cast<IDX_TYPE>(min.getLoc()), ref_minloc);
 
-  min.set(min_init, minloc_init);
-  ASSERT_EQ(static_cast<DATA_TYPE>(min.getVal()), min_init);
-  ASSERT_EQ(static_cast<IDX_TYPE>(min.getLoc()), minloc_init);
+  VL_TYPE min2(min_init, minloc_init);
 
-  factor = 4;
   RAJA::forall<EXEC_POLICY>(seg,
     RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
-    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &m) {
-      m.min( working_array[idx] * factor);
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&min2),
+    [=] RAJA_HOST_DEVICE(IDX_TYPE RAJA_UNUSED_ARG(idx), VL_LAMBDA_TYPE RAJA_UNUSED_ARG(&m), VL_LAMBDA_TYPE &m2) {
+      m2.min( min );
   });
-  ASSERT_EQ(static_cast<DATA_TYPE>(min.getVal()), ref_min * factor);
-  ASSERT_EQ(static_cast<IDX_TYPE>(min.getLoc()), minloc_init);
+  ASSERT_EQ(static_cast<DATA_TYPE>(min2.getVal()), static_cast<DATA_TYPE>(min.getVal()));
+  ASSERT_EQ(static_cast<IDX_TYPE>(min2.getLoc()), static_cast<IDX_TYPE>(min.getLoc()));
    
 
   deallocateForallTestData<DATA_TYPE>(working_res,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLoc.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLoc.hpp
@@ -57,17 +57,17 @@ void ForallReduceMinLocBasicTestImpl(const SEG_TYPE& seg,
   working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
 
-  using VL_TYPE = RAJA::expt::ValLoc<DATA_TYPE>;
+  using VL_TYPE = RAJA::expt::ValLocOp<DATA_TYPE, IDX_TYPE, RAJA::operators::minimum>;
   VL_TYPE mininit(small_min, minloc_init);
   VL_TYPE min(min_init, minloc_init);
 
   RAJA::forall<EXEC_POLICY>(seg, 
-    RAJA::expt::Reduce<RAJA::operators::minimum>(&mininit),
-    RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
+    RAJA::expt::Reduce<>(&mininit),
+    RAJA::expt::Reduce<>(&min),
     RAJA::expt::KernelName("RAJA Reduce MinLoc"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_TYPE &mi, VL_TYPE &m) {
-      mi.min( working_array[idx], idx );
-      m.min( working_array[idx], idx );
+      mi.minloc( working_array[idx], idx );
+      m.minloc( working_array[idx], idx );
   });
 
   ASSERT_EQ(static_cast<DATA_TYPE>(mininit.getVal()), small_min);
@@ -75,24 +75,25 @@ void ForallReduceMinLocBasicTestImpl(const SEG_TYPE& seg,
   ASSERT_EQ(static_cast<DATA_TYPE>(min.getVal()), ref_min);
   ASSERT_EQ(static_cast<IDX_TYPE>(min.getLoc()), ref_minloc);
 
-  min = VL_TYPE(min_init, minloc_init);
+  min.setVal(min_init);
+  min.setLoc(minloc_init);
   ASSERT_EQ(static_cast<DATA_TYPE>(min.getVal()), min_init);
   ASSERT_EQ(static_cast<IDX_TYPE>(min.getLoc()), minloc_init);
 
   DATA_TYPE factor = 2;
   RAJA::forall<EXEC_POLICY>(seg,
-    RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
+    RAJA::expt::Reduce<>(&min),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_TYPE &m) {
-      m.min( working_array[idx] * factor, idx);
+      m.minloc( working_array[idx] * factor, idx);
   });
   ASSERT_EQ(static_cast<DATA_TYPE>(min.getVal()), ref_min * factor);
   ASSERT_EQ(static_cast<IDX_TYPE>(min.getLoc()), ref_minloc);
 
   factor = 3;
   RAJA::forall<EXEC_POLICY>(seg,
-    RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
+    RAJA::expt::Reduce<>(&min),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_TYPE &m) {
-      m.min( working_array[idx] * factor, idx);
+      m.minloc( working_array[idx] * factor, idx);
   });
   ASSERT_EQ(static_cast<DATA_TYPE>(min.getVal()), ref_min * factor);
   ASSERT_EQ(static_cast<IDX_TYPE>(min.getLoc()), ref_minloc);

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLoc.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLoc.hpp
@@ -96,6 +96,19 @@ void ForallReduceMinLocBasicTestImpl(const SEG_TYPE& seg,
   });
   ASSERT_EQ(static_cast<DATA_TYPE>(min.getVal()), ref_min * factor);
   ASSERT_EQ(static_cast<IDX_TYPE>(min.getLoc()), ref_minloc);
+
+  min.set(min_init, minloc_init);
+  ASSERT_EQ(static_cast<DATA_TYPE>(min.getVal()), min_init);
+  ASSERT_EQ(static_cast<IDX_TYPE>(min.getLoc()), minloc_init);
+
+  factor = 4;
+  RAJA::forall<EXEC_POLICY>(seg,
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
+    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &m) {
+      m.min( working_array[idx] * factor);
+  });
+  ASSERT_EQ(static_cast<DATA_TYPE>(min.getVal()), ref_min * factor);
+  ASSERT_EQ(static_cast<IDX_TYPE>(min.getLoc()), minloc_init);
    
 
   deallocateForallTestData<DATA_TYPE>(working_res,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLoc.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLoc.hpp
@@ -88,49 +88,6 @@ void ForallReduceMinLocBasicTestImpl(const SEG_TYPE& seg,
   ASSERT_EQ(static_cast<DATA_TYPE>(min.getVal()), ref_min * factor);
   ASSERT_EQ(static_cast<IDX_TYPE>(min.getLoc()), ref_minloc);
 
-  factor = 3;
-  RAJA::forall<EXEC_POLICY>(seg,
-    RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
-    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &m) {
-      m.minloc( working_array[idx] * factor, idx);
-  });
-  ASSERT_EQ(static_cast<DATA_TYPE>(min.getVal()), ref_min * factor);
-  ASSERT_EQ(static_cast<IDX_TYPE>(min.getLoc()), ref_minloc);
-
-  VL_TYPE min2(min_init, minloc_init);
-
-  RAJA::forall<EXEC_POLICY>(seg,
-    RAJA::expt::Reduce<RAJA::operators::minimum>(&min2),
-    [=] RAJA_HOST_DEVICE(IDX_TYPE RAJA_UNUSED_ARG(idx), VL_LAMBDA_TYPE &m2) {
-      m2.min( min );
-  });
-  ASSERT_EQ(static_cast<DATA_TYPE>(min2.getVal()), static_cast<DATA_TYPE>(min.getVal()));
-  ASSERT_EQ(static_cast<IDX_TYPE>(min2.getLoc()), static_cast<IDX_TYPE>(min.getLoc()));
-
-  DATA_TYPE s_min = min_init;
-  IDX_TYPE s_minloc = minloc_init;
-
-  factor = 4;
-  RAJA::forall<EXEC_POLICY>(seg,
-    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&s_min, &s_minloc),
-    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &m) {
-      m.minloc( working_array[idx] * factor, idx);
-  });
-  ASSERT_EQ(static_cast<DATA_TYPE>(s_min), ref_min * factor);
-  ASSERT_EQ(static_cast<IDX_TYPE>(s_minloc), ref_minloc);
-
-  DATA_TYPE s_min2 = min_init;
-  IDX_TYPE s_minloc2 = minloc_init;
-
-  RAJA::forall<EXEC_POLICY>(seg,
-    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&s_min2, &s_minloc2),
-    [=] RAJA_HOST_DEVICE(IDX_TYPE RAJA_UNUSED_ARG(idx), VL_LAMBDA_TYPE &m2) {
-      m2.min(min2);
-  });
-  ASSERT_EQ(static_cast<DATA_TYPE>(s_min2), static_cast<DATA_TYPE>(min2.getVal()));
-  ASSERT_EQ(static_cast<IDX_TYPE>(s_minloc2), static_cast<IDX_TYPE>(min2.getLoc()));
-   
-
   deallocateForallTestData<DATA_TYPE>(working_res,
                                       working_array,
                                       check_array,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLoc.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLoc.hpp
@@ -100,29 +100,33 @@ void ForallReduceMinLocBasicTestImpl(const SEG_TYPE& seg,
   VL_TYPE min2(min_init, minloc_init);
 
   RAJA::forall<EXEC_POLICY>(seg,
-    RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&min2),
-    [=] RAJA_HOST_DEVICE(IDX_TYPE RAJA_UNUSED_ARG(idx), VL_LAMBDA_TYPE RAJA_UNUSED_ARG(&m), VL_LAMBDA_TYPE &m2) {
+    [=] RAJA_HOST_DEVICE(IDX_TYPE RAJA_UNUSED_ARG(idx), VL_LAMBDA_TYPE &m2) {
       m2.min( min );
   });
   ASSERT_EQ(static_cast<DATA_TYPE>(min2.getVal()), static_cast<DATA_TYPE>(min.getVal()));
   ASSERT_EQ(static_cast<IDX_TYPE>(min2.getLoc()), static_cast<IDX_TYPE>(min.getLoc()));
 
   DATA_TYPE s_min = min_init;
-  DATA_TYPE s_min2 = min_init;
   IDX_TYPE s_minloc = minloc_init;
-  IDX_TYPE s_minloc2 = minloc_init;
 
   factor = 4;
   RAJA::forall<EXEC_POLICY>(seg,
     RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&s_min, &s_minloc),
-    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&s_min2, &s_minloc2),
-    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &m, VL_LAMBDA_TYPE &m2) {
+    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &m) {
       m.minloc( working_array[idx] * factor, idx);
-      m2.min(min2);
   });
   ASSERT_EQ(static_cast<DATA_TYPE>(s_min), ref_min * factor);
   ASSERT_EQ(static_cast<IDX_TYPE>(s_minloc), ref_minloc);
+
+  DATA_TYPE s_min2 = min_init;
+  IDX_TYPE s_minloc2 = minloc_init;
+
+  RAJA::forall<EXEC_POLICY>(seg,
+    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&s_min2, &s_minloc2),
+    [=] RAJA_HOST_DEVICE(IDX_TYPE RAJA_UNUSED_ARG(idx), VL_LAMBDA_TYPE &m2) {
+      m2.min(min2);
+  });
   ASSERT_EQ(static_cast<DATA_TYPE>(s_min2), static_cast<DATA_TYPE>(min2.getVal()));
   ASSERT_EQ(static_cast<IDX_TYPE>(s_minloc2), static_cast<IDX_TYPE>(min2.getLoc()));
    

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLoc.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLoc.hpp
@@ -107,6 +107,24 @@ void ForallReduceMinLocBasicTestImpl(const SEG_TYPE& seg,
   });
   ASSERT_EQ(static_cast<DATA_TYPE>(min2.getVal()), static_cast<DATA_TYPE>(min.getVal()));
   ASSERT_EQ(static_cast<IDX_TYPE>(min2.getLoc()), static_cast<IDX_TYPE>(min.getLoc()));
+
+  DATA_TYPE s_min = min_init;
+  DATA_TYPE s_min2 = min_init;
+  IDX_TYPE s_minloc = minloc_init;
+  IDX_TYPE s_minloc2 = minloc_init;
+
+  factor = 4;
+  RAJA::forall<EXEC_POLICY>(seg,
+    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&s_min, &s_minloc),
+    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&s_min2, &s_minloc2),
+    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &m, VL_LAMBDA_TYPE &m2) {
+      m.minloc( working_array[idx] * factor, idx);
+      m2.min(min2);
+  });
+  ASSERT_EQ(static_cast<DATA_TYPE>(s_min), ref_min * factor);
+  ASSERT_EQ(static_cast<IDX_TYPE>(s_minloc), ref_minloc);
+  ASSERT_EQ(static_cast<DATA_TYPE>(s_min2), static_cast<DATA_TYPE>(min2.getVal()));
+  ASSERT_EQ(static_cast<IDX_TYPE>(s_minloc2), static_cast<IDX_TYPE>(min2.getLoc()));
    
 
   deallocateForallTestData<DATA_TYPE>(working_res,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLocAlt.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLocAlt.hpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#ifndef __TEST_FORALL_BASIC_REDUCEMAXLOC_HPP__
-#define __TEST_FORALL_BASIC_REDUCEMAXLOC_HPP__
+#ifndef __TEST_FORALL_BASIC_REDUCEMINLOCALT_HPP__
+#define __TEST_FORALL_BASIC_REDUCEMINLOCALT_HPP__
 
 #include <cstdlib>
 #include <ctime>
@@ -16,7 +16,7 @@
 template <typename IDX_TYPE, typename DATA_TYPE,
           typename SEG_TYPE,
           typename EXEC_POLICY, typename REDUCE_POLICY>
-void ForallReduceMaxLocBasicTestImpl(const SEG_TYPE& seg,
+void ForallReduceMinLocAltBasicTestImpl(const SEG_TYPE& seg,
                                      const std::vector<IDX_TYPE>& seg_idx,
                                      camp::resources::Resource working_res)
 {
@@ -34,60 +34,80 @@ void ForallReduceMaxLocBasicTestImpl(const SEG_TYPE& seg,
                                     &test_array);
 
   const int modval = 100;
-  const DATA_TYPE max_init = -modval;
-  const IDX_TYPE maxloc_init = -1;
-  const IDX_TYPE maxloc_idx = seg_idx[ idx_len * 2/3 ];
-  const DATA_TYPE big_max = modval*10;
-  const IDX_TYPE big_maxloc = maxloc_init;
+  const DATA_TYPE min_init = modval+1;
+  const IDX_TYPE minloc_init = -1;
+  const IDX_TYPE minloc_idx = seg_idx[ idx_len * 2/3 ];
+  const DATA_TYPE small_min = -modval;
+  const IDX_TYPE small_minloc = minloc_init;
 
   for (IDX_TYPE i = 0; i < data_len; ++i) {
-    test_array[i] = static_cast<DATA_TYPE>( 1000 % modval );
+    test_array[i] = static_cast<DATA_TYPE>( rand() % modval );
   }
-  test_array[maxloc_idx] = static_cast<DATA_TYPE>(big_max);
+  test_array[minloc_idx] = static_cast<DATA_TYPE>(small_min);
 
-  DATA_TYPE ref_max = max_init;
-  IDX_TYPE ref_maxloc = maxloc_init;
+  DATA_TYPE ref_min = min_init;
+  IDX_TYPE ref_minloc = minloc_init;
   for (IDX_TYPE i = 0; i < idx_len; ++i) {
-    if ( test_array[ seg_idx[i] ] > ref_max ) {
-       ref_max = test_array[ seg_idx[i] ];
-       ref_maxloc = seg_idx[i];
+    if ( test_array[ seg_idx[i] ] < ref_min ) {
+       ref_min = test_array[ seg_idx[i] ];
+       ref_minloc = seg_idx[i];
     } 
   }
 
   working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
-
   using VL_TYPE = RAJA::expt::ValLoc<DATA_TYPE, IDX_TYPE>;
-  using VL_LAMBDA_TYPE = RAJA::expt::ValLocOp<DATA_TYPE, IDX_TYPE, RAJA::operators::maximum>;
-  VL_TYPE maxinit(big_max, maxloc_init);
-  VL_TYPE max(max_init, maxloc_init);
+  using VL_LAMBDA_TYPE = RAJA::expt::ValLocOp<DATA_TYPE, IDX_TYPE, RAJA::operators::minimum>;
+  VL_TYPE mininit(small_min, minloc_init);
+  VL_TYPE min(min_init, minloc_init);
 
   RAJA::forall<EXEC_POLICY>(seg, 
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&maxinit),
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&max),
-    RAJA::expt::KernelName("RAJA Reduce MaxLoc"),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&mininit),
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
+    RAJA::expt::KernelName("RAJA Reduce MinLoc"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &mi, VL_LAMBDA_TYPE &m) {
-      mi.maxloc( working_array[idx], idx );
-      m.maxloc( working_array[idx], idx );
+      mi.minloc( working_array[idx], idx );
+      m.minloc( working_array[idx], idx );
   });
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(maxinit.getVal()), big_max);
-  ASSERT_EQ(static_cast<IDX_TYPE>(maxinit.getLoc()), big_maxloc);
-  ASSERT_EQ(static_cast<DATA_TYPE>(max.getVal()), ref_max);
-  ASSERT_EQ(static_cast<IDX_TYPE>(max.getLoc()), ref_maxloc);
+  ASSERT_EQ(static_cast<DATA_TYPE>(mininit.getVal()), small_min);
+  ASSERT_EQ(static_cast<IDX_TYPE>(mininit.getLoc()), small_minloc);
+  ASSERT_EQ(static_cast<DATA_TYPE>(min.getVal()), ref_min);
+  ASSERT_EQ(static_cast<IDX_TYPE>(min.getLoc()), ref_minloc);
 
-  max.set(max_init, maxloc_init);
-  ASSERT_EQ(static_cast<DATA_TYPE>(max.getVal()), max_init);
-  ASSERT_EQ(static_cast<IDX_TYPE>(max.getLoc()), maxloc_init);
+  VL_TYPE min2(min_init, minloc_init);
 
-  DATA_TYPE factor = 2;
   RAJA::forall<EXEC_POLICY>(seg,
-    RAJA::expt::Reduce<RAJA::operators::maximum>(&max),
-    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &m) {
-      m.maxloc( working_array[idx] * factor, idx);
+    RAJA::expt::Reduce<RAJA::operators::minimum>(&min2),
+    [=] RAJA_HOST_DEVICE(IDX_TYPE RAJA_UNUSED_ARG(idx), VL_LAMBDA_TYPE &m2) {
+      m2.min( min );
   });
-  ASSERT_EQ(static_cast<DATA_TYPE>(max.getVal()), ref_max * factor);
-  ASSERT_EQ(static_cast<IDX_TYPE>(max.getLoc()), ref_maxloc);
+  ASSERT_EQ(static_cast<DATA_TYPE>(min2.getVal()), static_cast<DATA_TYPE>(min.getVal()));
+  ASSERT_EQ(static_cast<IDX_TYPE>(min2.getLoc()), static_cast<IDX_TYPE>(min.getLoc()));
+
+  DATA_TYPE s_min = min_init;
+  IDX_TYPE s_minloc = minloc_init;
+
+  const int factor = 4;
+  RAJA::forall<EXEC_POLICY>(seg,
+    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&s_min, &s_minloc),
+    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &m) {
+      m.minloc( working_array[idx] * factor, idx);
+  });
+  ASSERT_EQ(static_cast<DATA_TYPE>(s_min), ref_min * factor);
+  ASSERT_EQ(static_cast<IDX_TYPE>(s_minloc), ref_minloc);
+
+  DATA_TYPE s_min2 = min_init;
+  IDX_TYPE s_minloc2 = minloc_init;
+
+  RAJA::forall<EXEC_POLICY>(seg,
+    RAJA::expt::ReduceLoc<RAJA::operators::minimum>(&s_min2, &s_minloc2),
+    [=] RAJA_HOST_DEVICE(IDX_TYPE RAJA_UNUSED_ARG(idx), VL_LAMBDA_TYPE &m2) {
+      m2.min(min2);
+  });
+  ASSERT_EQ(static_cast<DATA_TYPE>(s_min2), static_cast<DATA_TYPE>(min2.getVal()));
+  ASSERT_EQ(static_cast<IDX_TYPE>(s_minloc2), static_cast<IDX_TYPE>(min2.getLoc()));
+   
 
   deallocateForallTestData<DATA_TYPE>(working_res,
                                       working_array,
@@ -95,13 +115,13 @@ void ForallReduceMaxLocBasicTestImpl(const SEG_TYPE& seg,
                                       test_array);
 }
 
-TYPED_TEST_SUITE_P(ForallReduceMaxLocBasicTest);
+TYPED_TEST_SUITE_P(ForallReduceMinLocAltBasicTest);
 template <typename T>
-class ForallReduceMaxLocBasicTest : public ::testing::Test
+class ForallReduceMinLocAltBasicTest : public ::testing::Test
 {
 };
 
-TYPED_TEST_P(ForallReduceMaxLocBasicTest, ReduceMaxLocBasicForall)
+TYPED_TEST_P(ForallReduceMinLocAltBasicTest, ReduceMinLocAltBasicForall)
 {
   using IDX_TYPE      = typename camp::at<TypeParam, camp::num<0>>::type;
   using DATA_TYPE     = typename camp::at<TypeParam, camp::num<1>>::type;
@@ -116,7 +136,7 @@ TYPED_TEST_P(ForallReduceMaxLocBasicTest, ReduceMaxLocBasicForall)
 // Range segment tests
   RAJA::TypedRangeSegment<IDX_TYPE> r1( 0, 28 );
   RAJA::getIndices(seg_idx, r1);
-  ForallReduceMaxLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+  ForallReduceMinLocAltBasicTestImpl<IDX_TYPE, DATA_TYPE,
                                   RAJA::TypedRangeSegment<IDX_TYPE>,
                                   EXEC_POLICY, REDUCE_POLICY>(
                                     r1, seg_idx, working_res);
@@ -124,7 +144,7 @@ TYPED_TEST_P(ForallReduceMaxLocBasicTest, ReduceMaxLocBasicForall)
   seg_idx.clear();
   RAJA::TypedRangeSegment<IDX_TYPE> r2( 3, 642 );
   RAJA::getIndices(seg_idx, r2);
-  ForallReduceMaxLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+  ForallReduceMinLocAltBasicTestImpl<IDX_TYPE, DATA_TYPE,
                                   RAJA::TypedRangeSegment<IDX_TYPE>,
                                   EXEC_POLICY, REDUCE_POLICY>(
                                     r2, seg_idx, working_res);
@@ -132,7 +152,7 @@ TYPED_TEST_P(ForallReduceMaxLocBasicTest, ReduceMaxLocBasicForall)
   seg_idx.clear();
   RAJA::TypedRangeSegment<IDX_TYPE> r3( 0, 2057 );
   RAJA::getIndices(seg_idx, r3);
-  ForallReduceMaxLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+  ForallReduceMinLocAltBasicTestImpl<IDX_TYPE, DATA_TYPE,
                                   RAJA::TypedRangeSegment<IDX_TYPE>,
                                   EXEC_POLICY, REDUCE_POLICY>(
                                     r3, seg_idx, working_res);
@@ -141,7 +161,7 @@ TYPED_TEST_P(ForallReduceMaxLocBasicTest, ReduceMaxLocBasicForall)
   seg_idx.clear();
   RAJA::TypedRangeStrideSegment<IDX_TYPE> r4( 0, 188, 2 );
   RAJA::getIndices(seg_idx, r4);
-  ForallReduceMaxLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+  ForallReduceMinLocAltBasicTestImpl<IDX_TYPE, DATA_TYPE,
                                   RAJA::TypedRangeStrideSegment<IDX_TYPE>,
                                   EXEC_POLICY, REDUCE_POLICY>(
                                     r4, seg_idx, working_res);
@@ -149,7 +169,7 @@ TYPED_TEST_P(ForallReduceMaxLocBasicTest, ReduceMaxLocBasicForall)
   seg_idx.clear();
   RAJA::TypedRangeStrideSegment<IDX_TYPE> r5( 3, 1029, 3 );
   RAJA::getIndices(seg_idx, r5);
-  ForallReduceMaxLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+  ForallReduceMinLocAltBasicTestImpl<IDX_TYPE, DATA_TYPE,
                                   RAJA::TypedRangeStrideSegment<IDX_TYPE>,
                                   EXEC_POLICY, REDUCE_POLICY>(
                                     r5, seg_idx, working_res);
@@ -166,13 +186,13 @@ TYPED_TEST_P(ForallReduceMaxLocBasicTest, ReduceMaxLocBasicForall)
   }
   RAJA::TypedListSegment<IDX_TYPE> l1( &seg_idx[0], seg_idx.size(),
                                        working_res );
-  ForallReduceMaxLocBasicTestImpl<IDX_TYPE, DATA_TYPE,
+  ForallReduceMinLocAltBasicTestImpl<IDX_TYPE, DATA_TYPE,
                                   RAJA::TypedListSegment<IDX_TYPE>,
                                   EXEC_POLICY, REDUCE_POLICY>(
                                     l1, seg_idx, working_res);
 }
 
-REGISTER_TYPED_TEST_SUITE_P(ForallReduceMaxLocBasicTest,
-                            ReduceMaxLocBasicForall);
+REGISTER_TYPED_TEST_SUITE_P(ForallReduceMinLocAltBasicTest,
+                            ReduceMinLocAltBasicForall);
 
-#endif  // __TEST_FORALL_BASIC_REDUCEMAXLOC_HPP__
+#endif  // __TEST_FORALL_BASIC_REDUCEMINLOCALT_HPP__

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceSum.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceSum.hpp
@@ -48,34 +48,34 @@ void ForallReduceSumBasicTestImpl(const SEG_TYPE& seg,
 
   working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
-  REF_SUM sum(0);
-  REF_SUM sum2(2);
+  DATA_TYPE sum(0);
+  DATA_TYPE sum2(2);
 
   RAJA::forall<EXEC_POLICY>(seg, 
-    RAJA::expt::Reduce<>(&sum),
-    RAJA::expt::Reduce<>(&sum2),
+    RAJA::expt::Reduce<RAJA::operators::plus>(&sum),
+    RAJA::expt::Reduce<RAJA::operators::plus>(&sum2),
     RAJA::expt::KernelName("RAJA Reduce Sum"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_SUM &s1, REF_SUM &s2) {
       s1 += working_array[idx];
       s2 += working_array[idx];
   });
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(sum.get()), ref_sum);
-  ASSERT_EQ(static_cast<DATA_TYPE>(sum2.get()), ref_sum + 2);
+  ASSERT_EQ(static_cast<DATA_TYPE>(sum), ref_sum);
+  ASSERT_EQ(static_cast<DATA_TYPE>(sum2), ref_sum + 2);
 
-  sum.set(0);
+  sum = 0;
 
   const int nloops = 2;
 
   for (int j = 0; j < nloops; ++j) {
     RAJA::forall<EXEC_POLICY>(seg, 
-      RAJA::expt::Reduce<>(&sum),
+      RAJA::expt::Reduce<RAJA::operators::plus>(&sum),
       [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_SUM &s) {
         s += working_array[idx];
     });
   }
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(sum.get()), nloops * ref_sum);
+  ASSERT_EQ(static_cast<DATA_TYPE>(sum), nloops * ref_sum);
 
 
   deallocateForallTestData<DATA_TYPE>(working_res,

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceSum.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceSum.hpp
@@ -20,7 +20,7 @@ void ForallReduceSumBasicTestImpl(const SEG_TYPE& seg,
                                   const std::vector<IDX_TYPE>& seg_idx,
                                   camp::resources::Resource working_res)
 {
-  using REF_INT_SUM = RAJA::expt::ValOp<DATA_TYPE, RAJA::operators::plus>;
+  using REF_SUM = RAJA::expt::ValOp<DATA_TYPE, RAJA::operators::plus>;
 
   IDX_TYPE data_len = seg_idx[seg_idx.size() - 1] + 1;
   IDX_TYPE idx_len = static_cast<IDX_TYPE>( seg_idx.size() );
@@ -48,14 +48,14 @@ void ForallReduceSumBasicTestImpl(const SEG_TYPE& seg,
 
   working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
-  REF_INT_SUM sum(0);
-  REF_INT_SUM sum2(2);
+  REF_SUM sum(0);
+  REF_SUM sum2(2);
 
   RAJA::forall<EXEC_POLICY>(seg, 
     RAJA::expt::Reduce<>(&sum),
     RAJA::expt::Reduce<>(&sum2),
     RAJA::expt::KernelName("RAJA Reduce Sum"),
-    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_INT_SUM &s1, REF_INT_SUM &s2) {
+    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_SUM &s1, REF_SUM &s2) {
       s1 += working_array[idx];
       s2 += working_array[idx];
   });
@@ -70,7 +70,7 @@ void ForallReduceSumBasicTestImpl(const SEG_TYPE& seg,
   for (int j = 0; j < nloops; ++j) {
     RAJA::forall<EXEC_POLICY>(seg, 
       RAJA::expt::Reduce<>(&sum),
-      [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_INT_SUM &s) {
+      [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_SUM &s) {
         s += working_array[idx];
     });
   }

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceSum.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceSum.hpp
@@ -20,6 +20,8 @@ void ForallReduceSumBasicTestImpl(const SEG_TYPE& seg,
                                   const std::vector<IDX_TYPE>& seg_idx,
                                   camp::resources::Resource working_res)
 {
+  using REF_INT_SUM = RAJA::expt::ValOp<DATA_TYPE, RAJA::operators::plus>;
+
   IDX_TYPE data_len = seg_idx[seg_idx.size() - 1] + 1;
   IDX_TYPE idx_len = static_cast<IDX_TYPE>( seg_idx.size() );
 
@@ -46,34 +48,34 @@ void ForallReduceSumBasicTestImpl(const SEG_TYPE& seg,
 
   working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
-  DATA_TYPE sum = 0;
-  DATA_TYPE sum2 = 2;
+  REF_INT_SUM sum(0);
+  REF_INT_SUM sum2(2);
 
   RAJA::forall<EXEC_POLICY>(seg, 
-    RAJA::expt::Reduce<RAJA::operators::plus>(&sum),
-    RAJA::expt::Reduce<RAJA::operators::plus>(&sum2),
+    RAJA::expt::Reduce<>(&sum),
+    RAJA::expt::Reduce<>(&sum2),
     RAJA::expt::KernelName("RAJA Reduce Sum"),
-    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, DATA_TYPE &s1, DATA_TYPE &s2) {
+    [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_INT_SUM &s1, REF_INT_SUM &s2) {
       s1 += working_array[idx];
       s2 += working_array[idx];
   });
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(sum), ref_sum);
-  ASSERT_EQ(static_cast<DATA_TYPE>(sum2), ref_sum + 2);
+  ASSERT_EQ(static_cast<DATA_TYPE>(sum.get()), ref_sum);
+  ASSERT_EQ(static_cast<DATA_TYPE>(sum2.get()), ref_sum + 2);
 
-  sum = 0;
+  sum.set(0);
 
   const int nloops = 2;
 
   for (int j = 0; j < nloops; ++j) {
     RAJA::forall<EXEC_POLICY>(seg, 
-      RAJA::expt::Reduce<RAJA::operators::plus>(&sum),
-      [=] RAJA_HOST_DEVICE(IDX_TYPE idx, DATA_TYPE &s) {
+      RAJA::expt::Reduce<>(&sum),
+      [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_INT_SUM &s) {
         s += working_array[idx];
     });
   }
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(sum), nloops * ref_sum);
+  ASSERT_EQ(static_cast<DATA_TYPE>(sum.get()), nloops * ref_sum);
 
 
   deallocateForallTestData<DATA_TYPE>(working_res,

--- a/test/functional/launch/reduce-params/tests/test-launch-basic-param-expt-ReduceBitAnd.hpp
+++ b/test/functional/launch/reduce-params/tests/test-launch-basic-param-expt-ReduceBitAnd.hpp
@@ -48,11 +48,11 @@ void LaunchParamExptReduceBitAndBasicTestImpl(const SEG_TYPE& seg,
   }
   working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
-  REF_BITAND simpand(21);
+  DATA_TYPE simpand(21);
 
   RAJA::launch<LAUNCH_POLICY>
     (RAJA::LaunchParams(RAJA::Teams(blocks), RAJA::Threads(threads)),
-     RAJA::expt::Reduce<>(&simpand),
+     RAJA::expt::Reduce<RAJA::operators::bit_and>(&simpand),
      [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx, REF_BITAND &_simpand) {
 
       RAJA::loop<GLOBAL_THREAD_POLICY>(ctx, seg, [&](IDX_TYPE idx) {
@@ -62,7 +62,7 @@ void LaunchParamExptReduceBitAndBasicTestImpl(const SEG_TYPE& seg,
 
   });
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(simpand.get()), 5);
+  ASSERT_EQ(static_cast<DATA_TYPE>(simpand), 5);
 
 
   //
@@ -81,13 +81,13 @@ void LaunchParamExptReduceBitAndBasicTestImpl(const SEG_TYPE& seg,
     ref_and &= test_array[ seg_idx[i] ];
   }
 
-  REF_BITAND redand(0);
-  REF_BITAND redand2(2);
+  DATA_TYPE redand(0);
+  DATA_TYPE redand2(2);
 
   RAJA::launch<LAUNCH_POLICY>
     (RAJA::LaunchParams(RAJA::Teams(blocks), RAJA::Threads(threads)),
-     RAJA::expt::Reduce<>(&redand),
-     RAJA::expt::Reduce<>(&redand2),
+     RAJA::expt::Reduce<RAJA::operators::bit_and>(&redand),
+     RAJA::expt::Reduce<RAJA::operators::bit_and>(&redand2),
      [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx, REF_BITAND &_redand, REF_BITAND &_redand2) {
       RAJA::loop<GLOBAL_THREAD_POLICY>(ctx, seg, [&](IDX_TYPE idx) {
         _redand  &= working_array[idx];
@@ -95,16 +95,16 @@ void LaunchParamExptReduceBitAndBasicTestImpl(const SEG_TYPE& seg,
     });
   });
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(redand.get()), ref_and);
-  ASSERT_EQ(static_cast<DATA_TYPE>(redand2.get()), ref_and);
+  ASSERT_EQ(static_cast<DATA_TYPE>(redand), ref_and);
+  ASSERT_EQ(static_cast<DATA_TYPE>(redand2), ref_and);
 
-  redand.set(0);
+  redand = 0;
 
   const int nloops = 3;
   for (int j = 0; j < nloops; ++j) {
     RAJA::launch<LAUNCH_POLICY>
       (RAJA::LaunchParams(RAJA::Teams(blocks), RAJA::Threads(threads)),
-       RAJA::expt::Reduce<>(&redand),
+       RAJA::expt::Reduce<RAJA::operators::bit_and>(&redand),
        [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx, REF_BITAND _redand) {
         RAJA::loop<GLOBAL_THREAD_POLICY>(ctx, seg, [&](IDX_TYPE idx) {
           _redand &= working_array[idx];
@@ -112,7 +112,7 @@ void LaunchParamExptReduceBitAndBasicTestImpl(const SEG_TYPE& seg,
     });
   }
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(redand.get()), ref_and);
+  ASSERT_EQ(static_cast<DATA_TYPE>(redand), ref_and);
 
 
   deallocateForallTestData<DATA_TYPE>(working_res,

--- a/test/functional/launch/reduce-params/tests/test-launch-basic-param-expt-ReduceMin.hpp
+++ b/test/functional/launch/reduce-params/tests/test-launch-basic-param-expt-ReduceMin.hpp
@@ -54,14 +54,14 @@ void LaunchParamExptReduceMinBasicTestImpl(const SEG_TYPE& seg,
 
   working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
-  REF_MIN mininit(small_min);
-  REF_MIN min(min_init);
+  DATA_TYPE mininit(small_min);
+  DATA_TYPE min(min_init);
   
   RAJA::launch<LAUNCH_POLICY>
     (RAJA::LaunchParams(RAJA::Teams(blocks), RAJA::Threads(threads)),
      "LaunchMinBasicTest",
-     RAJA::expt::Reduce<>(&mininit),
-     RAJA::expt::Reduce<>(&min),
+     RAJA::expt::Reduce<RAJA::operators::minimum>(&mininit),
+     RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
      [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx, REF_MIN &_mininit, REF_MIN &_min) {
 
       RAJA::loop<GLOBAL_THREAD_POLICY>(ctx, seg, [&](IDX_TYPE idx) {
@@ -74,16 +74,16 @@ void LaunchParamExptReduceMinBasicTestImpl(const SEG_TYPE& seg,
   });
 
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(mininit.get()), small_min);
-  ASSERT_EQ(static_cast<DATA_TYPE>(min.get()), ref_min);
+  ASSERT_EQ(static_cast<DATA_TYPE>(mininit), small_min);
+  ASSERT_EQ(static_cast<DATA_TYPE>(min), ref_min);
 
-  min.set(min_init);
-  ASSERT_EQ(static_cast<DATA_TYPE>(min.get()), min_init);
+  min = min_init;
+  ASSERT_EQ(static_cast<DATA_TYPE>(min), min_init);
 
   DATA_TYPE factor = 3;
   RAJA::launch<LAUNCH_POLICY>
     (RAJA::LaunchParams(RAJA::Teams(blocks), RAJA::Threads(threads)),
-     RAJA::expt::Reduce<>(&min),
+     RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
      [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx, REF_MIN &_min) {
 
       RAJA::loop<GLOBAL_THREAD_POLICY>(ctx, seg, [&](IDX_TYPE idx) {
@@ -93,13 +93,13 @@ void LaunchParamExptReduceMinBasicTestImpl(const SEG_TYPE& seg,
 
   });
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(min.get()), ref_min * factor);
+  ASSERT_EQ(static_cast<DATA_TYPE>(min), ref_min * factor);
 
 
   factor = 2;
   RAJA::launch<LAUNCH_POLICY>
     (RAJA::LaunchParams(RAJA::Teams(blocks), RAJA::Threads(threads)),
-     RAJA::expt::Reduce<>(&min),
+     RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
      [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx, REF_MIN &_min) {
       RAJA::loop<GLOBAL_THREAD_POLICY>(ctx, seg, [&](IDX_TYPE idx) {
 
@@ -107,7 +107,7 @@ void LaunchParamExptReduceMinBasicTestImpl(const SEG_TYPE& seg,
       });
   });
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(min.get()), ref_min * factor);
+  ASSERT_EQ(static_cast<DATA_TYPE>(min), ref_min * factor);
 
 
   deallocateForallTestData<DATA_TYPE>(working_res,

--- a/test/functional/launch/reduce-params/tests/test-launch-basic-param-expt-ReduceSum.hpp
+++ b/test/functional/launch/reduce-params/tests/test-launch-basic-param-expt-ReduceSum.hpp
@@ -53,13 +53,13 @@ void LaunchParamExptReduceSumBasicTestImpl(const SEG_TYPE& seg,
   working_res.memcpy(working_array, test_array, sizeof(DATA_TYPE) * data_len);
 
 
-  REF_SUM sum(0), sum2(2);
+  DATA_TYPE sum(0), sum2(2);
 
   RAJA::launch<LAUNCH_POLICY>
     (RAJA::LaunchParams(RAJA::Teams(blocks), RAJA::Threads(threads)),
      "LaunchSumBasicTest",
-     RAJA::expt::Reduce<>(&sum),
-     RAJA::expt::Reduce<>(&sum2),
+     RAJA::expt::Reduce<RAJA::operators::plus>(&sum),
+     RAJA::expt::Reduce<RAJA::operators::plus>(&sum2),
      [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx, REF_SUM &_sum, REF_SUM &_sum2) {
 
       RAJA::loop<GLOBAL_THREAD_POLICY>(ctx, seg, [&](IDX_TYPE idx) {
@@ -69,17 +69,17 @@ void LaunchParamExptReduceSumBasicTestImpl(const SEG_TYPE& seg,
 
   });
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(sum.get()), ref_sum);
-  ASSERT_EQ(static_cast<DATA_TYPE>(sum2.get()), ref_sum + 2);
+  ASSERT_EQ(static_cast<DATA_TYPE>(sum), ref_sum);
+  ASSERT_EQ(static_cast<DATA_TYPE>(sum2), ref_sum + 2);
 
-  sum.set(0);
+  sum = 0;
 
   const int nloops = 2;
 
   for (int j = 0; j < nloops; ++j) {
     RAJA::launch<LAUNCH_POLICY>
       (RAJA::LaunchParams(RAJA::Teams(blocks), RAJA::Threads(threads)),
-       RAJA::expt::Reduce<>(&sum),
+       RAJA::expt::Reduce<RAJA::operators::plus>(&sum),
        [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx, REF_SUM &_sum) {
 
         RAJA::loop<GLOBAL_THREAD_POLICY>(ctx, seg, [&](IDX_TYPE idx) {
@@ -88,7 +88,7 @@ void LaunchParamExptReduceSumBasicTestImpl(const SEG_TYPE& seg,
       });
   }
 
-  ASSERT_EQ(static_cast<DATA_TYPE>(sum.get()), nloops * ref_sum);
+  ASSERT_EQ(static_cast<DATA_TYPE>(sum), nloops * ref_sum);
 
 
   deallocateForallTestData<DATA_TYPE>(working_res,


### PR DESCRIPTION
# Summary

- This PR is a refactoring:
- It does the following:
  - Refactors new reduction interface to have consistent min/max/loc operator semantics.
  - Introduces type safety to reduction operators.
  - Interface will be changed to require passing in ValOp objects, as opposed to the old interface which used raw data types. Changes will be highlighted with a comparison chart soon.
  - ValLoc now requires IndexType, and must be used within a ValOp, e.g. `ValOp<ValLoc<T,IndexType>, Op>`.
  - Satisfies this request https://github.com/LLNL/RAJA/issues/1582.

Original interface:
```
int sum = 0;
int min = large_num;
RAJA::expt::ValLoc<T, RAJA::Index_type> minloc(large_num, -1);

RAJA::forall<seqpol>(host_res, range,

  RAJA::expt::Reduce<RAJA::operators::plus>(&sum),
  RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
  RAJA::expt::Reduce<RAJA::operators::minimum>(&minloc),

  [=] (int i,
    int & _sum,
    int & _min,
    RAJA::expt::ValLoc<T,RAJA::Index_type> & _minloc) {

            _sum += a[i];
            _min = RAJA_MIN(a[i], _min);
            _minloc = RAJA_MIN(RAJA::expt::ValLoc<T,RAJA::Index_type>(a[i], i), _minloc);
});
```

Changes in this PR:

```
int sum(0);
int min(large_num);
RAJA::expt::ValLoc<T, RAJA::Index_type> minloc(large_num, -1);

RAJA::expt::ValLoc<T, RAJA::Index_type> temploc(large_num, -1);

int max = small_num;
RAJA::Index_type loc(-1);

RAJA::forall<seqpol>(host_res, range,

  RAJA::expt::Reduce<RAJA::operators::plus>(&sum),
  RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
  RAJA::expt::Reduce<RAJA::operators::minimum>(&minloc),
  RAJA::expt::ReduceLoc<RAJA::operators::maximum>(&max, &loc),

  [=] (int i,
    RAJA::expt::ValOp<T, RAJA::operators::plus> & _sum,
    RAJA::expt::ValOp<T, RAJA::operators::minimum> & _min,
    RAJA::expt::ValOp<RAJA::expt::ValLoc<T, RAJA::Index_type>, RAJA::operators::minimum> & _minloc,
    RAJA::expt::ValOp<RAJA::expt::ValLoc<T, RAJA::Index_type>, RAJA::operators::maximum> & _maxloc) {

            _sum += a[i];
            _min.min(a[i]);
            _minloc.minloc(a[i], i);

            _minloc.min(temploc);

            _maxloc.maxloc(a[i], i);
});

minloc.set(large_num, -1);
```

Todo's:
- [x] Clean up accessors to `val`
- [x] Documentation
- [x] Modify tests to use ValOp
- [x] Launch
- [x] SYCL
- [x] OpenMP Target

Enhancements for later:
- Reset function. Like set(), but puts max/min and -1 for locs.
- Default init to min/max values and -1 for loc.
- Expand launch/reduce-param tests (BitOr, Max, locs).