### PR TITLE
Fix CMake version

### DIFF
--- a/scripts/lc-builds/corona_sycl.sh
+++ b/scripts/lc-builds/corona_sycl.sh
@@ -38,7 +38,7 @@ DATE=$(printf '%(%Y-%m-%d)T\n' -1)
 export PATH=${SYCL_PATH}/bin:$PATH
 export LD_LIBRARY_PATH=${SYCL_PATH}/lib:${SYCL_PATH}/lib64:$LD_LIBRARY_PATH
 
-module load cmake/3.24.2
+module load cmake/3.23.1
 
 cmake \
   -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \


### PR DESCRIPTION
# Summary

- This PR is a bugfix.
- It fixes the CMake version in the SYCL build script. What was there does not exist on corona.