### PR TITLE
Update and sandardize implementation of packages, in sync with spack update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build_docker:
     strategy:
       matrix:
-        target: [gcc12_debug, gcc13, clang13, clang15, rocm6, rocm6_desul, intel2024, intel2024_debug, intel2024_sycl]
+        target: [gcc12_debug, gcc13, clang13, clang14_debug, clang15, rocm6, rocm6_desul, intel2024, intel2024_debug, intel2024_sycl]
     runs-on: ubuntu-latest
     steps:
     - run: |

--- a/.gitlab/jobs/poodle.yml
+++ b/.gitlab/jobs/poodle.yml
@@ -17,6 +17,18 @@
 # project. We keep ${PROJECT_<MACHINE>_VARIANTS} and ${PROJECT_<MACHINE>_DEPS}
 # when possible so that the comparison with the original job is easier.
 
+# Identical to shared job, but use OpenMP tasks and no vectorization
+clang_14_0_6:
+  variables:
+    SPEC: " ~shared +openmp +omptask ~vectorization +tests %clang@=14.0.6 ${PROJECT_POODLE_DEPS}"
+  extends: .job_on_poodle
+
+# Identical to shared job, but use OpenMP tasks and no vectorization
+gcc_10_3_1:
+  variables:
+    SPEC: " ~shared +openmp +omptask ~vectorization +tests %gcc@=10.3.1 ${PROJECT_POODLE_DEPS}"
+  extends: .job_on_poodle
+
 # Known issue currently under investigation
 # https://github.com/LLNL/RAJA/pull/1712#issuecomment-2292006843
 intel_2023_2_1:
@@ -24,18 +36,6 @@ intel_2023_2_1:
     SPEC: "${PROJECT_POODLE_VARIANTS} %intel@=2023.2.1 ${PROJECT_POODLE_DEPS}"
   extends: .job_on_poodle
   allow_failure: true
-
-# Identical to shared job, but use OpenMP tasks and no vectorization
-clang_14_0_6:
-  variables:
-    SPEC: " ~shared +openmp +omptask +tests %clang@=14.0.6 ${PROJECT_POODLE_DEPS}"
-  extends: .job_on_poodle
-
-# Identical to shared job, but use OpenMP tasks and no vectorization
-gcc_10_3_1:
-  variables:
-    SPEC: " ~shared +openmp +omptask +tests %gcc@=10.3.1 ${PROJECT_POODLE_DEPS}"
-  extends: .job_on_poodle
 
 ############
 # Extra jobs

--- a/.gitlab/jobs/ruby.yml
+++ b/.gitlab/jobs/ruby.yml
@@ -20,13 +20,13 @@
 # Identical to shared job, but use OpenMP tasks and no vectorization
 clang_14_0_6:
   variables:
-    SPEC: " ~shared +openmp +omptask +tests %clang@=14.0.6 ${PROJECT_RUBY_DEPS}"
+    SPEC: " ~shared +openmp +omptask ~vectorization +tests %clang@=14.0.6 ${PROJECT_RUBY_DEPS}"
   extends: .job_on_ruby
 
 # Identical to shared job, but use OpenMP tasks and no vectorization
 gcc_10_3_1:
   variables:
-    SPEC: " ~shared +openmp +omptask +tests %gcc@=10.3.1 ${PROJECT_RUBY_DEPS}"
+    SPEC: " ~shared +openmp +omptask ~vectorization +tests %gcc@=10.3.1 ${PROJECT_RUBY_DEPS}"
   extends: .job_on_ruby
 
 # Known issue currently under investigation

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "woptim/radiuss-packages-sync",
+"spack_branch": "woptim/radiuss-packages-update",
 "spack_activate" : {},
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "woptim/radiuss-packages-update",
+"spack_commit": "d7f5dbaf8911387d6c38035f0d508702ee71b03a",
 "spack_activate" : {},
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_commit": "d7f5dbaf8911387d6c38035f0d508702ee71b03a",
+"spack_branch": "develop-2024-10-06",
 "spack_activate" : {},
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "woptim/radiuss-packages-update",
+"spack_branch": "woptim/radiuss-packages-sync",
 "spack_activate" : {},
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "develop-2024-07-07",
+"spack_branch": "woptim/radiuss-packages-update",
 "spack_activate" : {},
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,8 +42,6 @@ jobs:
         docker_target: gcc12
       gcc12_desul:
         docker_target: gcc12_desul
-      clang14_debug:
-        docker_target: clang14_debug
       clang15_desul:
         docker_target: clang15_desul
   pool:

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -28,6 +28,7 @@ job_unique_id=${CI_JOB_ID:-""}
 use_dev_shm=${USE_DEV_SHM:-true}
 spack_debug=${SPACK_DEBUG:-false}
 debug_mode=${DEBUG_MODE:-false}
+push_to_registry=${PUSH_TO_REGISTRY:-true}
 
 # REGISTRY_TOKEN allows you to provide your own personal access token to the CI
 # registry. Be sure to set the token with at least read access to the registry.
@@ -53,6 +54,7 @@ then
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     use_dev_shm=false
     spack_debug=true
+    push_to_registry=false
 fi
 
 if [[ -n ${module_list} ]]
@@ -130,7 +132,7 @@ then
     timed_message "Spack build of dependencies"
     ${uberenv_cmd} --skip-setup-and-env --spec="${spec}" ${prefix_opt}
 
-    if [[ -n ${ci_registry_token} && ${debug_mode} == false ]]
+    if [[ -n ${ci_registry_token} && ${push_to_registry} == true ]]
     then
         timed_message "Push dependencies to buildcache"
         ${spack_cmd} -D ${spack_env_path} buildcache push --only dependencies gitlab_ci


### PR DESCRIPTION
### Summary

This PR :

- migrates CARE and Caliper to CachedCMakePackage, reducing the gap with implementations found in llnl/radiuss-spack-configs.
- improves coherency in version constraints across RADIUSS packages.
- updates Spack.

⚠️  TODO Before Merge:
- [x] Wait for merge of https://github.com/spack/spack/pull/45648,
- [x] then wait for subsequent develop snapshot (Sunday).
- [x] Update Spack to new snapshot version in `.uberenv-config.json`.
- [x] Confirm CI is passing.
