### PR TITLE
Fix kernel to not launch a kernel if there is no work

### DIFF
--- a/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
+++ b/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
@@ -549,9 +549,13 @@ struct StatementExecutor<
 
 
     // Only launch kernel if we have something to iterate over
-    int num_blocks  = launch_dims.num_blocks();
-    int num_threads = launch_dims.num_threads();
-    if (num_blocks > 0 || num_threads > 0)
+    bool active_threads = launch_dims.threads_are_active();
+    bool active_blocks  = launch_dims.blocks_are_active();
+    int  num_blocks     = launch_dims.num_blocks();
+    int  num_threads    = launch_dims.num_threads();
+    if ((active_threads || active_blocks) &&
+        (!active_blocks || num_blocks > 0) &&
+        (!active_threads || num_threads > 0))
     {
 
       //

--- a/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
+++ b/include/RAJA/policy/cuda/kernel/CudaKernel.hpp
@@ -551,8 +551,8 @@ struct StatementExecutor<
     // Only launch kernel if we have something to iterate over
     bool active_threads = launch_dims.threads_are_active();
     bool active_blocks  = launch_dims.blocks_are_active();
-    int  num_blocks     = launch_dims.num_blocks();
-    int  num_threads    = launch_dims.num_threads();
+    int num_blocks      = launch_dims.num_blocks();
+    int num_threads     = launch_dims.num_threads();
     if ((active_threads || active_blocks) &&
         (!active_blocks || num_blocks > 0) &&
         (!active_threads || num_threads > 0))

--- a/include/RAJA/policy/cuda/kernel/For.hpp
+++ b/include/RAJA/policy/cuda/kernel/For.hpp
@@ -85,13 +85,11 @@ struct CudaStatementExecutor<
   {
     const diff_t len = segment_length<ArgumentId>(data);
 
-    CudaDims my_dims(0), my_min_dims(0);
-    DimensionCalculator::set_dimensions(my_dims, my_min_dims, len);
-    LaunchDims dims {my_dims, my_min_dims};
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
-    // combine with enclosed statements
     LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);
-    return dims.max(enclosed_dims);
+
+    return combine(dims, enclosed_dims);
   }
 };
 
@@ -162,13 +160,11 @@ struct CudaStatementExecutor<
   {
     diff_t len = segment_length<ArgumentId>(data);
 
-    CudaDims my_dims(0), my_min_dims(0);
-    DimensionCalculator {}.set_dimensions(my_dims, my_min_dims, len);
-    LaunchDims dims {my_dims, my_min_dims};
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
-    // combine with enclosed statements
     LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);
-    return dims.max(enclosed_dims);
+
+    return combine(dims, enclosed_dims);
   }
 };
 
@@ -234,13 +230,11 @@ struct CudaStatementExecutor<
   {
     const diff_t len = segment_length<ArgumentId>(data);
 
-    CudaDims my_dims(0), my_min_dims(0);
-    DimensionCalculator {}.set_dimensions(my_dims, my_min_dims, len);
-    LaunchDims dims {my_dims, my_min_dims};
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
-    // combine with enclosed statements
     LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);
-    return dims.max(enclosed_dims);
+
+    return combine(dims, enclosed_dims);
   }
 };
 
@@ -363,6 +357,8 @@ struct CudaStatementExecutor<Data,
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
+  using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<cuda_warp_loop>;
+
   static_assert(mask_t::max_masked_size <=
                     RAJA::policy::cuda::device_constants.WARP_SIZE,
                 "BitMask is too large for CUDA warp size");
@@ -393,20 +389,13 @@ struct CudaStatementExecutor<Data,
 
   static inline LaunchDims calculateDimensions(Data const& data)
   {
-    // Get enclosed statements
-    LaunchDims dims = enclosed_stmts_t::calculateDimensions(data);
+    diff_t len = segment_length<ArgumentId>(data);
 
-    // we always get EXACTLY one warp by allocating one warp in the X
-    // dimension
-    const diff_t len = RAJA::policy::cuda::device_constants.WARP_SIZE;
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
-    // request one thread per element in the segment
-    set_cuda_dim<named_dim::x>(dims.dims.threads, len);
+    LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);
 
-    // since we are direct-mapping, we REQUIRE len
-    set_cuda_dim<named_dim::x>(dims.min_dims.threads, len);
-
-    return (dims);
+    return combine(dims, enclosed_dims);
   }
 };
 
@@ -440,6 +429,9 @@ struct CudaStatementExecutor<
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
+  using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<
+      cuda_thread_size_x_direct<mask_t::max_input_size>>;
+
   static inline RAJA_DEVICE void exec(Data& data, bool thread_active)
   {
     const diff_t len = segment_length<ArgumentId>(data);
@@ -455,21 +447,13 @@ struct CudaStatementExecutor<
 
   static inline LaunchDims calculateDimensions(Data const& data)
   {
-    // Get enclosed statements
-    LaunchDims dims;
+    const diff_t len = segment_length<ArgumentId>(data);
 
-    // we need to allocate enough threads for the segment size, and the
-    // shifted off bits
-    const diff_t len = mask_t::max_input_size;
-
-    // request one thread per element in the segment
-    set_cuda_dim<named_dim::x>(dims.dims.threads, len);
-
-    // since we are direct-mapping, we REQUIRE len
-    set_cuda_dim<named_dim::x>(dims.min_dims.threads, len);
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
     LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);
-    return (dims.max(enclosed_dims));
+
+    return combine(dims, enclosed_dims);
   }
 };
 
@@ -502,6 +486,9 @@ struct CudaStatementExecutor<Data,
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
+  using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<
+      cuda_thread_size_x_loop<mask_t::max_input_size>>;
+
   static inline RAJA_DEVICE void exec(Data& data, bool thread_active)
   {
     // masked size strided loop
@@ -528,21 +515,13 @@ struct CudaStatementExecutor<Data,
 
   static inline LaunchDims calculateDimensions(Data const& data)
   {
-    // Get enclosed statements
-    LaunchDims dims;
+    diff_t len = segment_length<ArgumentId>(data);
 
-    // we need to allocate enough threads for the segment size, and the
-    // shifted off bits
-    const diff_t len = mask_t::max_input_size;
-
-    // request one thread per element in the segment
-    set_cuda_dim<named_dim::x>(dims.dims.threads, len);
-
-    // since we are direct-mapping, we REQUIRE len
-    set_cuda_dim<named_dim::x>(dims.min_dims.threads, len);
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
     LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);
-    return (dims.max(enclosed_dims));
+
+    return combine(dims, enclosed_dims);
   }
 };
 

--- a/include/RAJA/policy/cuda/kernel/For.hpp
+++ b/include/RAJA/policy/cuda/kernel/For.hpp
@@ -357,7 +357,8 @@ struct CudaStatementExecutor<Data,
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
-  using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<cuda_warp_loop>;
+  using DimensionCalculator =
+      RAJA::internal::KernelDimensionCalculator<cuda_warp_loop>;
 
   static_assert(mask_t::max_masked_size <=
                     RAJA::policy::cuda::device_constants.WARP_SIZE,

--- a/include/RAJA/policy/cuda/kernel/Tile.hpp
+++ b/include/RAJA/policy/cuda/kernel/Tile.hpp
@@ -111,9 +111,7 @@ struct CudaStatementExecutor<
     const diff_t len =
         RAJA_DIVIDE_CEILING_INT(full_len, static_cast<diff_t>(chunk_size));
 
-    CudaDims my_dims(0), my_min_dims(0);
-    DimensionCalculator {}.set_dimensions(my_dims, my_min_dims, len);
-    LaunchDims dims {my_dims, my_min_dims};
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
     // privatize data, so we can mess with the segments
     using data_t        = camp::decay<Data>;
@@ -128,7 +126,7 @@ struct CudaStatementExecutor<
     LaunchDims enclosed_dims =
         enclosed_stmts_t::calculateDimensions(private_data);
 
-    return dims.max(enclosed_dims);
+    return combine(dims, enclosed_dims);
   }
 };
 
@@ -212,9 +210,7 @@ struct CudaStatementExecutor<
     const diff_t len =
         RAJA_DIVIDE_CEILING_INT(full_len, static_cast<diff_t>(chunk_size));
 
-    CudaDims my_dims(0), my_min_dims(0);
-    DimensionCalculator {}.set_dimensions(my_dims, my_min_dims, len);
-    LaunchDims dims {my_dims, my_min_dims};
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
     // privatize data, so we can mess with the segments
     using data_t        = camp::decay<Data>;
@@ -229,7 +225,7 @@ struct CudaStatementExecutor<
     LaunchDims enclosed_dims =
         enclosed_stmts_t::calculateDimensions(private_data);
 
-    return dims.max(enclosed_dims);
+    return combine(dims, enclosed_dims);
   }
 };
 
@@ -308,9 +304,7 @@ struct CudaStatementExecutor<
     const diff_t len =
         RAJA_DIVIDE_CEILING_INT(full_len, static_cast<diff_t>(chunk_size));
 
-    CudaDims my_dims(0), my_min_dims(0);
-    DimensionCalculator {}.set_dimensions(my_dims, my_min_dims, len);
-    LaunchDims dims {my_dims, my_min_dims};
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
     // privatize data, so we can mess with the segments
     using data_t        = camp::decay<Data>;
@@ -325,7 +319,7 @@ struct CudaStatementExecutor<
     LaunchDims enclosed_dims =
         enclosed_stmts_t::calculateDimensions(private_data);
 
-    return dims.max(enclosed_dims);
+    return combine(dims, enclosed_dims);
   }
 };
 

