### PR TITLE
OpenMP Target Testing

### DIFF
--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -60,12 +60,8 @@ gcc_8_3_1_cuda_11_7_desul_atomics:
     MODULE_LIST: "cuda/11.7.0"
   extends: .job_on_lassen
 
-# Warning: Allowed to fail temporarily
-# Deactivated due to issues with OpenMP Target and various tests and compilers.
-clang_16_0_6_ibm_omptarget:
+clang_16_0_6_omptarget:
   variables:
-    SPEC: " ~shared +openmp +omptarget +tests %clang@=16.0.6.ibm.gcc.8.3.1"
-    ON_LASSEN: "OFF"
+    SPEC: " ~shared +openmp +omptarget +tests %clang@=16.0.6.cuda.11.8.0.gcc.11.2.1 cxxflags==\"-Wunknown-cuda-version\""
   extends: .job_on_lassen
-  allow_failure: true
 

--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -62,6 +62,6 @@ gcc_8_3_1_cuda_11_7_desul_atomics:
 
 clang_16_0_6_omptarget:
   variables:
-    SPEC: " ~shared +openmp +omptarget +tests %clang@=16.0.6.cuda.11.8.0.gcc.11.2.1 cxxflags==\"-Wunknown-cuda-version\""
+    SPEC: " ~shared +openmp +omptarget +tests %clang@=16.0.6.cuda.11.8.0.gcc.11.2.1+allow-unsupported-compilers"
   extends: .job_on_lassen
 

--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -62,6 +62,6 @@ gcc_8_3_1_cuda_11_7_desul_atomics:
 
 clang_16_0_6_omptarget:
   variables:
-    SPEC: " ~shared +openmp +omptarget +tests %clang@=16.0.6.cuda.11.8.0.gcc.11.2.1+allow-unsupported-compilers"
+    SPEC: " ~shared +openmp +omptarget +tests %clang@=16.0.6.cuda.11.8.0.gcc.11.2.1"
   extends: .job_on_lassen
 

