### PR TITLE
feature: script to toggle clang-format on/off

### DIFF
--- a/examples/dynamic-forall.cpp
+++ b/examples/dynamic-forall.cpp
@@ -28,6 +28,7 @@
 void checkResult(int* res, int len);
 void printResult(int* res, int len);
 
+// clang-format off
 using policy_list = camp::list<RAJA::seq_exec
                                ,RAJA::simd_exec
 #if defined(RAJA_ENABLE_OPENMP)
@@ -39,6 +40,7 @@ using policy_list = camp::list<RAJA::seq_exec
 #endif
                                >;
 
+// clang-format on
 int main(int argc, char *argv[])
 {
 

--- a/examples/dynamic_mat_transpose.cpp
+++ b/examples/dynamic_mat_transpose.cpp
@@ -59,6 +59,7 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format off
 using launch_policy = RAJA::LaunchPolicy<
 #if defined(RAJA_ENABLE_OPENMP)
     RAJA::omp_launch_t
@@ -79,6 +80,7 @@ using launch_policy = RAJA::LaunchPolicy<
 #endif
     >;
 
+// clang-format on
 /*
  * Define team policies.
  * Up to 3 dimension are supported: x,y,z
@@ -322,6 +324,7 @@ int main(int argc, char *argv[])
   // _dynamic_mattranspose_shared_mem_end
 
   // _dynamic_mattranspose_kernel_start
+// clang-format off
   RAJA::launch<launch_policy>
     (res, RAJA::LaunchParams(RAJA::Teams(outer_Dimc, outer_Dimr),
                              RAJA::Threads(TILE_DIM, TILE_DIM), dynamic_shared_mem_size),
@@ -378,6 +381,7 @@ int main(int argc, char *argv[])
       });
   });
   // _dynamic_mattranspose_kernel_end
+// clang-format on
 
 #if defined(RAJA_GPU_ACTIVE)
   if(select_cpu_or_gpu == RAJA::ExecPlace::DEVICE) {
@@ -414,6 +418,7 @@ int main(int argc, char *argv[])
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -432,6 +437,7 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
+// clang-format on
 //
 // Function to print result.
 //

--- a/examples/forall-param-reductions.cpp
+++ b/examples/forall-param-reductions.cpp
@@ -134,6 +134,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   RAJA::Index_type seq_minloc2(-1);
   RAJA::Index_type seq_maxloc2(-1);
 
+// clang-format off
   RAJA::forall<EXEC_POL1>(host_res, arange,
     RAJA::expt::Reduce<RAJA::operators::plus>(&seq_sum),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&seq_min),
@@ -164,6 +165,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   std::cout << "\tsum = " << seq_sum << std::endl;
   std::cout << "\tmin = " << seq_min << std::endl;
   std::cout << "\tmax = " << seq_max << std::endl;
@@ -198,6 +200,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   RAJA::Index_type omp_minloc2(-1);
   RAJA::Index_type omp_maxloc2(-1);
 
+// clang-format off
   RAJA::forall<EXEC_POL2>(host_res, arange,
     RAJA::expt::Reduce<RAJA::operators::plus>(&omp_sum),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&omp_min),
@@ -228,6 +231,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   std::cout << "\tsum = " << omp_sum << std::endl;
   std::cout << "\tmin = " << omp_min << std::endl;
   std::cout << "\tmax = " << omp_max << std::endl;
@@ -264,6 +268,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   RAJA::Index_type omp_t_minloc2(-1);
   RAJA::Index_type omp_t_maxloc2(-1);
 
+// clang-format off
   RAJA::forall<EXEC_POL3>(omp_res, arange,
     RAJA::expt::Reduce<RAJA::operators::plus>(&omp_t_sum),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&omp_t_min),
@@ -294,6 +299,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   std::cout << "\tsum = " << omp_t_sum << std::endl;
   std::cout << "\tmin = " << omp_t_min << std::endl;
   std::cout << "\tmax = " << omp_t_max << std::endl;
@@ -334,6 +340,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   RAJA::Index_type cuda_minloc2(-1);
   RAJA::Index_type cuda_maxloc2(-1);
 
+// clang-format off
   RAJA::forall<EXEC_POL3>(cuda_res, arange,
     RAJA::expt::Reduce<RAJA::operators::plus>(&cuda_sum),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&cuda_min),
@@ -364,6 +371,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   std::cout << "\tsum = " << cuda_sum << std::endl;
   std::cout << "\tmin = " << cuda_min << std::endl;
   std::cout << "\tmax = " << cuda_max << std::endl;
@@ -403,6 +411,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   RAJA::Index_type hip_minloc2(-1);
   RAJA::Index_type hip_maxloc2(-1);
 
+// clang-format off
   RAJA::forall<EXEC_POL3>(hip_res, arange,
     RAJA::expt::Reduce<RAJA::operators::plus>(&hip_sum),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&hip_min),
@@ -433,6 +442,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   std::cout << "\tsum = " << hip_sum << std::endl;
   std::cout << "\tmin = " << hip_min << std::endl;
   std::cout << "\tmax = " << hip_max << std::endl;
@@ -473,6 +483,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   RAJA::Index_type sycl_minloc2(-1);
   RAJA::Index_type sycl_maxloc2(-1);
 
+// clang-format off
   RAJA::forall<EXEC_POL3>(sycl_res, arange,
     RAJA::expt::Reduce<RAJA::operators::plus>(&sycl_sum),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&sycl_min),
@@ -503,6 +514,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   std::cout << "\tsum = " << sycl_sum << std::endl;
   std::cout << "\tmin = " << sycl_min << std::endl;
   std::cout << "\tmax = " << sycl_max << std::endl;

--- a/examples/forall_multi-reductions.cpp
+++ b/examples/forall_multi-reductions.cpp
@@ -36,6 +36,7 @@ struct Backend
   std::string name;
 };
 
+// clang-format off
 auto example_policies = camp::make_tuple(
 
       Backend<RAJA::seq_exec, RAJA::seq_multi_reduce>{"Sequential"}
@@ -54,6 +55,7 @@ auto example_policies = camp::make_tuple(
 
     );
 
+// clang-format on
 template < typename exec_policy, typename multi_reduce_policy >
 void example_code(RAJA::RangeSegment arange, int num_bins, int* bins, int* a)
 {
@@ -131,6 +133,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv))
 
 //----------------------------------------------------------------------------//
 
+// clang-format off
   RAJA::for_each_tuple(example_policies, [&](auto const& backend) {
 
     std::cout << "Running " << backend.name << " policies" << '\n';
@@ -154,6 +157,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv))
     std::cout << std::endl;
   });
 
+// clang-format on
 //----------------------------------------------------------------------------//
 
 //

--- a/examples/jacobi.cpp
+++ b/examples/jacobi.cpp
@@ -184,10 +184,12 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   RAJA::RangeSegment gridRange(0, NN);
   RAJA::RangeSegment jacobiRange(1, (N + 1));
 
+// clang-format off
   using jacobiSeqNestedPolicy = RAJA::KernelPolicy<
   RAJA::statement::For<1, RAJA::seq_exec,
     RAJA::statement::For<0, RAJA::seq_exec, RAJA::statement::Lambda<0>> > >;
 
+// clang-format on
   printf("RAJA: Sequential Policy - Nested ForallN \n");
   resI2 = 1;
   iteration = 0;
@@ -257,10 +259,12 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
    *  operation for the residual in a thread-safe manner.
    */
   
+// clang-format off
   using jacobiOmpNestedPolicy = RAJA::KernelPolicy<
       RAJA::statement::For<1, RAJA::omp_parallel_for_exec,
         RAJA::statement::For<0, RAJA::seq_exec, RAJA::statement::Lambda<0> > > >;
 
+// clang-format on
   while (resI2 > tol * tol) {
     
     RAJA::kernel<jacobiOmpNestedPolicy>(RAJA::make_tuple(jacobiRange,jacobiRange),
@@ -315,6 +319,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   printf("RAJA: CUDA Policy - Nested ForallN \n");
 
+// clang-format off
   using jacobiCUDANestedPolicy = RAJA::KernelPolicy<
     RAJA::statement::CudaKernel<
       RAJA::statement::Tile<1, RAJA::tile_fixed<32>, RAJA::cuda_block_y_loop,
@@ -328,6 +333,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     > >;
   
+// clang-format on
   resI2 = 1;
   iteration = 0;
   memset(I, 0, NN * sizeof(double));
@@ -357,6 +363,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     // Compute residual and update Iold
     //
     RAJA::ReduceSum<RAJA::cuda_reduce, double> RAJA_resI2(0.0);
+// clang-format off
     RAJA::forall<RAJA::cuda_exec<CUDA_BLOCK_SIZE>>(
       gridRange, [=] RAJA_DEVICE (RAJA::Index_type k) {
       
@@ -365,6 +372,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
       });
 
+// clang-format on
     resI2 = RAJA_resI2;
 
     if (iteration > maxIter) {
@@ -392,6 +400,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   printf("RAJA: HIP Policy - Nested ForallN \n");
 
+// clang-format off
   using jacobiHIPNestedPolicy = RAJA::KernelPolicy<
     RAJA::statement::HipKernel<
       RAJA::statement::Tile<1, RAJA::tile_fixed<32>, RAJA::hip_block_y_loop,
@@ -405,6 +414,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     > >;
 
+// clang-format on
   resI2 = 1;
   iteration = 0;
   memset(I, 0, NN * sizeof(double));
@@ -439,6 +449,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     // Compute residual and update Iold
     //
     RAJA::ReduceSum<RAJA::hip_reduce, double> RAJA_resI2(0.0);
+// clang-format off
     RAJA::forall<RAJA::hip_exec<HIP_BLOCK_SIZE>>(
       gridRange, [=] RAJA_DEVICE (RAJA::Index_type k) {
 
@@ -447,6 +458,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
       });
 
+// clang-format on
     resI2 = RAJA_resI2;
 
     if (iteration > maxIter) {
@@ -488,10 +500,12 @@ void computeErr(double *I, grid_s grid)
   RAJA::RangeSegment gridRange(0, grid.n);
   RAJA::ReduceMax<RAJA::seq_reduce, double> tMax(-1.0);
 
+// clang-format off
   using jacobiSeqNestedPolicy = RAJA::KernelPolicy<
     RAJA::statement::For<1, RAJA::seq_exec,
       RAJA::statement::For<0, RAJA::seq_exec, RAJA::statement::Lambda<0> > > >;
 
+// clang-format on
   RAJA::kernel<jacobiSeqNestedPolicy>(RAJA::make_tuple(gridRange,gridRange),
                        [=] (RAJA::Index_type ty, RAJA::Index_type tx ) {
 

--- a/examples/kernel-dynamic-tile.cpp
+++ b/examples/kernel-dynamic-tile.cpp
@@ -14,6 +14,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   using namespace RAJA;
 
+// clang-format off
   kernel_param<
     KernelPolicy<
       statement::Tile<1, tile_dynamic<1>, seq_exec,
@@ -31,4 +32,5 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
        std::cout << "Running index (" << i << "," << j << ") of " << x.size << "x" << y.size << " tile." << std::endl;
   });
 
+// clang-format on
 }

--- a/examples/launch-param-reductions.cpp
+++ b/examples/launch-param-reductions.cpp
@@ -150,6 +150,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   RAJA::Index_type seq_minloc2(-1);
   RAJA::Index_type seq_maxloc2(-1);
 
+// clang-format off
   RAJA::launch<LAUNCH_POL1>
     (host_res, RAJA::LaunchParams(), "SeqReductionKernel",
     RAJA::expt::Reduce<RAJA::operators::plus   >(&seq_sum),
@@ -186,6 +187,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   std::cout << "\tsum = " << seq_sum << std::endl;
   std::cout << "\tmin = " << seq_min << std::endl;
   std::cout << "\tmax = " << seq_max << std::endl;
@@ -217,6 +219,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   RAJA::Index_type omp_minloc2(-1);
   RAJA::Index_type omp_maxloc2(-1);
 
+// clang-format off
   RAJA::launch<LAUNCH_POL2>
     (host_res, RAJA::LaunchParams(), "OmpReductionKernel",
     RAJA::expt::Reduce<RAJA::operators::plus   >(&omp_sum),
@@ -253,6 +256,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   std::cout << "\tsum = " << omp_sum << std::endl;
   std::cout << "\tmin = " << omp_min << std::endl;
   std::cout << "\tmax = " << omp_max << std::endl;
@@ -289,6 +293,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   RAJA::Index_type cuda_minloc2(-1);
   RAJA::Index_type cuda_maxloc2(-1);
 
+// clang-format off
   RAJA::launch<LAUNCH_POL3>
     (device_res, RAJA::LaunchParams(RAJA::Teams(NUMBER_OF_TEAMS), RAJA::Threads(CUDA_BLOCK_SIZE)),
      "CUDAReductionKernel",
@@ -329,6 +334,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   std::cout << "\tsum = " << cuda_sum << std::endl;
   std::cout << "\tmin = " << cuda_min << std::endl;
   std::cout << "\tmax = " << cuda_max << std::endl;
@@ -366,6 +372,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   RAJA::Index_type hip_minloc2(-1);
   RAJA::Index_type hip_maxloc2(-1);
 
+// clang-format off
   RAJA::launch<LAUNCH_POL3>
     (device_res, RAJA::LaunchParams(RAJA::Teams(NUMBER_OF_TEAMS), RAJA::Threads(HIP_BLOCK_SIZE)),
      "HipReductionKernel",
@@ -403,6 +410,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   std::cout << "\tsum = " << hip_sum << std::endl;
   std::cout << "\tmin = " << hip_min << std::endl;
   std::cout << "\tmax = " << hip_max << std::endl;
@@ -440,6 +448,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   RAJA::Index_type sycl_minloc2(-1);
   RAJA::Index_type sycl_maxloc2(-1);
 
+// clang-format off
   RAJA::launch<LAUNCH_POL4>
     (device_res, RAJA::LaunchParams(RAJA::Teams(NUMBER_OF_TEAMS), RAJA::Threads(SYCL_BLOCK_SIZE)),
      "SyclReductionKernel",
@@ -477,6 +486,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   std::cout << "\tsum = " << sycl_sum << std::endl;
   std::cout << "\tmin = " << sycl_min << std::endl;
   std::cout << "\tmax = " << sycl_max << std::endl;

--- a/examples/launch_flatten.cpp
+++ b/examples/launch_flatten.cpp
@@ -97,6 +97,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   RAJA::View<int, RAJA::Layout<2>> d_A_2DView(d_A_ptr, N, N);
   RAJA::View<int, RAJA::Layout<1>> d_A_1DView(d_A_ptr, NN);
 
+// clang-format off
   RAJA::launch<device_launch>
     (launch_params, [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx)
      {
@@ -117,6 +118,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
      });
 
+// clang-format on
 //----------------------------------------------------------------------------//
 
   std::cout << "\n Running host version of teams_flatten example ...\n";
@@ -125,6 +127,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   RAJA::View<int, RAJA::Layout<2>> h_A_2DView(h_A_ptr, N, N);
   RAJA::View<int, RAJA::Layout<1>> h_A_1DView(h_A_ptr, NN);
 
+// clang-format off
   RAJA::launch<host_launch>
     (launch_params, [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx)
     {
@@ -145,6 +148,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
      });
 
+// clang-format on
   if ( device_kernel_sum.get() == host_kernel_sum.get() ) {
     std::cout << "\n\t result -- PASS\n";
   } else {

--- a/examples/launch_matrix-multiply.cpp
+++ b/examples/launch_matrix-multiply.cpp
@@ -37,6 +37,7 @@
 /*
  * Define host/device launch policies
  */
+// clang-format off
 using launch_policy = RAJA::LaunchPolicy<
     RAJA::seq_launch_t
 #if defined(RAJA_ENABLE_CUDA)
@@ -49,6 +50,7 @@ using launch_policy = RAJA::LaunchPolicy<
 #endif
     >;
 
+// clang-format on
 using loop_policy = RAJA::seq_exec;
 
 #if defined(RAJA_ENABLE_CUDA)
@@ -188,18 +190,22 @@ __global__ void sharedMatMultKernel(int N, double* C, double* A, double* B)
 template <typename T>
 void checkResult(T *C, int N);
 
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Cview, int N);
 
+// clang-format on
 //
 // Functions for printing results
 //
 template <typename T>
 void printResult(T *C, int N);
 
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Cview, int N);
 
+// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -314,6 +320,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //two for loops.
 
   // _matmult_basickernel_start
+// clang-format off
   RAJA::launch<launch_policy>(RAJA::ExecPlace::HOST,
    RAJA::LaunchParams(RAJA::Teams(NTeams,NTeams),
                          RAJA::Threads(THREAD_SZ,THREAD_SZ)),
@@ -332,6 +339,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
   // _matmult_basickernel_end
+// clang-format on
 
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
@@ -355,6 +363,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   using omp_row_policy0 = RAJA::LoopPolicy<loop_policy>;
 
+// clang-format off
   RAJA::launch<omp_launch_policy>(RAJA::LaunchParams(),
        [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
 
@@ -371,6 +380,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
 
+// clang-format on
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
 
@@ -387,6 +397,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //
   using global_thread_xy = RAJA::LoopPolicy<RAJA::omp_for_exec>;
 
+// clang-format off
    RAJA::launch<omp_launch_policy>(RAJA::ExecPlace::HOST,
                                          RAJA::LaunchParams(),
    [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
@@ -403,6 +414,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
    });
 
+// clang-format on
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
 #endif // if RAJA_ENABLE_OPENMP
@@ -425,6 +437,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // and col = threadIdx.x in the kernel.
   //
   //
+// clang-format off
   RAJA::launch<launch_policy>(RAJA::ExecPlace::DEVICE,
     RAJA::LaunchParams(RAJA::Teams(N),
                           RAJA::Threads(N)),
@@ -443,6 +456,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
    });
 
+// clang-format on
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
 
@@ -461,6 +475,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //
   // The tiling capabilities in RAJA will also mask out of bounds iterations.
   //
+// clang-format off
   RAJA::launch<launch_policy>(RAJA::ExecPlace::DEVICE,
     RAJA::LaunchParams(RAJA::Teams(NTeams,NTeams),
                           RAJA::Threads(THREAD_SZ,THREAD_SZ)),
@@ -486,6 +501,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
         });
    });
 
+// clang-format on
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
 
@@ -521,6 +537,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // and col = threadIdx.x in the kernel.
   //
   //
+// clang-format off
   RAJA::launch<launch_policy>(RAJA::ExecPlace::DEVICE,
     RAJA::LaunchParams(RAJA::Teams(N),
                           RAJA::Threads(N)),
@@ -540,6 +557,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
      });
   });
 
+// clang-format on
   hipErrchk(hipMemcpy( C, d_C, N * N * sizeof(double), hipMemcpyDeviceToHost ));
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
@@ -561,6 +579,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //
   // The tiling capabilities in RAJA will also mask out of bounds iterations.
   //
+// clang-format off
   RAJA::launch<launch_policy>(RAJA::ExecPlace::DEVICE,
     RAJA::LaunchParams(RAJA::Teams(NTeams,NTeams),
                           RAJA::Threads(THREAD_SZ,THREAD_SZ)),
@@ -586,6 +605,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
         });
    });
 
+// clang-format on
   hipErrchk(hipMemcpy( C, d_C, N * N * sizeof(double), hipMemcpyDeviceToHost ));
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
@@ -610,6 +630,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // This example also uses the teamSync() method in the launch context
   // to add a barrier ensuring all threads have loaded/read from shared memory
   //
+// clang-format off
   RAJA::launch<launch_policy>(RAJA::ExecPlace::DEVICE,
     RAJA::LaunchParams(RAJA::Teams(NTeams,NTeams),
                           RAJA::Threads(THREAD_SZ,THREAD_SZ)),
@@ -672,6 +693,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
      });
   });  // kernel
 
+// clang-format on
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
 #endif
@@ -772,6 +794,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Functions to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(T* C, int N)
 {
@@ -790,6 +813,8 @@ void checkResult(T* C, int N)
   }
 };
 