--- a/include/RAJA/policy/cuda/kernel/internal.hpp
+++ b/include/RAJA/policy/cuda/kernel/internal.hpp
@@ -46,15 +46,15 @@ namespace internal
 struct LaunchDims
 {
 
-  CudaDims active{0};
-  CudaDims dims{0};
-  CudaDims min_dims{0};
+  CudaDims active {0};
+  CudaDims dims {0};
+  CudaDims min_dims {0};
 
   LaunchDims()                             = default;
   LaunchDims(LaunchDims const&)            = default;
-  LaunchDims(LaunchDims &&)                = default;
+  LaunchDims(LaunchDims&&)                 = default;
   LaunchDims& operator=(LaunchDims const&) = default;
-  LaunchDims& operator=(LaunchDims &&)     = default;
+  LaunchDims& operator=(LaunchDims&&)      = default;
 
   RAJA_INLINE
   LaunchDims(CudaDims _active, CudaDims _dims, CudaDims _min_dims)
@@ -113,11 +113,14 @@ struct LaunchDims
   RAJA_INLINE
   int num_blocks() const
   {
-    if (blocks_are_active()) {
+    if (blocks_are_active())
+    {
       return (active.blocks.x ? dims.blocks.x : 1) *
              (active.blocks.y ? dims.blocks.y : 1) *
              (active.blocks.z ? dims.blocks.z : 1);
-    } else {
+    }
+    else
+    {
       return 0;
     }
   }
@@ -125,11 +128,14 @@ struct LaunchDims
   RAJA_INLINE
   int num_threads() const
   {
-    if (threads_are_active()) {
+    if (threads_are_active())
+    {
       return (active.threads.x ? dims.threads.x : 1) *
              (active.threads.y ? dims.threads.y : 1) *
              (active.threads.z ? dims.threads.z : 1);
-    } else {
+    }
+    else
+    {
       return 0;
     }
   }
@@ -152,7 +158,7 @@ struct LaunchDims
 };
 
 RAJA_INLINE
-LaunchDims combine(LaunchDims const &lhs, LaunchDims const &rhs)
+LaunchDims combine(LaunchDims const& lhs, LaunchDims const& rhs)
 {
   return lhs.max(rhs);
 }
@@ -254,7 +260,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
   using IndexMapper =
       cuda::IndexGlobal<dim, named_usage::ignored, named_usage::ignored>;
 
-  template < typename IdxT >
+  template<typename IdxT>
   static LaunchDims get_dimensions(IdxT len)
   {
     if (len > static_cast<IdxT>(1))
@@ -263,7 +269,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
           "len exceeds the size of the directly mapped index space");
     }
 
-    return LaunchDims{};
+    return LaunchDims {};
   }
 };
 
@@ -284,9 +290,11 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     // BEWARE: if calculated block_size is too high then the kernel launch will
     // fail
-    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>(len));
-    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(len));
+    set_cuda_dim<dim>(dims.active.threads,
+                      static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.threads, static_cast<cuda_dim_member_t>(len));
+    set_cuda_dim<dim>(dims.min_dims.threads,
+                      static_cast<cuda_dim_member_t>(len));
 
     return dims;
   }
@@ -318,9 +326,13 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     LaunchDims dims;
 
-    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
-    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
+    set_cuda_dim<dim>(dims.active.threads,
+                      static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.threads,
+                      static_cast<cuda_dim_member_t>(
+                          (len > zero) ? IndexMapper::block_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.threads,
+                      static_cast<cuda_dim_member_t>(IndexMapper::block_size));
 
     return dims;
   }
@@ -341,9 +353,10 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
   {
     LaunchDims dims;
 
-    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>(len));
-    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(len));
+    set_cuda_dim<dim>(dims.active.blocks, static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.blocks, static_cast<cuda_dim_member_t>(len));
+    set_cuda_dim<dim>(dims.min_dims.blocks,
+                      static_cast<cuda_dim_member_t>(len));
 
     return dims;
   }
@@ -375,9 +388,12 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     LaunchDims dims;
 
-    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
-    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
+    set_cuda_dim<dim>(dims.active.blocks, static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.blocks,
+                      static_cast<cuda_dim_member_t>(
+                          (len > zero) ? IndexMapper::grid_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.blocks,
+                      static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
 
     return dims;
   }
@@ -393,7 +409,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
   using IndexMapper = cuda::
       IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>;
 
-  template < typename IdxT >
+  template<typename IdxT>
   static LaunchDims get_dimensions(IdxT len)
   {
     if (len > static_cast<IdxT>(0))
@@ -401,7 +417,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
       RAJA_ABORT_OR_THROW("must know one of block_size or grid_size");
     }
 
-    return LaunchDims{};
+    return LaunchDims {};
   }
 };
 
@@ -424,18 +440,26 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
   {
     constexpr auto zero = static_cast<IdxT>(0);
 
-    // BEWARE: if calculated block_size is too high then the kernel launch will fail
-    const IdxT block_size = RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::grid_size));
+    // BEWARE: if calculated block_size is too high then the kernel launch will
+    // fail
+    const IdxT block_size =
+        RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::grid_size));
 
     LaunchDims dims;
 
-    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>(block_size));
-    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(block_size));
+    set_cuda_dim<dim>(dims.active.threads,
+                      static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.threads,
+                      static_cast<cuda_dim_member_t>(block_size));
+    set_cuda_dim<dim>(dims.min_dims.threads,
+                      static_cast<cuda_dim_member_t>(block_size));
 
-    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
-    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
+    set_cuda_dim<dim>(dims.active.blocks, static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.blocks,
+                      static_cast<cuda_dim_member_t>(
+                          (len > zero) ? IndexMapper::grid_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.blocks,
+                      static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
 
     return dims;
   }
@@ -460,17 +484,24 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
   {
     constexpr auto zero = static_cast<IdxT>(0);
 
-    const IdxT grid_size = RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::block_size));
+    const IdxT grid_size = RAJA_DIVIDE_CEILING_INT(
+        len, static_cast<IdxT>(IndexMapper::block_size));
 
     LaunchDims dims;
 
-    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
-    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
+    set_cuda_dim<dim>(dims.active.threads,
+                      static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.threads,
+                      static_cast<cuda_dim_member_t>(
+                          (len > zero) ? IndexMapper::block_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.threads,
+                      static_cast<cuda_dim_member_t>(IndexMapper::block_size));
 
-    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>(grid_size));
-    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(grid_size));
+    set_cuda_dim<dim>(dims.active.blocks, static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.blocks,
+                      static_cast<cuda_dim_member_t>(grid_size));
+    set_cuda_dim<dim>(dims.min_dims.blocks,
+                      static_cast<cuda_dim_member_t>(grid_size));
 
     return dims;
   }
@@ -509,13 +540,20 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     LaunchDims dims;
 
-    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
-    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
+    set_cuda_dim<dim>(dims.active.threads,
+                      static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.threads,
+                      static_cast<cuda_dim_member_t>(
+                          (len > zero) ? IndexMapper::block_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.threads,
+                      static_cast<cuda_dim_member_t>(IndexMapper::block_size));
 
-    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
-    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
+    set_cuda_dim<dim>(dims.active.blocks, static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.blocks,
+                      static_cast<cuda_dim_member_t>(
+                          (len > zero) ? IndexMapper::grid_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.blocks,
+                      static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
 
     return dims;
   }
@@ -531,10 +569,10 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
   using IndexMapper =
       cuda::IndexGlobal<dim, named_usage::ignored, named_usage::ignored>;
 
-  template < typename IdxT >
+  template<typename IdxT>
   static LaunchDims get_dimensions(IdxT RAJA_UNUSED_ARG(len))
   {
-    return LaunchDims{};
+    return LaunchDims {};
   }
 };
 
@@ -555,8 +593,9 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     // BEWARE: if calculated block_size is too high then the kernel launch will
     // fail
-    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>(len));
+    set_cuda_dim<dim>(dims.active.threads,
+                      static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.threads, static_cast<cuda_dim_member_t>(len));
     set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(1));
 
     return dims;
@@ -576,16 +615,20 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
   using IndexMapper = cuda::IndexGlobal<dim, BLOCK_SIZE, named_usage::ignored>;
 
-  template < typename IdxT >
+  template<typename IdxT>
   static LaunchDims get_dimensions(IdxT len)
   {
     constexpr auto zero = static_cast<IdxT>(0);
 
     LaunchDims dims;
 
-    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
-    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
+    set_cuda_dim<dim>(dims.active.threads,
+                      static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.threads,
+                      static_cast<cuda_dim_member_t>(
+                          (len > zero) ? IndexMapper::block_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.threads,
+                      static_cast<cuda_dim_member_t>(IndexMapper::block_size));
 
     return dims;
   }
@@ -606,8 +649,8 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
   {
     LaunchDims dims;
 
-    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>(len));
+    set_cuda_dim<dim>(dims.active.blocks, static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.blocks, static_cast<cuda_dim_member_t>(len));
     set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(1));
 
     return dims;
@@ -627,16 +670,19 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
   using IndexMapper = cuda::IndexGlobal<dim, named_usage::ignored, GRID_SIZE>;
 
-  template < typename IdxT >
+  template<typename IdxT>
   static LaunchDims get_dimensions(IdxT len)
   {
     constexpr auto zero = static_cast<IdxT>(0);
 
     LaunchDims dims;
 
-    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
-    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
+    set_cuda_dim<dim>(dims.active.blocks, static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.blocks,
+                      static_cast<cuda_dim_member_t>(
+                          (len > zero) ? IndexMapper::grid_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.blocks,
+                      static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
 
     return dims;
   }
@@ -659,12 +705,15 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     LaunchDims dims;
 
-    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? 1 : 0));
+    set_cuda_dim<dim>(dims.active.threads,
+                      static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.threads,
+                      static_cast<cuda_dim_member_t>((len > zero) ? 1 : 0));
     set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(1));
 
