### PR TITLE
Add desul atomic header guard under benchmark

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -11,9 +11,11 @@ if (RAJA_ENABLE_CUDA)
     SOURCES host-device-lambda-benchmark.cpp)
 endif()
 
+if (RAJA_ENABLE_DESUL)
 raja_add_benchmark(
   NAME benchmark-atomic
   SOURCES benchmark-atomic.cpp)
+endif()
 
 raja_add_benchmark(
   NAME ltimes


### PR DESCRIPTION
# Summary

Adds a missing guard to desul atomic benchmark.

