### PR TITLE
Update Corona SYCL build to use new compiler with ROCM 6.0.2.

### DIFF
--- a/scripts/lc-builds/corona_sycl.sh
+++ b/scripts/lc-builds/corona_sycl.sh
@@ -13,7 +13,7 @@ if [[ $# -lt 1 ]]; then
   echo "   1) SYCL compiler installation path"
   echo
   echo "For example: "
-  echo "    corona_sycl.sh /usr/workspace/raja-dev/clang_sycl_2f03ef85fee5_hip_gcc10.3.1_rocm5.7.1"
+  echo "    corona_sycl.sh /usr/workspace/raja-dev/clang_sycl_730cd3a5275f_hip_gcc10.3.1_rocm6.0.2"
   exit
 fi
 


### PR DESCRIPTION
# Summary

- This PR is an update
- It does the following:
  - Updates Corona build script to reflect usage of the latest SYCL compiler, built with ROCM/6.0.2 and the hash from 11/5/2024.