-    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? 1 : 0));
+    set_cuda_dim<dim>(dims.active.blocks, static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.blocks,
+                      static_cast<cuda_dim_member_t>((len > zero) ? 1 : 0));
     set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(1));
 
     return dims;
@@ -690,18 +739,25 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
   {
     constexpr auto zero = static_cast<IdxT>(0);
 
-    // BEWARE: if calculated block_size is too high then the kernel launch will fail
-    const IdxT block_size = RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::grid_size));
+    // BEWARE: if calculated block_size is too high then the kernel launch will
+    // fail
+    const IdxT block_size =
+        RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::grid_size));
 
     LaunchDims dims;
 
-    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>(block_size));
+    set_cuda_dim<dim>(dims.active.threads,
+                      static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.threads,
+                      static_cast<cuda_dim_member_t>(block_size));
     set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(1));
 
-    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
-    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
+    set_cuda_dim<dim>(dims.active.blocks, static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.blocks,
+                      static_cast<cuda_dim_member_t>(
+                          (len > zero) ? IndexMapper::grid_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.blocks,
+                      static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
 
     return dims;
   }
@@ -726,16 +782,22 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
   {
     constexpr auto zero = static_cast<IdxT>(0);
 
-    const IdxT grid_size = RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::block_size));
+    const IdxT grid_size = RAJA_DIVIDE_CEILING_INT(
+        len, static_cast<IdxT>(IndexMapper::block_size));
 
     LaunchDims dims;
 
-    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
-    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
+    set_cuda_dim<dim>(dims.active.threads,
+                      static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.threads,
+                      static_cast<cuda_dim_member_t>(
+                          (len > zero) ? IndexMapper::block_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.threads,
+                      static_cast<cuda_dim_member_t>(IndexMapper::block_size));
 
-    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>(grid_size));
+    set_cuda_dim<dim>(dims.active.blocks, static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.blocks,
+                      static_cast<cuda_dim_member_t>(grid_size));
     set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(1));
 
     return dims;
@@ -761,20 +823,27 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
   using IndexMapper = cuda::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>;
 
-  template < typename IdxT >
+  template<typename IdxT>
   static LaunchDims get_dimensions(IdxT len)
   {
     constexpr auto zero = static_cast<IdxT>(0);
 
     LaunchDims dims;
 
-    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
-    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
+    set_cuda_dim<dim>(dims.active.threads,
+                      static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.threads,
+                      static_cast<cuda_dim_member_t>(
+                          (len > zero) ? IndexMapper::block_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.threads,
+                      static_cast<cuda_dim_member_t>(IndexMapper::block_size));
 
-    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
-    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
-    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
+    set_cuda_dim<dim>(dims.active.blocks, static_cast<cuda_dim_member_t>(true));
+    set_cuda_dim<dim>(dims.dims.blocks,
+                      static_cast<cuda_dim_member_t>(
+                          (len > zero) ? IndexMapper::grid_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.blocks,
+                      static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
 
     return dims;
   }

--- a/include/RAJA/policy/cuda/kernel/internal.hpp
+++ b/include/RAJA/policy/cuda/kernel/internal.hpp
@@ -159,14 +159,11 @@ struct CudaStatementListExecutorHelper
   template<typename Data>
   inline static LaunchDims calculateDimensions(Data& data)
   {
-    // Compute this statements launch dimensions
     LaunchDims statement_dims = cur_stmt_t::calculateDimensions(data);
 
-    // call the next statement in the list
     LaunchDims next_dims = next_helper_t::calculateDimensions(data);
 
-    // Return the maximum of the two
-    return statement_dims.max(next_dims);
+    return combine(statement_dims, next_dims);
   }
 };
 

--- a/include/RAJA/policy/cuda/kernel/internal.hpp
+++ b/include/RAJA/policy/cuda/kernel/internal.hpp
@@ -99,19 +99,39 @@ struct LaunchDims
   }
 
   RAJA_INLINE
+  int blocks_are_active() const
+  {
+    return active.blocks.x || active.blocks.y || active.blocks.z;
+  }
+
+  RAJA_INLINE
+  int threads_are_active() const
+  {
+    return active.threads.x || active.threads.y || active.threads.z;
+  }
+
+  RAJA_INLINE
   int num_blocks() const
   {
-    return (active.blocks.x ? dims.blocks.x : 1) *
-           (active.blocks.y ? dims.blocks.y : 1) *
-           (active.blocks.z ? dims.blocks.z : 1);
+    if (blocks_are_active()) {
+      return (active.blocks.x ? dims.blocks.x : 1) *
+             (active.blocks.y ? dims.blocks.y : 1) *
+             (active.blocks.z ? dims.blocks.z : 1);
+    } else {
+      return 0;
+    }
   }
 
   RAJA_INLINE
   int num_threads() const
   {
-    return (active.threads.x ? dims.threads.x : 1) *
-           (active.threads.y ? dims.threads.y : 1) *
-           (active.threads.z ? dims.threads.z : 1);
+    if (threads_are_active()) {
+      return (active.threads.x ? dims.threads.x : 1) *
+             (active.threads.y ? dims.threads.y : 1) *
+             (active.threads.z ? dims.threads.z : 1);
+    } else {
+      return 0;
+    }
   }
 
   RAJA_INLINE

--- a/include/RAJA/policy/cuda/kernel/internal.hpp
+++ b/include/RAJA/policy/cuda/kernel/internal.hpp
@@ -267,6 +267,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     // BEWARE: if calculated block_size is too high then the kernel launch will
     // fail
+    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>(len));
     set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(len));
 
@@ -300,6 +301,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     LaunchDims dims;
 
+    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
     set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
 
@@ -322,6 +324,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
   {
     LaunchDims dims;
 
+    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>(len));
     set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(len));
 
@@ -355,6 +358,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     LaunchDims dims;
 
+    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
     set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
 
@@ -408,9 +412,11 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     LaunchDims dims;
 
+    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>(block_size));
     set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(block_size));
 
+    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
     set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
 
@@ -441,9 +447,11 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     LaunchDims dims;
 
+    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
     set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
 
+    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>(grid_size));
     set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(grid_size));
 
@@ -484,9 +492,11 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     LaunchDims dims;
 
+    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
     set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
 
+    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
     set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
 
@@ -528,6 +538,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     // BEWARE: if calculated block_size is too high then the kernel launch will
     // fail
+    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>(len));
     set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(1));
 
@@ -555,6 +566,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     LaunchDims dims;
 
+    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
     set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
 
@@ -577,6 +589,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
   {
     LaunchDims dims;
 
+    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>(len));
     set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(1));
 
@@ -604,6 +617,7 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     LaunchDims dims;
 
+    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
     set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
 
@@ -628,9 +642,11 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     LaunchDims dims;
 
+    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? 1 : 0));
     set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(1));
 
+    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? 1 : 0));
     set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(1));
 
@@ -662,9 +678,11 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     LaunchDims dims;
 
+    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>(block_size));
     set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(1));
 
+    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
     set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
 
@@ -695,9 +713,11 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     LaunchDims dims;
 
+    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
     set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
 
+    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>(grid_size));
     set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(1));
 
@@ -731,9 +751,11 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
     LaunchDims dims;
 
+    set_cuda_dim<dim>(dims.  active.threads, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
     set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
 
+    set_cuda_dim<dim>(dims.  active.blocks, static_cast<cuda_dim_member_t>(true));
     set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
     set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
 

--- a/include/RAJA/policy/cuda/kernel/internal.hpp
+++ b/include/RAJA/policy/cuda/kernel/internal.hpp
@@ -212,16 +212,16 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
   using IndexMapper =
       cuda::IndexGlobal<dim, named_usage::ignored, named_usage::ignored>;
 
-  template<typename IdxT>
-  static void set_dimensions(CudaDims& RAJA_UNUSED_ARG(dims),
-                             CudaDims& RAJA_UNUSED_ARG(min_dims),
-                             IdxT len)
+  template < typename IdxT >
+  static LaunchDims get_dimensions(IdxT len)
   {
     if (len > static_cast<IdxT>(1))
     {
       RAJA_ABORT_OR_THROW(
           "len exceeds the size of the directly mapped index space");
     }
+
+    return LaunchDims{};
   }
 };
 
@@ -236,12 +236,16 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
       cuda::IndexGlobal<dim, named_usage::unspecified, named_usage::ignored>;
 
   template<typename IdxT>
-  static void set_dimensions(CudaDims& dims, CudaDims& min_dims, IdxT len)
+  static LaunchDims get_dimensions(IdxT len)
   {
+    LaunchDims dims;
+
     // BEWARE: if calculated block_size is too high then the kernel launch will
     // fail
-    set_cuda_dim<dim>(dims.threads, static_cast<IdxT>(len));
-    set_cuda_dim<dim>(min_dims.threads, static_cast<IdxT>(len));
+    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>(len));
+    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(len));
+
+    return dims;
   }
 };
 
@@ -259,16 +263,22 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
   using IndexMapper = cuda::IndexGlobal<dim, BLOCK_SIZE, named_usage::ignored>;
 
   template<typename IdxT>
-  static void set_dimensions(CudaDims& dims, CudaDims& min_dims, IdxT len)
+  static LaunchDims get_dimensions(IdxT len)
   {
+    constexpr auto zero = static_cast<IdxT>(0);
+
     if (len > static_cast<IdxT>(IndexMapper::block_size))
     {
       RAJA_ABORT_OR_THROW(
           "len exceeds the size of the directly mapped index space");
     }
-    set_cuda_dim<dim>(dims.threads, static_cast<IdxT>(IndexMapper::block_size));
-    set_cuda_dim<dim>(min_dims.threads,
-                      static_cast<IdxT>(IndexMapper::block_size));
+
+    LaunchDims dims;
+
+    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
+
+    return dims;
   }
 };
 