+// clang-format on
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Cview, int N)
 {
@@ -808,9 +833,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Cview, int N)
   }
 };
 
+// clang-format on
 //
 // Functions to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(T* C, int N)
 {

--- a/examples/launch_reductions.cpp
+++ b/examples/launch_reductions.cpp
@@ -149,6 +149,7 @@ int main(int argc, char *argv[])
   const int TEAM_SZ = 256;
   const int GRID_SZ = RAJA_DIVIDE_CEILING_INT(N,TEAM_SZ);
 
+// clang-format off
   RAJA::launch<launch_policy>
     (select_cpu_or_gpu,
      RAJA::LaunchParams(RAJA::Teams(GRID_SZ),
@@ -170,6 +171,7 @@ int main(int argc, char *argv[])
        
     });
 
+// clang-format on
   std::cout << "\tsum = " << kernel_sum.get() << std::endl;
   std::cout << "\tmin = " << kernel_min.get() << std::endl;
   std::cout << "\tmax = " << kernel_max.get() << std::endl;

--- a/examples/memoryManager.hpp
+++ b/examples/memoryManager.hpp
@@ -31,6 +31,7 @@ namespace memoryManager
   static camp::resources::Resource* sycl_res;
 #endif
 
+// clang-format off
 template <typename T>
 T *allocate(RAJA::Index_type size)
 {

--- a/examples/omp-target-kernel.cpp
+++ b/examples/omp-target-kernel.cpp
@@ -12,13 +12,16 @@ using namespace RAJA::statement;
 
 int main(int /*argc*/, char** /*argv[]*/) {
 
+// clang-format off
   // using Pol = KernelPolicy<
   //               For<1, RAJA::seq_exec>,
   //               For<0, RAJA::omp_target_parallel_for_exec<1>, Lambda<0> >
   //             >;
   using Pol = KernelPolicy<
+// clang-format on
     Collapse<omp_target_parallel_collapse_exec, ArgList<0,1>, Lambda<0> > >;
 
+// clang-format on
   double* array = new double[25*25];
 
 #pragma omp target enter data map(to: array[0:25*25])
@@ -35,10 +38,12 @@ int main(int /*argc*/, char** /*argv[]*/) {
       //array[0] = i*j;
   });
 #else
+// clang-format off
   RAJA::forall<RAJA::omp_target_parallel_for_exec<1>>(
       RAJA::RangeSegment(0,25),
       [=] (int i) {
       //
   });
 #endif
+// clang-format on
 }

--- a/examples/pi-reduce_vs_atomic.cpp
+++ b/examples/pi-reduce_vs_atomic.cpp
@@ -102,12 +102,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   *atomic_pi = 0.0;
 
+// clang-format off
   RAJA::forall<EXEC_POL1>(bins, [=](int i) {
       double x = (double(i) + 0.5) * dx;
       RAJA::atomicAdd<ATOMIC_POL1>(atomic_pi, 
                                    dx / (1.0 + x * x));
   });
   *atomic_pi *= 4.0;
+// clang-format on
 
   std::cout << "\tpi = " << std::setprecision(prec) 
             << *atomic_pi << std::endl;
@@ -140,12 +142,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   *atomic_pi = 0.0;
 
+// clang-format off
   RAJA::forall<EXEC_POL2>(bins, [=](int i) {
       double x = (double(i) + 0.5) * dx;
       RAJA::atomicAdd<ATOMIC_POL2>(atomic_pi, 
                                    dx / (1.0 + x * x));
   });
   *atomic_pi *= 4.0;
+// clang-format on
 
   std::cout << "\tpi = " << std::setprecision(prec)
             << *atomic_pi << std::endl;
@@ -180,11 +184,13 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   *atomic_pi = 0.0;
 
+// clang-format off
   RAJA::forall<EXEC_POL3>(bins, [=] RAJA_DEVICE (int i) {
       double x = (double(i) + 0.5) * dx;
       RAJA::atomicAdd<ATOMIC_POL3>(atomic_pi, dx / (1.0 + x * x));
   });
   *atomic_pi *= 4.0;
+// clang-format on
 
   std::cout << "\tpi = " << std::setprecision(prec)
             << *atomic_pi << std::endl;
@@ -219,11 +225,13 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   using ATOMIC_POL4 = RAJA::hip_atomic;
 
+// clang-format off
   RAJA::forall<EXEC_POL4>(bins, [=] RAJA_DEVICE (int i) {
       double x = (double(i) + 0.5) * dx;
       RAJA::atomicAdd<ATOMIC_POL4>(d_atomic_pi, dx / (1.0 + x * x));
   });
 
+// clang-format on
   hipErrchk(hipMemcpy( atomic_pi, d_atomic_pi, 1 * sizeof(double), hipMemcpyDeviceToHost ));
   *atomic_pi *= 4.0; 
   std::cout << "\tpi = " << std::setprecision(prec)

--- a/examples/raja-launch.cpp
+++ b/examples/raja-launch.cpp
@@ -34,6 +34,7 @@
 /*
  * Define host/device launch policies
  */
+// clang-format off
 using launch_policy = RAJA::LaunchPolicy<
 #if defined(RAJA_ENABLE_OPENMP)
     RAJA::omp_launch_t
@@ -50,6 +51,7 @@ using launch_policy = RAJA::LaunchPolicy<
 #endif
     >;
 
+// clang-format on
 /*
  * Define team policies.
  * Up to 3 dimension are supported: x,y,z
@@ -150,6 +152,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
     RAJA::View<int, RAJA::Layout<2>> D(Ddat, N_tri, N_tri);
 
+// clang-format off
     RAJA::launch<launch_policy>
       (select_cpu_or_gpu,
        RAJA::LaunchParams(RAJA::Teams(N_tri), RAJA::Threads(N_tri)),
@@ -175,6 +178,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
        });  // outer lambda
 
+// clang-format on
     if (select_cpu_or_gpu == RAJA::ExecPlace::HOST) {
       host_res.deallocate(Ddat);
     }

--- a/examples/red-black-gauss-seidel.cpp
+++ b/examples/red-black-gauss-seidel.cpp
@@ -174,6 +174,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //  to generate RAJA ListSegments and populate a RAJA Static Index
 //  Set.
 
+// clang-format off
 RAJA::TypedIndexSet<RAJA::ListSegment> 
   gsColorPolicy(int N, camp::resources::Resource res)
 {

--- a/examples/resource-dynamic-forall.cpp
+++ b/examples/resource-dynamic-forall.cpp
@@ -28,6 +28,7 @@
 void checkResult(int* res, int len);
 void printResult(int* res, int len);
 
+// clang-format off
 using policy_list = camp::list<RAJA::seq_exec
                                ,RAJA::simd_exec
 #if defined(RAJA_ENABLE_CUDA)
@@ -41,6 +42,7 @@ using policy_list = camp::list<RAJA::seq_exec
 #endif
                                >;
 
+// clang-format on
 
 int main(int argc, char *argv[])
 {

--- a/examples/resource-forall.cpp
+++ b/examples/resource-forall.cpp
@@ -128,11 +128,13 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   std::cout << "\n Running RAJA omp_parallel_for_static_exec (default chunksize) vector addition...\n";
 
+// clang-format off
   RAJA::forall<RAJA::omp_parallel_for_static_exec< >>(host, RAJA::RangeSegment(0, N),
   [=] (int i) {
     c[i] = a[i] + b[i]; 
   });
 
+// clang-format on
   checkResult(c, N);
 
 //----------------------------------------------------------------------------//
@@ -141,11 +143,13 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   std::cout << "\n Running RAJA omp_for_dynamic_exec (chunksize = 16) vector addition...\n";
 
+// clang-format off
   RAJA::forall<RAJA::omp_parallel_for_dynamic_exec<16>>(host, RAJA::RangeSegment(0, N),
   [=] (int i) {
     c[i] = a[i] + b[i]; 
   });
 
+// clang-format on
   checkResult(c, N);
 #endif
 

--- a/examples/resource-kernel.cpp
+++ b/examples/resource-kernel.cpp
@@ -29,6 +29,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   RAJA::RangeSegment n_range(0, N);
 
   using TEST_POL =
+// clang-format off
     RAJA::KernelPolicy<
       statement::CudaKernelAsync<
         statement::For<0, cuda_block_x_loop,
@@ -39,6 +40,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::forall<RAJA::seq_exec>(def_host_res, n_range,
     [=, &def_cuda_res](int i){
       RAJA::resources::Cuda res_cuda; 
@@ -58,6 +61,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   def_cuda_res.memcpy(h_array, d_array, sizeof(int) * N * M);
 
   int ec_count = 0;

--- a/examples/resource-launch.cpp
+++ b/examples/resource-launch.cpp
@@ -34,6 +34,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   using threads_x = RAJA::LoopPolicy<RAJA::cuda_thread_x_loop>;
 
+// clang-format off
   RAJA::forall<RAJA::seq_exec>(def_host_res, n_range,
     [=, &def_cuda_res](int i){
 
@@ -59,6 +60,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   def_cuda_res.memcpy(h_array, d_array, sizeof(int) * N * M);
 
   int ec_count = 0;

--- a/examples/resource-runtime-launch.cpp
+++ b/examples/resource-runtime-launch.cpp
@@ -160,6 +160,7 @@ int main(int argc, char *argv[])
 #endif
 
   //How the kernel executes now depends on how the resource is constructed (host or device)
+// clang-format off
   RAJA::launch<launch_policy>
     (res, RAJA::LaunchParams(RAJA::Teams(GRID_SZ),
                                    RAJA::Threads(TEAM_SZ)),
@@ -176,6 +177,7 @@ int main(int argc, char *argv[])
          });
     });
 
+// clang-format on
 
   std::cout << "\tsum = " << kernel_sum.get() << std::endl;
   std::cout << "\tmin = " << kernel_min.get() << std::endl;

--- a/examples/tut_daxpy.cpp
+++ b/examples/tut_daxpy.cpp
@@ -154,11 +154,13 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   cudaErrchk(cudaMemcpy( a, a0, N * sizeof(double), cudaMemcpyHostToDevice )); 
   cudaErrchk(cudaMemcpy( b, tb, N * sizeof(double), cudaMemcpyHostToDevice )); 
 
+// clang-format off
   RAJA::forall<RAJA::cuda_exec<256>>(RAJA::RangeSegment(0, N), 
     [=] RAJA_DEVICE (int i) {
     a[i] += b[i] * c;
   });
 
+// clang-format on
   cudaErrchk(cudaMemcpy( ta, a, N * sizeof(double), cudaMemcpyDeviceToHost ));
 
   cudaErrchk(cudaFree(a));
@@ -184,11 +186,13 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   hipErrchk(hipMemcpy( a, a0, N * sizeof(double), hipMemcpyHostToDevice ));
   hipErrchk(hipMemcpy( b, tb, N * sizeof(double), hipMemcpyHostToDevice ));
 
+// clang-format off
   RAJA::forall<RAJA::hip_exec<256>>(RAJA::RangeSegment(0, N),
     [=] RAJA_DEVICE (int i) {
     a[i] += b[i] * c;
   });
 
+// clang-format on
   hipErrchk(hipMemcpy( ta, a, N * sizeof(double), hipMemcpyDeviceToHost ));
 
   hipErrchk(hipFree(a));

--- a/examples/tut_halo-exchange.cpp
+++ b/examples/tut_halo-exchange.cpp
@@ -56,18 +56,23 @@ const int num_neighbors = 26;
 //
 // Functions for checking and printing results
 //
+// clang-format off
 void checkResult(std::vector<double*> const& vars, std::vector<double*> const& vars_ref,
                  int var_size, int num_vars);
 void printResult(std::vector<double*> const& vars, int var_size, int num_vars);
+// clang-format on
 
 //
 // Functions for allocating and populating packing and unpacking lists
 //
+// clang-format off
 void create_pack_lists(std::vector<int*>& pack_index_lists, std::vector<int>& pack_index_list_lengths,
                        const int halo_width, const int* grid_dims);
 void create_unpack_lists(std::vector<int*>& unpack_index_lists, std::vector<int>& unpack_index_list_lengths,
+// clang-format on
                          const int halo_width, const int* grid_dims);
 void destroy_pack_lists(std::vector<int*>& pack_index_lists);
+// clang-format on
 void destroy_unpack_lists(std::vector<int*>& unpack_index_lists);
 
 
@@ -79,6 +84,7 @@ struct memory_manager_allocator
   memory_manager_allocator() = default;
 
   template < typename U >
+// clang-format off
   constexpr memory_manager_allocator(memory_manager_allocator<U> const&) noexcept
   { }
 
@@ -110,7 +116,9 @@ bool operator==(memory_manager_allocator<T> const&, memory_manager_allocator<U> 
 {
   return true;
 }
+// clang-format on
 
+// clang-format off
 template <typename T, typename U>
 bool operator!=(memory_manager_allocator<T> const& lhs, memory_manager_allocator<U> const& rhs)
 {
@@ -161,6 +169,8 @@ struct pinned_allocator
   }
 };
 
+// clang-format on
+// clang-format off
 template <typename T, typename U>
 bool operator==(pinned_allocator<T> const&, pinned_allocator<U> const&)
 {
@@ -1787,9 +1797,11 @@ struct Extent
   int k_max;
 };
 
+// clang-format on
 //
 // Function to generate index lists for packing.
 //
+// clang-format off
 void create_pack_lists(std::vector<int*>& pack_index_lists,
                        std::vector<int >& pack_index_list_lengths,
                        const int halo_width, const int* grid_dims)

--- a/examples/tut_launch_basic.cpp
+++ b/examples/tut_launch_basic.cpp
@@ -175,6 +175,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv))
   const int Nthreads = 2;
   // __compute_grid_end
 
+// clang-format off
   RAJA::launch<launch_policy>(select_cpu_or_gpu,
     RAJA::LaunchParams(RAJA::Teams(Nteams,Nteams),
                      RAJA::Threads(Nthreads,Nthreads)),
@@ -200,6 +201,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv))
 
    });
 
+// clang-format on
   //Equivalent C style loops
   if(select_cpu_or_gpu == RAJA::ExecPlace::HOST) {
     // _c_style_loops_start

--- a/examples/tut_matrix-multiply.cpp
+++ b/examples/tut_matrix-multiply.cpp
@@ -81,18 +81,22 @@ __global__ void matMultKernel(int N, double* C, double* A, double* B)
 template <typename T>
 void checkResult(T *C, int N);
 
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Cview, int N);
 
+// clang-format on
 //
 // Functions for printing results
 //
 template <typename T>
 void printResult(T *C, int N);
 
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Cview, int N);
 
+// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -193,6 +197,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(C, 0, N*N * sizeof(double));
 
   // _matmult_outerforall_start
+// clang-format off
   RAJA::forall<RAJA::seq_exec>( row_range, [=](int row) {
 
     for (int col = 0; col < N; ++col) {
@@ -207,6 +212,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
   // _matmult_outerforall_end
+// clang-format on
 
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
@@ -230,6 +236,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(C, 0, N*N * sizeof(double));
 
   // _matmult_nestedforall_start
+// clang-format off
   RAJA::forall<RAJA::seq_exec>( row_range, [=](int row) {
 
     RAJA::forall<RAJA::seq_exec>( col_range, [=](int col) {
@@ -244,6 +251,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
   // _matmult_nestedforall_end
+// clang-format on
 
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
@@ -283,6 +291,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   // _matmult_basickernel_start
   using EXEC_POL =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::For<1, RAJA::seq_exec,    // row
         RAJA::statement::For<0, RAJA::seq_exec,  // col
@@ -291,6 +300,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL>(RAJA::make_tuple(col_range, row_range),
     [=](int col, int row) {
 
@@ -302,6 +313,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
   // _matmult_basickernel_end
+// clang-format on
 
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
@@ -316,6 +328,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   // _matmult_ompkernel_start
   using EXEC_POL1 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::For<1, RAJA::omp_parallel_for_exec,  // row
         RAJA::statement::For<0, RAJA::seq_exec,            // col
@@ -324,7 +337,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
   // _matmult_ompkernel_end
+// clang-format on
 
+// clang-format off
   RAJA::kernel<EXEC_POL1>(RAJA::make_tuple(col_range, row_range),
     [=](int col, int row) {
 
@@ -336,6 +351,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
 
+// clang-format on
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
 
@@ -354,6 +370,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //
   // _matmult_ompkernel_swap_start
   using EXEC_POL2 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::For<0, RAJA::seq_exec,                  // col
         RAJA::statement::For<1, RAJA::omp_parallel_for_exec,    // row
@@ -362,7 +379,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
   // _matmult_ompkernel_swap_end
+// clang-format on
 
+// clang-format off
   RAJA::kernel<EXEC_POL2>( RAJA::make_tuple(col_range, row_range),
     [=](int col, int row) {
 
@@ -374,6 +393,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
 
+// clang-format on
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
 
@@ -389,6 +409,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // outer loop with a 'collapse(2) clause.
   //
   using EXEC_POL3 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Collapse<RAJA::omp_parallel_collapse_exec,
                                 RAJA::ArgList<1, 0>,   // row, col
@@ -396,6 +417,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL3>(RAJA::make_tuple(col_range, row_range),
     [=](int col, int row) {
 
@@ -407,6 +430,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
   checkResult<double>(Cview, N);
+// clang-format on
 //printResult<double>(Cview, N);
 #endif // if RAJA_ENABLE_OPENMP
 
@@ -430,6 +454,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //
   //
   using EXEC_POL4 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernel<
         RAJA::statement::For<1, RAJA::cuda_block_x_loop,
@@ -440,6 +465,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL4>(RAJA::make_tuple(col_range, row_range),
     [=] RAJA_DEVICE (int col, int row) {
 
@@ -451,6 +478,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
   checkResult<double>(Cview, N);
+// clang-format on
 //printResult<double>(Cview, N);
 
 
@@ -470,6 +498,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // same as in this kernel and the one above.
   //
   using EXEC_POL5 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernel<
         RAJA::statement::Tile<1, RAJA::tile_fixed<CUDA_BLOCK_SIZE>, RAJA::cuda_block_y_loop,
@@ -484,6 +513,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL5>(RAJA::make_tuple(col_range, row_range),
     [=] RAJA_DEVICE (int col, int row) {
 
@@ -495,6 +526,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
   checkResult<double>(Cview, N);
+// clang-format on
 //printResult<double>(Cview, N);
 
 #endif // if RAJA_ENABLE_CUDA
@@ -530,6 +562,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // and col = threadIdx.x in the kernel.
   //
   using EXEC_POL4 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::HipKernel<
         RAJA::statement::For<1, RAJA::hip_block_x_loop,
@@ -540,6 +573,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL4>(RAJA::make_tuple(col_range, row_range),
     [=] RAJA_DEVICE (int col, int row) {
 
@@ -552,6 +587,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
   hipErrchk(hipMemcpy( C, d_C, N * N * sizeof(double), hipMemcpyDeviceToHost ));
+// clang-format on
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
 
@@ -573,6 +609,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // same as in this kernel and the one above.
   //
   using EXEC_POL5 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::HipKernel<
         RAJA::statement::Tile<1, RAJA::tile_fixed<HIP_BLOCK_SIZE>,
@@ -589,6 +626,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL5>(RAJA::make_tuple(col_range, row_range),
     [=] RAJA_DEVICE (int col, int row) {
 
@@ -601,6 +640,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
   hipErrchk(hipMemcpy( C, d_C, N * N * sizeof(double), hipMemcpyDeviceToHost ));
+// clang-format on
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
 #endif // if RAJA_ENABLE_HIP
@@ -633,6 +673,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //
   // _matmult_3lambdakernel_seq_start
   using EXEC_POL6a =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::For<1, RAJA::seq_exec,
         RAJA::statement::For<0, RAJA::seq_exec,
@@ -645,6 +686,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel_param<EXEC_POL6a>(
     RAJA::make_tuple(col_range, row_range, dot_range),
 
@@ -667,6 +710,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   );
   // _matmult_3lambdakernel_seq_end
+// clang-format on
 
   checkResult<double>(Cview, N);
   //printResult<double>(Cview, N);
@@ -689,6 +733,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using RAJA::Params;
 
   using EXEC_POL6b =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::For<1, RAJA::seq_exec,
         RAJA::statement::For<0, RAJA::seq_exec,
@@ -701,6 +746,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel_param<EXEC_POL6b>(
     RAJA::make_tuple(col_range, row_range, dot_range),
 
@@ -723,6 +770,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   );
   // _matmult_3lambdakernel_args_seq_end
+// clang-format on
 
   checkResult<double>(Cview, N);
   //printResult<double>(Cview, N);
@@ -737,6 +785,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   // _matmult_3lambdakernel_ompcollapse_start
   using EXEC_POL7 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Collapse<RAJA::omp_parallel_collapse_exec,
                                 RAJA::ArgList<1, 0>,   // row, col
@@ -748,7 +797,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
   // _matmult_3lambdakernel_ompcollapse_end
+// clang-format on
 
+// clang-format off
   RAJA::kernel_param<EXEC_POL7>(
     RAJA::make_tuple(col_range, row_range, dot_range),
 
@@ -771,6 +822,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   );
 
+// clang-format on
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
 #endif // if RAJA_ENABLE_OPENMP
@@ -785,6 +837,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   // _matmult_3lambdakernel_cuda_start
   using EXEC_POL8 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernel<
         RAJA::statement::For<1, RAJA::cuda_block_x_loop,    // row
@@ -799,7 +852,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
   // _matmult_3lambdakernel_cuda_end
+// clang-format on
 
+// clang-format off
   RAJA::kernel_param<EXEC_POL8>(
     RAJA::make_tuple(col_range, row_range, dot_range),
 
@@ -822,6 +877,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   );
 
+// clang-format on
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
 
@@ -833,6 +889,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   // _matmult_3lambdakernel_cudatiled_start
   using EXEC_POL9a =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernel<
         RAJA::statement::Tile<1, RAJA::tile_fixed<CUDA_BLOCK_SIZE>,
@@ -853,7 +910,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
   // _matmult_3lambdakernel_cudatiled_end
+// clang-format on
 
+// clang-format off
   RAJA::kernel_param<EXEC_POL9a>(
     RAJA::make_tuple(col_range, row_range, dot_range),
 
@@ -876,6 +935,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   );
 
+// clang-format on
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
 
@@ -886,6 +946,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(C, 0, N*N * sizeof(double));
 
   using EXEC_POL9b =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernel<
         RAJA::statement::Tile<1, RAJA::tile_fixed<CUDA_BLOCK_SIZE>,
@@ -906,6 +967,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel_param<EXEC_POL9b>(
     RAJA::make_tuple(col_range, row_range, dot_range),
 
@@ -928,6 +991,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   );
 
+// clang-format on
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
 
@@ -954,6 +1018,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using shmem_Lambda4 = RAJA::statement::Lambda<4, RAJA::Segs<0, 2>, RAJA::Offsets<0, 2>, RAJA::Params<2>>;
 
   using EXEC_POL10 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernelFixed<CUDA_BLOCK_SIZE*CUDA_BLOCK_SIZE,
         //Initalize thread private value
@@ -1010,8 +1075,10 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
          >//Cuda kernel
         >;
 
+// clang-format on
     Shmem aShared, bShared, cShared;
 
+// clang-format off
     RAJA::kernel_param<EXEC_POL10>(
       RAJA::make_tuple(RAJA::TypedRangeSegment<int>(0, N),
                        RAJA::TypedRangeSegment<int>(0, N),
@@ -1053,6 +1120,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
     });
 
+// clang-format on
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
 #endif // if RAJA_ENABLE_CUDA
@@ -1095,6 +1163,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   // _matmult_3lambdakernel_hip_start
   using EXEC_POL8 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::HipKernel<
         RAJA::statement::For<1, RAJA::hip_block_x_loop,    // row
@@ -1110,7 +1179,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
   // _matmult_3lambdakernel_hip_end
+// clang-format on
 
+// clang-format off
   RAJA::kernel_param<EXEC_POL8>(
     RAJA::make_tuple(col_range, row_range, dot_range),
 
@@ -1133,6 +1204,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   );
 
+// clang-format on
   hipErrchk(hipMemcpy( C, d_C, N * N * sizeof(double), hipMemcpyDeviceToHost ));
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
@@ -1147,6 +1219,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   // _matmult_3lambdakernel_hiptiled_start
   using EXEC_POL9b =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::HipKernel<
         RAJA::statement::Tile<1, RAJA::tile_fixed<HIP_BLOCK_SIZE>,
@@ -1167,7 +1240,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
  // _matmult_3lambdakernel_hiptiled_end
+// clang-format on
 
+// clang-format off
   RAJA::kernel_param<EXEC_POL9b>(
     RAJA::make_tuple(col_range, row_range, dot_range),
 
@@ -1190,6 +1265,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   );
 
+// clang-format on
   hipErrchk(hipMemcpy( C, d_C, N * N * sizeof(double), hipMemcpyDeviceToHost ));
   checkResult<double>(Cview, N);
 //printResult<double>(Cview, N);
@@ -1240,6 +1316,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Functions to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(T* C, int N)
 {
@@ -1258,6 +1335,8 @@ void checkResult(T* C, int N)
   }
 };
 
+// clang-format on
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Cview, int N)
 {
@@ -1276,9 +1355,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Cview, int N)
   }
 };
 
+// clang-format on
 //
 // Functions to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(T* C, int N)
 {

--- a/examples/wave-eqn.cpp
+++ b/examples/wave-eqn.cpp
@@ -123,17 +123,22 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //
 
   // Sequential policy
+// clang-format off
   using fdPolicy = RAJA::KernelPolicy<
     RAJA::statement::For<1, RAJA::seq_exec,
     RAJA::statement::For<0, RAJA::seq_exec, RAJA::statement::Lambda<0> > > >;
 
+// clang-format on
   // OpenMP policy
+// clang-format off
   //using fdPolicy = RAJA::KernelPolicy<
   //RAJA::statement::For<1, RAJA::omp_parallel_for_exec,
   //  RAJA::statement::For<0, RAJA::seq_exec, RAJA::statement::Lambda<0> > > >;
 
+// clang-format on
   // CUDA policy
   //using fdPolicy =
+// clang-format off
   //RAJA::KernelPolicy<
   //  RAJA::statement::CudaKernel<
   //      RAJA::statement::Tile<1, RAJA::tile_fixed<16>, RAJA::cuda_block_y_direct,
@@ -148,6 +153,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //    >
   //  >;
 
+// clang-format on
 
   time = 0;
   setIC(P1, P2, (time - dt), time, grid);
@@ -191,10 +197,12 @@ void computeErr(double *P, double tf, grid_s grid)
   RAJA::RangeSegment fdBounds(0, grid.nx);
   RAJA::ReduceMax<RAJA::seq_reduce, double> tMax(-1.0);
 
+// clang-format off
   using initialPolicy = RAJA::KernelPolicy<
   RAJA::statement::For<1, RAJA::seq_exec ,
     RAJA::statement::For<0, RAJA::seq_exec, RAJA::statement::Lambda<0> > > >;
 
+// clang-format on
   RAJA::kernel<initialPolicy>(RAJA::make_tuple(fdBounds,fdBounds),
                        [=] (RAJA::Index_type tx, RAJA::Index_type ty) {
 
@@ -222,10 +230,12 @@ void setIC(double *P1, double *P2, double t0, double t1, grid_s grid)
 
   RAJA::RangeSegment fdBounds(0, grid.nx);
 
+// clang-format off
   using initialPolicy = RAJA::KernelPolicy<
   RAJA::statement::For<1, RAJA::seq_exec,
     RAJA::statement::For<0, RAJA::seq_exec, RAJA::statement::Lambda<0>> > >;
   
+// clang-format on
   RAJA::kernel<initialPolicy>(RAJA::make_tuple(fdBounds,fdBounds),
                        [=] (RAJA::Index_type tx, RAJA::Index_type ty) {
                          
@@ -240,6 +250,7 @@ void setIC(double *P1, double *P2, double t0, double t1, grid_s grid)
 
 
 
+// clang-format off
 template <typename T, typename fdNestedPolicy>
 void wave(T *P1, T *P2, RAJA::RangeSegment fdBounds, double ct, int nx)
 {

--- a/exercises/atomic-histogram_solution.cpp
+++ b/exercises/atomic-histogram_solution.cpp
@@ -128,12 +128,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   RAJA::TypedRangeSegment<int> array_range(0,N);
   // _range_atomic_histogram_end 
 
+// clang-format off
   RAJA::forall<RAJA::seq_exec>(array_range, [=](int i) {
 
     RAJA::atomicAdd<RAJA::seq_atomic>(&hist[array[i]], 1);
 
   });
 
+// clang-format on
   checkResult(hist, hist_ref, M);
 //printArray(hist, M);
 
@@ -149,12 +151,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::memset(hist, 0, M * sizeof(int));
 
   // _rajaomp_atomic_histogram_start 
+// clang-format off
   RAJA::forall<RAJA::omp_parallel_for_exec>(array_range, [=](int i) {
 
     RAJA::atomicAdd<RAJA::omp_atomic>(&hist[array[i]], 1);
 
   });
   // _rajaomp_atomic_histogram_end
+// clang-format on
 
   checkResult(hist, hist_ref, M);
 //printArray(hist, M);
@@ -173,12 +177,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   
   std::memset(hist, 0, M * sizeof(int));
 
+// clang-format off
   RAJA::forall<RAJA::omp_parallel_for_exec>(array_range, [=](int i) {
 
     RAJA::atomicAdd<RAJA::auto_atomic>(&hist[array[i]], 1);
 
   });
     
+// clang-format on
   checkResult(hist, hist_ref, M);
 //printArray(hist, M);
 
@@ -196,12 +202,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::memset(hist, 0, M * sizeof(int));
 
   // _rajacuda_atomic_histogram_start 
+// clang-format off
   RAJA::forall<RAJA::cuda_exec<CUDA_BLOCK_SIZE>>(array_range, [=] RAJA_DEVICE (int i) {
 
     RAJA::atomicAdd<RAJA::cuda_atomic>(&hist[array[i]], 1);
 
   });
   // _rajacuda_atomic_histogram_end
+// clang-format on
 
   checkResult(hist, hist_ref, M);
 //printArray(hist, M);
@@ -221,12 +229,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::memset(hist, 0, M * sizeof(int));
 
   // _rajacuda_atomicauto_histogram_start 
+// clang-format off
   RAJA::forall<RAJA::cuda_exec<CUDA_BLOCK_SIZE>>(array_range, [=] RAJA_DEVICE (int i) {
 
     RAJA::atomicAdd<RAJA::auto_atomic>(&hist[array[i]], 1);
 
   });
   // _rajacuda_atomicauto_histogram_end
+// clang-format on
    
   checkResult(hist, hist_ref, M);
 //printArray(hist, M);
@@ -244,12 +254,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::memset(hist, 0, M * sizeof(int));
 
   // _rajahip_atomic_histogram_start 
+// clang-format off
   RAJA::forall<RAJA::hip_exec<HIP_BLOCK_SIZE>>(array_range, [=] RAJA_DEVICE (int i) {
 
     RAJA::atomicAdd<RAJA::hip_atomic>(&hist[array[i]], 1);
 
   });
   // _rajahip_atomic_histogram_end
+// clang-format on
 
   checkResult(hist, hist_ref, M);
 //printArray(hist, M);
@@ -269,12 +281,14 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::memset(hist, 0, M * sizeof(int));
 
   // _rajahip_atomicauto_histogram_start 
+// clang-format off
   RAJA::forall<RAJA::hip_exec<HIP_BLOCK_SIZE>>(array_range, [=] RAJA_DEVICE (int i) {
 
     RAJA::atomicAdd<RAJA::auto_atomic>(&hist[array[i]], 1);
 
   });
   // _rajahip_atomicauto_histogram_end
+// clang-format on
    
   checkResult(hist, hist_ref, M);
 //printArray(hist, M);

--- a/exercises/dot-product.cpp
+++ b/exercises/dot-product.cpp
@@ -90,10 +90,12 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   RAJA::ReduceSum<RAJA::seq_reduce, double> seqdot(0.0);
 
+// clang-format off
   RAJA::forall<RAJA::seq_exec>(RAJA::TypedRangeSegment<int>(0, N), [=] (int i) { 
     seqdot += a[i] * b[i]; 
   });
 
+// clang-format on
   dot = seqdot.get();
 
   std::cout << "\t (a, b) = " << dot << std::endl;

--- a/exercises/dot-product_solution.cpp
+++ b/exercises/dot-product_solution.cpp
@@ -84,10 +84,12 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // _rajaseq_dotprod_start
   RAJA::ReduceSum<RAJA::seq_reduce, double> seqdot(0.0);
 
+// clang-format off
   RAJA::forall<RAJA::seq_exec>(RAJA::TypedRangeSegment<int>(0, N), [=] (int i) { 
     seqdot += a[i] * b[i]; 
   });
 
+// clang-format on
   dot = seqdot.get();
   // _rajaseq_dotprod_end
 
@@ -132,11 +134,13 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // _rajacuda_dotprod_start
   RAJA::ReduceSum<RAJA::cuda_reduce, double> cudot(0.0);
 
+// clang-format off
   RAJA::forall<RAJA::cuda_exec<CUDA_BLOCK_SIZE>>(RAJA::RangeSegment(0, N), 
     [=] RAJA_DEVICE (int i) { 
     cudot += a[i] * b[i]; 
   });    
 
+// clang-format on
   dot = cudot.get();
   // _rajacuda_dotprod_end
 
@@ -164,11 +168,13 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // _rajahip_dotprod_start
   RAJA::ReduceSum<RAJA::hip_reduce, double> hpdot(0.0);
 
+// clang-format off
   RAJA::forall<RAJA::hip_exec<HIP_BLOCK_SIZE>>(RAJA::RangeSegment(0, N),
     [=] RAJA_DEVICE (int i) {
     hpdot += d_a[i] * d_b[i];
   });
 
+// clang-format on
   dot = hpdot.get();
   // _rajahip_dotprod_end
 
@@ -193,11 +199,13 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // _rajasycl_dotprod_start
   RAJA::ReduceSum<RAJA::sycl_reduce, double> hpdot(0.0);
 
+// clang-format off
   RAJA::forall<RAJA::sycl_exec<SYCL_BLOCK_SIZE, false>>(RAJA::RangeSegment(0, N),
     [=] RAJA_DEVICE (int i) {
     hpdot += a[i] * b[i];
   });
 
+// clang-format on
   dot = static_cast<double>(hpdot.get());
   // _rajasycl_dotprod_end
 

--- a/exercises/kernel-matrix-transpose-local-array.cpp
+++ b/exercises/kernel-matrix-transpose-local-array.cpp
@@ -56,15 +56,19 @@ constexpr int DIM = 2;
 //
 // Function for checking results
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 //
 // Function for printing results
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -207,6 +211,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   ///
   /*
   using SEQ_EXEC_POL_I =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
         RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
@@ -235,6 +240,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel_param<SEQ_EXEC_POL_I>( 
     RAJA::make_tuple(RAJA::TypedRangeSegment<int>(0, N_c),
                      RAJA::TypedRangeSegment<int>(0, N_r)),
@@ -251,6 +258,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   );
   */
+// clang-format on
   // _mattranspose_localarray_raja_end
 
   checkResult<int>(Atview, N_c, N_r);
@@ -271,6 +279,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   ///
   /*
   using OPENMP_EXEC_1_POL =
+// clang-format off
   RAJA::KernelPolicy<
     //
     // (0) Execution policies for outer loops
@@ -315,6 +324,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     >
    >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel_param<OPENMP_EXEC_1_POL>(
     RAJA::make_tuple(RAJA::TypedRangeSegment<int>(0, N_c),
                      RAJA::TypedRangeSegment<int>(0, N_r)),
@@ -333,6 +344,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
   */
+// clang-format on
 
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
@@ -344,6 +356,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(At, 0, N_r * N_c * sizeof(int));
 
   using OPENMP_EXEC_2_POL =
+// clang-format off
   RAJA::KernelPolicy<
     //
     // (0) Execution policies for outer loops
@@ -385,6 +398,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     >
   >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel_param<OPENMP_EXEC_2_POL>(
     RAJA::make_tuple(RAJA::TypedRangeSegment<int>(0, N_c),
                      RAJA::TypedRangeSegment<int>(0, N_r)),
@@ -403,6 +418,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_r, N_c);
 #endif
@@ -414,6 +430,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(At, 0, N_r * N_c * sizeof(int));
 
   using CUDA_EXEC_POL =
+// clang-format off
   RAJA::KernelPolicy<
     RAJA::statement::CudaKernel<
       //
@@ -463,7 +480,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     >
   >;
 
+// clang-format on
 
+// clang-format off
   RAJA::kernel_param<CUDA_EXEC_POL>(
     RAJA::make_tuple(RAJA::TypedRangeSegment<int>(0, N_c),
                      RAJA::TypedRangeSegment<int>(0, N_r)),
@@ -482,6 +501,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
 #endif
@@ -509,6 +529,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   hipErrchk(hipMemcpy( d_At, At, N_r * N_c * sizeof(int), hipMemcpyHostToDevice ));
 
   using HIP_EXEC_POL =
+// clang-format off
   RAJA::KernelPolicy<
     RAJA::statement::HipKernel<
       //
@@ -558,7 +579,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     >
   >;
 
+// clang-format on
 
+// clang-format off
   RAJA::kernel_param<HIP_EXEC_POL>(
     RAJA::make_tuple(RAJA::TypedRangeSegment<int>(0, N_c),
                      RAJA::TypedRangeSegment<int>(0, N_r)),
@@ -577,6 +600,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   hipErrchk(hipMemcpy( At, d_At, N_r * N_c * sizeof(int), hipMemcpyDeviceToHost ));
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
@@ -601,6 +625,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   ///
   /*
   using SEQ_EXEC_POL_II =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
         RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
@@ -624,6 +649,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel_param<SEQ_EXEC_POL_II>( 
     RAJA::make_tuple(RAJA::TypedRangeSegment<int>(0, N_c),
                      RAJA::TypedRangeSegment<int>(0, N_r)),
@@ -639,6 +666,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
   */
+// clang-format on
   // _mattranspose_localarray_raja_lambdaargs_end
 
   checkResult<int>(Atview, N_c, N_r);
@@ -653,6 +681,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -671,9 +700,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
+// clang-format on
 //
 // Function to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {

--- a/exercises/kernel-matrix-transpose-local-array_solution.cpp
+++ b/exercises/kernel-matrix-transpose-local-array_solution.cpp
@@ -56,15 +56,19 @@ constexpr int DIM = 2;
 //
 // Function for checking results
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 //
 // Function for printing results
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -201,6 +205,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   // _mattranspose_localarray_raja_start
   using SEQ_EXEC_POL_I =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
         RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
@@ -224,6 +229,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel_param<SEQ_EXEC_POL_I>( 
     RAJA::make_tuple(RAJA::TypedRangeSegment<int>(0, N_c),
                      RAJA::TypedRangeSegment<int>(0, N_r)),
@@ -240,6 +247,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   );
   // _mattranspose_localarray_raja_end
+// clang-format on
 
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
@@ -253,6 +261,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(At, 0, N_r * N_c * sizeof(int));
 
   using OPENMP_EXEC_1_POL =
+// clang-format off
   RAJA::KernelPolicy<
     //
     // (0) Execution policies for outer loops
@@ -294,6 +303,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     >
    >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel_param<OPENMP_EXEC_1_POL>(
     RAJA::make_tuple(RAJA::TypedRangeSegment<int>(0, N_c),
                      RAJA::TypedRangeSegment<int>(0, N_r)),
@@ -312,6 +323,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
 
@@ -322,6 +334,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(At, 0, N_r * N_c * sizeof(int));
 
   using OPENMP_EXEC_2_POL =
+// clang-format off
   RAJA::KernelPolicy<
     //
     // (0) Execution policies for outer loops
@@ -363,6 +376,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     >
   >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel_param<OPENMP_EXEC_2_POL>(
     RAJA::make_tuple(RAJA::TypedRangeSegment<int>(0, N_c),
                      RAJA::TypedRangeSegment<int>(0, N_r)),
@@ -381,6 +396,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_r, N_c);
 #endif
@@ -392,6 +408,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(At, 0, N_r * N_c * sizeof(int));
 
   using CUDA_EXEC_POL =
+// clang-format off
   RAJA::KernelPolicy<
     RAJA::statement::CudaKernel<
       //
@@ -441,7 +458,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     >
   >;
 
+// clang-format on
 
+// clang-format off
   RAJA::kernel_param<CUDA_EXEC_POL>(
     RAJA::make_tuple(RAJA::TypedRangeSegment<int>(0, N_c),
                      RAJA::TypedRangeSegment<int>(0, N_r)),
@@ -460,6 +479,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
 #endif
@@ -487,6 +507,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   hipErrchk(hipMemcpy( d_At, At, N_r * N_c * sizeof(int), hipMemcpyHostToDevice ));
 
   using HIP_EXEC_POL =
+// clang-format off
   RAJA::KernelPolicy<
     RAJA::statement::HipKernel<
       //
@@ -536,7 +557,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     >
   >;
 
+// clang-format on
 
+// clang-format off
   RAJA::kernel_param<HIP_EXEC_POL>(
     RAJA::make_tuple(RAJA::TypedRangeSegment<int>(0, N_c),
                      RAJA::TypedRangeSegment<int>(0, N_r)),
@@ -555,6 +578,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 
+// clang-format on
   hipErrchk(hipMemcpy( At, d_At, N_r * N_c * sizeof(int), hipMemcpyDeviceToHost ));
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
@@ -573,6 +597,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   // _raja_mattranspose_lambdaargs_start
   using SEQ_EXEC_POL_II =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
         RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
@@ -596,6 +621,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel_param<SEQ_EXEC_POL_II>( 
     RAJA::make_tuple(RAJA::TypedRangeSegment<int>(0, N_c),
                      RAJA::TypedRangeSegment<int>(0, N_r)),
@@ -611,6 +638,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
   // _raja_mattranspose_lambdaargs_start
+// clang-format on
 
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
@@ -623,6 +651,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -641,9 +670,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
+// clang-format on
 //
 // Function to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {

--- a/exercises/kernel-matrix-transpose-local-array_solution.cpp
+++ b/exercises/kernel-matrix-transpose-local-array_solution.cpp
@@ -56,19 +56,15 @@ constexpr int DIM = 2;
 //
 // Function for checking results
 //
-// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
-// clang-format on
 //
 // Function for printing results
 //
-// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
-// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {

--- a/exercises/kernel-matrix-transpose-tiled.cpp
+++ b/exercises/kernel-matrix-transpose-tiled.cpp
@@ -46,15 +46,19 @@ constexpr int DIM = 2;
 //
 // Function for checking results
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 //
 // Function for printing results
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -169,6 +173,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   ///
 
   using TILED_KERNEL_EXEC_POL = 
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
         RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
@@ -181,6 +186,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
   RAJA::kernel<TILED_KERNEL_EXEC_POL>( RAJA::make_tuple(col_Range, row_Range),
     [=](int col, int row) {
       Atview(col, row) = Aview(row, col);
@@ -234,6 +240,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // to/from the tile.
   //
   using TILED_KERNEL_EXEC_POL_OMP2 = 
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
         RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
@@ -245,6 +252,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       > // closes Tile 1
     >; // closes policy list
       
+// clang-format on
   RAJA::kernel<TILED_KERNEL_EXEC_POL_OMP2>( RAJA::make_tuple(col_Range, row_Range), 
     [=](int col, int row) {
       Atview(col, row) = Aview(row, col);
@@ -304,6 +312,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   hipErrchk(hipMemcpy( d_At, At, N_r * N_c * sizeof(int), hipMemcpyHostToDevice ));
 
   using TILED_KERNEL_EXEC_POL_HIP =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::HipKernel<
         RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::hip_block_y_loop,
@@ -318,6 +327,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
   RAJA::kernel<TILED_KERNEL_EXEC_POL_HIP>( RAJA::make_tuple(col_Range, row_Range),
     [=] RAJA_DEVICE (int col, int row) {
       d_Atview(col, row) = d_Aview(row, col);
@@ -345,6 +355,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -363,9 +374,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
+// clang-format on
 //
 // Function to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {

--- a/exercises/kernel-matrix-transpose-tiled_solution.cpp
+++ b/exercises/kernel-matrix-transpose-tiled_solution.cpp
@@ -46,15 +46,19 @@ constexpr int DIM = 2;
 //
 // Function for checking results
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 //
 // Function for printing results
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -159,6 +163,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //
   // _raja_tiled_mattranspose_start
   using TILED_KERNEL_EXEC_POL = 
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
         RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
@@ -171,6 +176,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
   RAJA::kernel<TILED_KERNEL_EXEC_POL>( RAJA::make_tuple(col_Range, row_Range),
     [=](int col, int row) {
       Atview(col, row) = Aview(row, col);
@@ -191,6 +197,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // one of the inner loops.
   //
   using TILED_KERNEL_EXEC_POL_OMP = 
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::omp_parallel_for_exec,
         RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
@@ -203,6 +210,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >; 
 
+// clang-format on
   RAJA::kernel<TILED_KERNEL_EXEC_POL_OMP>( RAJA::make_tuple(col_Range, row_Range), 
     [=](int col, int row) {
       Atview(col, row) = Aview(row, col);
@@ -222,6 +230,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // to/from the tile.
   //
   using TILED_KERNEL_EXEC_POL_OMP2 = 
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
         RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::seq_exec,
@@ -233,6 +242,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       > // closes Tile 1
     >; // closes policy list
       
+// clang-format on
   RAJA::kernel<TILED_KERNEL_EXEC_POL_OMP2>( RAJA::make_tuple(col_Range, row_Range), 
     [=](int col, int row) {
       Atview(col, row) = Aview(row, col);
@@ -252,6 +262,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   
   // _raja_mattranspose_cuda_start
   using TILED_KERNEL_EXEC_POL_CUDA = 
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernel<
         RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::cuda_block_y_loop,
@@ -266,6 +277,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
   RAJA::kernel<TILED_KERNEL_EXEC_POL_CUDA>( RAJA::make_tuple(col_Range, row_Range), 
     [=] RAJA_DEVICE (int col, int row) {
       Atview(col, row) = Aview(row, col);
@@ -292,6 +304,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   hipErrchk(hipMemcpy( d_At, At, N_r * N_c * sizeof(int), hipMemcpyHostToDevice ));
 
   using TILED_KERNEL_EXEC_POL_HIP =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::HipKernel<
         RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::hip_block_y_loop,
@@ -306,6 +319,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
   RAJA::kernel<TILED_KERNEL_EXEC_POL_HIP>( RAJA::make_tuple(col_Range, row_Range),
     [=] RAJA_DEVICE (int col, int row) {
       d_Atview(col, row) = d_Aview(row, col);
@@ -333,6 +347,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -351,9 +366,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
+// clang-format on
 //
 // Function to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {

--- a/exercises/kernel-matrix-transpose.cpp
+++ b/exercises/kernel-matrix-transpose.cpp
@@ -34,15 +34,19 @@ constexpr int DIM = 2;
 //
 // Function for checking results
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 //
 // Function for printing results
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -235,6 +239,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -253,9 +258,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
+// clang-format on
 //
 // Function to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {

--- a/exercises/kernel-matrix-transpose_solution.cpp
+++ b/exercises/kernel-matrix-transpose_solution.cpp
@@ -34,15 +34,19 @@ constexpr int DIM = 2;
 //
 // Function for checking results
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 //
 // Function for printing results
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -122,6 +126,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //
   // _raja_mattranspose_start
   using KERNEL_EXEC_POL = 
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::For<1, RAJA::seq_exec, 
         RAJA::statement::For<0, RAJA::seq_exec,
@@ -130,6 +135,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
   RAJA::kernel<KERNEL_EXEC_POL>( RAJA::make_tuple(col_Range, row_Range),
     [=](int col, int row) {
       Atview(col, row) = Aview(row, col);
@@ -149,6 +155,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // one of the inner loops.
   //
   using KERNEL_EXEC_POL_OMP = 
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::For<1, RAJA::omp_parallel_for_exec, 
         RAJA::statement::For<0, RAJA::seq_exec,
@@ -157,6 +164,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       > 
     >; 
 
+// clang-format on
   RAJA::kernel<KERNEL_EXEC_POL_OMP>( RAJA::make_tuple(col_Range, row_Range), 
     [=](int col, int row) {
       Atview(col, row) = Aview(row, col);
@@ -174,6 +182,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   
   // _raja_mattranspose_cuda_start
   using KERNEL_EXEC_POL_CUDA = 
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernel<
         RAJA::statement::For<1, RAJA::cuda_thread_x_loop,
@@ -184,6 +193,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
   RAJA::kernel<KERNEL_EXEC_POL_CUDA>( RAJA::make_tuple(col_Range, row_Range), 
     [=] RAJA_DEVICE (int col, int row) {
       Atview(col, row) = Aview(row, col);
@@ -210,6 +220,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -228,9 +239,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
+// clang-format on
 //
 // Function to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {

--- a/exercises/kernel-matrix-transpose_solution.cpp
+++ b/exercises/kernel-matrix-transpose_solution.cpp
@@ -34,19 +34,15 @@ constexpr int DIM = 2;
 //
 // Function for checking results
 //
-// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
-// clang-format on
 //
 // Function for printing results
 //
-// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
-// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -220,7 +216,6 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
-// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -239,11 +234,9 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
-// clang-format on
 //
 // Function to print result.
 //
-// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {

--- a/exercises/kernelintro-execpols.cpp
+++ b/exercises/kernelintro-execpols.cpp
@@ -166,6 +166,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 // _raja_tensorinit_omp_outer_start
   using EXEC_POL2 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::For<2, RAJA::omp_parallel_for_exec,    // k
         RAJA::statement::For<1, RAJA::seq_exec,              // j
@@ -176,6 +177,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL2>( 
     RAJA::make_tuple( RAJA::TypedRangeSegment<int>(0, N),
                       RAJA::TypedRangeSegment<int>(0, N),
@@ -186,6 +189,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 // _raja_tensorinit_omp_outer_end
+// clang-format on
 
   checkResult(a, a_ref, N_tot);
 
@@ -218,6 +222,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 // _raja_tensorinit_omp_collapse_start
   using EXEC_POL3 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Collapse<RAJA::omp_parallel_collapse_exec,
                                 RAJA::ArgList<2, 1, 0>,  // k, j, i
@@ -225,6 +230,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL3>( 
     RAJA::make_tuple( RAJA::TypedRangeSegment<int>(0, N),
                       RAJA::TypedRangeSegment<int>(0, N),
@@ -235,6 +242,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 // _raja_tensorinit_omp_collapse_end
+// clang-format on
 
   checkResult(a, a_ref, N_tot);
 
@@ -273,6 +281,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 // _raja_tensorinit_cuda_start
   using EXEC_POL5 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernel<
         RAJA::statement::For<2, RAJA::cuda_thread_z_loop,      // k
@@ -285,6 +294,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL5>(
     RAJA::make_tuple( RAJA::TypedRangeSegment<int>(0, N),
                       RAJA::TypedRangeSegment<int>(0, N),
@@ -295,6 +306,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 // _raja_tensorinit_cuda_end
+// clang-format on
 
   checkResult(a, a_ref, N_tot);
 
@@ -317,6 +329,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 // _raja_tensorinit_cuda_tiled_direct_start
   using EXEC_POL6 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernelFixed< i_block_sz * j_block_sz * k_block_sz,
         RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
@@ -335,6 +348,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL6>(
     RAJA::make_tuple( RAJA::TypedRangeSegment<int>(0, N),
                       RAJA::TypedRangeSegment<int>(0, N),
@@ -345,6 +360,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 // _raja_tensorinit_cuda_tiled_direct_end
+// clang-format on
 
   checkResult(a, a_ref, N_tot);
 
@@ -360,10 +376,12 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   static_assert(i_block_sz*j_block_sz*k_block_sz == block_size,
                 "Invalid block_size");
 
+// clang-format off
   dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N, i_block_sz)),
                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N, j_block_sz)),
                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N, k_block_sz)));
 
+// clang-format on
   nested_init<i_block_sz, j_block_sz, k_block_sz>
     <<<nblocks, nthreads_per_block>>>(a, c, N);
   cudaErrchk( cudaGetLastError() );
@@ -395,6 +413,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 // _raja_tensorinit_hip_start
   using EXEC_POL7 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::HipKernel<
         RAJA::statement::For<2, RAJA::hip_thread_z_loop,      // k
@@ -407,6 +426,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL7>(
     RAJA::make_tuple( RAJA::TypedRangeSegment<int>(0, N),
                       RAJA::TypedRangeSegment<int>(0, N),
@@ -417,6 +438,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 // _raja_tensorinit_hip_end
+// clang-format on
 
   hipErrchk(hipMemcpy( a, d_a, N_tot * sizeof(double), hipMemcpyDeviceToHost ));
   checkResult(a, a_ref, N_tot);
@@ -439,6 +461,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 // _raja_tensorinit_hip_tiled_direct_start
   using EXEC_POL8 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::HipKernelFixed< i_block_sz * j_block_sz * k_block_sz,
         RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
@@ -457,6 +480,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL8>(
     RAJA::make_tuple( RAJA::TypedRangeSegment<int>(0, N),
                       RAJA::TypedRangeSegment<int>(0, N),
@@ -467,6 +492,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 // _raja_tensorinit_hip_tiled_direct_end
+// clang-format on
 
   hipErrchk(hipMemcpy( a, d_a, N_tot * sizeof(double), hipMemcpyDeviceToHost ));
   checkResult(a, a_ref, N_tot);

--- a/exercises/kernelintro-execpols_solution.cpp
+++ b/exercises/kernelintro-execpols_solution.cpp
@@ -124,6 +124,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 // _raja_tensorinit_seq_start
   using EXEC_POL1 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::For<2, RAJA::seq_exec,    // k
         RAJA::statement::For<1, RAJA::seq_exec,  // j
@@ -134,6 +135,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL1>(
     RAJA::make_tuple( RAJA::TypedRangeSegment<int>(0, N),
                       RAJA::TypedRangeSegment<int>(0, N),
@@ -144,6 +147,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 // _raja_tensorinit_seq_end
+// clang-format on
 
   checkResult(a, a_ref, N_tot);
 
@@ -180,6 +184,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 // _raja_tensorinit_omp_outer_start
   using EXEC_POL2 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::For<2, RAJA::omp_parallel_for_exec,    // k
         RAJA::statement::For<1, RAJA::seq_exec,              // j
@@ -190,6 +195,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL2>(
     RAJA::make_tuple( RAJA::TypedRangeSegment<int>(0, N),
                       RAJA::TypedRangeSegment<int>(0, N),
@@ -200,6 +207,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 // _raja_tensorinit_omp_outer_end
+// clang-format on
 
   checkResult(a, a_ref, N_tot);
 
@@ -232,6 +240,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 // _raja_tensorinit_omp_collapse_start
   using EXEC_POL3 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Collapse<RAJA::omp_parallel_collapse_exec,
                                 RAJA::ArgList<2, 1, 0>,  // k, j, i
@@ -239,6 +248,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL3>(
     RAJA::make_tuple( RAJA::TypedRangeSegment<int>(0, N),
                       RAJA::TypedRangeSegment<int>(0, N),
@@ -249,6 +260,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 // _raja_tensorinit_omp_collapse_end
+// clang-format on
 
   checkResult(a, a_ref, N_tot);
 
@@ -261,6 +273,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 // _raja_tensorinit_omp_collapse_start
   using EXEC_POL4 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Collapse<RAJA::omp_parallel_collapse_exec,
                                 RAJA::ArgList<2, 1>,    // k, j
@@ -270,6 +283,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL4>(
     RAJA::make_tuple( RAJA::TypedRangeSegment<int>(0, N),
                       RAJA::TypedRangeSegment<int>(0, N),
@@ -280,6 +295,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 // _raja_tensorinit_omp_collapse_end
+// clang-format on
 
   checkResult(a, a_ref, N_tot);
 
@@ -299,6 +315,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 // _raja_tensorinit_cuda_start
   using EXEC_POL5 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernel<
         RAJA::statement::For<2, RAJA::cuda_thread_z_loop,      // k
@@ -311,6 +328,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL5>(
     RAJA::make_tuple( RAJA::TypedRangeSegment<int>(0, N),
                       RAJA::TypedRangeSegment<int>(0, N),
@@ -321,6 +340,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 // _raja_tensorinit_cuda_end
+// clang-format on
 
   checkResult(a, a_ref, N_tot);
 
@@ -343,6 +363,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 // _raja_tensorinit_cuda_tiled_direct_start
   using EXEC_POL6 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernelFixed< i_block_sz * j_block_sz * k_block_sz,
         RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
@@ -361,6 +382,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL6>(
     RAJA::make_tuple( RAJA::TypedRangeSegment<int>(0, N),
                       RAJA::TypedRangeSegment<int>(0, N),
@@ -371,6 +394,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 // _raja_tensorinit_cuda_tiled_direct_end
+// clang-format on
 
   checkResult(a, a_ref, N_tot);
 
@@ -386,10 +410,12 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   static_assert(i_block_sz*j_block_sz*k_block_sz == block_size,
                 "Invalid block_size");
 
+// clang-format off
   dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N, i_block_sz)),
                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N, j_block_sz)),
                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N, k_block_sz)));
 
+// clang-format on
   nested_init<i_block_sz, j_block_sz, k_block_sz>
     <<<nblocks, nthreads_per_block>>>(a, c, N);
   cudaErrchk( cudaGetLastError() );
@@ -421,6 +447,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 // _raja_tensorinit_hip_start
   using EXEC_POL7 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::HipKernel<
         RAJA::statement::For<2, RAJA::hip_thread_z_loop,      // k
@@ -433,6 +460,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL7>(
     RAJA::make_tuple( RAJA::TypedRangeSegment<int>(0, N),
                       RAJA::TypedRangeSegment<int>(0, N),
@@ -443,6 +472,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 // _raja_tensorinit_hip_end
+// clang-format on
 
   hipErrchk(hipMemcpy( a, d_a, N_tot * sizeof(double), hipMemcpyDeviceToHost ));
   checkResult(a, a_ref, N_tot);
@@ -465,6 +495,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 // _raja_tensorinit_hip_tiled_direct_start
   using EXEC_POL8 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::HipKernelFixed< i_block_sz * j_block_sz * k_block_sz,
         RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
@@ -483,6 +514,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
+// clang-format off
   RAJA::kernel<EXEC_POL8>(
      RAJA::make_tuple( RAJA::TypedRangeSegment<int>(0, N),
                        RAJA::TypedRangeSegment<int>(0, N),
@@ -493,6 +526,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   );
 // _raja_tensorinit_hip_tiled_direct_end
+// clang-format on
 
   hipErrchk(hipMemcpy( a, d_a, N_tot * sizeof(double), hipMemcpyDeviceToHost ));
   checkResult(a, a_ref, N_tot);

--- a/exercises/kernelintro-nested-loop-reorder.cpp
+++ b/exercises/kernelintro-nested-loop-reorder.cpp
@@ -86,6 +86,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
             << "...\n\n" << " (I, J, K)\n" << " ---------\n";
 
   // _raja_kji_loops_start
+// clang-format off
   using KJI_EXECPOL = RAJA::KernelPolicy<
                         RAJA::statement::For<2, RAJA::seq_exec,    // k
                           RAJA::statement::For<1, RAJA::seq_exec,  // j
@@ -96,6 +97,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
                         > 
                       >;
 
+// clang-format on
   RAJA::kernel<KJI_EXECPOL>( RAJA::make_tuple(IRange, JRange, KRange),
   [=] (IIDX i, JIDX j, KIDX k) { 
      printf( " (%d, %d, %d) \n", (int)(*i), (int)(*j), (int)(*k));

--- a/exercises/kernelintro-nested-loop-reorder_solution.cpp
+++ b/exercises/kernelintro-nested-loop-reorder_solution.cpp
@@ -86,6 +86,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
             << "...\n\n" << " (I, J, K)\n" << " ---------\n";
 
   // _raja_kji_loops_start
+// clang-format off
   using KJI_EXECPOL = RAJA::KernelPolicy<
                         RAJA::statement::For<2, RAJA::seq_exec,    // k
                           RAJA::statement::For<1, RAJA::seq_exec,  // j
@@ -96,6 +97,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
                         > 
                       >;
 
+// clang-format on
   RAJA::kernel<KJI_EXECPOL>( RAJA::make_tuple(IRange, JRange, KRange),
   [=] (IIDX i, JIDX j, KIDX k) { 
      printf( " (%d, %d, %d) \n", (int)(*i), (int)(*j), (int)(*k));
@@ -123,6 +125,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
             << "...\n\n" << " (I, J, K)\n" << " ---------\n";
 
   // _raja_jik_loops_start
+// clang-format off
   using JIK_EXECPOL = RAJA::KernelPolicy<
                         RAJA::statement::For<1, RAJA::seq_exec,    // j
                           RAJA::statement::For<0, RAJA::seq_exec,  // i
@@ -133,6 +136,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
                         > 
                       >;
 
+// clang-format on
   RAJA::kernel<JIK_EXECPOL>( RAJA::make_tuple(IRange, JRange, KRange),
   [=] (IIDX i, JIDX j, KIDX k) { 
      printf( " (%d, %d, %d) \n", (int)(*i), (int)(*j), (int)(*k));
@@ -161,6 +165,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
             << "...\n\n" << " (I, J, K)\n" << " ---------\n";
 
   // _raja_ikj_loops_start
+// clang-format off
   using IKJ_EXECPOL = RAJA::KernelPolicy<
                         RAJA::statement::For<0, RAJA::seq_exec,    // i
                           RAJA::statement::For<2, RAJA::seq_exec,  // k
@@ -171,6 +176,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
                         > 
                       >;
 
+// clang-format on
   RAJA::kernel<IKJ_EXECPOL>( RAJA::make_tuple(IRange, JRange, KRange),
   [=] (IIDX i, JIDX j, KIDX k) {
      printf( " (%d, %d, %d) \n", (int)(*i), (int)(*j), (int)(*k));

--- a/exercises/launch-matrix-transpose-local-array.cpp
+++ b/exercises/launch-matrix-transpose-local-array.cpp
@@ -55,15 +55,19 @@ const int DIM = 2;
 //
 // Function for checking results
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 //
 // Function for printing results
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -178,6 +182,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using loop_pol_1 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_1 = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
 
+// clang-format off
   RAJA::launch<launch_policy_1>(
     RAJA::LaunchParams(), //LaunchParams may be empty when only running on the cpu
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx) {
@@ -208,6 +213,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
     });
   // _mattranspose_localarray_raja_end
+// clang-format on
 
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
@@ -234,6 +240,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //using loop_pol_2 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_2 = RAJA::LaunchPolicy<RAJA::omp_launch_t>;
 
+// clang-format off
   RAJA::launch<launch_policy_2>(
     RAJA::LaunchParams(), //LaunchParams may be empty when only running on the cpu
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext /*ctx*/) {
@@ -265,6 +272,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     */
     });
 
+// clang-format on
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
 #endif
@@ -288,6 +296,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const bool cuda_async = false;
   using cuda_launch_policy = RAJA::LaunchPolicy<RAJA::cuda_launch_t<cuda_async>>;
 
+// clang-format off
   RAJA::launch<cuda_launch_policy>(
     RAJA::LaunchParams(RAJA::Teams(n_blocks_c, n_blocks_r),
                      RAJA::Threads(c_block_sz, r_block_sz)),
@@ -320,6 +329,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       */
   });
 
+// clang-format on
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
 #endif
@@ -360,6 +370,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const bool hip_async = false;
   using hip_launch_policy = RAJA::LaunchPolicy<RAJA::hip_launch_t<hip_async>>;
 
+// clang-format off
   RAJA::launch<hip_launch_policy>
      (RAJA::LaunchParams(RAJA::Teams(n_blocks_c, n_blocks_r),
                      RAJA::Threads(c_block_sz, r_block_sz)),
@@ -392,6 +403,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
     });
 
+// clang-format on
   hipErrchk(hipMemcpy( At, d_At, N_r * N_c * sizeof(int), hipMemcpyDeviceToHost ));
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
@@ -406,6 +418,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -424,9 +437,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
+// clang-format on
 //
 // Function to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {

--- a/exercises/launch-matrix-transpose-local-array_solution.cpp
+++ b/exercises/launch-matrix-transpose-local-array_solution.cpp
@@ -55,15 +55,19 @@ const int DIM = 2;
 //
 // Function for checking results
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 //
 // Function for printing results
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -178,6 +182,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using loop_pol_1 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_1 = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
 
+// clang-format off
   RAJA::launch<launch_policy_1>(
     RAJA::LaunchParams(), //LaunchParams may be empty when only running on the cpu
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx) {
@@ -209,6 +214,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
     });
   // _mattranspose_localarray_raja_end
+// clang-format on
 
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
@@ -228,6 +234,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using loop_pol_2 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_2 = RAJA::LaunchPolicy<RAJA::omp_launch_t>;
 
+// clang-format off
   RAJA::launch<launch_policy_2>(
     RAJA::LaunchParams(), //LaunchParams may be empty when only running on the cpu
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx) {
@@ -259,6 +266,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
     });
 
+// clang-format on
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
 #endif
@@ -283,6 +291,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const bool cuda_async = false;
   using cuda_launch_policy = RAJA::LaunchPolicy<RAJA::cuda_launch_t<cuda_async>>;
 
+// clang-format off
   RAJA::launch<cuda_launch_policy>(
     RAJA::LaunchParams(RAJA::Teams(n_blocks_c, n_blocks_r),
                      RAJA::Threads(c_block_sz, r_block_sz)),
@@ -315,6 +324,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
    });
 
+// clang-format on
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
 #endif
@@ -355,6 +365,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const bool hip_async = false;
   using hip_launch_policy = RAJA::LaunchPolicy<RAJA::hip_launch_t<hip_async>>;
 
+// clang-format off
   RAJA::launch<hip_launch_policy>
      (RAJA::LaunchParams(RAJA::Teams(n_blocks_c, n_blocks_r),
                      RAJA::Threads(c_block_sz, r_block_sz)),
@@ -387,6 +398,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
    });
 
+// clang-format on
   hipErrchk(hipMemcpy( At, d_At, N_r * N_c * sizeof(int), hipMemcpyDeviceToHost ));
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
@@ -401,6 +413,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -419,9 +432,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
+// clang-format on
 //
 // Function to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {

--- a/exercises/launch-matrix-transpose-tiled.cpp
+++ b/exercises/launch-matrix-transpose-tiled.cpp
@@ -46,15 +46,19 @@ constexpr int DIM = 2;
 //
 // Function for checking results
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 //
 // Function for printing results
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -168,6 +172,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //using loop_pol_1 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_1 = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
 
+// clang-format off
   RAJA::launch<launch_policy_1>(
     RAJA::LaunchParams(), //LaunchParams may be empty when running on the cpu
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext /*ctx*/) {
@@ -198,6 +203,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       */
   });
   // _raja_tiled_mattranspose_end
+// clang-format on
 
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
@@ -225,6 +231,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   ///           
 
   /*
+// clang-format off
   RAJA::launch<launch_policy_2>(
      RAJA::LaunchParams(), //LaunchParams may be empty when running on the cpu
      [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx) {
@@ -246,6 +253,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
     });
 */
+// clang-format on
 
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
@@ -282,6 +290,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   ///
 
 /*
+// clang-format off
   RAJA::launch<cuda_launch_policy>(
     RAJA::LaunchParams(RAJA::Teams(n_blocks_c, n_blocks_r),
                      RAJA::Threads(c_block_sz, r_block_sz)),
@@ -304,6 +313,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
 */
+// clang-format on
 
   checkResult<int>(Atview, N_c, N_r);
   //printResult<int>(Atview, N_c, N_r);
@@ -341,6 +351,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const bool hip_async = false;
   using hip_launch_policy = RAJA::LaunchPolicy<RAJA::hip_launch_t<hip_async>>;
 
+// clang-format off
   RAJA::launch<hip_launch_policy>
     (RAJA::LaunchParams(RAJA::Teams(n_blocks_c, n_blocks_r),
                         RAJA::Threads(c_block_sz, r_block_sz)),
@@ -363,6 +374,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
 
+// clang-format on
   hipErrchk(hipMemcpy( At, d_At, N_r * N_c * sizeof(int), hipMemcpyDeviceToHost ));
   checkResult<int>(Atview, N_c, N_r);
   //printResult<int>(Atview, N_c, N_r);
@@ -385,6 +397,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -403,9 +416,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
+// clang-format on
 //
 // Function to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {

--- a/exercises/launch-matrix-transpose-tiled_solution.cpp
+++ b/exercises/launch-matrix-transpose-tiled_solution.cpp
@@ -46,15 +46,19 @@ constexpr int DIM = 2;
 //
 // Function for checking results
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 //
 // Function for printing results
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -162,6 +166,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using loop_pol_1 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_1 = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
 
+// clang-format off
   RAJA::launch<launch_policy_1>(RAJA::LaunchParams(), //LaunchParams may be empty when running on the cpu
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx) {
 
@@ -182,6 +187,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
   // _raja_tiled_mattranspose_end
+// clang-format on
 
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
@@ -200,6 +206,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using loop_pol_2 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_2 = RAJA::LaunchPolicy<RAJA::omp_launch_t>;
 
+// clang-format off
   RAJA::launch<launch_policy_2>(
     RAJA::LaunchParams(), //LaunchParams may be empty when running on the cpu
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx) {
@@ -221,6 +228,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
 
+// clang-format on
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
 
@@ -248,6 +256,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const bool cuda_async = false;
   using cuda_launch_policy = RAJA::LaunchPolicy<RAJA::cuda_launch_t<cuda_async>>;
 
+// clang-format off
   RAJA::launch<cuda_launch_policy>(
     RAJA::LaunchParams(RAJA::Teams(n_blocks_c, n_blocks_r),
                      RAJA::Threads(c_block_sz, r_block_sz)),
@@ -270,6 +279,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
   // _raja_mattranspose_cuda_end
+// clang-format on
 
   checkResult<int>(Atview, N_c, N_r);
   //printResult<int>(Atview, N_c, N_r);
@@ -304,6 +314,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const bool hip_async = false;
   using hip_launch_policy = RAJA::LaunchPolicy<RAJA::hip_launch_t<hip_async>>;
 
+// clang-format off
   RAJA::launch<hip_launch_policy>(
     RAJA::LaunchParams(RAJA::Teams(n_blocks_c, n_blocks_r),
                      RAJA::Threads(c_block_sz, r_block_sz)),
@@ -326,6 +337,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
 
+// clang-format on
   hipErrchk(hipMemcpy( At, d_At, N_r * N_c * sizeof(int), hipMemcpyDeviceToHost ));
   checkResult<int>(Atview, N_c, N_r);
   //printResult<int>(Atview, N_c, N_r);
@@ -348,6 +360,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -366,9 +379,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
+// clang-format on
 //
 // Function to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {

--- a/exercises/launch-matrix-transpose.cpp
+++ b/exercises/launch-matrix-transpose.cpp
@@ -34,15 +34,19 @@ constexpr int DIM = 2;
 //
 // Function for checking results
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 //
 // Function for printing results
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -124,6 +128,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using loop_policy_seq = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_seq = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
 
+// clang-format off
   RAJA::launch<launch_policy_seq>
    (RAJA::LaunchParams(), //LaunchParams may be empty when running on the host
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx) {
@@ -141,6 +146,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
   // _raja_mattranspose_end
+// clang-format on
 
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
@@ -190,6 +196,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const bool async = false; //execute asynchronously
   using launch_policy_cuda = RAJA::LaunchPolicy<RAJA::cuda_launch_t<async>>;
 
+// clang-format off
   RAJA::launch<launch_policy_cuda>(
     RAJA::LaunchParams(RAJA::Teams(1), RAJA::Threads(16,16)),
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx) {
@@ -204,6 +211,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
   // _raja_mattranspose_cuda_end
+// clang-format on
 
   checkResult<int>(Atview, N_c, N_r);
   //printResult<int>(Atview, N_c, N_r);
@@ -225,6 +233,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -243,9 +252,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
+// clang-format on
 //
 // Function to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {

--- a/exercises/launch-matrix-transpose_solution.cpp
+++ b/exercises/launch-matrix-transpose_solution.cpp
@@ -34,15 +34,19 @@ constexpr int DIM = 2;
 //
 // Function for checking results
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 //
 // Function for printing results
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -124,6 +128,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using loop_policy_seq = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_seq = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
 
+// clang-format off
   RAJA::launch<launch_policy_seq>(
     RAJA::LaunchParams(), //LaunchParams may be empty when running on the host
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx) {
@@ -138,6 +143,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
   // _raja_mattranspose_end
+// clang-format on
 
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
@@ -154,6 +160,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using loop_policy_omp = RAJA::LoopPolicy<RAJA::omp_for_exec>;
   using launch_policy_omp = RAJA::LaunchPolicy<RAJA::omp_launch_t>;
 
+// clang-format off
   RAJA::launch<launch_policy_omp>(
     RAJA::LaunchParams(), //LaunchParams may be empty when running on the host
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx) {
@@ -168,6 +175,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
 
+// clang-format on
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
 #endif
@@ -185,6 +193,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const bool async = false; //execute asynchronously
   using launch_policy_cuda = RAJA::LaunchPolicy<RAJA::cuda_launch_t<async>>;
 
+// clang-format off
   RAJA::launch<launch_policy_cuda>
     (RAJA::LaunchParams(RAJA::Teams(1), RAJA::Threads(16,16)),
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx) {
@@ -199,6 +208,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
   // _raja_mattranspose_cuda_end
+// clang-format on
 
   checkResult<int>(Atview, N_c, N_r);
   //printResult<int>(Atview, N_c, N_r);
@@ -220,6 +230,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -238,9 +249,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
+// clang-format on
 //
 // Function to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {

--- a/exercises/launchintro-execpols.cpp
+++ b/exercises/launchintro-execpols.cpp
@@ -133,6 +133,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //using loop_policy_1 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_1 = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
 
+// clang-format off
   RAJA::launch<launch_policy_1>
     (RAJA::LaunchParams(), //LaunchParams may be empty when running on the host
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext /*ctx*/) {
@@ -145,6 +146,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       */
   });
 // _raja_tensorinit_seq_end
+// clang-format on
 
   checkResult(a, a_ref, N_tot);
 
@@ -193,6 +195,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   */
   using launch_policy_2 = RAJA::LaunchPolicy<RAJA::omp_launch_t>;
 
+// clang-format off
   RAJA::launch<launch_policy_2>
     (RAJA::LaunchParams(), //LaunchParams may be empty when running on the host
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext /*ctx*/) {
@@ -210,6 +213,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
 // _raja_tensorinit_omp_outer_end
+// clang-format on
 
   checkResult(a, a_ref, N_tot);
 #endif
@@ -248,6 +252,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const bool async_3 = false;
   using launch_policy_3 = RAJA::LaunchPolicy<RAJA::cuda_launch_t<async_3>>;
 
+// clang-format off
   RAJA::launch<launch_policy_3>
     (RAJA::LaunchParams(RAJA::Teams(n_blocks_i ,n_blocks_j, n_blocks_k),
                       RAJA::Threads(i_block_sz, j_block_sz, k_block_sz)),
@@ -264,6 +269,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       });
   });
 
+// clang-format on
 // _raja_tensorinit_cuda_end
 
   checkResult(a, a_ref, N_tot);
@@ -286,6 +292,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const bool async_4 = false;
   using launch_policy_4 = RAJA::LaunchPolicy<RAJA::cuda_launch_t<async_4>>;
 
+// clang-format off
   RAJA::launch<launch_policy_4>
     (RAJA::LaunchParams(RAJA::Teams(n_blocks_i, n_blocks_j, n_blocks_k),
                       RAJA::Threads(i_block_sz, j_block_sz, k_block_sz)),
@@ -313,6 +320,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       });
     });
 // _raja_tensorinit_cuda_tiled_direct_end
+// clang-format on
 
   checkResult(a, a_ref, N_tot);
 
@@ -328,10 +336,12 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   static_assert(i_block_sz*j_block_sz*k_block_sz == block_size,
                 "Invalid block_size");
 
+// clang-format off
   dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N, i_block_sz)),
                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N, j_block_sz)),
                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N, k_block_sz)));
 
+// clang-format on
   nested_init<i_block_sz, j_block_sz, k_block_sz>
     <<<nblocks, nthreads_per_block>>>(a, c, N);
   cudaErrchk( cudaGetLastError() );
@@ -381,6 +391,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const bool async_5 = false;
   using launch_policy_5 = RAJA::LaunchPolicy<RAJA::hip_launch_t<async_5>>;
 
+// clang-format off
   RAJA::launch<launch_policy_5>
     (RAJA::LaunchParams(RAJA::Teams(n_blocks_i, n_blocks_j, n_blocks_k),
                       RAJA::Threads(i_block_sz, j_block_sz, k_block_sz)),
@@ -398,6 +409,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
 // _raja_tensorinit_hip_end
+// clang-format on
 
   hipErrchk(hipMemcpy( a, d_a, N_tot * sizeof(double), hipMemcpyDeviceToHost ));
   checkResult(a, a_ref, N_tot);
@@ -421,6 +433,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const bool async_6 = false;
   using launch_policy_6 = RAJA::LaunchPolicy<RAJA::hip_launch_t<async_6>>;
 
+// clang-format off
   RAJA::launch<launch_policy_6>
     (RAJA::LaunchParams(RAJA::Teams(n_blocks_i, n_blocks_j, n_blocks_k),
                       RAJA::Threads(i_block_sz, j_block_sz, k_block_sz)),
@@ -448,6 +461,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       });
     });
 // _raja_tensorinit_hip_tiled_direct_end
+// clang-format on
 
   hipErrchk(hipMemcpy( a, d_a, N_tot * sizeof(double), hipMemcpyDeviceToHost ));
   checkResult(a, a_ref, N_tot);

--- a/exercises/launchintro-execpols_solution.cpp
+++ b/exercises/launchintro-execpols_solution.cpp
@@ -126,6 +126,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using loop_policy_1 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_1 = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
 
+// clang-format off
   RAJA::launch<launch_policy_1>
     (RAJA::LaunchParams(), //LaunchParams may be empty when running on the host
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx) {
@@ -141,6 +142,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       });
   });
 // _raja_tensorinit_seq_end
+// clang-format on
 
   checkResult(a, a_ref, N_tot);
 
@@ -180,6 +182,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using loop_policy_2 = RAJA::LoopPolicy<RAJA::seq_exec>;
   using launch_policy_2 = RAJA::LaunchPolicy<RAJA::omp_launch_t>;
 
+// clang-format off
   RAJA::launch<launch_policy_2>
     (RAJA::LaunchParams(), //LaunchParams may be empty when running on the host
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx) {
@@ -195,6 +198,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       });
   });
 // _raja_tensorinit_omp_outer_end
+// clang-format on
 
   checkResult(a, a_ref, N_tot);
 #endif
@@ -233,6 +237,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const bool async_3 = false;
   using launch_policy_3 = RAJA::LaunchPolicy<RAJA::cuda_launch_t<async_3>>;
 
+// clang-format off
   RAJA::launch<launch_policy_3>
     (RAJA::LaunchParams(RAJA::Teams(n_blocks_i ,n_blocks_j, n_blocks_k),
                       RAJA::Threads(i_block_sz, j_block_sz, k_block_sz)),
@@ -249,6 +254,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       });
   });
 
+// clang-format on
 // _raja_tensorinit_cuda_end
 
   checkResult(a, a_ref, N_tot);
@@ -271,6 +277,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const bool async_4 = false;
   using launch_policy_4 = RAJA::LaunchPolicy<RAJA::cuda_launch_t<async_4>>;
 
+// clang-format off
   RAJA::launch<launch_policy_4>
     (RAJA::LaunchParams(RAJA::Teams(n_blocks_i, n_blocks_j, n_blocks_k),
                         RAJA::Threads(i_block_sz, j_block_sz, k_block_sz)),
@@ -298,6 +305,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       });
     });
 // _raja_tensorinit_cuda_tiled_direct_end
+// clang-format on
 
   checkResult(a, a_ref, N_tot);
 
@@ -313,10 +321,12 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   static_assert(i_block_sz*j_block_sz*k_block_sz == block_size,
                 "Invalid block_size");
 
+// clang-format off
   dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N, i_block_sz)),
                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N, j_block_sz)),
                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N, k_block_sz)));
 
+// clang-format on
   nested_init<i_block_sz, j_block_sz, k_block_sz>
     <<<nblocks, nthreads_per_block>>>(a, c, N);
   cudaErrchk( cudaGetLastError() );
@@ -366,6 +376,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const bool async_5 = false;
   using launch_policy_5 = RAJA::LaunchPolicy<RAJA::hip_launch_t<async_5>>;
 
+// clang-format off
   RAJA::launch<launch_policy_5>
     (RAJA::LaunchParams(RAJA::Teams(n_blocks_i, n_blocks_j, n_blocks_k),
                         RAJA::Threads(i_block_sz, j_block_sz, k_block_sz)),
@@ -383,6 +394,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   });
 // _raja_tensorinit_hip_end
+// clang-format on
 
   hipErrchk(hipMemcpy( a, d_a, N_tot * sizeof(double), hipMemcpyDeviceToHost ));
   checkResult(a, a_ref, N_tot);
@@ -406,6 +418,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const bool async_6 = false;
   using launch_policy_6 = RAJA::LaunchPolicy<RAJA::hip_launch_t<async_6>>;
 
+// clang-format off
   RAJA::launch<launch_policy_6>
     (RAJA::LaunchParams(RAJA::Teams(n_blocks_i, n_blocks_j, n_blocks_k),
                       RAJA::Threads(i_block_sz, j_block_sz, k_block_sz)),
@@ -433,6 +446,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       });
     });
 // _raja_tensorinit_hip_tiled_direct_end
+// clang-format on
 
   hipErrchk(hipMemcpy( a, d_a, N_tot * sizeof(double), hipMemcpyDeviceToHost ));
   checkResult(a, a_ref, N_tot);

--- a/exercises/memoryManager.hpp
+++ b/exercises/memoryManager.hpp
@@ -31,6 +31,7 @@ namespace memoryManager
   static camp::resources::Resource* sycl_res;
 #endif
 
+// clang-format off
 template <typename T>
 T *allocate(RAJA::Index_type size)
 {

--- a/exercises/offset-layout-stencil.cpp
+++ b/exercises/offset-layout-stencil.cpp
@@ -190,9 +190,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   // _offsetlayout_views_start
   const int DIM = 2;
 
+// clang-format off
   RAJA::OffsetLayout<DIM, int> layout =
       RAJA::make_offset_layout<DIM, int>({{-1, -1}}, {{N_r+1, N_c+1}});
 
+// clang-format on
   RAJA::View<int, RAJA::OffsetLayout<DIM, int>> inputView(input, layout);
   RAJA::View<int, RAJA::OffsetLayout<DIM, int>> outputView(output, layout);
   // _offsetlayout_views_end
@@ -213,6 +215,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   // _offsetlayout_rajaseq_start
   using NESTED_EXEC_POL1 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::For<1, RAJA::seq_exec,    // row
         RAJA::statement::For<0, RAJA::seq_exec,  // col
@@ -221,6 +224,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
       >  
     >;  
 
+// clang-format on
   RAJA::kernel<NESTED_EXEC_POL1>(RAJA::make_tuple(col_range, row_range),
                                  [=](int col, int row) {
 
@@ -271,6 +275,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   // _offsetlayout_rajacuda_start
   using NESTED_EXEC_POL3 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernel<
         RAJA::statement::For<1, RAJA::cuda_block_x_loop, //row
@@ -281,6 +286,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
       >
     >;                                                     
 
+// clang-format on
   RAJA::kernel<NESTED_EXEC_POL3>(RAJA::make_tuple(col_range, row_range),
                                  [=] RAJA_DEVICE(int col, int row) {
 
@@ -316,6 +322,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   // _offsetlayout_rajahip_start
   using NESTED_EXEC_POL4 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::HipKernel<
         RAJA::statement::For<1, RAJA::hip_block_x_loop, //row
@@ -326,6 +333,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
   RAJA::kernel<NESTED_EXEC_POL4>(RAJA::make_tuple(col_range, row_range),
                                  [=] RAJA_DEVICE(int col, int row) {
 

--- a/exercises/offset-layout-stencil_solution.cpp
+++ b/exercises/offset-layout-stencil_solution.cpp
@@ -191,9 +191,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   // _offsetlayout_views_start
   const int DIM = 2;
 
+// clang-format off
   RAJA::OffsetLayout<DIM, int> layout =
       RAJA::make_offset_layout<DIM, int>({{-1, -1}}, {{N_r+1, N_c+1}});
 
+// clang-format on
   RAJA::View<int, RAJA::OffsetLayout<DIM, int>> inputView(input, layout);
   RAJA::View<int, RAJA::OffsetLayout<DIM, int>> outputView(output, layout);
   // _offsetlayout_views_end
@@ -214,6 +216,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   // _offsetlayout_rajaseq_start
   using NESTED_EXEC_POL1 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::For<1, RAJA::seq_exec,    // row
         RAJA::statement::For<0, RAJA::seq_exec,  // col
@@ -222,6 +225,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
       >  
     >;  
 
+// clang-format on
   RAJA::kernel<NESTED_EXEC_POL1>(RAJA::make_tuple(col_range, row_range),
                                  [=](int col, int row) {
 
@@ -249,6 +253,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   // _offsetlayout_rajaomp_start
   using NESTED_EXEC_POL2 = 
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Collapse<RAJA::omp_parallel_collapse_exec,
                                 RAJA::ArgList<1, 0>,   // row, col
@@ -256,6 +261,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
       > 
     >;
 
+// clang-format on
   RAJA::kernel<NESTED_EXEC_POL2>(RAJA::make_tuple(col_range, row_range),
                                  [=](int col, int row) {
 
@@ -284,6 +290,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   // _offsetlayout_rajacuda_start
   using NESTED_EXEC_POL3 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernel<
         RAJA::statement::For<1, RAJA::cuda_block_x_loop, //row
@@ -294,6 +301,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
       >
     >;                                                     
 
+// clang-format on
   RAJA::kernel<NESTED_EXEC_POL3>(RAJA::make_tuple(col_range, row_range),
                                  [=] RAJA_DEVICE(int col, int row) {
 
@@ -332,6 +340,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
   // _offsetlayout_rajahip_start
   using NESTED_EXEC_POL4 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::HipKernel<
         RAJA::statement::For<1, RAJA::hip_block_x_loop, //row
@@ -342,6 +351,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
   RAJA::kernel<NESTED_EXEC_POL4>(RAJA::make_tuple(col_range, row_range),
                                  [=] RAJA_DEVICE(int col, int row) {
 

--- a/exercises/permuted-layout-batch-matrix-multiply.cpp
+++ b/exercises/permuted-layout-batch-matrix-multiply.cpp
@@ -179,6 +179,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using INIT_POL = RAJA::seq_exec;
 #endif
 
+// clang-format off
   RAJA::forall<INIT_POL>(RAJA::TypedRangeSegment<int>(0, N), [=](int e) {
     for (int row = 0; row < N_r; ++row) {
       for (int col = 0; col < N_c; ++col) {
@@ -193,6 +194,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   });
 
+// clang-format on
 
 //----------------------------------------------------------------------------//
 
@@ -204,6 +206,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
     timer.start();
     // _permutedlayout_batchedmatmult_loop_start
+// clang-format off
     RAJA::forall<RAJA::seq_exec>(RAJA::TypedRangeSegment<int>(0, N),
       [=](int e) {
 
@@ -239,6 +242,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       }
     );
     // _permutedlayout_batchedmatmult_loop_end
+// clang-format on
     timer.stop();
 
     RAJA::Timer::ElapsedType tMin = timer.elapsed();
@@ -260,6 +264,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   for (int i = 0; i < NITER; ++i) {
 
     // _permutedlayout2_batchedmatmult_loop_start
+// clang-format off
     RAJA::forall<RAJA::seq_exec>(RAJA::TypedRangeSegment<int>(0, N), 
       [=](int e) {
 
@@ -296,6 +301,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       }
     );
     // _permutedlayout2_batchedmatmult_loop_end
+// clang-format on
     timer.stop();
 
     RAJA::Timer::ElapsedType tMin = timer.elapsed();
@@ -320,6 +326,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
     timer.start();
     // _permutedlayout_batchedmatmult_omp_start
+// clang-format off
     RAJA::forall<RAJA::omp_parallel_for_exec>(RAJA::TypedRangeSegment<int>(0, N), 
       [=](int e) {
 
@@ -356,6 +363,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       }
     );
     // _permutedlayout_batchedmatmult_omp_end
+// clang-format on
     timer.stop();
 
     RAJA::Timer::ElapsedType tMin = timer.elapsed();
@@ -378,6 +386,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   for (int i = 0; i < NITER; ++i) {
 
     timer.start();
+// clang-format off
     RAJA::forall<RAJA::omp_parallel_for_exec>(RAJA::TypedRangeSegment<int>(0, N), 
       [=](int e) {
 
@@ -414,6 +423,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       }
     );
     timer.stop();
+// clang-format on
 
     RAJA::Timer::ElapsedType tMin = timer.elapsed();
     if (tMin < minRun) minRun = tMin;
@@ -439,6 +449,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   for (int i = 0; i < NITER; ++i) {
 
     timer.start();
+// clang-format off
     RAJA::forall<RAJA::cuda_exec<CUDA_BLOCK_SIZE>>(RAJA::TypedRangeSegment<int>(0, N), 
       [=] RAJA_DEVICE(int e) {
 
@@ -475,6 +486,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       }
     );
     timer.stop();
+// clang-format on
 
     RAJA::Timer::ElapsedType tMin = timer.elapsed();
     if (tMin < minRun) minRun = tMin;
@@ -496,6 +508,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   for (int i = 0; i < NITER; ++i) {
 
     timer.start();
+// clang-format off
     RAJA::forall<RAJA::cuda_exec<CUDA_BLOCK_SIZE>>(RAJA::TypedRangeSegment<int>(0, N), 
       [=] RAJA_DEVICE(int e) {
 
@@ -532,6 +545,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       }
     );
     timer.stop();
+// clang-format on
 
     RAJA::Timer::ElapsedType tMin = timer.elapsed();
     if (tMin < minRun) minRun = tMin;
@@ -564,6 +578,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   for (int i = 0; i < NITER; ++i) {
 
     timer.start();
+// clang-format off
     RAJA::forall<RAJA::hip_exec<HIP_BLOCK_SIZE>>(RAJA::TypedRangeSegment<int>(0, N), 
       [=] RAJA_DEVICE(int e) {
 
@@ -600,6 +615,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       }
     );
     timer.stop();
+// clang-format on
 
     RAJA::Timer::ElapsedType tMin = timer.elapsed();
     if (tMin < minRun) minRun = tMin;
@@ -639,6 +655,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   for (int i = 0; i < NITER; ++i) {
 
     timer.start();
+// clang-format off
     RAJA::forall<RAJA::hip_exec<HIP_BLOCK_SIZE>>(RAJA::TypedRangeSegment<int>(0, N), 
       [=] RAJA_DEVICE(int e) {
 
@@ -675,6 +692,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       }
     );
     timer.stop();
+// clang-format on
 
     RAJA::Timer::ElapsedType tMin = timer.elapsed();
     if (tMin < minRun) minRun = tMin;
@@ -714,6 +732,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // check result
 //
+// clang-format off
 template <typename T>
 void checkResult(T C, int nMat, int nRows, int nCols)
 {

--- a/exercises/permuted-layout-batch-matrix-multiply_solution.cpp
+++ b/exercises/permuted-layout-batch-matrix-multiply_solution.cpp
@@ -169,6 +169,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   using INIT_POL = RAJA::seq_exec;
 #endif
 
+// clang-format off
   RAJA::forall<INIT_POL>(RAJA::TypedRangeSegment<int>(0, N), [=](int e) {
     for (int row = 0; row < N_r; ++row) {
       for (int col = 0; col < N_c; ++col) {
@@ -183,6 +184,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     }
   });
 
+// clang-format on
 
 //----------------------------------------------------------------------------//
 
@@ -194,6 +196,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
     timer.start();
     // _permutedlayout_batchedmatmult_loop_start
+// clang-format off
     RAJA::forall<RAJA::seq_exec>(RAJA::TypedRangeSegment<int>(0, N),
       [=](int e) {
 
@@ -229,6 +232,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       }
     );
     // _permutedlayout_batchedmatmult_loop_end
+// clang-format on
     timer.stop();
 
     RAJA::Timer::ElapsedType tMin = timer.elapsed();
@@ -249,6 +253,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
     timer.start();
     // _permutedlayout2_batchedmatmult_loop_start
+// clang-format off
     RAJA::forall<RAJA::seq_exec>(RAJA::TypedRangeSegment<int>(0, N), 
       [=](int e) {
 
@@ -285,6 +290,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       }
     );
     // _permutedlayout2_batchedmatmult_loop_end
+// clang-format on
     timer.stop();
 
     RAJA::Timer::ElapsedType tMin = timer.elapsed();
@@ -308,6 +314,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
     timer.start();
     // _permutedlayout_batchedmatmult_omp_start
+// clang-format off
     RAJA::forall<RAJA::omp_parallel_for_exec>(RAJA::TypedRangeSegment<int>(0, N), 
       [=](int e) {
 
@@ -344,6 +351,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       }
     );
     // _permutedlayout_batchedmatmult_omp_end
+// clang-format on
     timer.stop();
 
     RAJA::Timer::ElapsedType tMin = timer.elapsed();
@@ -365,6 +373,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   for (int i = 0; i < NITER; ++i) {
 
     timer.start();
+// clang-format off
     RAJA::forall<RAJA::omp_parallel_for_exec>(RAJA::TypedRangeSegment<int>(0, N), 
       [=](int e) {
 
@@ -401,6 +410,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       }
     );
     timer.stop();
+// clang-format on
 
     RAJA::Timer::ElapsedType tMin = timer.elapsed();
     if (tMin < minRun) minRun = tMin;
@@ -425,6 +435,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   for (int i = 0; i < NITER; ++i) {
 
     timer.start();
+// clang-format off
     RAJA::forall<RAJA::cuda_exec<CUDA_BLOCK_SIZE>>(RAJA::TypedRangeSegment<int>(0, N), 
       [=] RAJA_DEVICE(int e) {
 
@@ -461,6 +472,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       }
     );
     timer.stop();
+// clang-format on
 
     RAJA::Timer::ElapsedType tMin = timer.elapsed();
     if (tMin < minRun) minRun = tMin;
@@ -481,6 +493,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   for (int i = 0; i < NITER; ++i) {
 
     timer.start();
+// clang-format off
     RAJA::forall<RAJA::cuda_exec<CUDA_BLOCK_SIZE>>(RAJA::TypedRangeSegment<int>(0, N), 
       [=] RAJA_DEVICE(int e) {
 
@@ -517,6 +530,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       }
     );
     timer.stop();
+// clang-format on
 
     RAJA::Timer::ElapsedType tMin = timer.elapsed();
     if (tMin < minRun) minRun = tMin;
@@ -558,6 +572,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   for (int i = 0; i < NITER; ++i) {
 
     timer.start();
+// clang-format off
     RAJA::forall<RAJA::hip_exec<HIP_BLOCK_SIZE>>(RAJA::TypedRangeSegment<int>(0, N), 
       [=] RAJA_DEVICE(int e) {
 
@@ -594,6 +609,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       }
     );
     timer.stop();
+// clang-format on
 
     RAJA::Timer::ElapsedType tMin = timer.elapsed();
     if (tMin < minRun) minRun = tMin;
@@ -614,6 +630,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   for (int i = 0; i < NITER; ++i) {
 
     timer.start();
+// clang-format off
     RAJA::forall<RAJA::hip_exec<HIP_BLOCK_SIZE>>(RAJA::TypedRangeSegment<int>(0, N), 
       [=] RAJA_DEVICE(int e) {
 
@@ -650,6 +667,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       }
     );
     timer.stop();
+// clang-format on
 
     RAJA::Timer::ElapsedType tMin = timer.elapsed();
     if (tMin < minRun) minRun = tMin;
@@ -688,6 +706,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // check result
 //
+// clang-format off
 template <typename T>
 void checkResult(T C, int nMat, int nRows, int nCols)
 {

--- a/exercises/scan.cpp
+++ b/exercises/scan.cpp
@@ -5,11 +5,13 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+// clang-format off
 #define OP_PLUS_INT RAJA::operators::plus<int>
 #define OP_MIN_INT RAJA::operators::minimum<int>
 #define OP_MAX_INT RAJA::operators::maximum<int>
 #define CHECK_INC_SCAN_RESULTS(X) checkInclusiveScanResult<X>(in, out, N);
 #define CHECK_EXC_SCAN_RESULTS(X) checkExclusiveScanResult<X>(in, out, N);
+// clang-format on
 
 #include <cstdlib>
 #include <iostream>
@@ -364,6 +366,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check inclusive scan result
 //
+// clang-format off
 template <typename Function, typename T>
 void checkInclusiveScanResult(const T* in, const T* out, int N)
 {

--- a/exercises/scan_solution.cpp
+++ b/exercises/scan_solution.cpp
@@ -5,11 +5,13 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+// clang-format off
 #define OP_PLUS_INT RAJA::operators::plus<int>
 #define OP_MIN_INT RAJA::operators::minimum<int>
 #define OP_MAX_INT RAJA::operators::maximum<int>
 #define CHECK_INC_SCAN_RESULTS(X) checkInclusiveScanResult<X>(in, out, N);
 #define CHECK_EXC_SCAN_RESULTS(X) checkExclusiveScanResult<X>(in, out, N);
+// clang-format on
 
 #include <cstdlib>
 #include <iostream>
@@ -109,10 +111,12 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::copy_n(in, N, out);
 
   // _scan_inclusive_seq_plus_start
+// clang-format off
   RAJA::inclusive_scan<RAJA::seq_exec>(RAJA::make_span(in, N),
                                        RAJA::make_span(out, N),
                                        RAJA::operators::plus<int>{});
   // _scan_inclusive_seq_plus_end
+// clang-format on
 
   CHECK_INC_SCAN_RESULTS(OP_PLUS_INT)
   printArray(out, N);
@@ -125,10 +129,12 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::copy_n(in, N, out);
 
   // _scan_exclusive_seq_plus_start
+// clang-format off
   RAJA::exclusive_scan<RAJA::seq_exec>(RAJA::make_span(in, N),
                                        RAJA::make_span(out, N),
                                        RAJA::operators::plus<int>{});
   // _scan_exclusive_seq_plus_end
+// clang-format on
 
   CHECK_EXC_SCAN_RESULTS(OP_PLUS_INT)
   printArray(out, N);
@@ -141,9 +147,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   // _scan_inclusive_inplace_seq_min_start
   std::copy_n(in, N, out);
 
+// clang-format off
   RAJA::inclusive_scan_inplace<RAJA::seq_exec>(RAJA::make_span(out, N),
                                                RAJA::operators::minimum<int>{});
   // _scan_inclusive_inplace_seq_min_end
+// clang-format on
 
   CHECK_INC_SCAN_RESULTS(OP_MIN_INT)
   printArray(out, N);
@@ -156,9 +164,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::copy_n(in, N, out);
 
   // _scan_exclusive_inplace_seq_max_start
+// clang-format off
   RAJA::exclusive_scan_inplace<RAJA::seq_exec>(RAJA::make_span(out, N),
                                                RAJA::operators::maximum<int>{});
   // _scan_exclusive_inplace_seq_max_end
+// clang-format on
 
   CHECK_EXC_SCAN_RESULTS(OP_MAX_INT)
   printArray(out, N);
@@ -174,10 +184,12 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::cout << "\n Running OpenMP inclusive_scan (plus)...\n";
 
   // _scan_inclusive_omp_plus_start
+// clang-format off
   RAJA::inclusive_scan<RAJA::omp_parallel_for_exec>(RAJA::make_span(in, N),
                                                     RAJA::make_span(out, N),
                                                     RAJA::operators::plus<int>{});
   // _scan_inclusive_omp_plus_end
+// clang-format on
 
   CHECK_INC_SCAN_RESULTS(OP_PLUS_INT)
   printArray(out, N);
@@ -190,10 +202,12 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::copy_n(in, N, out);
 
   // _scan_exclusive_inplace_omp_plus_start
+// clang-format off
   RAJA::exclusive_scan_inplace<RAJA::omp_parallel_for_exec>(
       RAJA::make_span(out, N),
       RAJA::operators::plus<int>{});
   // _scan_exclusive_inplace_omp_plus_end
+// clang-format on
 
   CHECK_EXC_SCAN_RESULTS(OP_PLUS_INT)
   printArray(out, N);
@@ -214,10 +228,12 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::copy_n(in, N, out);
 
   // _scan_inclusive_inplace_cuda_plus_start
+// clang-format off
   RAJA::inclusive_scan_inplace<RAJA::cuda_exec<CUDA_BLOCK_SIZE>>(
       RAJA::make_span(out, N),
       RAJA::operators::plus<int>{});
   // _scan_inclusive_inplace_cuda_plus_end
+// clang-format on
 
   CHECK_INC_SCAN_RESULTS(OP_PLUS_INT)
   printArray(out, N);
@@ -230,10 +246,12 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::copy_n(in, N, out);
 
   // _scan_exclusive_inplace_cuda_plus_start
+// clang-format off
   RAJA::exclusive_scan_inplace<RAJA::cuda_exec<CUDA_BLOCK_SIZE>>(
       RAJA::make_span(out, N),
       RAJA::operators::plus<int>{});
   // _scan_exclusive_inplace_cuda_plus_end
+// clang-format on
 
   CHECK_EXC_SCAN_RESULTS(OP_PLUS_INT)
   printArray(out, N);
@@ -246,11 +264,13 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::copy_n(in, N, out);
 
   // _scan_exclusive_cuda_plus_start
+// clang-format off
   RAJA::exclusive_scan<RAJA::cuda_exec<CUDA_BLOCK_SIZE>>(
       RAJA::make_span(in, N),
       RAJA::make_span(out, N),
       RAJA::operators::plus<int>{});
   // _scan_exclusive_cuda_plus_end
+// clang-format on
 
   CHECK_EXC_SCAN_RESULTS(OP_PLUS_INT)
   printArray(out, N);
@@ -276,10 +296,12 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   hipErrchk(hipMemcpy( d_out, out, N * sizeof(int), hipMemcpyHostToDevice ));
 
   // _scan_inclusive_inplace_hip_plus_start
+// clang-format off
   RAJA::inclusive_scan_inplace<RAJA::hip_exec<HIP_BLOCK_SIZE>>(
       RAJA::make_span(d_out, N),
       RAJA::operators::plus<int>{});
   // _scan_inclusive_inplace_hip_plus_end
+// clang-format on
 
   hipErrchk(hipMemcpy( out, d_out, N * sizeof(int), hipMemcpyDeviceToHost ));
 
@@ -294,11 +316,13 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   hipErrchk(hipMemcpy( d_in, in, N * sizeof(int), hipMemcpyHostToDevice ));
   hipErrchk(hipMemcpy( d_out, out, N * sizeof(int), hipMemcpyHostToDevice ));
 
+// clang-format off
   RAJA::exclusive_scan<RAJA::hip_exec<HIP_BLOCK_SIZE>>(
       RAJA::make_span(d_in, N),
       RAJA::make_span(d_out, N),
       RAJA::operators::plus<int>{});
 
+// clang-format on
   hipErrchk(hipMemcpy( out, d_out, N * sizeof(int), hipMemcpyDeviceToHost ));
 
   CHECK_EXC_SCAN_RESULTS(OP_PLUS_INT)
@@ -327,6 +351,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check inclusive scan result
 //
+// clang-format off
 template <typename Function, typename T>
 void checkInclusiveScanResult(const T* in, const T* out, int N)
 {

--- a/exercises/sort.cpp
+++ b/exercises/sort.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+// clang-format off
 #define OP_GREATER RAJA::operators::greater<int>
 #define OP_LESS RAJA::operators::less<int>
 
@@ -49,6 +50,7 @@
 #if defined(RAJA_ENABLE_CUDA)
 //constexpr int CUDA_BLOCK_SIZE = 16;
 #endif
+// clang-format on
 
 #if defined(RAJA_ENABLE_HIP)
 //constexpr int HIP_BLOCK_SIZE = 16;
@@ -410,6 +412,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   return 0;
 }
 
+// clang-format off
 template <typename Comparator, typename T>
 bool equivalent(T const& a, T const& b, Comparator comp)
 {

--- a/exercises/sort_solution.cpp
+++ b/exercises/sort_solution.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+// clang-format off
 #define OP_GREATER RAJA::operators::greater<int>
 #define OP_LESS RAJA::operators::less<int>
 
@@ -49,6 +50,7 @@
 #if defined(RAJA_ENABLE_CUDA)
 constexpr int CUDA_BLOCK_SIZE = 16;
 #endif
+// clang-format on
 
 #if defined(RAJA_ENABLE_HIP)
 constexpr int HIP_BLOCK_SIZE = 16;
@@ -137,9 +139,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::copy_n(in, N, out);
 
   // _sort_seq_less_start
+// clang-format off
   RAJA::sort<RAJA::seq_exec>(RAJA::make_span(out, N),
                              RAJA::operators::less<int>{});
   // _sort_seq_less_end
+// clang-format on
 
   //checkUnstableSortResult<RAJA::operators::less<int>>(in, out, N);
   CHECK_UNSTABLE_SORT_RESULT(OP_LESS);
@@ -153,9 +157,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::copy_n(in, N, out);
 
   // _sort_stable_seq_less_start
+// clang-format off
   RAJA::stable_sort<RAJA::seq_exec>(RAJA::make_span(out, N),
                                     RAJA::operators::less<int>{});
   // _sort_stable_seq_less_end
+// clang-format on
 
   //checkStableSortResult<RAJA::operators::less<int>>(in, out, N);
   CHECK_STABLE_SORT_RESULT(OP_LESS);
@@ -169,9 +175,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::copy_n(in, N, out);
 
   // _sort_stable_seq_greater_start
+// clang-format off
   RAJA::stable_sort<RAJA::seq_exec>(RAJA::make_span(out, N),
                                     RAJA::operators::greater<int>{});
   // _sort_stable_seq_greater_end
+// clang-format on
 
   //checkStableSortResult<RAJA::operators::greater<int>>(in, out, N);
   CHECK_STABLE_SORT_RESULT(OP_GREATER);
@@ -186,10 +194,12 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::copy_n(in_vals, N, out_vals);
 
   // _sort_pairs_seq_less_start
+// clang-format off
   RAJA::sort_pairs<RAJA::seq_exec>(RAJA::make_span(out, N),
                                    RAJA::make_span(out_vals, N),
                                    RAJA::operators::less<int>{});
   // _sort_pairs_seq_less_end
+// clang-format on
 
   //checkUnstableSortResult<RAJA::operators::less<int>>(in, out, in_vals, out_vals, N);
   CHECK_UNSTABLE_SORT_PAIR_RESULT(OP_LESS);
@@ -204,10 +214,12 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::copy_n(in_vals, N, out_vals);
 
   // _sort_stable_pairs_seq_greater_start
+// clang-format off
   RAJA::stable_sort_pairs<RAJA::seq_exec>(RAJA::make_span(out, N),
                                           RAJA::make_span(out_vals, N),
                                           RAJA::operators::greater<int>{});
   // _sort_stable_pairs_seq_greater_end
+// clang-format on
 
   //checkStableSortResult<RAJA::operators::greater<int>>(in, out, in_vals, out_vals, N);
   CHECK_STABLE_SORT_PAIR_RESULT(OP_GREATER);
@@ -226,9 +238,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::copy_n(in, N, out);
 
   // _sort_omp_less_start
+// clang-format off
   RAJA::sort<RAJA::omp_parallel_for_exec>(RAJA::make_span(out, N),
                                           RAJA::operators::less<int>{});
   // _sort_omp_less_end
+// clang-format on
 
   //checkUnstableSortResult<RAJA::operators::less<int>>(in, out, N);
   CHECK_UNSTABLE_SORT_RESULT(OP_LESS);
@@ -243,10 +257,12 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::copy_n(in_vals, N, out_vals);
 
   // _sort_stable_pairs_omp_greater_start
+// clang-format off
   RAJA::stable_sort_pairs<RAJA::omp_parallel_for_exec>(RAJA::make_span(out, N),
                                                        RAJA::make_span(out_vals, N),
                                                        RAJA::operators::greater<int>{});
   // _sort_stable_pairs_omp_greater_end
+// clang-format on
 
   //checkStableSortResult<RAJA::operators::greater<int>>(in, out, in_vals, out_vals, N);
   CHECK_STABLE_SORT_PAIR_RESULT(OP_GREATER);
@@ -269,10 +285,12 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::copy_n(in_vals, N, out_vals);
 
   // _sort_pairs_cuda_greater_start
+// clang-format off
   RAJA::sort_pairs<RAJA::cuda_exec<CUDA_BLOCK_SIZE>>(RAJA::make_span(out, N),
                                                      RAJA::make_span(out_vals, N),
                                                      RAJA::operators::greater<int>{});
   // _sort_pairs_cuda_greater_end
+// clang-format on
 
   //checkUnstableSortResult<RAJA::operators::greater<int>>(in, out, in_vals, out_vals, N);
   CHECK_UNSTABLE_SORT_PAIR_RESULT(OP_GREATER);
@@ -286,9 +304,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   std::copy_n(in, N, out);
 
   // _sort_stable_cuda_less_start
+// clang-format off
   RAJA::stable_sort<RAJA::cuda_exec<CUDA_BLOCK_SIZE>>(RAJA::make_span(out, N),
                                                       RAJA::operators::less<int>{});
   // _sort_stable_cuda_less_end
+// clang-format on
 
   //checkStableSortResult<RAJA::operators::less<int>>(in, out, N);
   CHECK_STABLE_SORT_RESULT(OP_LESS);
@@ -316,10 +336,12 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   hipErrchk(hipMemcpy( d_out, out, N * sizeof(int), hipMemcpyHostToDevice ));
   hipErrchk(hipMemcpy( d_out_vals, out_vals, N * sizeof(int), hipMemcpyHostToDevice ));
 
+// clang-format off
   RAJA::sort_pairs<RAJA::hip_exec<HIP_BLOCK_SIZE>>(RAJA::make_span(d_out, N),
                                                    RAJA::make_span(d_out_vals, N),
                                                    RAJA::operators::less<int>{});
 
+// clang-format on
   hipErrchk(hipMemcpy( out, d_out, N * sizeof(int), hipMemcpyDeviceToHost ));
   hipErrchk(hipMemcpy( out_vals, d_out_vals, N * sizeof(int), hipMemcpyDeviceToHost ));
 
@@ -337,10 +359,12 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   hipErrchk(hipMemcpy( d_out, out, N * sizeof(int), hipMemcpyHostToDevice ));
 
   // _sort_stable_hip_greater_start
+// clang-format off
   RAJA::stable_sort<RAJA::hip_exec<HIP_BLOCK_SIZE>>(
     RAJA::make_span(d_out, N),
     RAJA::operators::greater<int>{});
   // _sort_stable_hip_greater_end
+// clang-format on
 
   hipErrchk(hipMemcpy( out, d_out, N * sizeof(int), hipMemcpyDeviceToHost ));
 
@@ -371,6 +395,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   return 0;
 }
 
+// clang-format off
 template <typename Comparator, typename T>
 bool equivalent(T const& a, T const& b, Comparator comp)
 {

--- a/exercises/tutorial_halfday/ex5_line-of-sight.cpp
+++ b/exercises/tutorial_halfday/ex5_line-of-sight.cpp
@@ -264,6 +264,7 @@ int checkResult(int* visible, int* visible_ref, int len)
 //
 // Function to print array.
 //
+// clang-format off
 template <typename T>
 void printArray(T* v, int len)
 {

--- a/exercises/tutorial_halfday/ex5_line-of-sight_solution.cpp
+++ b/exercises/tutorial_halfday/ex5_line-of-sight_solution.cpp
@@ -271,6 +271,7 @@ int checkResult(int* visible, int* visible_ref, int len)
 //
 // Function to print array.
 //
+// clang-format off
 template <typename T>
 void printArray(T* v, int len)
 {

--- a/exercises/tutorial_halfday/ex6_stencil-offset-layout.cpp
+++ b/exercises/tutorial_halfday/ex6_stencil-offset-layout.cpp
@@ -322,6 +322,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
 //
 // For array printing, 'stride1dim' indicates which mesh dimenstride is 
+// clang-format off
 // stride-1 (0 indicates each row is stride-1, 
 //           1 indicates each column is stride-1).
 //

--- a/exercises/tutorial_halfday/ex6_stencil-offset-layout_solution.cpp
+++ b/exercises/tutorial_halfday/ex6_stencil-offset-layout_solution.cpp
@@ -208,9 +208,11 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
   // we don't need a permutation for this case.
   //
 
+// clang-format off
   RAJA::OffsetLayout<DIM> B_layout =
       RAJA::make_offset_layout<DIM>({{-1, -1}}, {{Nc_tot-1, Nr_tot-1}});
 
+// clang-format on
   RAJA::View<int, RAJA::OffsetLayout<DIM>> Bview(B, B_layout);
   RAJA::View<int, RAJA::Layout<DIM>> Aview(A, Nc_int, Nr_int);
 
@@ -329,6 +331,7 @@ int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 
 //
 // For array printing, 'stride1dim' indicates which mesh dimenstride is 
+// clang-format off
 // stride-1 (0 indicates each row is stride-1, 
 //           1 indicates each column is stride-1).
 //

--- a/exercises/tutorial_halfday/ex8_tiled-matrix-transpose.cpp
+++ b/exercises/tutorial_halfday/ex8_tiled-matrix-transpose.cpp
@@ -43,15 +43,19 @@ const int DIM = 2;
 //
 // Function for checking results
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 //
 // Function for printing results
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
 
@@ -170,6 +174,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //
 #if 0
   using KERNEL_EXEC_POL_SEQ =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_SZ>,
                                RAJA::seq_exec,
@@ -183,6 +188,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 #endif
+// clang-format on
 
   ///
   /// TODO...
@@ -209,6 +215,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //
 #if 0
   using KERNEL_EXEC_POL_OMP =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_SZ>,
                                RAJA::seq_exec,
@@ -222,6 +229,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 #endif
+// clang-format on
 
   ///
   /// TODO...
@@ -250,6 +258,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // to/from the tile.
   //
   using KERNEL_EXEC_POL_OMP2 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_SZ>,
                                RAJA::seq_exec,
@@ -263,6 +272,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       > // closes Tile 1
     >; // closes policy list
 
+// clang-format on
   RAJA::kernel<KERNEL_EXEC_POL_OMP2>(
                         RAJA::make_tuple(col_Range, row_Range),
                         [=](int col, int row) {
@@ -283,6 +293,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 #if 0
   using KERNEL_EXEC_POL_CUDA =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernel<
         RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_SZ>,
@@ -298,6 +309,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 #endif
+// clang-format on
 
   ///
   /// TODO...
@@ -330,6 +342,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -348,9 +361,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
+// clang-format on
 //
 // Function to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {

--- a/exercises/tutorial_halfday/ex8_tiled-matrix-transpose_solution.cpp
+++ b/exercises/tutorial_halfday/ex8_tiled-matrix-transpose_solution.cpp
@@ -41,15 +41,19 @@ const int DIM = 2;
 //
 // Function for checking results
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 //
 // Function for printing results
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
 
@@ -163,6 +167,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //
 
   using KERNEL_EXEC_POL_SEQ =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_SZ>,
                                RAJA::seq_exec,
@@ -177,6 +182,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
   RAJA::kernel<KERNEL_EXEC_POL_SEQ>( RAJA::make_tuple(col_Range, row_Range),
     [=](int col, int row) {
       Atview(col, row) = Aview(row, col);
@@ -197,6 +203,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //
 
   using KERNEL_EXEC_POL_OMP =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_SZ>,
                                RAJA::seq_exec,
@@ -211,6 +218,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
   RAJA::kernel<KERNEL_EXEC_POL_OMP>(
                           RAJA::make_tuple(col_Range, row_Range),
                           [=](int col, int row) {
@@ -235,6 +243,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   //
 
   using KERNEL_EXEC_POL_OMP2 =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_SZ>,
                                RAJA::seq_exec,
@@ -248,6 +257,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       > // closes Tile 1
     >; // closes policy list
 
+// clang-format on
   RAJA::kernel<KERNEL_EXEC_POL_OMP2>(
                         RAJA::make_tuple(col_Range, row_Range),
                         [=](int col, int row) {
@@ -267,6 +277,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(At, 0, N_r * N_c * sizeof(int));
 
   using KERNEL_EXEC_POL_CUDA =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::CudaKernel<
         RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_SZ>,
@@ -283,6 +294,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
   RAJA::kernel<KERNEL_EXEC_POL_CUDA>(
                            RAJA::make_tuple(col_Range, row_Range),
                            [=] RAJA_DEVICE (int col, int row) {
@@ -310,6 +322,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -328,9 +341,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
+// clang-format on
 //
 // Function to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {

--- a/exercises/tutorial_halfday/ex9_matrix-transpose-local-array.cpp
+++ b/exercises/tutorial_halfday/ex9_matrix-transpose-local-array.cpp
@@ -47,15 +47,19 @@ const int DIM = 2;
 //
 // Function for checking results
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 //
 // Function for printing results
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -205,6 +209,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 #if 0
   using SEQ_EXEC_POL =
+// clang-format off
     RAJA::KernelPolicy<
       // Fill in sequential outer loop tiling execution statements....
       // (sequential  outer row loop, sequential inner column loop)...
@@ -232,6 +237,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
   ///
   /// TODO...
   ///
@@ -272,6 +278,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 #if 0
   using OPENMP_EXEC_POL =
+// clang-format off
   RAJA::KernelPolicy<
     // Fill in the outer loop tiling execttion statements
     // (OpenMP outer row loop, sequential inner column loop)...
@@ -298,6 +305,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     >
    >;
 
+// clang-format on
   ///
   /// TODO...
   ///
@@ -340,6 +348,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
 #if 0
   using CUDA_EXEC_POL =
+// clang-format off
   RAJA::KernelPolicy<
     RAJA::statement::CudaKernel<
       // Fill in the outer loop tiling execttion statements
@@ -372,6 +381,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     >
   >;
 
+// clang-format on
   ///
   /// TODO...
   ///
@@ -421,6 +431,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -439,9 +450,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
+// clang-format on
 //
 // Function to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {

--- a/exercises/tutorial_halfday/ex9_matrix-transpose-local-array_solution.cpp
+++ b/exercises/tutorial_halfday/ex9_matrix-transpose-local-array_solution.cpp
@@ -47,15 +47,19 @@ const int DIM = 2;
 //
 // Function for checking results
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 //
 // Function for printing results
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c);
 
+// clang-format on
 
 int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
@@ -202,6 +206,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(At, 0, N_r * N_c * sizeof(int));
 
   using SEQ_EXEC_POL =
+// clang-format off
     RAJA::KernelPolicy<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_SZ>,
                                RAJA::seq_exec,
@@ -231,6 +236,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       >
     >;
 
+// clang-format on
   RAJA::kernel_param<SEQ_EXEC_POL>( RAJA::make_tuple(col_Range, row_Range),
 
     RAJA::make_tuple((int)0, (int)0, RAJA_Tile),
@@ -258,6 +264,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(At, 0, N_r * N_c * sizeof(int));
 
   using OPENMP_EXEC_POL =
+// clang-format off
   RAJA::KernelPolicy<
     RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_SZ>,
                              RAJA::omp_parallel_for_exec,
@@ -286,6 +293,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     >
    >;
 
+// clang-format on
   RAJA::kernel_param<OPENMP_EXEC_POL>( RAJA::make_tuple(col_Range, row_Range),
 
       RAJA::make_tuple((int)0, (int)0, RAJA_Tile),
@@ -315,6 +323,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(At, 0, N_r * N_c * sizeof(int));
 
   using CUDA_EXEC_POL =
+// clang-format off
   RAJA::KernelPolicy<
     RAJA::statement::CudaKernel<
       RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_SZ>,
@@ -349,6 +358,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     >
   >;
 
+// clang-format on
 
   RAJA::kernel_param<CUDA_EXEC_POL>( RAJA::make_tuple(col_Range, row_Range),
 
@@ -387,6 +397,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {
@@ -405,9 +416,11 @@ void checkResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
   }
 };
 
+// clang-format on
 //
 // Function to print result.
 //
+// clang-format off
 template <typename T>
 void printResult(RAJA::View<T, RAJA::Layout<DIM>> Atview, int N_r, int N_c)
 {

--- a/exercises/tutorial_halfday/memoryManager.hpp
+++ b/exercises/tutorial_halfday/memoryManager.hpp
@@ -27,6 +27,7 @@
 namespace memoryManager
 {
 
+// clang-format off
 template <typename T>
 T *allocate(RAJA::Index_type size)
 {

--- a/exercises/vector-addition.cpp
+++ b/exercises/vector-addition.cpp
@@ -116,10 +116,12 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   ///
 
   // _rajaseq_vector_add_start
+// clang-format off
   RAJA::forall<RAJA::seq_exec>(RAJA::TypedRangeSegment<int>(0, N), [=] (int i) {
     c[i] = a[i] + b[i]; 
   });
   // _rajaseq_vector_add_end
+// clang-format on
 
   checkResult(c, c_ref, N);
 //printArray(c, N);

--- a/exercises/vector-addition_solution.cpp
+++ b/exercises/vector-addition_solution.cpp
@@ -127,12 +127,14 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   std::cout << "\n Running RAJA SIMD vector addition...\n";
 
+// clang-format off
   RAJA::forall<RAJA::simd_exec>(
     RAJA::TypedRangeSegment<int>(0, N), [=] (int i) { 
       c[i] = a[i] + b[i]; 
     }
   );    
 
+// clang-format on
   checkResult(c, c_ref, N);
 //printArray(c, N);
 
@@ -200,11 +202,13 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   cudaErrchk(cudaMemcpy( d_b, b, N * sizeof(int), cudaMemcpyHostToDevice ));
 
   // _rajacuda_vector_add_start
+// clang-format off
   RAJA::forall< RAJA::cuda_exec<CUDA_BLOCK_SIZE> >(RAJA::TypedRangeSegment<int>(0, N), 
     [=] RAJA_DEVICE (int i) {
     d_c[i] = d_a[i] + d_b[i];
   });
   // _rajacuda_vector_add_end
+// clang-format on
 
   cudaErrchk(cudaMemcpy( c, d_c, N * sizeof(int), cudaMemcpyDeviceToHost ));
 
@@ -223,11 +227,13 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   // _rajacuda_explicit_vector_add_start
   const bool Asynchronous = true;
 
+// clang-format off
   RAJA::forall<RAJA::cuda_exec_explicit<CUDA_BLOCK_SIZE, 2, Asynchronous>>(RAJA::TypedRangeSegment<int>(0, N), 
     [=] RAJA_DEVICE (int i) { 
     d_c[i] = d_a[i] + d_b[i]; 
   });    
   // _rajacuda_explicit_vector_add_end
+// clang-format on
 
   cudaErrchk(cudaMemcpy( c, d_c, N * sizeof(int), cudaMemcpyDeviceToHost ));
 
@@ -250,11 +256,13 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   hipErrchk(hipMemcpy( d_b, b, N * sizeof(int), hipMemcpyHostToDevice ));
 
   // _rajahip_vector_add_start
+// clang-format off
   RAJA::forall<RAJA::hip_exec<HIP_BLOCK_SIZE>>(RAJA::TypedRangeSegment<int>(0, N),
     [=] RAJA_DEVICE (int i) {
     d_c[i] = d_a[i] + d_b[i];
   });
   // _rajahip_vector_add_end
+// clang-format on
 
   hipErrchk(hipMemcpy( c, d_c, N * sizeof(int), hipMemcpyDeviceToHost ));
 
@@ -281,11 +289,13 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   memoryManager::sycl_res->memcpy(d_b, b, N * sizeof(int));
 
   // _rajasycl_vector_add_start
+// clang-format off
   RAJA::forall<RAJA::sycl_exec<SYCL_BLOCK_SIZE>>(RAJA::TypedRangeSegment<int>(0, N),
     [=] RAJA_DEVICE (int i) {
     d_c[i] = d_a[i] + d_b[i];
   });
   // _rajasycl_vector_add_end
+// clang-format on
 
   memoryManager::sycl_res->memcpy(c, d_c, N * sizeof(int));
 

--- a/exercises/vertexsum-indexset.cpp
+++ b/exercises/vertexsum-indexset.cpp
@@ -324,9 +324,11 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(areav, 0, Nvert*Nvert * sizeof(double));
 
 // _raja_vertexarea_cuda_start
+// clang-format off
   using EXEC_POL2 = RAJA::ExecPolicy<RAJA::seq_segit, 
                                      RAJA::cuda_exec<CUDA_BLOCK_SIZE>>;
 
+// clang-format on
   RAJA::forall<EXEC_POL2>(cuda_colorset, [=] RAJA_DEVICE (int ie) {
     int* iv = &(e2v_map[4*ie]);
     areav[ iv[0] ] += areae[ie] / 4.0 ;
@@ -383,9 +385,11 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::cout << "\n Running RAJA HIP index set vertex sum...\n";
 
 // _raja_vertexarea_hip_start
+// clang-format off
   using EXEC_POL3 = RAJA::ExecPolicy<RAJA::seq_segit,
                                      RAJA::hip_exec<HIP_BLOCK_SIZE>>;
 
+// clang-format on
   RAJA::forall<EXEC_POL3>(hip_colorset, [=] RAJA_DEVICE (int ie) {
     int* iv = &(d_e2v_map[4*ie]);
     d_areav[ iv[0] ] += d_areae[ie] / 4.0 ;

--- a/exercises/vertexsum-indexset_solution.cpp
+++ b/exercises/vertexsum-indexset_solution.cpp
@@ -316,9 +316,11 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(areav, 0, Nvert*Nvert * sizeof(double));
 
 // _raja_vertexarea_cuda_start
+// clang-format off
   using EXEC_POL2 = RAJA::ExecPolicy<RAJA::seq_segit, 
                                      RAJA::cuda_exec<CUDA_BLOCK_SIZE>>;
 
+// clang-format on
   RAJA::forall<EXEC_POL2>(cuda_colorset, [=] RAJA_DEVICE (int ie) {
     int* iv = &(e2v_map[4*ie]);
     areav[ iv[0] ] += areae[ie] / 4.0 ;
@@ -375,9 +377,11 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::cout << "\n Running RAJA HIP index set vertex sum...\n";
 
 // _raja_vertexarea_hip_start
+// clang-format off
   using EXEC_POL3 = RAJA::ExecPolicy<RAJA::seq_segit,
                                      RAJA::hip_exec<HIP_BLOCK_SIZE>>;
 
+// clang-format on
   RAJA::forall<EXEC_POL3>(hip_colorset, [=] RAJA_DEVICE (int ie) {
     int* iv = &(d_e2v_map[4*ie]);
     d_areav[ iv[0] ] += d_areae[ie] / 4.0 ;

--- a/exercises/view-layout.cpp
+++ b/exercises/view-layout.cpp
@@ -479,12 +479,16 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(ao, 0, Ntot_ao * sizeof(int));
 
   // _raja_offlayout1D_start
+// clang-format off
   RAJA::OffsetLayout<1, int> offlayout_1D = 
     RAJA::make_offset_layout<1, int>( {{imin}}, {{imax}} ); 
 
+// clang-format on
+// clang-format off
   RAJA::View< int, RAJA::OffsetLayout<1, int> > aoview_1Doff(ao,
                                                              offlayout_1D);
 
+// clang-format on
   for (int i = imin; i < imax; ++i) {
     aoview_1Doff(i) = i;
   }
@@ -563,14 +567,18 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   // _raja_permofflayout2D_start
   std::array<RAJA::idx_t, 2> perm1D {{1, 0}};
+// clang-format off
   RAJA::OffsetLayout<2> permofflayout_2D =
     RAJA::make_permuted_offset_layout<2>( {{imin, jmin}}, 
                                           {{imax, jmax}},
                                           perm1D );
 
+// clang-format on
+// clang-format off
   RAJA::View< int, RAJA::OffsetLayout<2> > aoview_2Dpermoff(ao,
                                                             permofflayout_2D);
 
+// clang-format on
   iter = 0;
   for (int j = jmin; j < jmax; ++j) {
     for (int i = imin; i < imax; ++i) {
@@ -600,6 +608,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(T* C, T* Cref, int N)
 {
@@ -616,6 +625,8 @@ void checkResult(T* C, T* Cref, int N)
   }
 };
 
+// clang-format on
+// clang-format off
 template <typename T>
 void printValues(T* C, int N)
 {

--- a/exercises/view-layout_solution.cpp
+++ b/exercises/view-layout_solution.cpp
@@ -490,12 +490,16 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(ao, 0, Ntot_ao * sizeof(int));
 
   // _raja_offlayout1D_start
+// clang-format off
   RAJA::OffsetLayout<1, int> offlayout_1D = 
     RAJA::make_offset_layout<1, int>( {{imin}}, {{imax}} ); 
 
+// clang-format on
+// clang-format off
   RAJA::View< int, RAJA::OffsetLayout<1, int> > aoview_1Doff(ao,
                                                              offlayout_1D);
 
+// clang-format on
   for (int i = imin; i < imax; ++i) {
     aoview_1Doff(i) = i;
   }
@@ -536,12 +540,16 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   std::memset(ao, 0, Ntot_ao * sizeof(int));
 
   // _raja_offlayout2D_start
+// clang-format off
   RAJA::OffsetLayout<2, int> offlayout_2D =
     RAJA::make_offset_layout<2, int>( {{imin, jmin}}, {{imax, jmax}} );
 
+// clang-format on
+// clang-format off
   RAJA::View< int, RAJA::OffsetLayout<2, int> > aoview_2Doff(ao,
                                                              offlayout_2D);
   iter = 0;
+// clang-format on
   for (int i = imin; i < imax; ++i) {
     for (int j = jmin; j < jmax; ++j) {
       aoview_2Doff(i, j) = iter;
@@ -581,14 +589,18 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   // _raja_permofflayout2D_start
   std::array<RAJA::idx_t, 2> perm1D {{1, 0}};
+// clang-format off
   RAJA::OffsetLayout<2> permofflayout_2D =
     RAJA::make_permuted_offset_layout<2>( {{imin, jmin}}, 
                                           {{imax, jmax}},
                                           perm1D );
 
+// clang-format on
+// clang-format off
   RAJA::View< int, RAJA::OffsetLayout<2> > aoview_2Dpermoff(ao,
                                                             permofflayout_2D);
 
+// clang-format on
   iter = 0;
   for (int j = jmin; j < jmax; ++j) {
     for (int i = imin; i < imax; ++i) {
@@ -618,6 +630,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 //
 // Function to check result and report P/F.
 //
+// clang-format off
 template <typename T>
 void checkResult(T* C, T* Cref, int N)
 {
@@ -634,6 +647,8 @@ void checkResult(T* C, T* Cref, int N)
   }
 };
 
+// clang-format on
+// clang-format off
 template <typename T>
 void printValues(T* C, int N)
 {

--- a/scripts/clang-format-on-off.py
+++ b/scripts/clang-format-on-off.py
@@ -19,8 +19,6 @@ def find_nested_template_declarations(inp : list[string], cutoff : int = 2) -> l
         num_closing_braces = 0
         num_paren_open = inp[ptr1].count('(')
         num_paren_close = inp[ptr1].count(')')
-        # stack for tracking bracket closure
-
         # bool for multiline template class invocation
         is_template_decl = (
                             (num_brackets > num_closing_brackets or
@@ -59,7 +57,6 @@ def add_clang_format_comments(inp : list[string], insertions: list[tuple[int,int
         if not done_inserting and i == insertions[current_insertion_idx][0]:
             out.append(clang_format_off)
         out.append(inp[i])
-        #print(i, insertions[current_insertion_idx][1] + 1)
         if not done_inserting and i == insertions[current_insertion_idx][1] + 1:
             out.append(clang_format_on)
             # we've handled one off-on pair, increment pointer in insertion array

--- a/scripts/clang-format-on-off.py
+++ b/scripts/clang-format-on-off.py
@@ -1,0 +1,151 @@
+import string
+import re
+import os
+from argparse import ArgumentParser
+
+# Parse a list of strings (that is assumed to be valid cpp code).  Identify all nested 
+# templated type definitions of depth greater than cutoff.  Return a list of integers
+# representing the indexes of such declarations
+def find_nested_template_declarations(inp : list[string], cutoff : int = 2) -> list[tuple[int,int]]:
+    out = []
+    i = 0
+    while i < len(inp):
+        line = inp[i]
+        ptr1 = i
+        ptr2 = i
+        num_brackets = len(re.findall(r'(?<!<)<(?!<| )', inp[ptr1]))
+        num_closing_brackets = len(re.findall(r'(?<!>)>(?!>| )', inp[ptr1]))
+        num_braces = 0
+        num_closing_braces = 0
+        num_paren_open = inp[ptr1].count('(')
+        num_paren_close = inp[ptr1].count(')')
+        # stack for tracking bracket closure
+
+        # bool for multiline template class invocation
+        is_template_decl = (
+                            (num_brackets > num_closing_brackets or
+                            (num_brackets > 0 and ';' not in inp[ptr1]) or
+                            num_paren_open > num_paren_close) and
+                            ";" not in inp[ptr1] and
+                            "include" not in inp[ptr1])
+        while is_template_decl and ptr2 < len(inp):
+            #print(i, num_brackets, num_closing_brackets)
+            num_brackets += len(re.findall(r'(?<!<)<(?!<)', inp[ptr2]))
+            # num_closing_brackets += inp[ptr2].count(">")
+            num_braces += inp[ptr2].count("{")
+            num_closing_braces += inp[ptr2].count("}")
+            # scroll till we get through all the the brackets and the declaration
+            if ";" in inp[ptr2]:
+                #print("kword", ptr2, num_brackets)
+                if num_braces == num_closing_braces:
+                 #   print("kword", inp[ptr2], ptr2, num_brackets)
+                    break
+            ptr2 += 1
+        # count the depth of template parametrization
+        if num_brackets > cutoff and ptr1 != ptr2:
+            out.append((ptr1, ptr2))
+        i = ptr2 + 1
+
+    return out
+
+def add_clang_format_comments(inp : list[string], insertions: list[tuple[int,int]]) -> list[string]:
+    clang_format_off = "// clang-format off\n"
+    clang_format_on = "// clang-format on\n"
+    num_insertions = 0
+    current_insertion_idx = 0
+    out = []
+    for i in range(0, len(inp)):
+        done_inserting = current_insertion_idx >= len(insertions)
+        if not done_inserting and i == insertions[current_insertion_idx][0]:
+            out.append(clang_format_off)
+        out.append(inp[i])
+        #print(i, insertions[current_insertion_idx][1] + 1)
+        if not done_inserting and i == insertions[current_insertion_idx][1] + 1:
+            out.append(clang_format_on)
+            # we've handled one off-on pair, increment pointer in insertion array
+            current_insertion_idx += 1
+        
+    return out
+
+def refactor_file(fname, str):
+    with open(fname, "w") as f:
+        f.write(str)
+         
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("-d", "--directory", dest="directory", help="directory to refactor")
+    args = parser.parse_args()
+    dir = args.directory
+    if args.directory is None or not os.path.exists(dir):
+        exit("please specify a valid directory to add clang format annotations")
+    for d, _, files in os.walk(dir):
+        for f in files:
+            out = ""
+            with open(os.path.abspath(os.path.join(d, f)), "r") as f_obj:
+                f_list = f_obj.readlines()
+                out = add_clang_format_comments(f_list, find_nested_template_declarations(f_list))
+            with open(os.path.abspath(os.path.join(d, f)), "w") as f_obj:
+                for line in out:
+                    f_obj.write(f"{line}")
+
+#
+    #test_str = """
+    #/*
+    #  Define CUDA/HIP matrix multiplication kernel for comparison to RAJA version
+    #*/
+    ##if defined(RAJA_ENABLE_CUDA) || defined(RAJA_ENABLE_HIP)
+    #__global__ void matMultKernel(int N, double* C, double* A, double* B)
+    #{
+    #  int row = blockIdx.y * blockDim.y + threadIdx.y;
+    #  int col = blockIdx.x * blockDim.x + threadIdx.x;
+#
+    #  if ( row < N && col < N ) {
+    #    double dot = 0.0;
+    #    for (int k = 0; k < N; ++k) {
+    #      dot += A(row, k) * B(k, col);
+    #    }
+#
+    #    C(row, col) = dot;
+    #  }
+    #}
+#
+    #__global__ void sharedMatMultKernel(int N, double* C, double* A, double* B)
+    #{
+#
+    #  int Row = blockIdx.y*THREAD_SZ + threadIdx.y;
+    #  int Col = blockIdx.x*THREAD_SZ + threadIdx.x;
+#
+    #  __shared__ double As[THREAD_SZ][THREAD_SZ];
+    #  __shared__ double Bs[THREAD_SZ][THREAD_SZ];
+    #  __shared__ double Cs[THREAD_SZ][THREAD_SZ];
+#
+    #  Cs[threadIdx.y][threadIdx.x] = 0.0;
+#
+    #  for (int k = 0; k < (THREAD_SZ + N - 1)/THREAD_SZ; k++) {
+#
+    #    if ( static_cast<int>(k*THREAD_SZ + threadIdx.x) < N && Row < N )
+    #      As[threadIdx.y][threadIdx.x] = A[Row*N + k*THREAD_SZ + threadIdx.x];
+    #    else
+    #      As[threadIdx.y][threadIdx.x] = 0.0;
+#
+    #    if ( static_cast<int>(k*THREAD_SZ + threadIdx.y) < N && Col < N)
+    #      Bs[threadIdx.y][threadIdx.x] = B[(k*THREAD_SZ + threadIdx.y)*N + Col];
+    #    else
+    #      Bs[threadIdx.y][threadIdx.x] = 0.0;
+#
+    #    __syncthreads();
+#
+    #    for (int n = 0; n < THREAD_SZ; ++n)
+    #      Cs[threadIdx.y][threadIdx.x] += As[threadIdx.y][n] * Bs[n][threadIdx.x];
+#
+    #    __syncthreads();
+    #  }
+#
+    #  if (Row < N && Col < N)
+    #    C[((blockIdx.y * blockDim.y + threadIdx.y)*N) +
+    #      (blockIdx.x * blockDim.x)+ threadIdx.x] = Cs[threadIdx.y][threadIdx.x];
+    #}
+    ##endif
+    #"""
+    #f_list = test_str.split('\n')
+    #"\n".join(add_clang_format_comments(f_list, find_nested_template_declarations(f_list)))


### PR DESCRIPTION
This is a refactoring PR that uses a script to insert annotations in cpp source code.  It inserts annotations before and after templated function calls or declarations inside the `examples` and `exercises` subdirectories, as these tend to have the most complex examples of such calls and declarations.
