### PR TITLE
Use dynamically allocated buffer instead of dynamically sized local array in kernel InitLocalMem

### DIFF
--- a/include/RAJA/pattern/kernel/InitLocalMem.hpp
+++ b/include/RAJA/pattern/kernel/InitLocalMem.hpp
@@ -22,6 +22,7 @@
 
 #include <iostream>
 #include <type_traits>
+#include <memory>
 
 namespace RAJA
 {
@@ -83,15 +84,14 @@ struct StatementExecutor<statement::InitLocalMem<RAJA::cpu_tile_mem,
         Pos, typename camp::decay<Data>::param_tuple_t>::value_type;
 
     // Initialize memory
-    varType* ptr = new varType[camp::get<Pos>(data.param_tuple).size()];
-    camp::get<Pos>(data.param_tuple).set_data(ptr);
+    auto local_mem = std::make_unique<varType[]>(camp::get<Pos>(data.param_tuple).size());
+    camp::get<Pos>(data.param_tuple).set_data(local_mem.get());
 
     // Initialize others and execute
     exec_expanded<others...>(data);
 
     // Cleanup and return
     camp::get<Pos>(data.param_tuple).set_data(nullptr);
-    delete[] ptr;
   }
 
   template<typename Data>

--- a/include/RAJA/pattern/kernel/InitLocalMem.hpp
+++ b/include/RAJA/pattern/kernel/InitLocalMem.hpp
@@ -83,23 +83,15 @@ struct StatementExecutor<statement::InitLocalMem<RAJA::cpu_tile_mem,
         Pos, typename camp::decay<Data>::param_tuple_t>::value_type;
 
     // Initialize memory
-#ifdef RAJA_COMPILER_MSVC
-    // MSVC doesn't like taking a pointer to stack allocated data?!?!
     varType* ptr = new varType[camp::get<Pos>(data.param_tuple).size()];
     camp::get<Pos>(data.param_tuple).set_data(ptr);
-#else
-    varType Array[camp::get<Pos>(data.param_tuple).size()];
-    camp::get<Pos>(data.param_tuple).set_data(&Array[0]);
-#endif
 
     // Initialize others and execute
     exec_expanded<others...>(data);
 
     // Cleanup and return
     camp::get<Pos>(data.param_tuple).set_data(nullptr);
-#ifdef RAJA_COMPILER_MSVC
     delete[] ptr;
-#endif
   }
 
   template<typename Data>

--- a/include/RAJA/pattern/kernel/InitLocalMem.hpp
+++ b/include/RAJA/pattern/kernel/InitLocalMem.hpp
@@ -84,7 +84,8 @@ struct StatementExecutor<statement::InitLocalMem<RAJA::cpu_tile_mem,
         Pos, typename camp::decay<Data>::param_tuple_t>::value_type;
 
     // Initialize memory
-    auto local_mem = std::make_unique<varType[]>(camp::get<Pos>(data.param_tuple).size());
+    auto local_mem =
+        std::make_unique<varType[]>(camp::get<Pos>(data.param_tuple).size());
     camp::get<Pos>(data.param_tuple).set_data(local_mem.get());
 
     // Initialize others and execute


### PR DESCRIPTION
# Use dynamically allocated arrays

Use dynamically allocated buffer instead of dynamically sized local array in kernel InitLocalMem.
This is a problem because it is not valid C++ and causes large warnings to be generated when compiling with hip.

- This PR is a refactoring
- It does the following (modify list as needed):
  - Fixes large warnings in some cases