@@ -283,10 +293,14 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
       cuda::IndexGlobal<dim, named_usage::ignored, named_usage::unspecified>;
 
   template<typename IdxT>
-  static void set_dimensions(CudaDims& dims, CudaDims& min_dims, IdxT len)
+  static LaunchDims get_dimensions(IdxT len)
   {
-    set_cuda_dim<dim>(dims.blocks, static_cast<IdxT>(len));
-    set_cuda_dim<dim>(min_dims.blocks, static_cast<IdxT>(len));
+    LaunchDims dims;
+
+    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>(len));
+    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(len));
+
+    return dims;
   }
 };
 
@@ -304,16 +318,22 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
   using IndexMapper = cuda::IndexGlobal<dim, named_usage::ignored, GRID_SIZE>;
 
   template<typename IdxT>
-  static void set_dimensions(CudaDims& dims, CudaDims& min_dims, IdxT len)
+  static LaunchDims get_dimensions(IdxT len)
   {
+    constexpr auto zero = static_cast<IdxT>(0);
+
     if (len > static_cast<IdxT>(IndexMapper::grid_size))
     {
       RAJA_ABORT_OR_THROW(
           "len exceeds the size of the directly mapped index space");
     }
-    set_cuda_dim<dim>(dims.blocks, static_cast<IdxT>(IndexMapper::grid_size));
-    set_cuda_dim<dim>(min_dims.blocks,
-                      static_cast<IdxT>(IndexMapper::grid_size));
+
+    LaunchDims dims;
+
+    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
+
+    return dims;
   }
 };
 
@@ -327,15 +347,15 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
   using IndexMapper = cuda::
       IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>;
 
-  template<typename IdxT>
-  static void set_dimensions(CudaDims& RAJA_UNUSED_ARG(dims),
-                             CudaDims& RAJA_UNUSED_ARG(min_dims),
-                             IdxT len)
+  template < typename IdxT >
+  static LaunchDims get_dimensions(IdxT len)
   {
     if (len > static_cast<IdxT>(0))
     {
       RAJA_ABORT_OR_THROW("must know one of block_size or grid_size");
     }
+
+    return LaunchDims{};
   }
 };
 
@@ -354,19 +374,22 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
       cuda::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>;
 
   template<typename IdxT>
-  static void set_dimensions(CudaDims& dims, CudaDims& min_dims, IdxT len)
+  static LaunchDims get_dimensions(IdxT len)
   {
-    // BEWARE: if calculated block_size is too high then the kernel launch will
-    // fail
-    set_cuda_dim<dim>(dims.threads,
-                      RAJA_DIVIDE_CEILING_INT(
-                          len, static_cast<IdxT>(IndexMapper::grid_size)));
-    set_cuda_dim<dim>(dims.blocks, static_cast<IdxT>(IndexMapper::grid_size));
-    set_cuda_dim<dim>(min_dims.threads,
-                      RAJA_DIVIDE_CEILING_INT(
-                          len, static_cast<IdxT>(IndexMapper::grid_size)));
-    set_cuda_dim<dim>(min_dims.blocks,
-                      static_cast<IdxT>(IndexMapper::grid_size));
+    constexpr auto zero = static_cast<IdxT>(0);
+
+    // BEWARE: if calculated block_size is too high then the kernel launch will fail
+    const IdxT block_size = RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::grid_size));
+
+    LaunchDims dims;
+
+    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>(block_size));
+    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(block_size));
+
+    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
+
+    return dims;
   }
 };
 
@@ -385,17 +408,21 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
       cuda::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>;
 
   template<typename IdxT>
-  static void set_dimensions(CudaDims& dims, CudaDims& min_dims, IdxT len)
+  static LaunchDims get_dimensions(IdxT len)
   {
-    set_cuda_dim<dim>(dims.threads, static_cast<IdxT>(IndexMapper::block_size));
-    set_cuda_dim<dim>(dims.blocks,
-                      RAJA_DIVIDE_CEILING_INT(
-                          len, static_cast<IdxT>(IndexMapper::block_size)));
-    set_cuda_dim<dim>(min_dims.threads,
-                      static_cast<IdxT>(IndexMapper::block_size));
-    set_cuda_dim<dim>(min_dims.blocks,
-                      RAJA_DIVIDE_CEILING_INT(
-                          len, static_cast<IdxT>(IndexMapper::block_size)));
+    constexpr auto zero = static_cast<IdxT>(0);
+
+    const IdxT grid_size = RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::block_size));
+
+    LaunchDims dims;
+
+    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
+
+    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>(grid_size));
+    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(grid_size));
+
+    return dims;
   }
 };
 
@@ -419,20 +446,26 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
   using IndexMapper = cuda::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>;
 
   template<typename IdxT>
-  static void set_dimensions(CudaDims& dims, CudaDims& min_dims, IdxT len)
+  static LaunchDims get_dimensions(IdxT len)
   {
+    constexpr auto zero = static_cast<IdxT>(0);
+
     if (len > (static_cast<IdxT>(IndexMapper::block_size) *
                static_cast<IdxT>(IndexMapper::grid_size)))
     {
       RAJA_ABORT_OR_THROW(
           "len exceeds the size of the directly mapped index space");
     }
-    set_cuda_dim<dim>(dims.threads, static_cast<IdxT>(IndexMapper::block_size));
-    set_cuda_dim<dim>(dims.blocks, static_cast<IdxT>(IndexMapper::grid_size));
-    set_cuda_dim<dim>(min_dims.threads,
-                      static_cast<IdxT>(IndexMapper::block_size));
-    set_cuda_dim<dim>(min_dims.blocks,
-                      static_cast<IdxT>(IndexMapper::grid_size));
+
+    LaunchDims dims;
+
+    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
+
+    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
+
+    return dims;
   }
 };
 
@@ -446,11 +479,11 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
   using IndexMapper =
       cuda::IndexGlobal<dim, named_usage::ignored, named_usage::ignored>;
 
-  template<typename IdxT>
-  static void set_dimensions(CudaDims& RAJA_UNUSED_ARG(dims),
-                             CudaDims& RAJA_UNUSED_ARG(min_dims),
-                             IdxT RAJA_UNUSED_ARG(len))
-  {}
+  template < typename IdxT >
+  static LaunchDims get_dimensions(IdxT RAJA_UNUSED_ARG(len))
+  {
+    return LaunchDims{};
+  }
 };
 
 // specialization for strided loop thread policies
@@ -464,12 +497,16 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
       cuda::IndexGlobal<dim, named_usage::unspecified, named_usage::ignored>;
 
   template<typename IdxT>
-  static void set_dimensions(CudaDims& dims, CudaDims& min_dims, IdxT len)
+  static LaunchDims get_dimensions(IdxT len)
   {
+    LaunchDims dims;
+
     // BEWARE: if calculated block_size is too high then the kernel launch will
     // fail
-    set_cuda_dim<dim>(dims.threads, static_cast<IdxT>(len));
-    set_cuda_dim<dim>(min_dims.threads, static_cast<IdxT>(1));
+    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>(len));
+    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(1));
+
+    return dims;
   }
 };
 
@@ -486,14 +523,17 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
   using IndexMapper = cuda::IndexGlobal<dim, BLOCK_SIZE, named_usage::ignored>;
 
-  template<typename IdxT>
-  static void set_dimensions(CudaDims& dims,
-                             CudaDims& min_dims,
-                             IdxT RAJA_UNUSED_ARG(len))
+  template < typename IdxT >
+  static LaunchDims get_dimensions(IdxT len)
   {
-    set_cuda_dim<dim>(dims.threads, static_cast<IdxT>(IndexMapper::block_size));
-    set_cuda_dim<dim>(min_dims.threads,
-                      static_cast<IdxT>(IndexMapper::block_size));
+    constexpr auto zero = static_cast<IdxT>(0);
+
+    LaunchDims dims;
+
+    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
+
+    return dims;
   }
 };
 
@@ -508,10 +548,14 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
       cuda::IndexGlobal<dim, named_usage::ignored, named_usage::unspecified>;
 
   template<typename IdxT>
-  static void set_dimensions(CudaDims& dims, CudaDims& min_dims, IdxT len)
+  static LaunchDims get_dimensions(IdxT len)
   {
-    set_cuda_dim<dim>(dims.blocks, static_cast<IdxT>(len));
-    set_cuda_dim<dim>(min_dims.blocks, static_cast<IdxT>(1));
+    LaunchDims dims;
+
+    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>(len));
+    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(1));
+
+    return dims;
   }
 };
 
@@ -528,14 +572,17 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
   using IndexMapper = cuda::IndexGlobal<dim, named_usage::ignored, GRID_SIZE>;
 
-  template<typename IdxT>
-  static void set_dimensions(CudaDims& dims,
-                             CudaDims& min_dims,
-                             IdxT RAJA_UNUSED_ARG(len))
+  template < typename IdxT >
+  static LaunchDims get_dimensions(IdxT len)
   {
-    set_cuda_dim<dim>(dims.blocks, static_cast<IdxT>(IndexMapper::grid_size));
-    set_cuda_dim<dim>(min_dims.blocks,
-                      static_cast<IdxT>(IndexMapper::grid_size));
+    constexpr auto zero = static_cast<IdxT>(0);
+
+    LaunchDims dims;
+
+    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
+
+    return dims;
   }
 };
 
@@ -550,15 +597,19 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
       IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>;
 
   template<typename IdxT>