--- a/cmake/SetupRajaOptions.cmake
+++ b/cmake/SetupRajaOptions.cmake
@@ -28,7 +28,7 @@ option(RAJA_ENABLE_FORCEINLINE_RECURSIVE "Enable Forceinline recursive (only sup
 option(RAJA_DEPRECATED_TESTS "Test deprecated features" Off)
 option(RAJA_ENABLE_BOUNDS_CHECK "Enable bounds checking in RAJA::Views/Layouts" Off)
 option(RAJA_TEST_EXHAUSTIVE "Build RAJA exhaustive tests" Off)
-option(RAJA_TEST_OPENMP_TARGET_SUBSET "Build subset of RAJA OpenMP target tests when it is enabled" On)
+option(RAJA_TEST_OPENMP_TARGET_SUBSET "Build subset of RAJA OpenMP target tests" On)
 option(RAJA_ENABLE_RUNTIME_PLUGINS "Enable support for loading plugins at runtime" Off)
 option(RAJA_ALLOW_INCONSISTENT_OPTIONS "Enable inconsistent values for ENABLE_X and RAJA_ENABLE_X options" Off)
 

--- a/test/functional/forall/CombiningAdapter/CMakeLists.txt
+++ b/test/functional/forall/CombiningAdapter/CMakeLists.txt
@@ -10,6 +10,15 @@
 #
 set(DIMENSIONS 1D 2D 3D)
 
+##
+## Enable OpenMP Target tests when support for Combining Adapter is fixed
+##
+if(RAJA_ENABLE_TARGET_OPENMP)
+  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
+    list(REMOVE_ITEM FORALL_BACKENDS OpenMPTarget)
+  endif() 
+endif()
+
 #
 # Generate tests for each enabled RAJA back-end.
 #

--- a/test/functional/forall/atomic-ref/CMakeLists.txt
+++ b/test/functional/forall/atomic-ref/CMakeLists.txt
@@ -11,20 +11,11 @@
 set(TESTTYPES AtomicRefAdd AtomicRefSub AtomicRefLoadStore AtomicRefCAS AtomicRefMinMax AtomicRefLogical)
 
 #
-# If building a subset of openmp target tests, remove the back-end from
-# from the list of tests to generate here.
-#
-if(RAJA_ENABLE_TARGET_OPENMP)
-  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-    list(REMOVE_ITEM FORALL_ATOMIC_BACKENDS OpenMPTarget)
-  endif()
-endif()
-
-#
 # Generate atomicref tests for each enabled RAJA back-end.
 #
 # Note: FORALL_ATOMIC_BACKENDS is defined in ../CMakeLists.txt
 #
+
 foreach( ATOMIC_BACKEND ${FORALL_ATOMIC_BACKENDS} )
   foreach( TEST ${TESTTYPES} )
     configure_file( test-forall-atomicref.cpp.in
@@ -33,34 +24,8 @@ foreach( ATOMIC_BACKEND ${FORALL_ATOMIC_BACKENDS} )
                    SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-forall-${TEST}-${ATOMIC_BACKEND}.cpp )
 
     target_include_directories(test-forall-${TEST}-${ATOMIC_BACKEND}.exe
-                                 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+                               PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
   endforeach()
 endforeach()
 
 unset( TESTTYPES )
-
-#
-# If building a subset of openmp target tests, add tests to build here.
-#
-if(RAJA_ENABLE_TARGET_OPENMP)
-  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-
-    set(ATOMIC_BACKEND OpenMPTarget)
-    set(TESTTYPES AtomicRefAdd AtomicRefCAS)
-    
-    foreach( TEST ${TESTTYPES} )
-      configure_file( test-forall-atomicref.cpp.in
-                      test-forall-${TEST}-${ATOMIC_BACKEND}.cpp )
-      raja_add_test( NAME test-forall-${TEST}-${ATOMIC_BACKEND}
-                     SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-forall-${TEST}-${ATOMIC_BACKEND}.cpp )
-
-      target_include_directories(test-forall-${TEST}-${ATOMIC_BACKEND}.exe
-                                 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    endforeach()
-
-    unset( TESTTYPES )
-
-  endif()
-endif()
-
-

--- a/test/functional/forall/atomic-view/CMakeLists.txt
+++ b/test/functional/forall/atomic-view/CMakeLists.txt
@@ -11,20 +11,11 @@
 set(TESTTYPES AtomicView AtomicMultiView)
 
 #
-# If building a subset of openmp target tests, remove the back-end from
-# from the list of tests to generate here.
-#
-if(RAJA_ENABLE_TARGET_OPENMP)
-  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-    list(REMOVE_ITEM FORALL_ATOMIC_BACKENDS OpenMPTarget)
-  endif()
-endif()
-
-#
 # Generate tests for each enabled RAJA back-end.
 #
 # Note: FORALL_ATOMIC_BACKENDS is defined in ../CMakeLists.txt
 #
+
 foreach( ATOMIC_BACKEND ${FORALL_ATOMIC_BACKENDS} )
   foreach( TEST ${TESTTYPES} )
     configure_file( test-forall-atomic-view.cpp.in
@@ -38,30 +29,6 @@ foreach( ATOMIC_BACKEND ${FORALL_ATOMIC_BACKENDS} )
 endforeach()
 
 unset( TESTTYPES )
-
-#
-# If building a subset of openmp target tests, add tests to build here.
-#
-if(RAJA_ENABLE_TARGET_OPENMP)
-  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-
-    set(ATOMIC_BACKEND OpenMPTarget)
-    set(TESTTYPES AtomicMultiView)
-
-    foreach( TEST ${TESTTYPES} )
-      configure_file( test-forall-atomic-view.cpp.in
-                      test-forall-${TEST}-${ATOMIC_BACKEND}.cpp )
-      raja_add_test( NAME test-forall-${TEST}-${ATOMIC_BACKEND}
-                     SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-forall-${TEST}-${ATOMIC_BACKEND}.cpp )
-
-      target_include_directories(test-forall-${TEST}-${ATOMIC_BACKEND}.exe
-                                 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    endforeach()
-
-    unset(TESTTYPES)
-
-  endif()
-endif()
 
 #
 # Testing failure cases with only Sequential. Failures for various backends differ immensely.
@@ -81,4 +48,3 @@ foreach( ATOMIC_BACKEND ${FORALL_FAIL_ATOMIC_BACKENDS} )
 endforeach()
 
 unset(FAILTESTS)
-

--- a/test/functional/forall/indexset-view/CMakeLists.txt
+++ b/test/functional/forall/indexset-view/CMakeLists.txt
@@ -10,17 +10,12 @@
 #
 set(INDEXSETTESTTYPES IndexSetView IcountIndexSetView)
 
-if(RAJA_ENABLE_TARGET_OPENMP)
-  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-    list(REMOVE_ITEM FORALL_BACKENDS OpenMPTarget)
-  endif()
-endif() 
-
 #
 # Generate tests for each enabled RAJA back-end.
 #
 # Note: FORALL_BACKENDS is defined in ../CMakeLists.txt
 #
+
 foreach( BACKEND ${FORALL_BACKENDS} )
   foreach( INDEXSETTESTTYPE ${INDEXSETTESTTYPES} )
     configure_file( test-forall-indexset-view.cpp.in

--- a/test/functional/forall/multi-reduce-basic/CMakeLists.txt
+++ b/test/functional/forall/multi-reduce-basic/CMakeLists.txt
@@ -11,18 +11,14 @@
 set(REDUCETYPES Sum Min Max BitAnd BitOr)
 
 #
-# If building openmp target tests, remove the back-end to
-# from the list of tests to generate here.
+# Do not create tests for OpenMP Target, support not currently implemented
 #
 if(RAJA_ENABLE_TARGET_OPENMP)
-  #if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-    list(REMOVE_ITEM FORALL_BACKENDS OpenMPTarget)
-  #endif()
+  list(REMOVE_ITEM FORALL_BACKENDS OpenMPTarget)
 endif()
 
 #
-# If building SYCL tests, remove the back-end to
-# from the list of tests to generate here.
+# Do not create tests for SYCL, support not currently implemented
 #
 if(RAJA_ENABLE_SYCL)
   list(REMOVE_ITEM FORALL_BACKENDS Sycl)
@@ -33,6 +29,7 @@ endif()
 #
 # Note: FORALL_BACKENDS is defined in ../CMakeLists.txt
 #
+
 foreach( BACKEND ${FORALL_BACKENDS} )
   foreach( REDUCETYPE ${REDUCETYPES} )
     configure_file( test-forall-basic-multi-reduce.cpp.in
@@ -44,30 +41,5 @@ foreach( BACKEND ${FORALL_BACKENDS} )
                                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
   endforeach()
 endforeach()
-
-unset( REDUCETYPES )
-
-
-#
-# If building a subset of openmp target tests, add tests to build here.
-#
-#if(RAJA_ENABLE_TARGET_OPENMP)
-#  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-#
-#    set(BACKEND OpenMPTarget)
-#    set(REDUCETYPES ReduceSum)
-#
-#    foreach( REDUCETYPE ${REDUCETYPES} )
-#      configure_file( test-forall-basic-multi-reduce.cpp.in
-#                      test-forall-basic-MultiReduce${REDUCETYPE}-${BACKEND}.cpp )
-#      raja_add_test( NAME test-forall-basic-MultiReduce${REDUCETYPE}-${BACKEND}
-#                     SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-forall-basic-MultiReduce${REDUCETYPE}-${BACKEND}.cpp )
-#
-#      target_include_directories(test-forall-basic-MultiReduce${REDUCETYPE}-${BACKEND}.exe
-#                                 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-#    endforeach()
-#
-#  endif()
-#endif()
 
 unset( REDUCETYPES )

--- a/test/functional/forall/reduce-basic/CMakeLists.txt
+++ b/test/functional/forall/reduce-basic/CMakeLists.txt
@@ -12,22 +12,13 @@ set(REDUCETYPES ReduceSum ReduceMin ReduceMax ReduceMaxLoc ReduceMinLoc ReduceMa
 
 set(DATATYPES CoreReductionDataTypeList)
 
-#
-# If building a subset of openmp target tests, remove the back-end from
-# from the list of tests to generate here.
-#
-if(RAJA_ENABLE_TARGET_OPENMP)
-  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-    list(REMOVE_ITEM FORALL_BACKENDS OpenMPTarget)
-  endif()
-endif()
-
 
 #
 # Generate core reduction tests for each enabled RAJA back-end
 #
 # Note: FORALL_BACKENDS is defined in ../CMakeLists.txt
 #
+
 foreach( BACKEND ${FORALL_BACKENDS} )
   foreach( REDUCETYPE ${REDUCETYPES} )
     configure_file( test-forall-basic-expt-reduce.cpp.in
@@ -86,14 +77,11 @@ set(REDUCETYPES ReduceSum ReduceMin ReduceMax ReduceMinLoc ReduceMaxLoc)
 
 set(DATATYPES CoreReductionDataTypeList)
 
-#
-# If building a subset of openmp target tests, remove the back-end from
-# from the list of tests to generate here.
-#
+##
+## Do not create OpenMP Target tests for "traditional" RAJA reduction interface
+##
 if(RAJA_ENABLE_TARGET_OPENMP)
-  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-    list(REMOVE_ITEM FORALL_BACKENDS OpenMPTarget)
-  endif()
+  list(REMOVE_ITEM FORALL_BACKENDS OpenMPTarget)
 endif()
 
 #
@@ -157,33 +145,6 @@ foreach( BACKEND ${FORALL_BACKENDS} )
                                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
   endforeach()
 endforeach()
-
-unset( DATATYPES )
-unset( REDUCETYPES )
-
-
-#
-# If building a subset of openmp target tests, add tests to build here.
-#
-if(RAJA_ENABLE_TARGET_OPENMP)
-  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-
-    set(BACKEND OpenMPTarget)
-    set(REDUCETYPES ReduceSum)
-    set(DATATYPES CoreReductionDataTypeList)
-
-    foreach( REDUCETYPE ${REDUCETYPES} )
-      configure_file( test-forall-basic-reduce.cpp.in
-                      test-forall-basic-${REDUCETYPE}-${BACKEND}.cpp )
-      raja_add_test( NAME test-forall-basic-${REDUCETYPE}-${BACKEND}
-                     SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-forall-basic-${REDUCETYPE}-${BACKEND}.cpp )
-
-      target_include_directories(test-forall-basic-${REDUCETYPE}-${BACKEND}.exe
-                                 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    endforeach()
-
-  endif()
-endif()
 
 unset( DATATYPES )
 unset( REDUCETYPES )

--- a/test/functional/forall/reduce-multiple-indexset/CMakeLists.txt
+++ b/test/functional/forall/reduce-multiple-indexset/CMakeLists.txt
@@ -10,10 +10,11 @@
 #
 set(REDUCETYPES ReduceSum ReduceMin ReduceMax ReduceMinLoc ReduceMaxLoc)
 
+##
+## Do not create OpenMP Target tests for "traditional" RAJA reduction interface
+##
 if(RAJA_ENABLE_TARGET_OPENMP)
-  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-    list(REMOVE_ITEM FORALL_BACKENDS OpenMPTarget)
-  endif()
+  list(REMOVE_ITEM FORALL_BACKENDS OpenMPTarget)
 endif()
 
 #

--- a/test/functional/forall/reduce-multiple-segment/CMakeLists.txt
+++ b/test/functional/forall/reduce-multiple-segment/CMakeLists.txt
@@ -10,10 +10,11 @@
 #
 set(REDUCETYPES ReduceSum ReduceMin ReduceMax ReduceMinLoc ReduceMaxLoc)
 
+##
+## Do not create OpenMP Target tests for "traditional" RAJA reduction interface
+##
 if(RAJA_ENABLE_TARGET_OPENMP)
-  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-    list(REMOVE_ITEM FORALL_BACKENDS OpenMPTarget)
-  endif()
+  list(REMOVE_ITEM FORALL_BACKENDS OpenMPTarget)
 endif()
 
 #
@@ -31,6 +32,7 @@ endif()
 #
 # Note: FORALL_BACKENDS is defined in ../CMakeLists.txt
 #
+
 foreach( BACKEND ${FORALL_BACKENDS} )
   foreach( REDUCETYPE ${REDUCETYPES} )
     configure_file( test-forall-segment-multiple-reduce.cpp.in

--- a/test/functional/forall/resource-indexset/CMakeLists.txt
+++ b/test/functional/forall/resource-indexset/CMakeLists.txt
@@ -10,17 +10,12 @@
 #
 set(INDEXSETTESTTYPES ResourceIndexSet ResourceIcountIndexSet)
 
-if(RAJA_ENABLE_TARGET_OPENMP)
-  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-    list(REMOVE_ITEM FORALL_BACKENDS OpenMPTarget)
-  endif()
-endif()
-
 #
 # Generate tests for each enabled RAJA back-end.
 #
 # Note: FORALL_BACKENDS is defined in ../CMakeLists.txt
 #
+
 foreach( BACKEND ${FORALL_BACKENDS} )
   foreach( INDEXSETTESTTYPE ${INDEXSETTESTTYPES} )
     configure_file( test-forall-resource-indexset.cpp.in

--- a/test/functional/kernel/basic-fission-fusion-loop/CMakeLists.txt
+++ b/test/functional/kernel/basic-fission-fusion-loop/CMakeLists.txt
@@ -11,6 +11,15 @@
 # Note: KERNEL_BACKENDS is defined in ../CMakeLists.txt
 #
 
+##
+## Enable OpenMP Target tests when support for fission-fusion is fixed
+##
+if(RAJA_ENABLE_TARGET_OPENMP)
+  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
+    list(REMOVE_ITEM KERNEL_BACKENDS OpenMPTarget)
+  endif()
+endif()
+
 foreach( BACKEND ${KERNEL_BACKENDS} )
       configure_file( test-kernel-basic-fission-fusion-loop.cpp.in
                       test-kernel-basic-fission-fusion-loop-${BACKEND}.cpp )

--- a/test/functional/kernel/conditional-fission-fusion-loop/CMakeLists.txt
+++ b/test/functional/kernel/conditional-fission-fusion-loop/CMakeLists.txt
@@ -20,6 +20,15 @@
 #  list(APPEND KERNEL_BACKENDS Sycl)
 #endif()
 
+##
+## Enable OpenMP Target tests when support for fission-fusion is fixed
+##
+if(RAJA_ENABLE_TARGET_OPENMP)
+  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
+    list(REMOVE_ITEM KERNEL_BACKENDS OpenMPTarget)
+  endif()
+endif()
+
 foreach( BACKEND ${KERNEL_BACKENDS} )
       configure_file( test-kernel-conditional-fission-fusion-loop.cpp.in
                       test-kernel-conditional-fission-fusion-loop-${BACKEND}.cpp )

--- a/test/functional/kernel/multi-reduce-nested/CMakeLists.txt
+++ b/test/functional/kernel/multi-reduce-nested/CMakeLists.txt
@@ -10,14 +10,11 @@
 #
 set(REDUCETYPES Sum Min Max BitAnd BitOr)
 
-#
-# If building openmp target tests, remove the back-end to
-# from the list of tests to generate here.
-#
+##
+## Disable traditional RAJA reductions test creation for OpenMP Target
+##
 if(RAJA_ENABLE_TARGET_OPENMP)
-  #if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-    list(REMOVE_ITEM KERNEL_BACKENDS OpenMPTarget)
-  #endif()
+  list(REMOVE_ITEM KERNEL_BACKENDS OpenMPTarget)
 endif()
 
 #
@@ -33,6 +30,7 @@ endif()
 #
 # Note: KERNEL_BACKENDS is defined in ../CMakeLists.txt
 #
+
 foreach( BACKEND ${KERNEL_BACKENDS} )
   foreach( REDUCETYPE ${REDUCETYPES} )
     configure_file( test-kernel-nested-multi-reduce.cpp.in

--- a/test/functional/kernel/nested-loop-reducesum/CMakeLists.txt
+++ b/test/functional/kernel/nested-loop-reducesum/CMakeLists.txt
@@ -19,14 +19,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
   endif()
 endif()
 
-#
-# If building a subset of openmp target tests, remove the back-end from
-# from the list of tests to generate here.
-#
+##
+## Don't create OpenMP Target tests for "traditional" RAJA reduce interface
+## 
 if(RAJA_ENABLE_TARGET_OPENMP)
-  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-    list(REMOVE_ITEM KERNEL_BACKENDS OpenMPTarget)
-  endif()
+  list(REMOVE_ITEM KERNEL_BACKENDS OpenMPTarget)
 endif()
 
 #
@@ -59,30 +56,5 @@ foreach( NESTED_LOOP_BACKEND ${KERNEL_BACKENDS} )
     endforeach()
   endforeach()
 endforeach()
-
-unset( NESTED_LOOPTYPES )
-
-#
-# If building a subset of openmp target tests, add tests to build here.
-#
-if(RAJA_ENABLE_TARGET_OPENMP)
-  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-
-    set(NESTED_LOOP_BACKEND OpenMPTarget)
-    set(NESTED_LOOPTYPES ReduceSum)
-
-    set(RESOURCE "-")
-    foreach( NESTED_LOOP_TYPE ${NESTED_LOOPTYPES} )
-      configure_file( test-kernel-nested-loop.cpp.in
-                      test-kernel-nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.cpp )
-      raja_add_test( NAME test-kernel-nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}
-                     SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-kernel-nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.cpp )
-
-      target_include_directories(test-kernel-nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.exe
-                                 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-  endforeach()
-
-  endif()
-endif()
 
 unset( NESTED_LOOPTYPES )

--- a/test/functional/kernel/nested-loop-segment-types/CMakeLists.txt
+++ b/test/functional/kernel/nested-loop-segment-types/CMakeLists.txt
@@ -11,27 +11,14 @@
 # Note: KERNEL_BACKENDS is defined in ../CMakeLists.txt
 #
 
-if(RAJA_ENABLE_TARGET_OPENMP)
-  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-    list(REMOVE_ITEM KERNEL_BACKENDS OpenMPTarget)
-  endif()
-endif()
-
-#
-# Remove SYCL until kernel reduction support is added
-#
-if(RAJA_ENABLE_SYCL)
-  list(REMOVE_ITEM KERNEL_BACKENDS Sycl)
-endif()
-
 #
 # While we're adding SYCL tests, enable it for each test set like this.
 #
 # Eventually, remove this and enable in the top-level CMakeLists.txt file.
 #
-#if(RAJA_ENABLE_SYCL)
-#  list(APPEND KERNEL_BACKENDS Sycl)
-#endif()
+if(RAJA_ENABLE_SYCL)
+  list(APPEND KERNEL_BACKENDS Sycl)
+endif()
 
 foreach( BACKEND ${KERNEL_BACKENDS} )
   configure_file( test-kernel-nested-loop-segments.cpp.in

--- a/test/functional/kernel/nested-loop-segment-types/CMakeLists.txt
+++ b/test/functional/kernel/nested-loop-segment-types/CMakeLists.txt
@@ -12,12 +12,10 @@
 #
 
 #
-# While we're adding SYCL tests, enable it for each test set like this.
-#
-# Eventually, remove this and enable in the top-level CMakeLists.txt file.
+# Eventually, enable SYCL tests when we know they work
 #
 if(RAJA_ENABLE_SYCL)
-  list(APPEND KERNEL_BACKENDS Sycl)
+  list(REMOVE_ITEM KERNEL_BACKENDS Sycl)
 endif()
 
 foreach( BACKEND ${KERNEL_BACKENDS} )

--- a/test/functional/kernel/nested-loop/CMakeLists.txt
+++ b/test/functional/kernel/nested-loop/CMakeLists.txt
@@ -10,16 +10,6 @@ set(NESTED_LOOPTYPES Basic)
 set( USE_RESOURCE "-resource-" "-" )
 
 #
-# If building a subset of openmp target tests, remove the back-end from
-# from the list of tests to generate here.
-#
-if(RAJA_ENABLE_TARGET_OPENMP)
-  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-    list(REMOVE_ITEM KERNEL_BACKENDS OpenMPTarget)
-  endif()
-endif()
-
-#
 # Generate kernel basic tests for each enabled RAJA back-end.
 #
 foreach( NESTED_LOOP_BACKEND ${KERNEL_BACKENDS} )
@@ -74,24 +64,24 @@ unset( NESTED_LOOPTYPES )
 #
 # If building a subset of openmp target tests, add tests to build here.
 #
-if(RAJA_ENABLE_TARGET_OPENMP)
-  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-
-    set(NESTED_LOOP_BACKEND OpenMPTarget)
-    set(NESTED_LOOPTYPES Basic MultiLambdaParam)
-
-    set(RESOURCE "-")
-    foreach( NESTED_LOOP_TYPE ${NESTED_LOOPTYPES} )
-      configure_file( test-kernel-nested-loop.cpp.in
-                      test-kernel-nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.cpp )
-      raja_add_test( NAME test-kernel-nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}
-                     SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-kernel-nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.cpp )
-
-      target_include_directories(test-kernel-nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.exe
-                                 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-  endforeach()
-
-  endif()
-endif()
+##if(RAJA_ENABLE_TARGET_OPENMP)
+##  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
+##
+##    set(NESTED_LOOP_BACKEND OpenMPTarget)
+##    set(NESTED_LOOPTYPES Basic MultiLambdaParam)
+##
+##    set(RESOURCE "-")
+##    foreach( NESTED_LOOP_TYPE ${NESTED_LOOPTYPES} )
+##      configure_file( test-kernel-nested-loop.cpp.in
+##                      test-kernel-nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.cpp )
+##      raja_add_test( NAME test-kernel-nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}
+##                     SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-kernel-nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.cpp )
+##
+##      target_include_directories(test-kernel-nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.exe
+##                                 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+##  endforeach()
+##
+##  endif()
+##endif()
 
 unset( NESTED_LOOPTYPES )

--- a/test/functional/kernel/nested-loop/CMakeLists.txt
+++ b/test/functional/kernel/nested-loop/CMakeLists.txt
@@ -60,28 +60,3 @@ foreach( NESTED_LOOP_BACKEND ${KERNEL_BACKENDS} )
 endforeach()
 
 unset( NESTED_LOOPTYPES )
-
-#
-# If building a subset of openmp target tests, add tests to build here.
-#
-##if(RAJA_ENABLE_TARGET_OPENMP)
-##  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-##
-##    set(NESTED_LOOP_BACKEND OpenMPTarget)
-##    set(NESTED_LOOPTYPES Basic MultiLambdaParam)
-##
-##    set(RESOURCE "-")
-##    foreach( NESTED_LOOP_TYPE ${NESTED_LOOPTYPES} )
-##      configure_file( test-kernel-nested-loop.cpp.in
-##                      test-kernel-nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.cpp )
-##      raja_add_test( NAME test-kernel-nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}
-##                     SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-kernel-nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.cpp )
-##
-##      target_include_directories(test-kernel-nested-loop-${NESTED_LOOP_TYPE}-${NESTED_LOOP_BACKEND}.exe
-##                                 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-##  endforeach()
-##
-##  endif()
-##endif()
-
-unset( NESTED_LOOPTYPES )

--- a/test/functional/kernel/single-loop-tile-icount-tcount/CMakeLists.txt
+++ b/test/functional/kernel/single-loop-tile-icount-tcount/CMakeLists.txt
@@ -16,20 +16,27 @@ set(TILESIZES 8 32)
 # 
 # Note: KERNEL_BACKENDS is defined in ../CMakeLists.txt
 #
+
+##
+## Disable OpenMP Target tests, which cause front-end crash in LLVM based compilers
+##
+if(RAJA_ENABLE_TARGET_OPENMP)
+  if(RAJA_TEST_OPENMP_TARGET_SUBSET)   
+    list(REMOVE_ITEM KERNEL_BACKENDS OpenMPTarget)
+  endif() 
+endif()
+
 foreach( BACKEND ${KERNEL_BACKENDS} )
-  # using omp target crashes the compiler with this one 
-  if( NOT ((BACKEND STREQUAL "OpenMPTarget")) )
-    foreach( TESTTYPE ${TESTTYPES} )
-      foreach( TILESIZE ${TILESIZES} )
-        configure_file( test-kernel-single-loop-tile-count.cpp.in
-                        test-kernel-single-loop-${TESTTYPE}-${TILESIZE}-${BACKEND}.cpp )
-        raja_add_test( NAME test-kernel-single-loop-${TESTTYPE}-${TILESIZE}-${BACKEND}
-                      SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-kernel-single-loop-${TESTTYPE}-${TILESIZE}-${BACKEND}.cpp )
-        target_include_directories(test-kernel-single-loop-${TESTTYPE}-${TILESIZE}-${BACKEND}.exe
-                                  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-      endforeach()
+  foreach( TESTTYPE ${TESTTYPES} )
+    foreach( TILESIZE ${TILESIZES} )
+      configure_file( test-kernel-single-loop-tile-count.cpp.in
+                      test-kernel-single-loop-${TESTTYPE}-${TILESIZE}-${BACKEND}.cpp )
+      raja_add_test( NAME test-kernel-single-loop-${TESTTYPE}-${TILESIZE}-${BACKEND}
+                    SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-kernel-single-loop-${TESTTYPE}-${TILESIZE}-${BACKEND}.cpp )
+      target_include_directories(test-kernel-single-loop-${TESTTYPE}-${TILESIZE}-${BACKEND}.exe
+                                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
     endforeach()
-  endif()
+  endforeach()
 endforeach()
 
 unset( TILESIZES )

--- a/test/functional/kernel/tile-variants/CMakeLists.txt
+++ b/test/functional/kernel/tile-variants/CMakeLists.txt
@@ -12,12 +12,14 @@ set(TILETYPES Fixed2D Fixed2DSum Fixed2DMinMax)
 
 foreach( TILE_BACKEND ${KERNEL_BACKENDS} )
   foreach( TILE_TYPE ${TILETYPES} )
-    # OpenMPTarget crashes the xl compiler when building this test... 
-    if( NOT((TILE_BACKEND STREQUAL "OpenMPTarget")) )
+    #
+    # OpenMPTarget tests fail for traditional RAJA reductions
+    #
+    if( (TILE_TYPE STREQUAL "Fixed2D") OR NOT((TILE_BACKEND STREQUAL "OpenMPTarget")) )
       configure_file( test-kernel-tilefixed.cpp.in
                       test-kernel-tile-${TILE_TYPE}-${TILE_BACKEND}.cpp )
       raja_add_test( NAME test-kernel-tile-${TILE_TYPE}-${TILE_BACKEND}
-                    SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-kernel-tile-${TILE_TYPE}-${TILE_BACKEND}.cpp )
+                     SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-kernel-tile-${TILE_TYPE}-${TILE_BACKEND}.cpp )
 
       target_include_directories(test-kernel-tile-${TILE_TYPE}-${TILE_BACKEND}.exe
                                 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
@@ -34,9 +36,10 @@ set(TILETYPES Dynamic2D)
 
 foreach( TILE_BACKEND ${KERNEL_BACKENDS} )
   foreach( TILE_TYPE ${TILETYPES} )
-    # Dynamic tiling not yet implemented for Cuda or Hip
-    # Removing OpenMPTarget because XLC compilation requires ~50 minutes
-    if( NOT ((TILE_BACKEND STREQUAL "Cuda") OR (TILE_BACKEND STREQUAL "Hip") OR (TILE_BACKEND STREQUAL "OpenMPTarget") OR (TILE_BACKEND STREQUAL "Sycl")) )
+    #
+    # Dynamic tiling not yet implemented for CUDA, HIP, or SYCL
+    #
+    if( NOT ((TILE_BACKEND STREQUAL "Cuda") OR (TILE_BACKEND STREQUAL "Hip") OR (TILE_BACKEND STREQUAL "Sycl")) )
       configure_file( test-kernel-tiledyn.cpp.in
                       test-kernel-tile-${TILE_TYPE}-${TILE_BACKEND}.cpp )
       raja_add_test( NAME test-kernel-tile-${TILE_TYPE}-${TILE_BACKEND}

--- a/test/functional/workgroup/CMakeLists.txt
+++ b/test/functional/workgroup/CMakeLists.txt
@@ -39,16 +39,6 @@ if(RAJA_ENABLE_OPENMP)
   list(APPEND BACKENDS OpenMP)
 endif()
 
-#
-# If building a subset of openmp target tests, do not add the back-end to
-# the list of tests to generate here.
-#
-if(RAJA_ENABLE_TARGET_OPENMP)
-  if(NOT RAJA_TEST_OPENMP_TARGET_SUBSET)
-    list(APPEND BACKENDS OpenMPTarget)
-  endif() 
-endif()
-
 if(RAJA_ENABLE_CUDA)
   list(APPEND BACKENDS Cuda)
 endif()
@@ -56,6 +46,10 @@ endif()
 if(RAJA_ENABLE_HIP)
   list(APPEND BACKENDS Hip)
 endif()
+
+##
+## Do not create OpenMP Target or SYCL tests for workgroup, since not supported yet 
+##
 
 
 set(DISPATCHERS IndirectFunction IndirectVirtual Direct)
@@ -66,20 +60,6 @@ buildfunctionalworkgrouptest(Ordered "${Ordered_SUBTESTS}" "${DISPATCHERS}" "${B
 
 set(Unordered_SUBTESTS Single MultipleReuse)
 buildfunctionalworkgrouptest(Unordered "${Unordered_SUBTESTS}" "${DISPATCHERS}" "${BACKENDS}")
-
-unset(BACKENDS)
-
-#
-# If building a subset of openmp target tests, add tests to build here.
-#
-if(RAJA_ENABLE_TARGET_OPENMP)
-  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
-
-    set(BACKENDS OpenMPTarget)
-    buildfunctionalworkgrouptest(Unordered "${Unordered_SUBTESTS}" "${DISPATCHERS}" "${BACKENDS}")
-
-  endif()
-endif()
 
 unset(DISPATCHERS)
 unset(BACKENDS)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -20,7 +20,9 @@ if(RAJA_ENABLE_HIP)
 endif()
 
 if(RAJA_ENABLE_TARGET_OPENMP)
-  #  list(APPEND PLUGIN_BACKENDS OpenMPTarget)
+  if(RAJA_TEST_OPENMP_TARGET_SUBSET)
+    list(REMOVE_ITEM FORALL_BACKENDS OpenMPTarget)
+  endif()
 endif()
 
 add_subdirectory(plugin)

--- a/test/unit/algorithm/CMakeLists.txt
+++ b/test/unit/algorithm/CMakeLists.txt
@@ -19,6 +19,9 @@ if(RAJA_ENABLE_HIP)
   list(APPEND SORT_BACKENDS Hip)
 endif()
 
+##
+## OpenMP Target back-end support missing for these tests
+##
 # if(RAJA_ENABLE_TARGET_OPENMP)
 #   list(APPEND SORT_BACKENDS OpenMPTarget)
 # endif()

--- a/test/unit/indexing/CMakeLists.txt
+++ b/test/unit/indexing/CMakeLists.txt
@@ -25,5 +25,5 @@ foreach( INDEXING_BACKEND ${INDEXING_BACKENDS} )
                  SOURCES ${CMAKE_CURRENT_BINARY_DIR}/test-indexing-global-${INDEXING_BACKEND}.cpp )
 
   target_include_directories(test-indexing-global-${INDEXING_BACKEND}.exe
-                               PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
 endforeach()

--- a/test/unit/multi_reducer/CMakeLists.txt
+++ b/test/unit/multi_reducer/CMakeLists.txt
@@ -37,7 +37,7 @@ if(RAJA_ENABLE_OPENMP)
   list(APPEND BACKENDS OpenMP)
 endif()
 
-# Add this back in when OpenMP Target implementation exists for multi-reducer
+# Add OpenMP Target tests when implementation exists for multi-reducer
 #if(RAJA_ENABLE_TARGET_OPENMP)
 #  list(APPEND BACKENDS OpenMPTarget)
 #endif()

--- a/test/unit/reducer/test-reducer-constructors-openmp-target.cpp
+++ b/test/unit/reducer/test-reducer-constructors-openmp-target.cpp
@@ -12,6 +12,22 @@
 #include "tests/test-reducer-constructors.hpp"
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#if 0 
+// Tests cannot be created since OpenMP Target reduction type constructor is
+// explicitly marked deleted, which is inconsistent with other back-ends --RDH
+using OpenMPTargetBasicReducerConstructorTypes =
+  Test< camp::cartesian_product< OpenMPTargetReducerPolicyList,
+                                 DataTypeList,
+                                 OpenMPTargetResourceList > >::Types;
+INSTANTIATE_TYPED_TEST_SUITE_P(OpenMPTargetBasicTest,
+                               ReducerBasicConstructorUnitTest,
+                               OpenMPTargetBasicReducerConstructorTypes);
+#else
+// This is needed to suppress a runtime test error for uninstantiated test
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(ReducerBasicConstructorUnitTest);
+#endif
+
 using OpenMPTargetInitReducerConstructorTypes = 
   Test< camp::cartesian_product< OpenMPTargetReducerPolicyList,
                                  DataTypeList,


### PR DESCRIPTION
# Summary

- This PR cleans up OpenMP Target testing by doing the following:
- [x] Enabling all OpenMP Target tests that build and run correctly
- [x] Disabling tests that have compilation or run issues (e.g., OpenMP Target tests that use the "traditional" RAJA reduction interface, back-end support is missing, cause LLVM front-end crashes, etc.)
- [x] Making CMakeLists.txt files in test directories more consistent w.r.t. how tests are enabled or disabled

- It also adds a working GItLab CI test jobs for lassen.

- Several RAJA issues have been added to capture tasks for future work.