### PR TITLE
Don't enable google benchmark in corona build script.

### DIFF
--- a/scripts/lc-builds/corona_sycl.sh
+++ b/scripts/lc-builds/corona_sycl.sh
@@ -55,7 +55,6 @@ cmake \
   -DBLT_CXX_STD=c++17 \
   -DENABLE_TESTS=On \
   -DENABLE_EXAMPLES=On \
-  -DENABLE_BENCHMARKS=On \
   "$@" \
   ..
 


### PR DESCRIPTION
# Summary

- This PR removes the line that enables benchmarks in the corona SYCL build script. The dpcpp compiler does not support C++ standards less than 17 and the version of google mark that comes with BLT does not support C++17.
- Support for C++17 in google benchmark was added yesterday. 
- I made an issue for BLT to update, after which we can re-enable. https://github.com/LLNL/blt/issues/709