-  static void set_dimensions(CudaDims& dims, CudaDims& min_dims, IdxT len)
+  static LaunchDims get_dimensions(IdxT len)
   {
-    if (len > static_cast<IdxT>(0))
-    {
-      set_cuda_dim<dim>(dims.threads, static_cast<IdxT>(1));
-      set_cuda_dim<dim>(dims.blocks, static_cast<IdxT>(1));
-      set_cuda_dim<dim>(min_dims.threads, static_cast<IdxT>(1));
-      set_cuda_dim<dim>(min_dims.blocks, static_cast<IdxT>(1));
-    }
+    constexpr auto zero = static_cast<IdxT>(0);
+
+    LaunchDims dims;
+
+    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? 1 : 0));
+    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(1));
+
+    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? 1 : 0));
+    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(1));
+
+    return dims;
   }
 };
 
@@ -577,17 +628,22 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
       cuda::IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>;
 
   template<typename IdxT>
-  static void set_dimensions(CudaDims& dims, CudaDims& min_dims, IdxT len)
+  static LaunchDims get_dimensions(IdxT len)
   {
-    // BEWARE: if calculated block_size is too high then the kernel launch will
-    // fail
-    set_cuda_dim<dim>(dims.threads,
-                      RAJA_DIVIDE_CEILING_INT(
-                          len, static_cast<IdxT>(IndexMapper::grid_size)));
-    set_cuda_dim<dim>(dims.blocks, static_cast<IdxT>(IndexMapper::grid_size));
-    set_cuda_dim<dim>(min_dims.threads, static_cast<IdxT>(1));
-    set_cuda_dim<dim>(min_dims.blocks,
-                      static_cast<IdxT>(IndexMapper::grid_size));
+    constexpr auto zero = static_cast<IdxT>(0);
+
+    // BEWARE: if calculated block_size is too high then the kernel launch will fail
+    const IdxT block_size = RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::grid_size));
+
+    LaunchDims dims;
+
+    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>(block_size));
+    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(1));
+
+    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
+
+    return dims;
   }
 };
 
@@ -606,15 +662,21 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
       cuda::IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>;
 
   template<typename IdxT>
-  static void set_dimensions(CudaDims& dims, CudaDims& min_dims, IdxT len)
+  static LaunchDims get_dimensions(IdxT len)
   {
-    set_cuda_dim<dim>(dims.threads, static_cast<IdxT>(IndexMapper::block_size));
-    set_cuda_dim<dim>(dims.blocks,
-                      RAJA_DIVIDE_CEILING_INT(
-                          len, static_cast<IdxT>(IndexMapper::block_size)));
-    set_cuda_dim<dim>(min_dims.threads,
-                      static_cast<IdxT>(IndexMapper::block_size));
-    set_cuda_dim<dim>(min_dims.blocks, static_cast<IdxT>(1));
+    constexpr auto zero = static_cast<IdxT>(0);
+
+    const IdxT grid_size = RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::block_size));
+
+    LaunchDims dims;
+
+    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
+
+    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>(grid_size));
+    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(1));
+
+    return dims;
   }
 };
 
@@ -637,17 +699,20 @@ struct KernelDimensionCalculator<RAJA::policy::cuda::cuda_indexer<
 
   using IndexMapper = cuda::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>;
 
-  template<typename IdxT>
-  static void set_dimensions(CudaDims& dims,
-                             CudaDims& min_dims,
-                             IdxT RAJA_UNUSED_ARG(len))
+  template < typename IdxT >
+  static LaunchDims get_dimensions(IdxT len)
   {
-    set_cuda_dim<dim>(dims.threads, static_cast<IdxT>(IndexMapper::block_size));
-    set_cuda_dim<dim>(dims.blocks, static_cast<IdxT>(IndexMapper::grid_size));
-    set_cuda_dim<dim>(min_dims.threads,
-                      static_cast<IdxT>(IndexMapper::block_size));
-    set_cuda_dim<dim>(min_dims.blocks,
-                      static_cast<IdxT>(IndexMapper::grid_size));
+    constexpr auto zero = static_cast<IdxT>(0);
+
+    LaunchDims dims;
+
+    set_cuda_dim<dim>(dims.    dims.threads, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.threads, static_cast<cuda_dim_member_t>(IndexMapper::block_size));
+
+    set_cuda_dim<dim>(dims.    dims.blocks, static_cast<cuda_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
+    set_cuda_dim<dim>(dims.min_dims.blocks, static_cast<cuda_dim_member_t>(IndexMapper::grid_size));
+
+    return dims;
   }
 };
 

--- a/include/RAJA/policy/hip/kernel/For.hpp
+++ b/include/RAJA/policy/hip/kernel/For.hpp
@@ -292,7 +292,8 @@ struct HipStatementExecutor<Data,
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
-  using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<hip_warp_direct>;
+  using DimensionCalculator =
+      RAJA::internal::KernelDimensionCalculator<hip_warp_direct>;
 
   static_assert(mask_t::max_masked_size <=
                     RAJA::policy::hip::device_constants.WARP_SIZE,
@@ -352,7 +353,8 @@ struct HipStatementExecutor<Data,
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
-  using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<hip_warp_loop>;
+  using DimensionCalculator =
+      RAJA::internal::KernelDimensionCalculator<hip_warp_loop>;
 
   static_assert(mask_t::max_masked_size <=
                     RAJA::policy::hip::device_constants.WARP_SIZE,

--- a/include/RAJA/policy/hip/kernel/For.hpp
+++ b/include/RAJA/policy/hip/kernel/For.hpp
@@ -85,13 +85,11 @@ struct HipStatementExecutor<
   {
     const diff_t len = segment_length<ArgumentId>(data);
 
-    HipDims my_dims(0), my_min_dims(0);
-    DimensionCalculator::set_dimensions(my_dims, my_min_dims, len);
-    LaunchDims dims {my_dims, my_min_dims};
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
-    // combine with enclosed statements
     LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);
-    return dims.max(enclosed_dims);
+
+    return combine(dims, enclosed_dims);
   }
 };
 
@@ -162,13 +160,11 @@ struct HipStatementExecutor<
   {
     diff_t len = segment_length<ArgumentId>(data);
 
-    HipDims my_dims(0), my_min_dims(0);
-    DimensionCalculator {}.set_dimensions(my_dims, my_min_dims, len);
-    LaunchDims dims {my_dims, my_min_dims};
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
-    // combine with enclosed statements
     LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);
-    return dims.max(enclosed_dims);
+
+    return combine(dims, enclosed_dims);
   }
 };
 
@@ -234,13 +230,11 @@ struct HipStatementExecutor<
   {
     const diff_t len = segment_length<ArgumentId>(data);
 
-    HipDims my_dims(0), my_min_dims(0);
-    DimensionCalculator {}.set_dimensions(my_dims, my_min_dims, len);
-    LaunchDims dims {my_dims, my_min_dims};
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
-    // combine with enclosed statements
     LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);
-    return dims.max(enclosed_dims);
+
+    return combine(dims, enclosed_dims);
   }
 };
 
@@ -298,6 +292,8 @@ struct HipStatementExecutor<Data,
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
+  using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<hip_warp_direct>;
+
   static_assert(mask_t::max_masked_size <=
                     RAJA::policy::hip::device_constants.WARP_SIZE,
                 "BitMask is too large for HIP warp size");
@@ -317,20 +313,13 @@ struct HipStatementExecutor<Data,
 
   static inline LaunchDims calculateDimensions(Data const& data)
   {
-    // Get enclosed statements
-    LaunchDims dims = enclosed_stmts_t::calculateDimensions(data);
+    diff_t len = segment_length<ArgumentId>(data);
 
-    // we always get EXACTLY one warp by allocating one warp in the X
-    // dimension
-    const diff_t len = RAJA::policy::hip::device_constants.WARP_SIZE;
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
-    // request one thread per element in the segment
-    set_hip_dim<named_dim::x>(dims.dims.threads, len);
+    LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);
 
-    // since we are direct-mapping, we REQUIRE len
-    set_hip_dim<named_dim::x>(dims.min_dims.threads, len);
-
-    return (dims);
+    return combine(dims, enclosed_dims);
   }
 };
 
@@ -363,6 +352,8 @@ struct HipStatementExecutor<Data,
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
+  using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<hip_warp_loop>;
+
   static_assert(mask_t::max_masked_size <=
                     RAJA::policy::hip::device_constants.WARP_SIZE,
                 "BitMask is too large for HIP warp size");
@@ -393,20 +384,13 @@ struct HipStatementExecutor<Data,
 
   static inline LaunchDims calculateDimensions(Data const& data)
   {
-    // Get enclosed statements
-    LaunchDims dims = enclosed_stmts_t::calculateDimensions(data);
+    diff_t len = segment_length<ArgumentId>(data);
 
-    // we always get EXACTLY one warp by allocating one warp in the X
-    // dimension
-    const diff_t len = RAJA::policy::hip::device_constants.WARP_SIZE;
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
-    // request one thread per element in the segment
-    set_hip_dim<named_dim::x>(dims.dims.threads, len);
+    LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);
 
-    // since we are direct-mapping, we REQUIRE len
-    set_hip_dim<named_dim::x>(dims.min_dims.threads, len);
-
-    return (dims);
+    return combine(dims, enclosed_dims);
   }
 };
 
@@ -439,6 +423,9 @@ struct HipStatementExecutor<Data,
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
+  using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<
+      hip_thread_size_x_direct<mask_t::max_input_size>>;
+
   static inline RAJA_DEVICE void exec(Data& data, bool thread_active)
   {
     const diff_t len = segment_length<ArgumentId>(data);
@@ -454,21 +441,13 @@ struct HipStatementExecutor<Data,
 
   static inline LaunchDims calculateDimensions(Data const& data)
   {
-    // Get enclosed statements
-    LaunchDims dims;
+    const diff_t len = segment_length<ArgumentId>(data);
 
-    // we need to allocate enough threads for the segment size, and the
-    // shifted off bits
-    const diff_t len = mask_t::max_input_size;
-
-    // request one thread per element in the segment
-    set_hip_dim<named_dim::x>(dims.dims.threads, len);
-
-    // since we are direct-mapping, we REQUIRE len
-    set_hip_dim<named_dim::x>(dims.min_dims.threads, len);
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
     LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);
-    return (dims.max(enclosed_dims));
+
+    return combine(dims, enclosed_dims);
   }
 };
 
