### PR TITLE
Fixes for OpenMP Target 

### DIFF
--- a/include/RAJA/policy/openmp_target/params/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/params/reduce.hpp
@@ -26,7 +26,7 @@ namespace detail {
   // Resolve
   template<typename EXEC_POL, typename OP, typename T, typename VOp>
   camp::concepts::enable_if< type_traits::is_target_openmp_policy<EXEC_POL> >
-  resolve(Reducer<OP, T, I, VOp>& red) {
+  resolve(Reducer<OP, T, VOp>& red) {
     red.combineTarget(red.m_valop.val);
   }
 

--- a/test/unit/multi_reducer/CMakeLists.txt
+++ b/test/unit/multi_reducer/CMakeLists.txt
@@ -37,9 +37,10 @@ if(RAJA_ENABLE_OPENMP)
   list(APPEND BACKENDS OpenMP)
 endif()
 
-if(RAJA_ENABLE_TARGET_OPENMP)
-  list(APPEND BACKENDS OpenMPTarget)
-endif()
+# Add this back in when OpenMP Target implementation exists for multi-reducer
+#if(RAJA_ENABLE_TARGET_OPENMP)
+#  list(APPEND BACKENDS OpenMPTarget)
+#endif()
 
 if(RAJA_ENABLE_CUDA)
   list(APPEND BACKENDS Cuda)


### PR DESCRIPTION
# Summary

- This PR is a bugfix:
  - Fixes typo in OpenMP Target new reducer.
  - Turns off OpenMP Target tests with the multi-reducer, because that backend is not yet implemented.