@@ -501,6 +480,9 @@ struct HipStatementExecutor<Data,
 
   using diff_t = segment_diff_type<ArgumentId, Data>;
 
+  using DimensionCalculator = RAJA::internal::KernelDimensionCalculator<
+      hip_thread_size_x_loop<mask_t::max_input_size>>;
+
   static inline RAJA_DEVICE void exec(Data& data, bool thread_active)
   {
     // masked size strided loop
@@ -527,21 +509,13 @@ struct HipStatementExecutor<Data,
 
   static inline LaunchDims calculateDimensions(Data const& data)
   {
-    // Get enclosed statements
-    LaunchDims dims;
+    diff_t len = segment_length<ArgumentId>(data);
 
-    // we need to allocate enough threads for the segment size, and the
-    // shifted off bits
-    const diff_t len = mask_t::max_input_size;
-
-    // request one thread per element in the segment
-    set_hip_dim<named_dim::x>(dims.dims.threads, len);
-
-    // since we are direct-mapping, we REQUIRE len
-    set_hip_dim<named_dim::x>(dims.min_dims.threads, len);
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
     LaunchDims enclosed_dims = enclosed_stmts_t::calculateDimensions(data);
-    return (dims.max(enclosed_dims));
+
+    return combine(dims, enclosed_dims);
   }
 };
 

--- a/include/RAJA/policy/hip/kernel/HipKernel.hpp
+++ b/include/RAJA/policy/hip/kernel/HipKernel.hpp
@@ -509,9 +509,13 @@ struct StatementExecutor<
 
 
     // Only launch kernel if we have something to iterate over
-    int num_blocks  = launch_dims.num_blocks();
-    int num_threads = launch_dims.num_threads();
-    if (num_blocks > 0 || num_threads > 0)
+    bool active_threads = launch_dims.threads_are_active();
+    bool active_blocks  = launch_dims.blocks_are_active();
+    int  num_blocks     = launch_dims.num_blocks();
+    int  num_threads    = launch_dims.num_threads();
+    if ((active_threads || active_blocks) &&
+        (!active_blocks || num_blocks > 0) &&
+        (!active_threads || num_threads > 0))
     {
 
       //

--- a/include/RAJA/policy/hip/kernel/HipKernel.hpp
+++ b/include/RAJA/policy/hip/kernel/HipKernel.hpp
@@ -511,8 +511,8 @@ struct StatementExecutor<
     // Only launch kernel if we have something to iterate over
     bool active_threads = launch_dims.threads_are_active();
     bool active_blocks  = launch_dims.blocks_are_active();
-    int  num_blocks     = launch_dims.num_blocks();
-    int  num_threads    = launch_dims.num_threads();
+    int num_blocks      = launch_dims.num_blocks();
+    int num_threads     = launch_dims.num_threads();
     if ((active_threads || active_blocks) &&
         (!active_blocks || num_blocks > 0) &&
         (!active_threads || num_threads > 0))

--- a/include/RAJA/policy/hip/kernel/Tile.hpp
+++ b/include/RAJA/policy/hip/kernel/Tile.hpp
@@ -111,9 +111,7 @@ struct HipStatementExecutor<
     const diff_t len =
         RAJA_DIVIDE_CEILING_INT(full_len, static_cast<diff_t>(chunk_size));
 
-    HipDims my_dims(0), my_min_dims(0);
-    DimensionCalculator {}.set_dimensions(my_dims, my_min_dims, len);
-    LaunchDims dims {my_dims, my_min_dims};
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
     // privatize data, so we can mess with the segments
     using data_t        = camp::decay<Data>;
@@ -128,7 +126,7 @@ struct HipStatementExecutor<
     LaunchDims enclosed_dims =
         enclosed_stmts_t::calculateDimensions(private_data);
 
-    return dims.max(enclosed_dims);
+    return combine(dims, enclosed_dims);
   }
 };
 
@@ -212,9 +210,7 @@ struct HipStatementExecutor<
     const diff_t len =
         RAJA_DIVIDE_CEILING_INT(full_len, static_cast<diff_t>(chunk_size));
 
-    HipDims my_dims(0), my_min_dims(0);
-    DimensionCalculator {}.set_dimensions(my_dims, my_min_dims, len);
-    LaunchDims dims {my_dims, my_min_dims};
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
     // privatize data, so we can mess with the segments
     using data_t        = camp::decay<Data>;
@@ -229,7 +225,7 @@ struct HipStatementExecutor<
     LaunchDims enclosed_dims =
         enclosed_stmts_t::calculateDimensions(private_data);
 
-    return dims.max(enclosed_dims);
+    return combine(dims, enclosed_dims);
   }
 };
 
@@ -308,9 +304,7 @@ struct HipStatementExecutor<
     const diff_t len =
         RAJA_DIVIDE_CEILING_INT(full_len, static_cast<diff_t>(chunk_size));
 
-    HipDims my_dims(0), my_min_dims(0);
-    DimensionCalculator {}.set_dimensions(my_dims, my_min_dims, len);
-    LaunchDims dims {my_dims, my_min_dims};
+    LaunchDims dims = DimensionCalculator::get_dimensions(len);
 
     // privatize data, so we can mess with the segments
     using data_t        = camp::decay<Data>;
@@ -325,7 +319,7 @@ struct HipStatementExecutor<
     LaunchDims enclosed_dims =
         enclosed_stmts_t::calculateDimensions(private_data);
 
-    return dims.max(enclosed_dims);
+    return combine(dims, enclosed_dims);
   }
 };
 

--- a/include/RAJA/policy/hip/kernel/internal.hpp
+++ b/include/RAJA/policy/hip/kernel/internal.hpp
@@ -46,15 +46,15 @@ namespace internal
 struct LaunchDims
 {
 
-  HipDims active{0};
-  HipDims dims{0};
-  HipDims min_dims{0};
+  HipDims active {0};
+  HipDims dims {0};
+  HipDims min_dims {0};
 
   LaunchDims()                             = default;
   LaunchDims(LaunchDims const&)            = default;
-  LaunchDims(LaunchDims &&)                = default;
+  LaunchDims(LaunchDims&&)                 = default;
   LaunchDims& operator=(LaunchDims const&) = default;
-  LaunchDims& operator=(LaunchDims &&)     = default;
+  LaunchDims& operator=(LaunchDims&&)      = default;
 
   RAJA_INLINE
   LaunchDims(HipDims _active, HipDims _dims, HipDims _min_dims)
@@ -113,11 +113,14 @@ struct LaunchDims
   RAJA_INLINE
   int num_blocks() const
   {
-    if (blocks_are_active()) {
+    if (blocks_are_active())
+    {
       return (active.blocks.x ? dims.blocks.x : 1) *
              (active.blocks.y ? dims.blocks.y : 1) *
              (active.blocks.z ? dims.blocks.z : 1);
-    } else {
+    }
+    else
+    {
       return 0;
     }
   }
@@ -125,11 +128,14 @@ struct LaunchDims
   RAJA_INLINE
   int num_threads() const
   {
-    if (threads_are_active()) {
+    if (threads_are_active())
+    {
       return (active.threads.x ? dims.threads.x : 1) *
              (active.threads.y ? dims.threads.y : 1) *
              (active.threads.z ? dims.threads.z : 1);
-    } else {
+    }
+    else
+    {
       return 0;
     }
   }
@@ -152,7 +158,7 @@ struct LaunchDims
 };
 
 RAJA_INLINE
-LaunchDims combine(LaunchDims const &lhs, LaunchDims const &rhs)
+LaunchDims combine(LaunchDims const& lhs, LaunchDims const& rhs)
 {
   return lhs.max(rhs);
 }
@@ -254,7 +260,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
   using IndexMapper =
       hip::IndexGlobal<dim, named_usage::ignored, named_usage::ignored>;
 
-  template < typename IdxT >
+  template<typename IdxT>
   static LaunchDims get_dimensions(IdxT len)
   {
     if (len > static_cast<IdxT>(1))
@@ -263,7 +269,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
           "len exceeds the size of the directly mapped index space");
     }
 
-    return LaunchDims{};
+    return LaunchDims {};
   }
 };
 
@@ -284,8 +290,8 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     // BEWARE: if calculated block_size is too high then the kernel launch will
     // fail
-    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>(len));
+    set_hip_dim<dim>(dims.active.threads, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.threads, static_cast<hip_dim_member_t>(len));
     set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(len));
 
     return dims;
@@ -318,9 +324,12 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     LaunchDims dims;
 
-    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
-    set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(IndexMapper::block_size));
+    set_hip_dim<dim>(dims.active.threads, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.threads,
+                     static_cast<hip_dim_member_t>(
+                         (len > zero) ? IndexMapper::block_size : 0));
+    set_hip_dim<dim>(dims.min_dims.threads,
+                     static_cast<hip_dim_member_t>(IndexMapper::block_size));
 
     return dims;
   }
@@ -341,8 +350,8 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
   {
     LaunchDims dims;
 
-    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>(len));
+    set_hip_dim<dim>(dims.active.blocks, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.blocks, static_cast<hip_dim_member_t>(len));
     set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(len));
 
     return dims;
@@ -375,9 +384,12 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     LaunchDims dims;
 
-    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
-    set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(IndexMapper::grid_size));
+    set_hip_dim<dim>(dims.active.blocks, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.blocks,
+                     static_cast<hip_dim_member_t>(
+                         (len > zero) ? IndexMapper::grid_size : 0));
+    set_hip_dim<dim>(dims.min_dims.blocks,
+                     static_cast<hip_dim_member_t>(IndexMapper::grid_size));
 
     return dims;
   }
@@ -393,7 +405,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
   using IndexMapper =
       hip::IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>;
 
-  template < typename IdxT >
+  template<typename IdxT>
   static LaunchDims get_dimensions(IdxT len)
   {
     if (len > static_cast<IdxT>(0))
@@ -401,7 +413,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
       RAJA_ABORT_OR_THROW("must know one of block_size or grid_size");
     }
 
-    return LaunchDims{};
+    return LaunchDims {};
   }
 };
 
@@ -424,18 +436,25 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
   {
     constexpr auto zero = static_cast<IdxT>(0);
 
-    // BEWARE: if calculated block_size is too high then the kernel launch will fail
-    const IdxT block_size = RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::grid_size));
+    // BEWARE: if calculated block_size is too high then the kernel launch will
+    // fail
+    const IdxT block_size =
+        RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::grid_size));
 
     LaunchDims dims;
 
-    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>(block_size));
-    set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(block_size));
+    set_hip_dim<dim>(dims.active.threads, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.threads,
+                     static_cast<hip_dim_member_t>(block_size));
+    set_hip_dim<dim>(dims.min_dims.threads,
+                     static_cast<hip_dim_member_t>(block_size));
 
-    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
-    set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(IndexMapper::grid_size));
+    set_hip_dim<dim>(dims.active.blocks, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.blocks,
+                     static_cast<hip_dim_member_t>(
+                         (len > zero) ? IndexMapper::grid_size : 0));
+    set_hip_dim<dim>(dims.min_dims.blocks,
+                     static_cast<hip_dim_member_t>(IndexMapper::grid_size));
 
     return dims;
   }
@@ -460,17 +479,23 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
   {
     constexpr auto zero = static_cast<IdxT>(0);
 
-    const IdxT grid_size = RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::block_size));
+    const IdxT grid_size = RAJA_DIVIDE_CEILING_INT(
+        len, static_cast<IdxT>(IndexMapper::block_size));
 
     LaunchDims dims;
 
-    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
-    set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(IndexMapper::block_size));
+    set_hip_dim<dim>(dims.active.threads, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.threads,
+                     static_cast<hip_dim_member_t>(
+                         (len > zero) ? IndexMapper::block_size : 0));
+    set_hip_dim<dim>(dims.min_dims.threads,
+                     static_cast<hip_dim_member_t>(IndexMapper::block_size));
 
-    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>(grid_size));
-    set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(grid_size));
+    set_hip_dim<dim>(dims.active.blocks, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.blocks,
+                     static_cast<hip_dim_member_t>(grid_size));
+    set_hip_dim<dim>(dims.min_dims.blocks,
+                     static_cast<hip_dim_member_t>(grid_size));
 
     return dims;
   }
@@ -509,13 +534,19 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     LaunchDims dims;
 
-    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
-    set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(IndexMapper::block_size));
+    set_hip_dim<dim>(dims.active.threads, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.threads,
+                     static_cast<hip_dim_member_t>(
+                         (len > zero) ? IndexMapper::block_size : 0));
+    set_hip_dim<dim>(dims.min_dims.threads,
+                     static_cast<hip_dim_member_t>(IndexMapper::block_size));
 
-    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
-    set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(IndexMapper::grid_size));
+    set_hip_dim<dim>(dims.active.blocks, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.blocks,
+                     static_cast<hip_dim_member_t>(
+                         (len > zero) ? IndexMapper::grid_size : 0));
+    set_hip_dim<dim>(dims.min_dims.blocks,
+                     static_cast<hip_dim_member_t>(IndexMapper::grid_size));
 
     return dims;
   }
@@ -531,10 +562,10 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
   using IndexMapper =
       hip::IndexGlobal<dim, named_usage::ignored, named_usage::ignored>;
 
-  template < typename IdxT >
+  template<typename IdxT>
   static LaunchDims get_dimensions(IdxT RAJA_UNUSED_ARG(len))
   {
-    return LaunchDims{};
+    return LaunchDims {};
   }
 };
 
@@ -555,8 +586,8 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     // BEWARE: if calculated block_size is too high then the kernel launch will
     // fail
-    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>(len));
+    set_hip_dim<dim>(dims.active.threads, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.threads, static_cast<hip_dim_member_t>(len));
     set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(1));
 
     return dims;
@@ -576,16 +607,19 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
   using IndexMapper = hip::IndexGlobal<dim, BLOCK_SIZE, named_usage::ignored>;
 
-  template < typename IdxT >
+  template<typename IdxT>
   static LaunchDims get_dimensions(IdxT len)
   {
     constexpr auto zero = static_cast<IdxT>(0);
 
     LaunchDims dims;
 
-    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
-    set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(IndexMapper::block_size));
+    set_hip_dim<dim>(dims.active.threads, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.threads,
+                     static_cast<hip_dim_member_t>(
+                         (len > zero) ? IndexMapper::block_size : 0));
+    set_hip_dim<dim>(dims.min_dims.threads,
+                     static_cast<hip_dim_member_t>(IndexMapper::block_size));
 
     return dims;
   }
@@ -606,8 +640,8 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
   {
     LaunchDims dims;
 
-    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>(len));
+    set_hip_dim<dim>(dims.active.blocks, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.blocks, static_cast<hip_dim_member_t>(len));
     set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(1));
 
     return dims;
@@ -627,16 +661,19 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
   using IndexMapper = hip::IndexGlobal<dim, named_usage::ignored, GRID_SIZE>;
 
-  template < typename IdxT >
+  template<typename IdxT>
   static LaunchDims get_dimensions(IdxT len)
   {
     constexpr auto zero = static_cast<IdxT>(0);
 
     LaunchDims dims;
 
-    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
-    set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(IndexMapper::grid_size));
+    set_hip_dim<dim>(dims.active.blocks, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.blocks,
+                     static_cast<hip_dim_member_t>(
+                         (len > zero) ? IndexMapper::grid_size : 0));
+    set_hip_dim<dim>(dims.min_dims.blocks,
+                     static_cast<hip_dim_member_t>(IndexMapper::grid_size));
 
     return dims;
   }
@@ -659,12 +696,14 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     LaunchDims dims;
 
-    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>((len > zero) ? 1 : 0));
+    set_hip_dim<dim>(dims.active.threads, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.threads,
+                     static_cast<hip_dim_member_t>((len > zero) ? 1 : 0));
     set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(1));
 
-    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>((len > zero) ? 1 : 0));
+    set_hip_dim<dim>(dims.active.blocks, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.blocks,
+                     static_cast<hip_dim_member_t>((len > zero) ? 1 : 0));
     set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(1));
 
     return dims;
@@ -690,18 +729,24 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
   {
     constexpr auto zero = static_cast<IdxT>(0);
 
-    // BEWARE: if calculated block_size is too high then the kernel launch will fail
-    const IdxT block_size = RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::grid_size));
+    // BEWARE: if calculated block_size is too high then the kernel launch will
+    // fail
+    const IdxT block_size =
+        RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::grid_size));
 
     LaunchDims dims;
 
-    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>(block_size));
+    set_hip_dim<dim>(dims.active.threads, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.threads,
+                     static_cast<hip_dim_member_t>(block_size));
     set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(1));
 
-    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
-    set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(IndexMapper::grid_size));
+    set_hip_dim<dim>(dims.active.blocks, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.blocks,
+                     static_cast<hip_dim_member_t>(
+                         (len > zero) ? IndexMapper::grid_size : 0));
+    set_hip_dim<dim>(dims.min_dims.blocks,
+                     static_cast<hip_dim_member_t>(IndexMapper::grid_size));
 
     return dims;
   }
@@ -726,16 +771,21 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
   {
     constexpr auto zero = static_cast<IdxT>(0);
 
-    const IdxT grid_size = RAJA_DIVIDE_CEILING_INT(len, static_cast<IdxT>(IndexMapper::block_size));
+    const IdxT grid_size = RAJA_DIVIDE_CEILING_INT(
+        len, static_cast<IdxT>(IndexMapper::block_size));
 
     LaunchDims dims;
 
-    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
-    set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(IndexMapper::block_size));
+    set_hip_dim<dim>(dims.active.threads, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.threads,
+                     static_cast<hip_dim_member_t>(
+                         (len > zero) ? IndexMapper::block_size : 0));
+    set_hip_dim<dim>(dims.min_dims.threads,
+                     static_cast<hip_dim_member_t>(IndexMapper::block_size));
 
-    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>(grid_size));
+    set_hip_dim<dim>(dims.active.blocks, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.blocks,
+                     static_cast<hip_dim_member_t>(grid_size));
     set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(1));
 
     return dims;
@@ -761,20 +811,26 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
   using IndexMapper = hip::IndexGlobal<dim, BLOCK_SIZE, GRID_SIZE>;
 
-  template < typename IdxT >
+  template<typename IdxT>
   static LaunchDims get_dimensions(IdxT len)
   {
     constexpr auto zero = static_cast<IdxT>(0);
 
     LaunchDims dims;
 
-    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
-    set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(IndexMapper::block_size));
+    set_hip_dim<dim>(dims.active.threads, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.threads,
+                     static_cast<hip_dim_member_t>(
+                         (len > zero) ? IndexMapper::block_size : 0));
+    set_hip_dim<dim>(dims.min_dims.threads,
+                     static_cast<hip_dim_member_t>(IndexMapper::block_size));
 
-    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
-    set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
-    set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(IndexMapper::grid_size));
+    set_hip_dim<dim>(dims.active.blocks, static_cast<hip_dim_member_t>(true));
+    set_hip_dim<dim>(dims.dims.blocks,
+                     static_cast<hip_dim_member_t>(
+                         (len > zero) ? IndexMapper::grid_size : 0));
+    set_hip_dim<dim>(dims.min_dims.blocks,
+                     static_cast<hip_dim_member_t>(IndexMapper::grid_size));
 
     return dims;
   }

--- a/include/RAJA/policy/hip/kernel/internal.hpp
+++ b/include/RAJA/policy/hip/kernel/internal.hpp
@@ -46,19 +46,20 @@ namespace internal
 struct LaunchDims
 {
 
-  HipDims dims;
-  HipDims min_dims;
+  HipDims active{0};
+  HipDims dims{0};
+  HipDims min_dims{0};
 
   LaunchDims()                             = default;
   LaunchDims(LaunchDims const&)            = default;
+  LaunchDims(LaunchDims &&)                = default;
   LaunchDims& operator=(LaunchDims const&) = default;
+  LaunchDims& operator=(LaunchDims &&)     = default;
 
   RAJA_INLINE
-  LaunchDims(HipDims _dims) : dims {_dims}, min_dims {} {}
-
-  RAJA_INLINE
-  LaunchDims(HipDims _dims, HipDims _min_dims)
-      : dims {_dims},
+  LaunchDims(HipDims _active, HipDims _dims, HipDims _min_dims)
+      : active {_active},
+        dims {_dims},
         min_dims {_min_dims}
   {}
 
@@ -67,6 +68,10 @@ struct LaunchDims
   {
     LaunchDims result;
 
+    result.active.blocks.x = std::max(c.active.blocks.x, active.blocks.x);
+    result.active.blocks.y = std::max(c.active.blocks.y, active.blocks.y);
+    result.active.blocks.z = std::max(c.active.blocks.z, active.blocks.z);
+
     result.dims.blocks.x = std::max(c.dims.blocks.x, dims.blocks.x);
     result.dims.blocks.y = std::max(c.dims.blocks.y, dims.blocks.y);
     result.dims.blocks.z = std::max(c.dims.blocks.z, dims.blocks.z);
@@ -74,6 +79,10 @@ struct LaunchDims
     result.min_dims.blocks.x = std::max(c.min_dims.blocks.x, min_dims.blocks.x);
     result.min_dims.blocks.y = std::max(c.min_dims.blocks.y, min_dims.blocks.y);
     result.min_dims.blocks.z = std::max(c.min_dims.blocks.z, min_dims.blocks.z);
+
+    result.active.threads.x = std::max(c.active.threads.x, active.threads.x);
+    result.active.threads.y = std::max(c.active.threads.y, active.threads.y);
+    result.active.threads.z = std::max(c.active.threads.z, active.threads.z);
 
     result.dims.threads.x = std::max(c.dims.threads.x, dims.threads.x);
     result.dims.threads.y = std::max(c.dims.threads.y, dims.threads.y);
@@ -90,10 +99,20 @@ struct LaunchDims
   }
 
   RAJA_INLINE
-  int num_blocks() const { return dims.num_blocks(); }
+  int num_blocks() const
+  {
+    return (active.blocks.x ? dims.blocks.x : 1) *
+           (active.blocks.y ? dims.blocks.y : 1) *
+           (active.blocks.z ? dims.blocks.z : 1);
+  }
 
   RAJA_INLINE
-  int num_threads() const { return dims.num_threads(); }
+  int num_threads() const
+  {
+    return (active.threads.x ? dims.threads.x : 1) *
+           (active.threads.y ? dims.threads.y : 1) *
+           (active.threads.z ? dims.threads.z : 1);
+  }
 
   RAJA_INLINE
   void clamp_to_min_blocks()
@@ -111,6 +130,12 @@ struct LaunchDims
     dims.threads.z = std::max(min_dims.threads.z, dims.threads.z);
   };
 };
+
+RAJA_INLINE
+LaunchDims combine(LaunchDims const &lhs, LaunchDims const &rhs)
+{
+  return lhs.max(rhs);
+}
 
 template<camp::idx_t cur_stmt, camp::idx_t num_stmts, typename StmtList>
 struct HipStatementListExecutorHelper

--- a/include/RAJA/policy/hip/kernel/internal.hpp
+++ b/include/RAJA/policy/hip/kernel/internal.hpp
@@ -99,19 +99,39 @@ struct LaunchDims
   }
 
   RAJA_INLINE
+  int blocks_are_active() const
+  {
+    return active.blocks.x || active.blocks.y || active.blocks.z;
+  }
+
+  RAJA_INLINE
+  int threads_are_active() const
+  {
+    return active.threads.x || active.threads.y || active.threads.z;
+  }
+
+  RAJA_INLINE
   int num_blocks() const
   {
-    return (active.blocks.x ? dims.blocks.x : 1) *
-           (active.blocks.y ? dims.blocks.y : 1) *
-           (active.blocks.z ? dims.blocks.z : 1);
+    if (blocks_are_active()) {
+      return (active.blocks.x ? dims.blocks.x : 1) *
+             (active.blocks.y ? dims.blocks.y : 1) *
+             (active.blocks.z ? dims.blocks.z : 1);
+    } else {
+      return 0;
+    }
   }
 
   RAJA_INLINE
   int num_threads() const
   {
-    return (active.threads.x ? dims.threads.x : 1) *
-           (active.threads.y ? dims.threads.y : 1) *
-           (active.threads.z ? dims.threads.z : 1);
+    if (threads_are_active()) {
+      return (active.threads.x ? dims.threads.x : 1) *
+             (active.threads.y ? dims.threads.y : 1) *
+             (active.threads.z ? dims.threads.z : 1);
+    } else {
+      return 0;
+    }
   }
 
   RAJA_INLINE

--- a/include/RAJA/policy/hip/kernel/internal.hpp
+++ b/include/RAJA/policy/hip/kernel/internal.hpp
@@ -159,14 +159,11 @@ struct HipStatementListExecutorHelper
   template<typename Data>
   inline static LaunchDims calculateDimensions(Data& data)
   {
-    // Compute this statements launch dimensions
     LaunchDims statement_dims = cur_stmt_t::calculateDimensions(data);
 
-    // call the next statement in the list
     LaunchDims next_dims = next_helper_t::calculateDimensions(data);
 
-    // Return the maximum of the two
-    return statement_dims.max(next_dims);
+    return combine(statement_dims, next_dims);
   }
 };
 

--- a/include/RAJA/policy/hip/kernel/internal.hpp
+++ b/include/RAJA/policy/hip/kernel/internal.hpp
@@ -267,6 +267,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     // BEWARE: if calculated block_size is too high then the kernel launch will
     // fail
+    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>(len));
     set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(len));
 
@@ -300,6 +301,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     LaunchDims dims;
 
+    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
     set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(IndexMapper::block_size));
 
@@ -322,6 +324,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
   {
     LaunchDims dims;
 
+    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>(len));
     set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(len));
 
@@ -355,6 +358,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     LaunchDims dims;
 
+    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
     set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(IndexMapper::grid_size));
 
@@ -408,9 +412,11 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     LaunchDims dims;
 
+    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>(block_size));
     set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(block_size));
 
+    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
     set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(IndexMapper::grid_size));
 
@@ -441,9 +447,11 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     LaunchDims dims;
 
+    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
     set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(IndexMapper::block_size));
 
+    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>(grid_size));
     set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(grid_size));
 
@@ -484,9 +492,11 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     LaunchDims dims;
 
+    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
     set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(IndexMapper::block_size));
 
+    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
     set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(IndexMapper::grid_size));
 
@@ -528,6 +538,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     // BEWARE: if calculated block_size is too high then the kernel launch will
     // fail
+    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>(len));
     set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(1));
 
@@ -555,6 +566,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     LaunchDims dims;
 
+    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
     set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(IndexMapper::block_size));
 
@@ -577,6 +589,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
   {
     LaunchDims dims;
 
+    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>(len));
     set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(1));
 
@@ -604,6 +617,7 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     LaunchDims dims;
 
+    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
     set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(IndexMapper::grid_size));
 
@@ -628,9 +642,11 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     LaunchDims dims;
 
+    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>((len > zero) ? 1 : 0));
     set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(1));
 
+    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>((len > zero) ? 1 : 0));
     set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(1));
 
@@ -662,9 +678,11 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     LaunchDims dims;
 
+    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>(block_size));
     set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(1));
 
+    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
     set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(IndexMapper::grid_size));
 
@@ -695,9 +713,11 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     LaunchDims dims;
 
+    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
     set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(IndexMapper::block_size));
 
+    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>(grid_size));
     set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(1));
 
@@ -731,9 +751,11 @@ struct KernelDimensionCalculator<RAJA::policy::hip::hip_indexer<
 
     LaunchDims dims;
 
+    set_hip_dim<dim>(dims.  active.threads, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.threads, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::block_size : 0));
     set_hip_dim<dim>(dims.min_dims.threads, static_cast<hip_dim_member_t>(IndexMapper::block_size));
 
+    set_hip_dim<dim>(dims.  active.blocks, static_cast<hip_dim_member_t>(true));
     set_hip_dim<dim>(dims.    dims.blocks, static_cast<hip_dim_member_t>((len > zero) ? IndexMapper::grid_size : 0));
     set_hip_dim<dim>(dims.min_dims.blocks, static_cast<hip_dim_member_t>(IndexMapper::grid_size));
 


### PR DESCRIPTION
# Fix kernel to not launch a kernel if there is no work

Track which dimensions are active when calculating dimensions in kernel. This allows us to know that we have no work to do in some cases where there was ambiguity before and kernels were launched despite having no work.

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes #1733 