### PR TITLE
Rename param implementation

### DIFF
--- a/include/RAJA/pattern/params/forall.hpp
+++ b/include/RAJA/pattern/params/forall.hpp
@@ -43,45 +43,45 @@ struct ForallParamPack
 private:
   // Init
   template<typename EXEC_POL, camp::idx_t... Seq, typename... Args>
-  static constexpr void params_init(EXEC_POL,
+  static constexpr void params_init(EXEC_POL const& pol,
                                     camp::idx_seq<Seq...>,
                                     ForallParamPack& f_params,
                                     Args&&... args)
   {
-    CAMP_EXPAND(param_init<EXEC_POL>(camp::get<Seq>(f_params.param_tup),
-                                     std::forward<Args>(args)...));
+    CAMP_EXPAND(param_init(pol, camp::get<Seq>(f_params.param_tup),
+                                std::forward<Args>(args)...));
   }
 
   // Combine
   template<typename EXEC_POL, camp::idx_t... Seq>
   RAJA_HOST_DEVICE static constexpr void params_combine(
-      EXEC_POL,
+      EXEC_POL const& pol,
       camp::idx_seq<Seq...>,
       ForallParamPack& out,
       const ForallParamPack& in)
   {
-    CAMP_EXPAND(param_combine<EXEC_POL>(camp::get<Seq>(out.param_tup),
-                                        camp::get<Seq>(in.param_tup)));
+    CAMP_EXPAND(param_combine(pol, camp::get<Seq>(out.param_tup),
+                                   camp::get<Seq>(in.param_tup)));
   }
 
   template<typename EXEC_POL, camp::idx_t... Seq>
   RAJA_HOST_DEVICE static constexpr void params_combine(
-      EXEC_POL,
+      EXEC_POL const& pol,
       camp::idx_seq<Seq...>,
       ForallParamPack& f_params)
   {
-    CAMP_EXPAND(param_combine<EXEC_POL>(camp::get<Seq>(f_params.param_tup)));
+    CAMP_EXPAND(param_combine(pol, camp::get<Seq>(f_params.param_tup)));
   }
 
   // Resolve
   template<typename EXEC_POL, camp::idx_t... Seq, typename... Args>
-  static constexpr void params_resolve(EXEC_POL,
+  static constexpr void params_resolve(EXEC_POL const& pol,
                                        camp::idx_seq<Seq...>,
                                        ForallParamPack& f_params,
                                        Args&&... args)
   {
-    CAMP_EXPAND(param_resolve<EXEC_POL>(camp::get<Seq>(f_params.param_tup),
-                                        std::forward<Args>(args)...));
+    CAMP_EXPAND(param_resolve(pol, camp::get<Seq>(f_params.param_tup),
+                                   std::forward<Args>(args)...));
   }
 
   // Used to construct the argument TYPES that will be invoked with the lambda.
@@ -155,10 +155,11 @@ struct ParamMultiplexer
            typename... Params,
            typename... Args,
            typename FP = ForallParamPack<Params...>>
-  static void constexpr params_init(ForallParamPack<Params...>& f_params,
-                             Args&&... args)
+  static void constexpr params_init(EXEC_POL const& pol,
+                                    ForallParamPack<Params...>& f_params,
+                                    Args&&... args)
   {
-    FP::params_init(EXEC_POL(), typename FP::params_seq(), f_params,
+    FP::params_init(pol, typename FP::params_seq(), f_params,
                     std::forward<Args>(args)...);
   }
 
@@ -166,10 +167,11 @@ struct ParamMultiplexer
            typename... Params,
            typename... Args,
            typename FP = ForallParamPack<Params...>>
-  static void constexpr params_combine(ForallParamPack<Params...>& f_params,
-                                Args&&... args)
+  static void constexpr params_combine(EXEC_POL const& pol,
+                                       ForallParamPack<Params...>& f_params,
+                                       Args&&... args)
   {
-    FP::params_combine(EXEC_POL(), typename FP::params_seq(), f_params,
+    FP::params_combine(pol, typename FP::params_seq(), f_params,
                        std::forward<Args>(args)...);
   }
 
@@ -177,10 +179,11 @@ struct ParamMultiplexer
            typename... Params,
            typename... Args,
            typename FP = ForallParamPack<Params...>>
-  static void constexpr params_resolve(ForallParamPack<Params...>& f_params,
-                                Args&&... args)
+  static void constexpr params_resolve(EXEC_POL const& pol,
+                                       ForallParamPack<Params...>& f_params,
+                                       Args&&... args)
   {
-    FP::params_resolve(EXEC_POL(), typename FP::params_seq(), f_params,
+    FP::params_resolve(pol, typename FP::params_seq(), f_params,
                        std::forward<Args>(args)...);
   }
 };

--- a/include/RAJA/pattern/params/forall.hpp
+++ b/include/RAJA/pattern/params/forall.hpp
@@ -43,10 +43,10 @@ struct ForallParamPack
 private:
   // Init
   template<typename EXEC_POL, camp::idx_t... Seq, typename... Args>
-  static constexpr void params_init(EXEC_POL const& pol,
-                                    camp::idx_seq<Seq...>,
-                                    ForallParamPack& f_params,
-                                    Args&&... args)
+  static constexpr void parampack_init(EXEC_POL const& pol,
+                                       camp::idx_seq<Seq...>,
+                                       ForallParamPack& f_params,
+                                       Args&&... args)
   {
     CAMP_EXPAND(param_init(pol, camp::get<Seq>(f_params.param_tup),
                            std::forward<Args>(args)...));
@@ -54,7 +54,7 @@ private:
 
   // Combine
   template<typename EXEC_POL, camp::idx_t... Seq>
-  RAJA_HOST_DEVICE static constexpr void params_combine(
+  RAJA_HOST_DEVICE static constexpr void parampack_combine(
       EXEC_POL const& pol,
       camp::idx_seq<Seq...>,
       ForallParamPack& out,
@@ -65,7 +65,7 @@ private:
   }
 
   template<typename EXEC_POL, camp::idx_t... Seq>
-  RAJA_HOST_DEVICE static constexpr void params_combine(
+  RAJA_HOST_DEVICE static constexpr void parampack_combine(
       EXEC_POL const& pol,
       camp::idx_seq<Seq...>,
       ForallParamPack& f_params)
@@ -75,10 +75,10 @@ private:
 
   // Resolve
   template<typename EXEC_POL, camp::idx_t... Seq, typename... Args>
-  static constexpr void params_resolve(EXEC_POL const& pol,
-                                       camp::idx_seq<Seq...>,
-                                       ForallParamPack& f_params,
-                                       Args&&... args)
+  static constexpr void parampack_resolve(EXEC_POL const& pol,
+                                          camp::idx_seq<Seq...>,
+                                          ForallParamPack& f_params,
+                                          Args&&... args)
   {
     CAMP_EXPAND(param_resolve(pol, camp::get<Seq>(f_params.param_tup),
                               std::forward<Args>(args)...));
@@ -155,23 +155,11 @@ struct ParamMultiplexer
            typename... Params,
            typename... Args,
            typename FP = ForallParamPack<Params...>>
-  static void constexpr params_init(EXEC_POL const& pol,
-                                    ForallParamPack<Params...>& f_params,
-                                    Args&&... args)
-  {
-    FP::params_init(pol, typename FP::params_seq(), f_params,
-                    std::forward<Args>(args)...);
-  }
-
-  template<typename EXEC_POL,
-           typename... Params,
-           typename... Args,
-           typename FP = ForallParamPack<Params...>>
-  static void constexpr params_combine(EXEC_POL const& pol,
+  static void constexpr parampack_init(EXEC_POL const& pol,
                                        ForallParamPack<Params...>& f_params,
                                        Args&&... args)
   {
-    FP::params_combine(pol, typename FP::params_seq(), f_params,
+    FP::parampack_init(pol, typename FP::params_seq(), f_params,
                        std::forward<Args>(args)...);
   }
 
@@ -179,12 +167,24 @@ struct ParamMultiplexer
            typename... Params,
            typename... Args,
            typename FP = ForallParamPack<Params...>>
-  static void constexpr params_resolve(EXEC_POL const& pol,
-                                       ForallParamPack<Params...>& f_params,
-                                       Args&&... args)
+  static void constexpr parampack_combine(EXEC_POL const& pol,
+                                          ForallParamPack<Params...>& f_params,
+                                          Args&&... args)
   {
-    FP::params_resolve(pol, typename FP::params_seq(), f_params,
-                       std::forward<Args>(args)...);
+    FP::parampack_combine(pol, typename FP::params_seq(), f_params,
+                          std::forward<Args>(args)...);
+  }
+
+  template<typename EXEC_POL,
+           typename... Params,
+           typename... Args,
+           typename FP = ForallParamPack<Params...>>
+  static void constexpr parampack_resolve(EXEC_POL const& pol,
+                                          ForallParamPack<Params...>& f_params,
+                                          Args&&... args)
+  {
+    FP::parampack_resolve(pol, typename FP::params_seq(), f_params,
+                          std::forward<Args>(args)...);
   }
 };
 

--- a/include/RAJA/pattern/params/forall.hpp
+++ b/include/RAJA/pattern/params/forall.hpp
@@ -49,7 +49,7 @@ private:
                                     Args&&... args)
   {
     CAMP_EXPAND(param_init(pol, camp::get<Seq>(f_params.param_tup),
-                                std::forward<Args>(args)...));
+                           std::forward<Args>(args)...));
   }
 
   // Combine
@@ -61,7 +61,7 @@ private:
       const ForallParamPack& in)
   {
     CAMP_EXPAND(param_combine(pol, camp::get<Seq>(out.param_tup),
-                                   camp::get<Seq>(in.param_tup)));
+                              camp::get<Seq>(in.param_tup)));
   }
 
   template<typename EXEC_POL, camp::idx_t... Seq>
@@ -81,7 +81,7 @@ private:
                                        Args&&... args)
   {
     CAMP_EXPAND(param_resolve(pol, camp::get<Seq>(f_params.param_tup),
-                                   std::forward<Args>(args)...));
+                              std::forward<Args>(args)...));
   }
 
   // Used to construct the argument TYPES that will be invoked with the lambda.

--- a/include/RAJA/pattern/params/forall.hpp
+++ b/include/RAJA/pattern/params/forall.hpp
@@ -43,45 +43,45 @@ struct ForallParamPack
 private:
   // Init
   template<typename EXEC_POL, camp::idx_t... Seq, typename... Args>
-  static constexpr void detail_init(EXEC_POL,
+  static constexpr void params_init(EXEC_POL,
                                     camp::idx_seq<Seq...>,
                                     ForallParamPack& f_params,
                                     Args&&... args)
   {
-    CAMP_EXPAND(expt::detail::init<EXEC_POL>(camp::get<Seq>(f_params.param_tup),
-                                             std::forward<Args>(args)...));
+    CAMP_EXPAND(param_init<EXEC_POL>(camp::get<Seq>(f_params.param_tup),
+                                     std::forward<Args>(args)...));
   }
 
   // Combine
   template<typename EXEC_POL, camp::idx_t... Seq>
-  RAJA_HOST_DEVICE static constexpr void detail_combine(
+  RAJA_HOST_DEVICE static constexpr void params_combine(
       EXEC_POL,
       camp::idx_seq<Seq...>,
       ForallParamPack& out,
       const ForallParamPack& in)
   {
-    CAMP_EXPAND(detail::combine<EXEC_POL>(camp::get<Seq>(out.param_tup),
-                                          camp::get<Seq>(in.param_tup)));
+    CAMP_EXPAND(param_combine<EXEC_POL>(camp::get<Seq>(out.param_tup),
+                                        camp::get<Seq>(in.param_tup)));
   }
 
   template<typename EXEC_POL, camp::idx_t... Seq>
-  RAJA_HOST_DEVICE static constexpr void detail_combine(
+  RAJA_HOST_DEVICE static constexpr void params_combine(
       EXEC_POL,
       camp::idx_seq<Seq...>,
       ForallParamPack& f_params)
   {
-    CAMP_EXPAND(detail::combine<EXEC_POL>(camp::get<Seq>(f_params.param_tup)));
+    CAMP_EXPAND(param_combine<EXEC_POL>(camp::get<Seq>(f_params.param_tup)));
   }
 
   // Resolve
   template<typename EXEC_POL, camp::idx_t... Seq, typename... Args>
-  static constexpr void detail_resolve(EXEC_POL,
+  static constexpr void params_resolve(EXEC_POL,
                                        camp::idx_seq<Seq...>,
                                        ForallParamPack& f_params,
                                        Args&&... args)
   {
-    CAMP_EXPAND(detail::resolve<EXEC_POL>(camp::get<Seq>(f_params.param_tup),
-                                          std::forward<Args>(args)...));
+    CAMP_EXPAND(param_resolve<EXEC_POL>(camp::get<Seq>(f_params.param_tup),
+                                        std::forward<Args>(args)...));
   }
 
   // Used to construct the argument TYPES that will be invoked with the lambda.
@@ -155,10 +155,10 @@ struct ParamMultiplexer
            typename... Params,
            typename... Args,
            typename FP = ForallParamPack<Params...>>
-  static void constexpr init(ForallParamPack<Params...>& f_params,
+  static void constexpr params_init(ForallParamPack<Params...>& f_params,
                              Args&&... args)
   {
-    FP::detail_init(EXEC_POL(), typename FP::params_seq(), f_params,
+    FP::params_init(EXEC_POL(), typename FP::params_seq(), f_params,
                     std::forward<Args>(args)...);
   }
 
@@ -166,10 +166,10 @@ struct ParamMultiplexer
            typename... Params,
            typename... Args,
            typename FP = ForallParamPack<Params...>>
-  static void constexpr combine(ForallParamPack<Params...>& f_params,
+  static void constexpr params_combine(ForallParamPack<Params...>& f_params,
                                 Args&&... args)
   {
-    FP::detail_combine(EXEC_POL(), typename FP::params_seq(), f_params,
+    FP::params_combine(EXEC_POL(), typename FP::params_seq(), f_params,
                        std::forward<Args>(args)...);
   }
 
@@ -177,10 +177,10 @@ struct ParamMultiplexer
            typename... Params,
            typename... Args,
            typename FP = ForallParamPack<Params...>>
-  static void constexpr resolve(ForallParamPack<Params...>& f_params,
+  static void constexpr params_resolve(ForallParamPack<Params...>& f_params,
                                 Args&&... args)
   {
-    FP::detail_resolve(EXEC_POL(), typename FP::params_seq(), f_params,
+    FP::params_resolve(EXEC_POL(), typename FP::params_seq(), f_params,
                        std::forward<Args>(args)...);
   }
 };

--- a/include/RAJA/pattern/params/reducer.hpp
+++ b/include/RAJA/pattern/params/reducer.hpp
@@ -89,7 +89,7 @@ struct Reducer : public ForallParamBase
   value_type* target = nullptr;
 
   // combineTarget() performs the final op on the target data and location in
-  // resolve()
+  // param_resolve()
   RAJA_HOST_DEVICE void combineTarget(value_type in)
   {
     value_type temp = op {}(*target, in);
@@ -173,7 +173,7 @@ struct Reducer<Op<ValLoc<T, I>, ValLoc<T, I>, ValLoc<T, I>>,
   target_index_type* target_index = nullptr;
 
   // combineTarget() performs the final op on the target data and location in
-  // resolve()
+  // param_resolve()
   RAJA_HOST_DEVICE void combineTarget(value_type in)
   {
     // Create a different temp ValLoc solely for combining

--- a/include/RAJA/policy/cuda/forall.hpp
+++ b/include/RAJA/policy/cuda/forall.hpp
@@ -445,7 +445,7 @@ __launch_bounds__(BlockSize, BlocksPerSM) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
 }
 
 ///
@@ -474,7 +474,7 @@ __global__ void forallp_cuda_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
 }
 
 template<
@@ -565,7 +565,7 @@ __launch_bounds__(BlockSize, BlocksPerSM) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
 }
 
 ///
@@ -597,7 +597,7 @@ __global__ void forallp_cuda_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
 }
 
 }  // namespace impl
@@ -712,7 +712,7 @@ forall_impl(resources::Cuda cuda_res,
                                                      IterationGetter,
                                                      Concretizer,
                                                      BlocksPerSM,
-                                                     Async> const&,
+                                                     Async> const& pol,
             Iterable&& iter,
             LoopBody&& loop_body,
             ForallParam f_params)
@@ -764,7 +764,7 @@ forall_impl(resources::Cuda cuda_res,
     launch_info.res      = cuda_res;
 
     {
-      RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params, launch_info);
+      RAJA::expt::ParamMultiplexer::params_init(pol, f_params, launch_info);
 
       //
       // Privatize the loop_body, using make_launch_body to setup reductions
@@ -781,7 +781,7 @@ forall_impl(resources::Cuda cuda_res,
       RAJA::cuda::launch(func, dims.blocks, dims.threads, args, shmem, cuda_res,
                          Async);
 
-      RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params, launch_info);
+      RAJA::expt::ParamMultiplexer::params_resolve(pol, f_params, launch_info);
     }
 
     RAJA_FT_END;

--- a/include/RAJA/policy/cuda/forall.hpp
+++ b/include/RAJA/policy/cuda/forall.hpp
@@ -445,7 +445,7 @@ __launch_bounds__(BlockSize, BlocksPerSM) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
 }
 
 ///
@@ -474,7 +474,7 @@ __global__ void forallp_cuda_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
 }
 
 template<
@@ -565,7 +565,7 @@ __launch_bounds__(BlockSize, BlocksPerSM) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
 }
 
 ///
@@ -597,7 +597,7 @@ __global__ void forallp_cuda_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
 }
 
 }  // namespace impl

--- a/include/RAJA/policy/cuda/forall.hpp
+++ b/include/RAJA/policy/cuda/forall.hpp
@@ -445,7 +445,7 @@ __launch_bounds__(BlockSize, BlocksPerSM) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, f_params);
 }
 
 ///
@@ -474,7 +474,7 @@ __global__ void forallp_cuda_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, f_params);
 }
 
 template<
@@ -565,7 +565,7 @@ __launch_bounds__(BlockSize, BlocksPerSM) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, f_params);
 }
 
 ///
@@ -597,7 +597,7 @@ __global__ void forallp_cuda_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, f_params);
 }
 
 }  // namespace impl
@@ -764,7 +764,7 @@ forall_impl(resources::Cuda cuda_res,
     launch_info.res      = cuda_res;
 
     {
-      RAJA::expt::ParamMultiplexer::params_init(pol, f_params, launch_info);
+      RAJA::expt::ParamMultiplexer::parampack_init(pol, f_params, launch_info);
 
       //
       // Privatize the loop_body, using make_launch_body to setup reductions
@@ -781,7 +781,8 @@ forall_impl(resources::Cuda cuda_res,
       RAJA::cuda::launch(func, dims.blocks, dims.threads, args, shmem, cuda_res,
                          Async);
 
-      RAJA::expt::ParamMultiplexer::params_resolve(pol, f_params, launch_info);
+      RAJA::expt::ParamMultiplexer::parampack_resolve(pol, f_params,
+                                                      launch_info);
     }
 
     RAJA_FT_END;

--- a/include/RAJA/policy/cuda/forall.hpp
+++ b/include/RAJA/policy/cuda/forall.hpp
@@ -445,7 +445,7 @@ __launch_bounds__(BlockSize, BlocksPerSM) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::combine<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params);
 }
 
 ///
@@ -474,7 +474,7 @@ __global__ void forallp_cuda_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::combine<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params);
 }
 
 template<
@@ -565,7 +565,7 @@ __launch_bounds__(BlockSize, BlocksPerSM) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::combine<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params);
 }
 
 ///
@@ -597,7 +597,7 @@ __global__ void forallp_cuda_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::combine<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params);
 }
 
 }  // namespace impl
@@ -764,7 +764,7 @@ forall_impl(resources::Cuda cuda_res,
     launch_info.res      = cuda_res;
 
     {
-      RAJA::expt::ParamMultiplexer::init<EXEC_POL>(f_params, launch_info);
+      RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params, launch_info);
 
       //
       // Privatize the loop_body, using make_launch_body to setup reductions
@@ -781,7 +781,7 @@ forall_impl(resources::Cuda cuda_res,
       RAJA::cuda::launch(func, dims.blocks, dims.threads, args, shmem, cuda_res,
                          Async);
 
-      RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params, launch_info);
+      RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params, launch_info);
     }
 
     RAJA_FT_END;

--- a/include/RAJA/policy/cuda/launch.hpp
+++ b/include/RAJA/policy/cuda/launch.hpp
@@ -61,7 +61,7 @@ __global__ void launch_new_reduce_global_fcn(BODY body_in,
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::combine<RAJA::cuda_flatten_global_xyz_direct>(
+  RAJA::expt::ParamMultiplexer::params_combine<RAJA::cuda_flatten_global_xyz_direct>(
       reduce_params);
 }
 
@@ -186,7 +186,7 @@ struct LaunchExecute<
       {
         using EXEC_POL = RAJA::policy::cuda::cuda_launch_explicit_t<
             async, named_usage::unspecified, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::init<EXEC_POL>(launch_reducers,
+        RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(launch_reducers,
                                                      launch_info);
 
         //
@@ -203,7 +203,7 @@ struct LaunchExecute<
         RAJA::cuda::launch(func, gridSize, blockSize, args, shared_mem_size,
                            cuda_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(launch_reducers,
+        RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(launch_reducers,
                                                         launch_info);
       }
 
@@ -252,7 +252,7 @@ __launch_bounds__(num_threads, BLOCKS_PER_SM) __global__
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::combine<RAJA::cuda_flatten_global_xyz_direct>(
+  RAJA::expt::ParamMultiplexer::params_combine<RAJA::cuda_flatten_global_xyz_direct>(
       reduce_params);
 }
 
@@ -378,7 +378,7 @@ struct LaunchExecute<
         using EXEC_POL =
             RAJA::policy::cuda::cuda_launch_explicit_t<async, nthreads,
                                                        BLOCKS_PER_SM>;
-        RAJA::expt::ParamMultiplexer::init<EXEC_POL>(launch_reducers,
+        RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(launch_reducers,
                                                      launch_info);
 
         //
@@ -395,7 +395,7 @@ struct LaunchExecute<
         RAJA::cuda::launch(func, gridSize, blockSize, args, shared_mem_size,
                            cuda_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(launch_reducers,
+        RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(launch_reducers,
                                                         launch_info);
       }
 

--- a/include/RAJA/policy/cuda/launch.hpp
+++ b/include/RAJA/policy/cuda/launch.hpp
@@ -61,7 +61,7 @@ __global__ void launch_new_reduce_global_fcn(BODY body_in,
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine<RAJA::cuda_flatten_global_xyz_direct>(
+  RAJA::expt::ParamMultiplexer::params_combine(RAJA::cuda_flatten_global_xyz_direct{},
       reduce_params);
 }
 
@@ -186,7 +186,7 @@ struct LaunchExecute<
       {
         using EXEC_POL = RAJA::policy::cuda::cuda_launch_explicit_t<
             async, named_usage::unspecified, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(launch_reducers,
+        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL{}, launch_reducers,
                                                      launch_info);
 
         //
@@ -203,7 +203,7 @@ struct LaunchExecute<
         RAJA::cuda::launch(func, gridSize, blockSize, args, shared_mem_size,
                            cuda_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(launch_reducers,
+        RAJA::expt::ParamMultiplexer::params_resolve(EXEC_POL{}, launch_reducers,
                                                         launch_info);
       }
 
@@ -252,7 +252,7 @@ __launch_bounds__(num_threads, BLOCKS_PER_SM) __global__
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine<RAJA::cuda_flatten_global_xyz_direct>(
+  RAJA::expt::ParamMultiplexer::params_combine(RAJA::cuda_flatten_global_xyz_direct{},
       reduce_params);
 }
 
@@ -375,10 +375,11 @@ struct LaunchExecute<
       launch_info.res          = cuda_res;
 
       {
+        // Use a generic block size policy here to match that used in params_combine
         using EXEC_POL =
-            RAJA::policy::cuda::cuda_launch_explicit_t<async, nthreads,
-                                                       BLOCKS_PER_SM>;
-        RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(launch_reducers,
+            RAJA::policy::cuda::cuda_launch_explicit_t<
+                async, named_usage::unspecified, named_usage::unspecified>;
+        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL{}, launch_reducers,
                                                      launch_info);
 
         //
@@ -395,7 +396,7 @@ struct LaunchExecute<
         RAJA::cuda::launch(func, gridSize, blockSize, args, shared_mem_size,
                            cuda_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(launch_reducers,
+        RAJA::expt::ParamMultiplexer::params_resolve(EXEC_POL{}, launch_reducers,
                                                         launch_info);
       }
 

--- a/include/RAJA/policy/cuda/launch.hpp
+++ b/include/RAJA/policy/cuda/launch.hpp
@@ -61,8 +61,8 @@ __global__ void launch_new_reduce_global_fcn(BODY body_in,
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine(RAJA::cuda_flatten_global_xyz_direct{},
-      reduce_params);
+  RAJA::expt::ParamMultiplexer::params_combine(
+      RAJA::cuda_flatten_global_xyz_direct {}, reduce_params);
 }
 
 template<bool async>
@@ -186,8 +186,8 @@ struct LaunchExecute<
       {
         using EXEC_POL = RAJA::policy::cuda::cuda_launch_explicit_t<
             async, named_usage::unspecified, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL{}, launch_reducers,
-                                                     launch_info);
+        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL {}, launch_reducers,
+                                                  launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -203,8 +203,8 @@ struct LaunchExecute<
         RAJA::cuda::launch(func, gridSize, blockSize, args, shared_mem_size,
                            cuda_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve(EXEC_POL{}, launch_reducers,
-                                                        launch_info);
+        RAJA::expt::ParamMultiplexer::params_resolve(
+            EXEC_POL {}, launch_reducers, launch_info);
       }
 
       RAJA_FT_END;
@@ -252,8 +252,8 @@ __launch_bounds__(num_threads, BLOCKS_PER_SM) __global__
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine(RAJA::cuda_flatten_global_xyz_direct{},
-      reduce_params);
+  RAJA::expt::ParamMultiplexer::params_combine(
+      RAJA::cuda_flatten_global_xyz_direct {}, reduce_params);
 }
 
 template<bool async, int nthreads, size_t BLOCKS_PER_SM>
@@ -375,12 +375,12 @@ struct LaunchExecute<
       launch_info.res          = cuda_res;
 
       {
-        // Use a generic block size policy here to match that used in params_combine
-        using EXEC_POL =
-            RAJA::policy::cuda::cuda_launch_explicit_t<
-                async, named_usage::unspecified, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL{}, launch_reducers,
-                                                     launch_info);
+        // Use a generic block size policy here to match that used in
+        // params_combine
+        using EXEC_POL = RAJA::policy::cuda::cuda_launch_explicit_t<
+            async, named_usage::unspecified, named_usage::unspecified>;
+        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL {}, launch_reducers,
+                                                  launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -396,8 +396,8 @@ struct LaunchExecute<
         RAJA::cuda::launch(func, gridSize, blockSize, args, shared_mem_size,
                            cuda_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve(EXEC_POL{}, launch_reducers,
-                                                        launch_info);
+        RAJA::expt::ParamMultiplexer::params_resolve(
+            EXEC_POL {}, launch_reducers, launch_info);
       }
 
       RAJA_FT_END;

--- a/include/RAJA/policy/cuda/launch.hpp
+++ b/include/RAJA/policy/cuda/launch.hpp
@@ -61,7 +61,7 @@ __global__ void launch_new_reduce_global_fcn(BODY body_in,
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine(
+  RAJA::expt::ParamMultiplexer::parampack_combine(
       RAJA::cuda_flatten_global_xyz_direct {}, reduce_params);
 }
 
@@ -186,8 +186,8 @@ struct LaunchExecute<
       {
         using EXEC_POL = RAJA::policy::cuda::cuda_launch_explicit_t<
             async, named_usage::unspecified, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL {}, launch_reducers,
-                                                  launch_info);
+        RAJA::expt::ParamMultiplexer::parampack_init(
+            EXEC_POL {}, launch_reducers, launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -203,7 +203,7 @@ struct LaunchExecute<
         RAJA::cuda::launch(func, gridSize, blockSize, args, shared_mem_size,
                            cuda_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve(
+        RAJA::expt::ParamMultiplexer::parampack_resolve(
             EXEC_POL {}, launch_reducers, launch_info);
       }
 
@@ -252,7 +252,7 @@ __launch_bounds__(num_threads, BLOCKS_PER_SM) __global__
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine(
+  RAJA::expt::ParamMultiplexer::parampack_combine(
       RAJA::cuda_flatten_global_xyz_direct {}, reduce_params);
 }
 
@@ -376,11 +376,11 @@ struct LaunchExecute<
 
       {
         // Use a generic block size policy here to match that used in
-        // params_combine
+        // parampack_combine
         using EXEC_POL = RAJA::policy::cuda::cuda_launch_explicit_t<
             async, named_usage::unspecified, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL {}, launch_reducers,
-                                                  launch_info);
+        RAJA::expt::ParamMultiplexer::parampack_init(
+            EXEC_POL {}, launch_reducers, launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -396,7 +396,7 @@ struct LaunchExecute<
         RAJA::cuda::launch(func, gridSize, blockSize, args, shared_mem_size,
                            cuda_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve(
+        RAJA::expt::ParamMultiplexer::parampack_resolve(
             EXEC_POL {}, launch_reducers, launch_info);
       }
 

--- a/include/RAJA/policy/cuda/params/kernel_name.hpp
+++ b/include/RAJA/policy/cuda/params/kernel_name.hpp
@@ -16,7 +16,7 @@ namespace detail
 
 // Init
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> init(
+camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_init(
     KernelName& kn,
     const RAJA::cuda::detail::cudaInfo&)
 {
@@ -31,12 +31,12 @@ camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> init(
 template<typename EXEC_POL>
 RAJA_HOST_DEVICE camp::concepts::enable_if<
     type_traits::is_cuda_policy<EXEC_POL>>
-combine(KernelName&)
+param_combine(KernelName&)
 {}
 
 // Resolve
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> resolve(
+camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_resolve(
     KernelName&,
     const RAJA::cuda::detail::cudaInfo&)
 {

--- a/include/RAJA/policy/cuda/params/kernel_name.hpp
+++ b/include/RAJA/policy/cuda/params/kernel_name.hpp
@@ -17,6 +17,7 @@ namespace detail
 // Init
 template<typename EXEC_POL>
 camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_init(
+    EXEC_POL const&,
     KernelName& kn,
     const RAJA::cuda::detail::cudaInfo&)
 {
@@ -31,12 +32,13 @@ camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_init(
 template<typename EXEC_POL>
 RAJA_HOST_DEVICE camp::concepts::enable_if<
     type_traits::is_cuda_policy<EXEC_POL>>
-param_combine(KernelName&)
+param_combine(EXEC_POL const&, KernelName&)
 {}
 
 // Resolve
 template<typename EXEC_POL>
 camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_resolve(
+    EXEC_POL const&,
     KernelName&,
     const RAJA::cuda::detail::cudaInfo&)
 {

--- a/include/RAJA/policy/cuda/params/reduce.hpp
+++ b/include/RAJA/policy/cuda/params/reduce.hpp
@@ -19,7 +19,7 @@ namespace detail
 
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> init(
+camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_init(
     Reducer<OP, T, VOp>& red,
     RAJA::cuda::detail::cudaInfo& ci)
 {
@@ -34,7 +34,7 @@ camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> init(
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 RAJA_HOST_DEVICE camp::concepts::enable_if<
     type_traits::is_cuda_policy<EXEC_POL>>
-combine(Reducer<OP, T, VOp>& red)
+param_combine(Reducer<OP, T, VOp>& red)
 {
   RAJA::cuda::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter, OP>(
       red.devicetarget, red.getVal(), red.device_mem, red.device_count);
@@ -42,7 +42,7 @@ combine(Reducer<OP, T, VOp>& red)
 
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> resolve(
+camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_resolve(
     Reducer<OP, T, VOp>& red,
     RAJA::cuda::detail::cudaInfo& ci)
 {

--- a/include/RAJA/policy/cuda/params/reduce.hpp
+++ b/include/RAJA/policy/cuda/params/reduce.hpp
@@ -20,6 +20,7 @@ namespace detail
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_init(
+    EXEC_POL const&,
     Reducer<OP, T, VOp>& red,
     RAJA::cuda::detail::cudaInfo& ci)
 {
@@ -34,7 +35,8 @@ camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_init(
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 RAJA_HOST_DEVICE camp::concepts::enable_if<
     type_traits::is_cuda_policy<EXEC_POL>>
-param_combine(Reducer<OP, T, VOp>& red)
+param_combine(EXEC_POL const&,
+    Reducer<OP, T, VOp>& red)
 {
   RAJA::cuda::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter, OP>(
       red.devicetarget, red.getVal(), red.device_mem, red.device_count);
@@ -43,6 +45,7 @@ param_combine(Reducer<OP, T, VOp>& red)
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_resolve(
+    EXEC_POL const&,
     Reducer<OP, T, VOp>& red,
     RAJA::cuda::detail::cudaInfo& ci)
 {

--- a/include/RAJA/policy/cuda/params/reduce.hpp
+++ b/include/RAJA/policy/cuda/params/reduce.hpp
@@ -35,8 +35,7 @@ camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_init(
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 RAJA_HOST_DEVICE camp::concepts::enable_if<
     type_traits::is_cuda_policy<EXEC_POL>>
-param_combine(EXEC_POL const&,
-    Reducer<OP, T, VOp>& red)
+param_combine(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   RAJA::cuda::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter, OP>(
       red.devicetarget, red.getVal(), red.device_mem, red.device_count);

--- a/include/RAJA/policy/hip/forall.hpp
+++ b/include/RAJA/policy/hip/forall.hpp
@@ -443,7 +443,7 @@ __launch_bounds__(BlockSize, 1) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
 }
 
 ///
@@ -471,7 +471,7 @@ __global__ void forallp_hip_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
 }
 
 template<
@@ -559,7 +559,7 @@ __launch_bounds__(BlockSize, 1) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
 }
 
 ///
@@ -590,7 +590,7 @@ __global__ void forallp_hip_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
 }
 
 }  // namespace impl
@@ -696,13 +696,14 @@ RAJA_INLINE concepts::enable_if_t<
     RAJA::expt::type_traits::is_ForallParamPack<ForallParam>,
     concepts::negate<
         RAJA::expt::type_traits::is_ForallParamPack_empty<ForallParam>>>
-forall_impl(
-    resources::Hip hip_res,
-    ::RAJA::policy::hip::
-        hip_exec<IterationMapping, IterationGetter, Concretizer, Async> const& pol,
-    Iterable&& iter,
-    LoopBody&& loop_body,
-    ForallParam f_params)
+forall_impl(resources::Hip hip_res,
+            ::RAJA::policy::hip::hip_exec<IterationMapping,
+                                          IterationGetter,
+                                          Concretizer,
+                                          Async> const& pol,
+            Iterable&& iter,
+            LoopBody&& loop_body,
+            ForallParam f_params)
 {
   using Iterator  = camp::decay<decltype(std::begin(iter))>;
   using LOOP_BODY = camp::decay<LoopBody>;

--- a/include/RAJA/policy/hip/forall.hpp
+++ b/include/RAJA/policy/hip/forall.hpp
@@ -443,7 +443,7 @@ __launch_bounds__(BlockSize, 1) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::combine<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params);
 }
 
 ///
@@ -471,7 +471,7 @@ __global__ void forallp_hip_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::combine<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params);
 }
 
 template<
@@ -559,7 +559,7 @@ __launch_bounds__(BlockSize, 1) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::combine<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params);
 }
 
 ///
@@ -590,7 +590,7 @@ __global__ void forallp_hip_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::combine<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params);
 }
 
 }  // namespace impl
@@ -751,7 +751,7 @@ forall_impl(
     launch_info.res      = hip_res;
 
     {
-      RAJA::expt::ParamMultiplexer::init<EXEC_POL>(f_params, launch_info);
+      RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params, launch_info);
 
       //
       // Privatize the loop_body, using make_launch_body to setup reductions
@@ -768,7 +768,7 @@ forall_impl(
       RAJA::hip::launch(func, dims.blocks, dims.threads, args, shmem, hip_res,
                         Async);
 
-      RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params, launch_info);
+      RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params, launch_info);
     }
 
     RAJA_FT_END;

--- a/include/RAJA/policy/hip/forall.hpp
+++ b/include/RAJA/policy/hip/forall.hpp
@@ -443,7 +443,7 @@ __launch_bounds__(BlockSize, 1) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
 }
 
 ///
@@ -471,7 +471,7 @@ __global__ void forallp_hip_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
 }
 
 template<
@@ -559,7 +559,7 @@ __launch_bounds__(BlockSize, 1) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
 }
 
 ///
@@ -590,7 +590,7 @@ __global__ void forallp_hip_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
 }
 
 }  // namespace impl
@@ -699,7 +699,7 @@ RAJA_INLINE concepts::enable_if_t<
 forall_impl(
     resources::Hip hip_res,
     ::RAJA::policy::hip::
-        hip_exec<IterationMapping, IterationGetter, Concretizer, Async> const&,
+        hip_exec<IterationMapping, IterationGetter, Concretizer, Async> const& pol,
     Iterable&& iter,
     LoopBody&& loop_body,
     ForallParam f_params)
@@ -751,7 +751,7 @@ forall_impl(
     launch_info.res      = hip_res;
 
     {
-      RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params, launch_info);
+      RAJA::expt::ParamMultiplexer::params_init(pol, f_params, launch_info);
 
       //
       // Privatize the loop_body, using make_launch_body to setup reductions
@@ -768,7 +768,7 @@ forall_impl(
       RAJA::hip::launch(func, dims.blocks, dims.threads, args, shmem, hip_res,
                         Async);
 
-      RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params, launch_info);
+      RAJA::expt::ParamMultiplexer::params_resolve(pol, f_params, launch_info);
     }
 
     RAJA_FT_END;

--- a/include/RAJA/policy/hip/forall.hpp
+++ b/include/RAJA/policy/hip/forall.hpp
@@ -443,7 +443,7 @@ __launch_bounds__(BlockSize, 1) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, f_params);
 }
 
 ///
@@ -471,7 +471,7 @@ __global__ void forallp_hip_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, f_params);
 }
 
 template<
@@ -559,7 +559,7 @@ __launch_bounds__(BlockSize, 1) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, f_params);
 }
 
 ///
@@ -590,7 +590,7 @@ __global__ void forallp_hip_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, f_params);
 }
 
 }  // namespace impl
@@ -752,7 +752,7 @@ forall_impl(resources::Hip hip_res,
     launch_info.res      = hip_res;
 
     {
-      RAJA::expt::ParamMultiplexer::params_init(pol, f_params, launch_info);
+      RAJA::expt::ParamMultiplexer::parampack_init(pol, f_params, launch_info);
 
       //
       // Privatize the loop_body, using make_launch_body to setup reductions
@@ -769,7 +769,8 @@ forall_impl(resources::Hip hip_res,
       RAJA::hip::launch(func, dims.blocks, dims.threads, args, shmem, hip_res,
                         Async);
 
-      RAJA::expt::ParamMultiplexer::params_resolve(pol, f_params, launch_info);
+      RAJA::expt::ParamMultiplexer::parampack_resolve(pol, f_params,
+                                                      launch_info);
     }
 
     RAJA_FT_END;

--- a/include/RAJA/policy/hip/launch.hpp
+++ b/include/RAJA/policy/hip/launch.hpp
@@ -61,8 +61,8 @@ __global__ void launch_new_reduce_global_fcn(BODY body_in,
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine(RAJA::hip_flatten_global_xyz_direct{},
-      reduce_params);
+  RAJA::expt::ParamMultiplexer::params_combine(
+      RAJA::hip_flatten_global_xyz_direct {}, reduce_params);
 }
 
 template<bool async>
@@ -184,8 +184,8 @@ struct LaunchExecute<
       {
         using EXEC_POL =
             RAJA::policy::hip::hip_launch_t<async, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL{}, launch_reducers,
-                                                     launch_info);
+        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL {}, launch_reducers,
+                                                  launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -201,8 +201,8 @@ struct LaunchExecute<
         RAJA::hip::launch(func, gridSize, blockSize, args, shared_mem_size,
                           hip_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve(EXEC_POL{}, launch_reducers,
-                                                        launch_info);
+        RAJA::expt::ParamMultiplexer::params_resolve(
+            EXEC_POL {}, launch_reducers, launch_info);
       }
 
       RAJA_FT_END;
@@ -247,8 +247,8 @@ __launch_bounds__(num_threads, 1) __global__
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine(RAJA::hip_flatten_global_xyz_direct{},
-      reduce_params);
+  RAJA::expt::ParamMultiplexer::params_combine(
+      RAJA::hip_flatten_global_xyz_direct {}, reduce_params);
 }
 
 template<bool async, int nthreads>
@@ -371,8 +371,8 @@ struct LaunchExecute<RAJA::policy::hip::hip_launch_t<async, nthreads>>
       {
         using EXEC_POL =
             RAJA::policy::hip::hip_launch_t<async, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL{}, launch_reducers,
-                                                     launch_info);
+        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL {}, launch_reducers,
+                                                  launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -388,8 +388,8 @@ struct LaunchExecute<RAJA::policy::hip::hip_launch_t<async, nthreads>>
         RAJA::hip::launch(func, gridSize, blockSize, args, shared_mem_size,
                           hip_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve(EXEC_POL{}, launch_reducers,
-                                                        launch_info);
+        RAJA::expt::ParamMultiplexer::params_resolve(
+            EXEC_POL {}, launch_reducers, launch_info);
       }
 
       RAJA_FT_END;

--- a/include/RAJA/policy/hip/launch.hpp
+++ b/include/RAJA/policy/hip/launch.hpp
@@ -61,7 +61,7 @@ __global__ void launch_new_reduce_global_fcn(BODY body_in,
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine<RAJA::hip_flatten_global_xyz_direct>(
+  RAJA::expt::ParamMultiplexer::params_combine(RAJA::hip_flatten_global_xyz_direct{},
       reduce_params);
 }
 
@@ -184,7 +184,7 @@ struct LaunchExecute<
       {
         using EXEC_POL =
             RAJA::policy::hip::hip_launch_t<async, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(launch_reducers,
+        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL{}, launch_reducers,
                                                      launch_info);
 
         //
@@ -201,7 +201,7 @@ struct LaunchExecute<
         RAJA::hip::launch(func, gridSize, blockSize, args, shared_mem_size,
                           hip_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(launch_reducers,
+        RAJA::expt::ParamMultiplexer::params_resolve(EXEC_POL{}, launch_reducers,
                                                         launch_info);
       }
 
@@ -247,7 +247,7 @@ __launch_bounds__(num_threads, 1) __global__
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine<RAJA::hip_flatten_global_xyz_direct>(
+  RAJA::expt::ParamMultiplexer::params_combine(RAJA::hip_flatten_global_xyz_direct{},
       reduce_params);
 }
 
@@ -371,7 +371,7 @@ struct LaunchExecute<RAJA::policy::hip::hip_launch_t<async, nthreads>>
       {
         using EXEC_POL =
             RAJA::policy::hip::hip_launch_t<async, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(launch_reducers,
+        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL{}, launch_reducers,
                                                      launch_info);
 
         //
@@ -388,7 +388,7 @@ struct LaunchExecute<RAJA::policy::hip::hip_launch_t<async, nthreads>>
         RAJA::hip::launch(func, gridSize, blockSize, args, shared_mem_size,
                           hip_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(launch_reducers,
+        RAJA::expt::ParamMultiplexer::params_resolve(EXEC_POL{}, launch_reducers,
                                                         launch_info);
       }
 

--- a/include/RAJA/policy/hip/launch.hpp
+++ b/include/RAJA/policy/hip/launch.hpp
@@ -61,7 +61,7 @@ __global__ void launch_new_reduce_global_fcn(BODY body_in,
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine(
+  RAJA::expt::ParamMultiplexer::parampack_combine(
       RAJA::hip_flatten_global_xyz_direct {}, reduce_params);
 }
 
@@ -184,8 +184,8 @@ struct LaunchExecute<
       {
         using EXEC_POL =
             RAJA::policy::hip::hip_launch_t<async, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL {}, launch_reducers,
-                                                  launch_info);
+        RAJA::expt::ParamMultiplexer::parampack_init(
+            EXEC_POL {}, launch_reducers, launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -201,7 +201,7 @@ struct LaunchExecute<
         RAJA::hip::launch(func, gridSize, blockSize, args, shared_mem_size,
                           hip_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve(
+        RAJA::expt::ParamMultiplexer::parampack_resolve(
             EXEC_POL {}, launch_reducers, launch_info);
       }
 
@@ -247,7 +247,7 @@ __launch_bounds__(num_threads, 1) __global__
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine(
+  RAJA::expt::ParamMultiplexer::parampack_combine(
       RAJA::hip_flatten_global_xyz_direct {}, reduce_params);
 }
 
@@ -371,8 +371,8 @@ struct LaunchExecute<RAJA::policy::hip::hip_launch_t<async, nthreads>>
       {
         using EXEC_POL =
             RAJA::policy::hip::hip_launch_t<async, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL {}, launch_reducers,
-                                                  launch_info);
+        RAJA::expt::ParamMultiplexer::parampack_init(
+            EXEC_POL {}, launch_reducers, launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -388,7 +388,7 @@ struct LaunchExecute<RAJA::policy::hip::hip_launch_t<async, nthreads>>
         RAJA::hip::launch(func, gridSize, blockSize, args, shared_mem_size,
                           hip_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve(
+        RAJA::expt::ParamMultiplexer::parampack_resolve(
             EXEC_POL {}, launch_reducers, launch_info);
       }
 

--- a/include/RAJA/policy/hip/launch.hpp
+++ b/include/RAJA/policy/hip/launch.hpp
@@ -61,7 +61,7 @@ __global__ void launch_new_reduce_global_fcn(BODY body_in,
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::combine<RAJA::hip_flatten_global_xyz_direct>(
+  RAJA::expt::ParamMultiplexer::params_combine<RAJA::hip_flatten_global_xyz_direct>(
       reduce_params);
 }
 
@@ -184,7 +184,7 @@ struct LaunchExecute<
       {
         using EXEC_POL =
             RAJA::policy::hip::hip_launch_t<async, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::init<EXEC_POL>(launch_reducers,
+        RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(launch_reducers,
                                                      launch_info);
 
         //
@@ -201,7 +201,7 @@ struct LaunchExecute<
         RAJA::hip::launch(func, gridSize, blockSize, args, shared_mem_size,
                           hip_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(launch_reducers,
+        RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(launch_reducers,
                                                         launch_info);
       }
 
@@ -247,7 +247,7 @@ __launch_bounds__(num_threads, 1) __global__
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::combine<RAJA::hip_flatten_global_xyz_direct>(
+  RAJA::expt::ParamMultiplexer::params_combine<RAJA::hip_flatten_global_xyz_direct>(
       reduce_params);
 }
 
@@ -371,7 +371,7 @@ struct LaunchExecute<RAJA::policy::hip::hip_launch_t<async, nthreads>>
       {
         using EXEC_POL =
             RAJA::policy::hip::hip_launch_t<async, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::init<EXEC_POL>(launch_reducers,
+        RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(launch_reducers,
                                                      launch_info);
 
         //
@@ -388,7 +388,7 @@ struct LaunchExecute<RAJA::policy::hip::hip_launch_t<async, nthreads>>
         RAJA::hip::launch(func, gridSize, blockSize, args, shared_mem_size,
                           hip_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(launch_reducers,
+        RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(launch_reducers,
                                                         launch_info);
       }
 

--- a/include/RAJA/policy/hip/params/kernel_name.hpp
+++ b/include/RAJA/policy/hip/params/kernel_name.hpp
@@ -20,7 +20,7 @@ namespace detail
 
 // Init
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> init(
+camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_init(
     KernelName& kn,
     const RAJA::hip::detail::hipInfo&)
 {
@@ -34,12 +34,12 @@ camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> init(
 // Combine
 template<typename EXEC_POL>
 RAJA_HOST_DEVICE camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>>
-combine(KernelName&)
+param_combine(KernelName&)
 {}
 
 // Resolve
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> resolve(
+camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_resolve(
     KernelName&,
     const RAJA::hip::detail::hipInfo&)
 {

--- a/include/RAJA/policy/hip/params/kernel_name.hpp
+++ b/include/RAJA/policy/hip/params/kernel_name.hpp
@@ -35,8 +35,7 @@ camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_init(
 // Combine
 template<typename EXEC_POL>
 RAJA_HOST_DEVICE camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>>
-param_combine(EXEC_POL const&,
-    KernelName&)
+param_combine(EXEC_POL const&, KernelName&)
 {}
 
 // Resolve

--- a/include/RAJA/policy/hip/params/kernel_name.hpp
+++ b/include/RAJA/policy/hip/params/kernel_name.hpp
@@ -21,6 +21,7 @@ namespace detail
 // Init
 template<typename EXEC_POL>
 camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_init(
+    EXEC_POL const&,
     KernelName& kn,
     const RAJA::hip::detail::hipInfo&)
 {
@@ -34,12 +35,14 @@ camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_init(
 // Combine
 template<typename EXEC_POL>
 RAJA_HOST_DEVICE camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>>
-param_combine(KernelName&)
+param_combine(EXEC_POL const&,
+    KernelName&)
 {}
 
 // Resolve
 template<typename EXEC_POL>
 camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_resolve(
+    EXEC_POL const&,
     KernelName&,
     const RAJA::hip::detail::hipInfo&)
 {

--- a/include/RAJA/policy/hip/params/reduce.hpp
+++ b/include/RAJA/policy/hip/params/reduce.hpp
@@ -17,7 +17,7 @@ namespace detail
 
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> init(
+camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_init(
     Reducer<OP, T, VOp>& red,
     RAJA::hip::detail::hipInfo& hi)
 {
@@ -31,7 +31,7 @@ camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> init(
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 RAJA_HOST_DEVICE camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>>
-combine(Reducer<OP, T, VOp>& red)
+param_combine(Reducer<OP, T, VOp>& red)
 {
   RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter, OP>(
       red.devicetarget, red.getVal(), red.device_mem, red.device_count);
@@ -39,7 +39,7 @@ combine(Reducer<OP, T, VOp>& red)
 
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> resolve(
+camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_resolve(
     Reducer<OP, T, VOp>& red,
     RAJA::hip::detail::hipInfo& hi)
 {

--- a/include/RAJA/policy/hip/params/reduce.hpp
+++ b/include/RAJA/policy/hip/params/reduce.hpp
@@ -18,6 +18,7 @@ namespace detail
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_init(
+    EXEC_POL const&,
     Reducer<OP, T, VOp>& red,
     RAJA::hip::detail::hipInfo& hi)
 {
@@ -31,7 +32,8 @@ camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_init(
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 RAJA_HOST_DEVICE camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>>
-param_combine(Reducer<OP, T, VOp>& red)
+param_combine(EXEC_POL const&,
+    Reducer<OP, T, VOp>& red)
 {
   RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter, OP>(
       red.devicetarget, red.getVal(), red.device_mem, red.device_count);
@@ -40,6 +42,7 @@ param_combine(Reducer<OP, T, VOp>& red)
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_resolve(
+    EXEC_POL const&,
     Reducer<OP, T, VOp>& red,
     RAJA::hip::detail::hipInfo& hi)
 {

--- a/include/RAJA/policy/hip/params/reduce.hpp
+++ b/include/RAJA/policy/hip/params/reduce.hpp
@@ -32,8 +32,7 @@ camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_init(
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 RAJA_HOST_DEVICE camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>>
-param_combine(EXEC_POL const&,
-    Reducer<OP, T, VOp>& red)
+param_combine(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter, OP>(
       red.devicetarget, red.getVal(), red.device_mem, red.device_count);

--- a/include/RAJA/policy/openmp/launch.hpp
+++ b/include/RAJA/policy/openmp/launch.hpp
@@ -72,7 +72,7 @@ struct LaunchExecute<RAJA::omp_launch_t>
     using EXEC_POL = RAJA::omp_launch_t;
     EXEC_POL pol {};
 
-    expt::ParamMultiplexer::params_init(pol, f_params);
+    expt::ParamMultiplexer::parampack_init(pol, f_params);
 
     // reducer object must be named f_params as expected by macro below
     RAJA_OMP_DECLARE_REDUCTION_COMBINE;
@@ -93,7 +93,7 @@ struct LaunchExecute<RAJA::omp_launch_t>
       ctx.shared_mem_ptr = nullptr;
     }
 
-    expt::ParamMultiplexer::params_resolve(pol, f_params);
+    expt::ParamMultiplexer::parampack_resolve(pol, f_params);
 
     return resources::EventProxy<resources::Resource>(res);
   }

--- a/include/RAJA/policy/openmp/launch.hpp
+++ b/include/RAJA/policy/openmp/launch.hpp
@@ -70,8 +70,9 @@ struct LaunchExecute<RAJA::omp_launch_t>
   {
 
     using EXEC_POL = RAJA::omp_launch_t;
+    EXEC_POL pol{};
 
-    expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
+    expt::ParamMultiplexer::params_init(pol, f_params);
 
     // reducer object must be named f_params as expected by macro below
     RAJA_OMP_DECLARE_REDUCTION_COMBINE;
@@ -92,7 +93,7 @@ struct LaunchExecute<RAJA::omp_launch_t>
       ctx.shared_mem_ptr = nullptr;
     }
 
-    expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
+    expt::ParamMultiplexer::params_resolve(pol, f_params);
 
     return resources::EventProxy<resources::Resource>(res);
   }

--- a/include/RAJA/policy/openmp/launch.hpp
+++ b/include/RAJA/policy/openmp/launch.hpp
@@ -71,7 +71,7 @@ struct LaunchExecute<RAJA::omp_launch_t>
 
     using EXEC_POL = RAJA::omp_launch_t;
 
-    expt::ParamMultiplexer::init<EXEC_POL>(f_params);
+    expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
 
     // reducer object must be named f_params as expected by macro below
     RAJA_OMP_DECLARE_REDUCTION_COMBINE;
@@ -92,7 +92,7 @@ struct LaunchExecute<RAJA::omp_launch_t>
       ctx.shared_mem_ptr = nullptr;
     }
 
-    expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+    expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
 
     return resources::EventProxy<resources::Resource>(res);
   }

--- a/include/RAJA/policy/openmp/launch.hpp
+++ b/include/RAJA/policy/openmp/launch.hpp
@@ -70,7 +70,7 @@ struct LaunchExecute<RAJA::omp_launch_t>
   {
 
     using EXEC_POL = RAJA::omp_launch_t;
-    EXEC_POL pol{};
+    EXEC_POL pol {};
 
     expt::ParamMultiplexer::params_init(pol, f_params);
 

--- a/include/RAJA/policy/openmp/params/forall.hpp
+++ b/include/RAJA/policy/openmp/params/forall.hpp
@@ -34,7 +34,7 @@ forall_impl(const ExecPol& p,
             ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::init<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -44,7 +44,7 @@ forall_impl(const ExecPol& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
 }
 
 //
@@ -64,7 +64,7 @@ forall_impl(const ExecPol<ChunkSize>& p,
             ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::init<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -74,7 +74,7 @@ forall_impl(const ExecPol<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
 }
 
 //
@@ -94,7 +94,7 @@ forall_impl(const ExecPol<ChunkSize>& p,
             ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::init<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -105,7 +105,7 @@ forall_impl(const ExecPol<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
 }
 
 //
@@ -118,7 +118,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Runtime& p,
                              ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::init<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -128,7 +128,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Runtime& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
 }
 
 //
@@ -141,7 +141,7 @@ RAJA_INLINE void forall_impl_nowait(const ::RAJA::policy::omp::Auto& p,
                                     ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::init<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -154,7 +154,7 @@ RAJA_INLINE void forall_impl_nowait(const ::RAJA::policy::omp::Auto& p,
     }
   }
 
-  RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
 }
 
 //
@@ -171,7 +171,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
                              ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::init<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -181,7 +181,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
 }
 
 //
@@ -198,7 +198,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
                              ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::init<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -209,7 +209,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
 }
 
 //
@@ -226,7 +226,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
                              ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::init<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -236,7 +236,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
 }
 
 //
@@ -253,7 +253,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
                              ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::init<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -264,7 +264,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
 }
 
 //
@@ -282,7 +282,7 @@ RAJA_INLINE void forall_impl_nowait(
     ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::init<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -295,7 +295,7 @@ RAJA_INLINE void forall_impl_nowait(
     }
   }
 
-  RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
 }
 
 //
@@ -313,7 +313,7 @@ RAJA_INLINE void forall_impl_nowait(
     ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::init<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -326,7 +326,7 @@ RAJA_INLINE void forall_impl_nowait(
     }
   }
 
-  RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
 }
 
 }  //  namespace internal

--- a/include/RAJA/policy/openmp/params/forall.hpp
+++ b/include/RAJA/policy/openmp/params/forall.hpp
@@ -34,7 +34,7 @@ forall_impl(const ExecPol& p,
             ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -44,7 +44,7 @@ forall_impl(const ExecPol& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -64,7 +64,7 @@ forall_impl(const ExecPol<ChunkSize>& p,
             ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -74,7 +74,7 @@ forall_impl(const ExecPol<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -94,7 +94,7 @@ forall_impl(const ExecPol<ChunkSize>& p,
             ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -105,7 +105,7 @@ forall_impl(const ExecPol<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -118,7 +118,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Runtime& p,
                              ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -128,7 +128,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Runtime& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -141,7 +141,7 @@ RAJA_INLINE void forall_impl_nowait(const ::RAJA::policy::omp::Auto& p,
                                     ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -154,7 +154,7 @@ RAJA_INLINE void forall_impl_nowait(const ::RAJA::policy::omp::Auto& p,
     }
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -171,7 +171,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
                              ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -181,7 +181,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -198,7 +198,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
                              ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -209,7 +209,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -226,7 +226,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
                              ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -236,7 +236,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -253,7 +253,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
                              ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -264,7 +264,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -282,7 +282,7 @@ RAJA_INLINE void forall_impl_nowait(
     ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -295,7 +295,7 @@ RAJA_INLINE void forall_impl_nowait(
     }
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -313,7 +313,7 @@ RAJA_INLINE void forall_impl_nowait(
     ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -326,7 +326,7 @@ RAJA_INLINE void forall_impl_nowait(
     }
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 }  //  namespace internal

--- a/include/RAJA/policy/openmp/params/forall.hpp
+++ b/include/RAJA/policy/openmp/params/forall.hpp
@@ -33,8 +33,8 @@ forall_impl(const ExecPol& p,
             Func&& loop_body,
             ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
+  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -44,7 +44,7 @@ forall_impl(const ExecPol& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
 }
 
 //
@@ -63,8 +63,8 @@ forall_impl(const ExecPol<ChunkSize>& p,
             Func&& loop_body,
             ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
+  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -74,7 +74,7 @@ forall_impl(const ExecPol<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
 }
 
 //
@@ -93,8 +93,8 @@ forall_impl(const ExecPol<ChunkSize>& p,
             Func&& loop_body,
             ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
+  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -105,7 +105,7 @@ forall_impl(const ExecPol<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
 }
 
 //
@@ -117,8 +117,8 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Runtime& p,
                              Func&& loop_body,
                              ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
+  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -128,7 +128,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Runtime& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
 }
 
 //
@@ -140,8 +140,8 @@ RAJA_INLINE void forall_impl_nowait(const ::RAJA::policy::omp::Auto& p,
                                     Func&& loop_body,
                                     ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
+  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -154,7 +154,7 @@ RAJA_INLINE void forall_impl_nowait(const ::RAJA::policy::omp::Auto& p,
     }
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
 }
 
 //
@@ -170,8 +170,8 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
                              Func&& loop_body,
                              ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
+  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -181,7 +181,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
 }
 
 //
@@ -197,8 +197,8 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
                              Func&& loop_body,
                              ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
+  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -209,7 +209,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
 }
 
 //
@@ -225,8 +225,8 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
                              Func&& loop_body,
                              ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
+  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -236,7 +236,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
 }
 
 //
@@ -252,8 +252,8 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
                              Func&& loop_body,
                              ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
+  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -264,7 +264,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
 }
 
 //
@@ -281,8 +281,8 @@ RAJA_INLINE void forall_impl_nowait(
     Func&& loop_body,
     ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
+  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -295,7 +295,7 @@ RAJA_INLINE void forall_impl_nowait(
     }
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
 }
 
 //
@@ -312,8 +312,8 @@ RAJA_INLINE void forall_impl_nowait(
     Func&& loop_body,
     ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
+  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -326,7 +326,7 @@ RAJA_INLINE void forall_impl_nowait(
     }
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
 }
 
 }  //  namespace internal

--- a/include/RAJA/policy/openmp/params/kernel_name.hpp
+++ b/include/RAJA/policy/openmp/params/kernel_name.hpp
@@ -15,6 +15,7 @@ namespace detail
 // Init
 template<typename EXEC_POL>
 camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_init(
+    EXEC_POL const&,
     KernelName&)
 {
   // TODO: Define kernel naming
@@ -23,6 +24,7 @@ camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_init(
 // Combine
 template<typename EXEC_POL, typename T>
 camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_combine(
+    EXEC_POL const&,
     KernelName&,
     T& /*place holder argument*/)
 {}
@@ -30,6 +32,7 @@ camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_combine
 // Resolve
 template<typename EXEC_POL>
 camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_resolve(
+    EXEC_POL const&,
     KernelName&)
 {
   // TODO: Define kernel naming

--- a/include/RAJA/policy/openmp/params/kernel_name.hpp
+++ b/include/RAJA/policy/openmp/params/kernel_name.hpp
@@ -23,17 +23,14 @@ camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_init(
 
 // Combine
 template<typename EXEC_POL, typename T>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_combine(
-    EXEC_POL const&,
-    KernelName&,
-    T& /*place holder argument*/)
+camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>>
+param_combine(EXEC_POL const&, KernelName&, T& /*place holder argument*/)
 {}
 
 // Resolve
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_resolve(
-    EXEC_POL const&,
-    KernelName&)
+camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>>
+param_resolve(EXEC_POL const&, KernelName&)
 {
   // TODO: Define kernel naming
 }

--- a/include/RAJA/policy/openmp/params/kernel_name.hpp
+++ b/include/RAJA/policy/openmp/params/kernel_name.hpp
@@ -14,7 +14,7 @@ namespace detail
 
 // Init
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> init(
+camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_init(
     KernelName&)
 {
   // TODO: Define kernel naming
@@ -22,14 +22,14 @@ camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> init(
 
 // Combine
 template<typename EXEC_POL, typename T>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> combine(
+camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_combine(
     KernelName&,
     T& /*place holder argument*/)
 {}
 
 // Resolve
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> resolve(
+camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_resolve(
     KernelName&)
 {
   // TODO: Define kernel naming

--- a/include/RAJA/policy/openmp/params/reduce.hpp
+++ b/include/RAJA/policy/openmp/params/reduce.hpp
@@ -15,6 +15,7 @@ namespace detail
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_init(
+    EXEC_POL const&,
     Reducer<OP, T, VOp>& red)
 {
   red.m_valop.val = OP::identity();
@@ -23,6 +24,7 @@ camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_init(
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_combine(
+    EXEC_POL const&,
     Reducer<OP, T, VOp>& out,
     const Reducer<OP, T, VOp>& in)
 {
@@ -32,6 +34,7 @@ camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_combine
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_resolve(
+    EXEC_POL const&,
     Reducer<OP, T, VOp>& red)
 {
   red.combineTarget(red.m_valop.val);

--- a/include/RAJA/policy/openmp/params/reduce.hpp
+++ b/include/RAJA/policy/openmp/params/reduce.hpp
@@ -14,7 +14,7 @@ namespace detail
 
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> init(
+camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_init(
     Reducer<OP, T, VOp>& red)
 {
   red.m_valop.val = OP::identity();
@@ -22,7 +22,7 @@ camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> init(
 
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> combine(
+camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_combine(
     Reducer<OP, T, VOp>& out,
     const Reducer<OP, T, VOp>& in)
 {
@@ -31,7 +31,7 @@ camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> combine(
 
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> resolve(
+camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_resolve(
     Reducer<OP, T, VOp>& red)
 {
   red.combineTarget(red.m_valop.val);

--- a/include/RAJA/policy/openmp/params/reduce.hpp
+++ b/include/RAJA/policy/openmp/params/reduce.hpp
@@ -23,19 +23,18 @@ camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_init(
 
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_combine(
-    EXEC_POL const&,
-    Reducer<OP, T, VOp>& out,
-    const Reducer<OP, T, VOp>& in)
+camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>>
+param_combine(EXEC_POL const&,
+              Reducer<OP, T, VOp>& out,
+              const Reducer<OP, T, VOp>& in)
 {
   out.m_valop.val = OP {}(out.m_valop.val, in.m_valop.val);
 }
 
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_resolve(
-    EXEC_POL const&,
-    Reducer<OP, T, VOp>& red)
+camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>>
+param_resolve(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   red.combineTarget(red.m_valop.val);
 }

--- a/include/RAJA/policy/openmp_target/forall.hpp
+++ b/include/RAJA/policy/openmp_target/forall.hpp
@@ -49,7 +49,7 @@ forall_impl(resources::Omp omp_res,
             ForallParam f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   using Body = typename std::remove_reference<decltype(loop_body)>::type;
@@ -88,7 +88,7 @@ forall_impl(resources::Omp omp_res,
     RAJA::expt::invoke_body(f_params, ib, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
   return resources::EventProxy<resources::Omp>(omp_res);
 }
 
@@ -157,7 +157,7 @@ forall_impl(resources::Omp omp_res,
             ForallParam f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   using Body = typename std::remove_reference<decltype(loop_body)>::type;
@@ -174,7 +174,7 @@ forall_impl(resources::Omp omp_res,
     RAJA::expt::invoke_body(f_params, ib, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
   return resources::EventProxy<resources::Omp>(omp_res);
 }
 

--- a/include/RAJA/policy/openmp_target/forall.hpp
+++ b/include/RAJA/policy/openmp_target/forall.hpp
@@ -48,8 +48,8 @@ forall_impl(resources::Omp omp_res,
             Func&& loop_body,
             ForallParam f_params)
 {
-  using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
+  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   using Body = typename std::remove_reference<decltype(loop_body)>::type;
@@ -88,7 +88,7 @@ forall_impl(resources::Omp omp_res,
     RAJA::expt::invoke_body(f_params, ib, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
   return resources::EventProxy<resources::Omp>(omp_res);
 }
 
@@ -156,8 +156,8 @@ forall_impl(resources::Omp omp_res,
             Func&& loop_body,
             ForallParam f_params)
 {
-  using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
+  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   using Body = typename std::remove_reference<decltype(loop_body)>::type;
@@ -174,7 +174,7 @@ forall_impl(resources::Omp omp_res,
     RAJA::expt::invoke_body(f_params, ib, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
   return resources::EventProxy<resources::Omp>(omp_res);
 }
 

--- a/include/RAJA/policy/openmp_target/forall.hpp
+++ b/include/RAJA/policy/openmp_target/forall.hpp
@@ -49,7 +49,7 @@ forall_impl(resources::Omp omp_res,
             ForallParam f_params)
 {
   using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::init<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   using Body = typename std::remove_reference<decltype(loop_body)>::type;
@@ -88,7 +88,7 @@ forall_impl(resources::Omp omp_res,
     RAJA::expt::invoke_body(f_params, ib, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
   return resources::EventProxy<resources::Omp>(omp_res);
 }
 
@@ -157,7 +157,7 @@ forall_impl(resources::Omp omp_res,
             ForallParam f_params)
 {
   using EXEC_POL = typename std::decay<decltype(p)>::type;
-  RAJA::expt::ParamMultiplexer::init<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   using Body = typename std::remove_reference<decltype(loop_body)>::type;
@@ -174,7 +174,7 @@ forall_impl(resources::Omp omp_res,
     RAJA::expt::invoke_body(f_params, ib, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
   return resources::EventProxy<resources::Omp>(omp_res);
 }
 

--- a/include/RAJA/policy/openmp_target/params/kernel_name.hpp
+++ b/include/RAJA/policy/openmp_target/params/kernel_name.hpp
@@ -15,6 +15,7 @@ namespace detail
 // Init
 template<typename EXEC_POL>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> param_init(
+    EXEC_POL const&,
     KernelName&)
 {
   // TODO: Define kernel naming
@@ -23,13 +24,15 @@ camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> param_
 // Combine
 template<typename EXEC_POL, typename T>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
-param_combine(KernelName&, T& /*place holder argument*/)
+param_combine(EXEC_POL const&,
+    KernelName&, T& /*place holder argument*/)
 {}
 
 // Resolve
 template<typename EXEC_POL>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
-param_resolve(KernelName&)
+param_resolve(EXEC_POL const&,
+    KernelName&)
 {
   // TODO: Define kernel naming
 }

--- a/include/RAJA/policy/openmp_target/params/kernel_name.hpp
+++ b/include/RAJA/policy/openmp_target/params/kernel_name.hpp
@@ -14,7 +14,7 @@ namespace detail
 
 // Init
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> init(
+camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> param_init(
     KernelName&)
 {
   // TODO: Define kernel naming
@@ -23,13 +23,13 @@ camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> init(
 // Combine
 template<typename EXEC_POL, typename T>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
-combine(KernelName&, T& /*place holder argument*/)
+param_combine(KernelName&, T& /*place holder argument*/)
 {}
 
 // Resolve
 template<typename EXEC_POL>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
-resolve(KernelName&)
+param_resolve(KernelName&)
 {
   // TODO: Define kernel naming
 }

--- a/include/RAJA/policy/openmp_target/params/kernel_name.hpp
+++ b/include/RAJA/policy/openmp_target/params/kernel_name.hpp
@@ -14,9 +14,8 @@ namespace detail
 
 // Init
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> param_init(
-    EXEC_POL const&,
-    KernelName&)
+camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
+param_init(EXEC_POL const&, KernelName&)
 {
   // TODO: Define kernel naming
 }
@@ -24,15 +23,13 @@ camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> param_
 // Combine
 template<typename EXEC_POL, typename T>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
-param_combine(EXEC_POL const&,
-    KernelName&, T& /*place holder argument*/)
+param_combine(EXEC_POL const&, KernelName&, T& /*place holder argument*/)
 {}
 
 // Resolve
 template<typename EXEC_POL>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
-param_resolve(EXEC_POL const&,
-    KernelName&)
+param_resolve(EXEC_POL const&, KernelName&)
 {
   // TODO: Define kernel naming
 }

--- a/include/RAJA/policy/openmp_target/params/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/params/reduce.hpp
@@ -15,6 +15,7 @@ namespace detail
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> param_init(
+    EXEC_POL const&,
     Reducer<OP, T, VOp>& red)
 {
   red.m_valop.val = OP::identity();
@@ -23,7 +24,8 @@ camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> param_
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
-param_combine(Reducer<OP, T, VOp>& out, const Reducer<OP, T, VOp>& in)
+param_combine(EXEC_POL const&,
+    Reducer<OP, T, VOp>& out, const Reducer<OP, T, VOp>& in)
 {
   out.m_valop.val = OP {}(out.m_valop.val, in.m_valop.val);
 }
@@ -31,7 +33,8 @@ param_combine(Reducer<OP, T, VOp>& out, const Reducer<OP, T, VOp>& in)
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
-param_resolve(Reducer<OP, T, VOp>& red)
+param_resolve(EXEC_POL const&,
+    Reducer<OP, T, VOp>& red)
 {
   red.combineTarget(red.m_valop.val);
 }

--- a/include/RAJA/policy/openmp_target/params/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/params/reduce.hpp
@@ -14,9 +14,8 @@ namespace detail
 
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> param_init(
-    EXEC_POL const&,
-    Reducer<OP, T, VOp>& red)
+camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
+param_init(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   red.m_valop.val = OP::identity();
 }
@@ -25,7 +24,8 @@ camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> param_
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
 param_combine(EXEC_POL const&,
-    Reducer<OP, T, VOp>& out, const Reducer<OP, T, VOp>& in)
+              Reducer<OP, T, VOp>& out,
+              const Reducer<OP, T, VOp>& in)
 {
   out.m_valop.val = OP {}(out.m_valop.val, in.m_valop.val);
 }
@@ -33,8 +33,7 @@ param_combine(EXEC_POL const&,
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
-param_resolve(EXEC_POL const&,
-    Reducer<OP, T, VOp>& red)
+param_resolve(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   red.combineTarget(red.m_valop.val);
 }

--- a/include/RAJA/policy/openmp_target/params/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/params/reduce.hpp
@@ -14,7 +14,7 @@ namespace detail
 
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> init(
+camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> param_init(
     Reducer<OP, T, VOp>& red)
 {
   red.m_valop.val = OP::identity();
@@ -23,7 +23,7 @@ camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> init(
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
-combine(Reducer<OP, T, VOp>& out, const Reducer<OP, T, VOp>& in)
+param_combine(Reducer<OP, T, VOp>& out, const Reducer<OP, T, VOp>& in)
 {
   out.m_valop.val = OP {}(out.m_valop.val, in.m_valop.val);
 }
@@ -31,7 +31,7 @@ combine(Reducer<OP, T, VOp>& out, const Reducer<OP, T, VOp>& in)
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
-resolve(Reducer<OP, T, VOp>& red)
+param_resolve(Reducer<OP, T, VOp>& red)
 {
   red.combineTarget(red.m_valop.val);
 }

--- a/include/RAJA/policy/sequential/forall.hpp
+++ b/include/RAJA/policy/sequential/forall.hpp
@@ -69,7 +69,7 @@ forall_impl(Resource res,
             Func&& body,
             ForallParam f_params)
 {
-  expt::ParamMultiplexer::init<seq_exec>(f_params);
+  expt::ParamMultiplexer::params_init<seq_exec>(f_params);
 
   RAJA_EXTRACT_BED_IT(iter);
 
@@ -78,7 +78,7 @@ forall_impl(Resource res,
     expt::invoke_body(f_params, body, *(begin_it + i));
   }
 
-  expt::ParamMultiplexer::resolve<seq_exec>(f_params);
+  expt::ParamMultiplexer::params_resolve<seq_exec>(f_params);
   return resources::EventProxy<Resource>(res);
 }
 

--- a/include/RAJA/policy/sequential/forall.hpp
+++ b/include/RAJA/policy/sequential/forall.hpp
@@ -64,12 +64,12 @@ RAJA_INLINE concepts::enable_if_t<
     expt::type_traits::is_ForallParamPack<ForallParam>,
     concepts::negate<expt::type_traits::is_ForallParamPack_empty<ForallParam>>>
 forall_impl(Resource res,
-            const seq_exec&,
+            const seq_exec& pol,
             Iterable&& iter,
             Func&& body,
             ForallParam f_params)
 {
-  expt::ParamMultiplexer::params_init<seq_exec>(f_params);
+  expt::ParamMultiplexer::params_init(pol, f_params);
 
   RAJA_EXTRACT_BED_IT(iter);
 
@@ -78,7 +78,7 @@ forall_impl(Resource res,
     expt::invoke_body(f_params, body, *(begin_it + i));
   }
 
-  expt::ParamMultiplexer::params_resolve<seq_exec>(f_params);
+  expt::ParamMultiplexer::params_resolve(pol, f_params);
   return resources::EventProxy<Resource>(res);
 }
 

--- a/include/RAJA/policy/sequential/forall.hpp
+++ b/include/RAJA/policy/sequential/forall.hpp
@@ -69,7 +69,7 @@ forall_impl(Resource res,
             Func&& body,
             ForallParam f_params)
 {
-  expt::ParamMultiplexer::params_init(pol, f_params);
+  expt::ParamMultiplexer::parampack_init(pol, f_params);
 
   RAJA_EXTRACT_BED_IT(iter);
 
@@ -78,7 +78,7 @@ forall_impl(Resource res,
     expt::invoke_body(f_params, body, *(begin_it + i));
   }
 
-  expt::ParamMultiplexer::params_resolve(pol, f_params);
+  expt::ParamMultiplexer::parampack_resolve(pol, f_params);
   return resources::EventProxy<Resource>(res);
 }
 

--- a/include/RAJA/policy/sequential/launch.hpp
+++ b/include/RAJA/policy/sequential/launch.hpp
@@ -77,7 +77,7 @@ struct LaunchExecute<RAJA::seq_launch_t>
        BODY const& body,
        ReduceParams& launch_reducers)
   {
-    expt::ParamMultiplexer::params_init(seq_exec{}, launch_reducers);
+    expt::ParamMultiplexer::params_init(seq_exec {}, launch_reducers);
 
     LaunchContext ctx;
     char* kernel_local_mem = new char[launch_params.shared_mem_size];
@@ -88,7 +88,7 @@ struct LaunchExecute<RAJA::seq_launch_t>
     delete[] kernel_local_mem;
     ctx.shared_mem_ptr = nullptr;
 
-    expt::ParamMultiplexer::params_resolve(seq_exec{}, launch_reducers);
+    expt::ParamMultiplexer::params_resolve(seq_exec {}, launch_reducers);
 
     return resources::EventProxy<resources::Resource>(res);
   }

--- a/include/RAJA/policy/sequential/launch.hpp
+++ b/include/RAJA/policy/sequential/launch.hpp
@@ -77,7 +77,7 @@ struct LaunchExecute<RAJA::seq_launch_t>
        BODY const& body,
        ReduceParams& launch_reducers)
   {
-    expt::ParamMultiplexer::params_init<seq_exec>(launch_reducers);
+    expt::ParamMultiplexer::params_init(seq_exec{}, launch_reducers);
 
     LaunchContext ctx;
     char* kernel_local_mem = new char[launch_params.shared_mem_size];
@@ -88,7 +88,7 @@ struct LaunchExecute<RAJA::seq_launch_t>
     delete[] kernel_local_mem;
     ctx.shared_mem_ptr = nullptr;
 
-    expt::ParamMultiplexer::params_resolve<seq_exec>(launch_reducers);
+    expt::ParamMultiplexer::params_resolve(seq_exec{}, launch_reducers);
 
     return resources::EventProxy<resources::Resource>(res);
   }

--- a/include/RAJA/policy/sequential/launch.hpp
+++ b/include/RAJA/policy/sequential/launch.hpp
@@ -77,7 +77,7 @@ struct LaunchExecute<RAJA::seq_launch_t>
        BODY const& body,
        ReduceParams& launch_reducers)
   {
-    expt::ParamMultiplexer::params_init(seq_exec {}, launch_reducers);
+    expt::ParamMultiplexer::parampack_init(seq_exec {}, launch_reducers);
 
     LaunchContext ctx;
     char* kernel_local_mem = new char[launch_params.shared_mem_size];
@@ -88,7 +88,7 @@ struct LaunchExecute<RAJA::seq_launch_t>
     delete[] kernel_local_mem;
     ctx.shared_mem_ptr = nullptr;
 
-    expt::ParamMultiplexer::params_resolve(seq_exec {}, launch_reducers);
+    expt::ParamMultiplexer::parampack_resolve(seq_exec {}, launch_reducers);
 
     return resources::EventProxy<resources::Resource>(res);
   }

--- a/include/RAJA/policy/sequential/launch.hpp
+++ b/include/RAJA/policy/sequential/launch.hpp
@@ -77,7 +77,7 @@ struct LaunchExecute<RAJA::seq_launch_t>
        BODY const& body,
        ReduceParams& launch_reducers)
   {
-    expt::ParamMultiplexer::init<seq_exec>(launch_reducers);
+    expt::ParamMultiplexer::params_init<seq_exec>(launch_reducers);
 
     LaunchContext ctx;
     char* kernel_local_mem = new char[launch_params.shared_mem_size];
@@ -88,7 +88,7 @@ struct LaunchExecute<RAJA::seq_launch_t>
     delete[] kernel_local_mem;
     ctx.shared_mem_ptr = nullptr;
 
-    expt::ParamMultiplexer::resolve<seq_exec>(launch_reducers);
+    expt::ParamMultiplexer::params_resolve<seq_exec>(launch_reducers);
 
     return resources::EventProxy<resources::Resource>(res);
   }

--- a/include/RAJA/policy/sequential/params/kernel_name.hpp
+++ b/include/RAJA/policy/sequential/params/kernel_name.hpp
@@ -12,7 +12,7 @@ namespace detail
 
 // Init
 template<typename EXEC_POL>
-camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> init(
+camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> param_init(
     KernelName&)
 {
   // TODO: Define kernel naming
@@ -22,12 +22,12 @@ camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> init(
 template<typename EXEC_POL, typename T>
 RAJA_HOST_DEVICE camp::concepts::enable_if<
     std::is_same<EXEC_POL, RAJA::seq_exec>>
-combine(KernelName&, T)
+param_combine(KernelName&, T)
 {}
 
 // Resolve
 template<typename EXEC_POL>
-camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> resolve(
+camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> param_resolve(
     KernelName&)
 {
   // TODO: Define kernel naming

--- a/include/RAJA/policy/sequential/params/kernel_name.hpp
+++ b/include/RAJA/policy/sequential/params/kernel_name.hpp
@@ -13,6 +13,7 @@ namespace detail
 // Init
 template<typename EXEC_POL>
 camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> param_init(
+    EXEC_POL const&,
     KernelName&)
 {
   // TODO: Define kernel naming
@@ -22,12 +23,14 @@ camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> param_init(
 template<typename EXEC_POL, typename T>
 RAJA_HOST_DEVICE camp::concepts::enable_if<
     std::is_same<EXEC_POL, RAJA::seq_exec>>
-param_combine(KernelName&, T)
+param_combine(EXEC_POL const&,
+    KernelName&, T)
 {}
 
 // Resolve
 template<typename EXEC_POL>
 camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> param_resolve(
+    EXEC_POL const&,
     KernelName&)
 {
   // TODO: Define kernel naming

--- a/include/RAJA/policy/sequential/params/kernel_name.hpp
+++ b/include/RAJA/policy/sequential/params/kernel_name.hpp
@@ -23,8 +23,7 @@ camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> param_init(
 template<typename EXEC_POL, typename T>
 RAJA_HOST_DEVICE camp::concepts::enable_if<
     std::is_same<EXEC_POL, RAJA::seq_exec>>
-param_combine(EXEC_POL const&,
-    KernelName&, T)
+param_combine(EXEC_POL const&, KernelName&, T)
 {}
 
 // Resolve

--- a/include/RAJA/policy/sequential/params/reduce.hpp
+++ b/include/RAJA/policy/sequential/params/reduce.hpp
@@ -12,7 +12,7 @@ namespace detail
 
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> init(
+camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> param_init(
     Reducer<OP, T, VOp>& red)
 {
   red.m_valop.val = OP::identity();
@@ -20,7 +20,7 @@ camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> init(
 
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> combine(
+camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> param_combine(
     Reducer<OP, T, VOp>& out,
     const Reducer<OP, T, VOp>& in)
 {
@@ -29,7 +29,7 @@ camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> combine(
 
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> resolve(
+camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> param_resolve(
     Reducer<OP, T, VOp>& red)
 {
   red.combineTarget(red.m_valop.val);

--- a/include/RAJA/policy/sequential/params/reduce.hpp
+++ b/include/RAJA/policy/sequential/params/reduce.hpp
@@ -13,6 +13,7 @@ namespace detail
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> param_init(
+    EXEC_POL const&,
     Reducer<OP, T, VOp>& red)
 {
   red.m_valop.val = OP::identity();
@@ -21,6 +22,7 @@ camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> param_init(
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> param_combine(
+    EXEC_POL const&,
     Reducer<OP, T, VOp>& out,
     const Reducer<OP, T, VOp>& in)
 {
@@ -30,6 +32,7 @@ camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> param_combine(
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> param_resolve(
+    EXEC_POL const&,
     Reducer<OP, T, VOp>& red)
 {
   red.combineTarget(red.m_valop.val);

--- a/include/RAJA/policy/simd/forall.hpp
+++ b/include/RAJA/policy/simd/forall.hpp
@@ -58,7 +58,7 @@ forall_impl(RAJA::resources::Host host_res,
             Func&& loop_body,
             ForallParam f_params)
 {
-  expt::ParamMultiplexer::params_init(seq_exec {}, f_params);
+  expt::ParamMultiplexer::parampack_init(seq_exec {}, f_params);
 
   auto begin    = std::begin(iter);
   auto end      = std::end(iter);
@@ -69,7 +69,7 @@ forall_impl(RAJA::resources::Host host_res,
     expt::invoke_body(f_params, loop_body, *(begin + i));
   }
 
-  expt::ParamMultiplexer::params_resolve(seq_exec {}, f_params);
+  expt::ParamMultiplexer::parampack_resolve(seq_exec {}, f_params);
   return RAJA::resources::EventProxy<resources::Host>(host_res);
 }
 

--- a/include/RAJA/policy/simd/forall.hpp
+++ b/include/RAJA/policy/simd/forall.hpp
@@ -58,7 +58,7 @@ forall_impl(RAJA::resources::Host host_res,
             Func&& loop_body,
             ForallParam f_params)
 {
-  expt::ParamMultiplexer::params_init(seq_exec{}, f_params);
+  expt::ParamMultiplexer::params_init(seq_exec {}, f_params);
 
   auto begin    = std::begin(iter);
   auto end      = std::end(iter);
@@ -69,7 +69,7 @@ forall_impl(RAJA::resources::Host host_res,
     expt::invoke_body(f_params, loop_body, *(begin + i));
   }
 
-  expt::ParamMultiplexer::params_resolve(seq_exec{}, f_params);
+  expt::ParamMultiplexer::params_resolve(seq_exec {}, f_params);
   return RAJA::resources::EventProxy<resources::Host>(host_res);
 }
 

--- a/include/RAJA/policy/simd/forall.hpp
+++ b/include/RAJA/policy/simd/forall.hpp
@@ -58,7 +58,7 @@ forall_impl(RAJA::resources::Host host_res,
             Func&& loop_body,
             ForallParam f_params)
 {
-  expt::ParamMultiplexer::init<seq_exec>(f_params);
+  expt::ParamMultiplexer::params_init<seq_exec>(f_params);
 
   auto begin    = std::begin(iter);
   auto end      = std::end(iter);
@@ -69,7 +69,7 @@ forall_impl(RAJA::resources::Host host_res,
     expt::invoke_body(f_params, loop_body, *(begin + i));
   }
 
-  expt::ParamMultiplexer::resolve<seq_exec>(f_params);
+  expt::ParamMultiplexer::params_resolve<seq_exec>(f_params);
   return RAJA::resources::EventProxy<resources::Host>(host_res);
 }
 

--- a/include/RAJA/policy/simd/forall.hpp
+++ b/include/RAJA/policy/simd/forall.hpp
@@ -53,12 +53,12 @@ RAJA_INLINE concepts::enable_if_t<
     expt::type_traits::is_ForallParamPack<ForallParam>,
     concepts::negate<expt::type_traits::is_ForallParamPack_empty<ForallParam>>>
 forall_impl(RAJA::resources::Host host_res,
-            const simd_exec&,
+            const simd_exec& RAJA_UNUSED_ARG(pol),
             Iterable&& iter,
             Func&& loop_body,
             ForallParam f_params)
 {
-  expt::ParamMultiplexer::params_init<seq_exec>(f_params);
+  expt::ParamMultiplexer::params_init(seq_exec{}, f_params);
 
   auto begin    = std::begin(iter);
   auto end      = std::end(iter);
@@ -69,7 +69,7 @@ forall_impl(RAJA::resources::Host host_res,
     expt::invoke_body(f_params, loop_body, *(begin + i));
   }
 
-  expt::ParamMultiplexer::params_resolve<seq_exec>(f_params);
+  expt::ParamMultiplexer::params_resolve(seq_exec{}, f_params);
   return RAJA::resources::EventProxy<resources::Host>(host_res);
 }
 

--- a/include/RAJA/policy/sycl/forall.hpp
+++ b/include/RAJA/policy/sycl/forall.hpp
@@ -275,7 +275,7 @@ forall_impl(resources::Sycl& sycl_res,
     ::sycl::queue* q = sycl_res.get_queue();
 
     auto combiner = [](ForallParam x, ForallParam y) {
-      RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, x, y);
+      RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, x, y);
       return x;
     };
 
@@ -352,7 +352,7 @@ forall_impl(resources::Sycl& sycl_res,
     ::sycl::queue* q = sycl_res.get_queue();
 
     auto combiner = [](ForallParam x, ForallParam y) {
-      RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, x, y);
+      RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, x, y);
       return x;
     };
 

--- a/include/RAJA/policy/sycl/forall.hpp
+++ b/include/RAJA/policy/sycl/forall.hpp
@@ -259,7 +259,7 @@ forall_impl(resources::Sycl& sycl_res,
   Iterator end   = std::end(iter);
   IndexType len  = std::distance(begin, end);
 
-  RAJA::expt::ParamMultiplexer::init<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
 
   // Only launch kernel if we have something to iterate over
   if (len > 0 && BlockSize > 0)
@@ -274,19 +274,19 @@ forall_impl(resources::Sycl& sycl_res,
     ::sycl::queue* q = sycl_res.get_queue();
 
     auto combiner = [](ForallParam x, ForallParam y) {
-      RAJA::expt::ParamMultiplexer::combine<EXEC_POL>(x, y);
+      RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(x, y);
       return x;
     };
 
     ForallParam* res = ::sycl::malloc_shared<ForallParam>(1, *q);
-    RAJA::expt::ParamMultiplexer::init<EXEC_POL>(*res);
+    RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(*res);
     auto reduction = ::sycl::reduction(res, f_params, combiner);
 
     q->submit([&](::sycl::handler& h) {
       h.parallel_for(::sycl::range<1>(len), reduction,
                      [=](::sycl::item<1> it, auto& red) {
                        ForallParam fp;
-                       RAJA::expt::ParamMultiplexer::init<EXEC_POL>(fp);
+                       RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(fp);
                        IndexType ii = it.get_id(0);
                        if (ii < len)
                        {
@@ -297,10 +297,10 @@ forall_impl(resources::Sycl& sycl_res,
     });
 
     q->wait();
-    RAJA::expt::ParamMultiplexer::combine<EXEC_POL>(f_params, *res);
+    RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params, *res);
     ::sycl::free(res, *q);
   }
-  RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
 
   return resources::EventProxy<resources::Sycl>(sycl_res);
 }
@@ -336,7 +336,7 @@ forall_impl(resources::Sycl& sycl_res,
   Iterator end   = std::end(iter);
   IndexType len  = std::distance(begin, end);
 
-  RAJA::expt::ParamMultiplexer::init<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
 
   // Only launch kernel if we have something to iterate over
   if (len > 0 && BlockSize > 0)
@@ -350,7 +350,7 @@ forall_impl(resources::Sycl& sycl_res,
     ::sycl::queue* q = sycl_res.get_queue();
 
     auto combiner = [](ForallParam x, ForallParam y) {
-      RAJA::expt::ParamMultiplexer::combine<EXEC_POL>(x, y);
+      RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(x, y);
       return x;
     };
 
@@ -371,7 +371,7 @@ forall_impl(resources::Sycl& sycl_res,
     q->memcpy(beg, &begin, sizeof(Iterator)).wait();
 
     ForallParam* res = ::sycl::malloc_shared<ForallParam>(1, *q);
-    RAJA::expt::ParamMultiplexer::init<EXEC_POL>(*res);
+    RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(*res);
     auto reduction = ::sycl::reduction(res, f_params, combiner);
 
     q->submit([&](::sycl::handler& h) {
@@ -379,7 +379,7 @@ forall_impl(resources::Sycl& sycl_res,
                       [=](::sycl::item<1> it, auto& red) {
                         Index_type ii = it.get_id(0);
                         ForallParam fp;
-                        RAJA::expt::ParamMultiplexer::init<EXEC_POL>(fp);
+                        RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(fp);
                         if (ii < len)
                         {
                           RAJA::expt::invoke_body(fp, *lbody, (*beg)[ii]);
@@ -387,7 +387,7 @@ forall_impl(resources::Sycl& sycl_res,
                         red.combine(fp);
                       });
      }).wait();  // Need to wait for completion to free memory
-    RAJA::expt::ParamMultiplexer::combine<EXEC_POL>(f_params, *res);
+    RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params, *res);
     // Free our device memory
     ::sycl::free(res, *q);
     ::sycl::free(lbody, *q);
@@ -395,7 +395,7 @@ forall_impl(resources::Sycl& sycl_res,
 
     RAJA_FT_END;
   }
-  RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
 
   return resources::EventProxy<resources::Sycl>(sycl_res);
 }

--- a/include/RAJA/policy/sycl/forall.hpp
+++ b/include/RAJA/policy/sycl/forall.hpp
@@ -260,7 +260,7 @@ forall_impl(resources::Sycl& sycl_res,
   Iterator end   = std::end(iter);
   IndexType len  = std::distance(begin, end);
 
-  RAJA::expt::ParamMultiplexer::params_init(pol, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(pol, f_params);
 
   // Only launch kernel if we have something to iterate over
   if (len > 0 && BlockSize > 0)
@@ -275,19 +275,19 @@ forall_impl(resources::Sycl& sycl_res,
     ::sycl::queue* q = sycl_res.get_queue();
 
     auto combiner = [](ForallParam x, ForallParam y) {
-      RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, x, y);
+      RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, x, y);
       return x;
     };
 
     ForallParam* res = ::sycl::malloc_shared<ForallParam>(1, *q);
-    RAJA::expt::ParamMultiplexer::params_init(pol, *res);
+    RAJA::expt::ParamMultiplexer::parampack_init(pol, *res);
     auto reduction = ::sycl::reduction(res, f_params, combiner);
 
     q->submit([&](::sycl::handler& h) {
       h.parallel_for(::sycl::range<1>(len), reduction,
                      [=](::sycl::item<1> it, auto& red) {
                        ForallParam fp;
-                       RAJA::expt::ParamMultiplexer::params_init(pol, fp);
+                       RAJA::expt::ParamMultiplexer::parampack_init(pol, fp);
                        IndexType ii = it.get_id(0);
                        if (ii < len)
                        {
@@ -298,10 +298,10 @@ forall_impl(resources::Sycl& sycl_res,
     });
 
     q->wait();
-    RAJA::expt::ParamMultiplexer::params_combine(pol, f_params, *res);
+    RAJA::expt::ParamMultiplexer::parampack_combine(pol, f_params, *res);
     ::sycl::free(res, *q);
   }
-  RAJA::expt::ParamMultiplexer::params_resolve(pol, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(pol, f_params);
 
   return resources::EventProxy<resources::Sycl>(sycl_res);
 }
@@ -338,7 +338,7 @@ forall_impl(resources::Sycl& sycl_res,
   Iterator end   = std::end(iter);
   IndexType len  = std::distance(begin, end);
 
-  RAJA::expt::ParamMultiplexer::params_init(pol, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(pol, f_params);
 
   // Only launch kernel if we have something to iterate over
   if (len > 0 && BlockSize > 0)
@@ -352,7 +352,7 @@ forall_impl(resources::Sycl& sycl_res,
     ::sycl::queue* q = sycl_res.get_queue();
 
     auto combiner = [](ForallParam x, ForallParam y) {
-      RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, x, y);
+      RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, x, y);
       return x;
     };
 
@@ -373,7 +373,7 @@ forall_impl(resources::Sycl& sycl_res,
     q->memcpy(beg, &begin, sizeof(Iterator)).wait();
 
     ForallParam* res = ::sycl::malloc_shared<ForallParam>(1, *q);
-    RAJA::expt::ParamMultiplexer::params_init(pol, *res);
+    RAJA::expt::ParamMultiplexer::parampack_init(pol, *res);
     auto reduction = ::sycl::reduction(res, f_params, combiner);
 
     q->submit([&](::sycl::handler& h) {
@@ -381,7 +381,7 @@ forall_impl(resources::Sycl& sycl_res,
                       [=](::sycl::item<1> it, auto& red) {
                         Index_type ii = it.get_id(0);
                         ForallParam fp;
-                        RAJA::expt::ParamMultiplexer::params_init(pol, fp);
+                        RAJA::expt::ParamMultiplexer::parampack_init(pol, fp);
                         if (ii < len)
                         {
                           RAJA::expt::invoke_body(fp, *lbody, (*beg)[ii]);
@@ -389,7 +389,7 @@ forall_impl(resources::Sycl& sycl_res,
                         red.combine(fp);
                       });
      }).wait();  // Need to wait for completion to free memory
-    RAJA::expt::ParamMultiplexer::params_combine(pol, f_params, *res);
+    RAJA::expt::ParamMultiplexer::parampack_combine(pol, f_params, *res);
     // Free our device memory
     ::sycl::free(res, *q);
     ::sycl::free(lbody, *q);
@@ -397,7 +397,7 @@ forall_impl(resources::Sycl& sycl_res,
 
     RAJA_FT_END;
   }
-  RAJA::expt::ParamMultiplexer::params_resolve(pol, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(pol, f_params);
 
   return resources::EventProxy<resources::Sycl>(sycl_res);
 }

--- a/include/RAJA/policy/sycl/forall.hpp
+++ b/include/RAJA/policy/sycl/forall.hpp
@@ -241,7 +241,7 @@ RAJA_INLINE concepts::enable_if_t<
     concepts::negate<
         RAJA::expt::type_traits::is_ForallParamPack_empty<ForallParam>>>
 forall_impl(resources::Sycl& sycl_res,
-            sycl_exec<BlockSize, Async>,
+            sycl_exec<BlockSize, Async> const& pol,
             Iterable&& iter,
             LoopBody&& loop_body,
             ForallParam f_params)
@@ -251,7 +251,8 @@ forall_impl(resources::Sycl& sycl_res,
   using LOOP_BODY = camp::decay<LoopBody>;
   using IndexType =
       camp::decay<decltype(std::distance(std::begin(iter), std::end(iter)))>;
-  using EXEC_POL = RAJA::sycl_exec<BlockSize, Async>;
+  using EXEC_POL = typename std::decay_t<decltype(pol)>;
+
   //
   // Compute the requested iteration space size
   //
@@ -259,7 +260,7 @@ forall_impl(resources::Sycl& sycl_res,
   Iterator end   = std::end(iter);
   IndexType len  = std::distance(begin, end);
 
-  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_init(pol, f_params);
 
   // Only launch kernel if we have something to iterate over
   if (len > 0 && BlockSize > 0)
@@ -274,19 +275,19 @@ forall_impl(resources::Sycl& sycl_res,
     ::sycl::queue* q = sycl_res.get_queue();
 
     auto combiner = [](ForallParam x, ForallParam y) {
-      RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(x, y);
+      RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, x, y);
       return x;
     };
 
     ForallParam* res = ::sycl::malloc_shared<ForallParam>(1, *q);
-    RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(*res);
+    RAJA::expt::ParamMultiplexer::params_init(pol, *res);
     auto reduction = ::sycl::reduction(res, f_params, combiner);
 
     q->submit([&](::sycl::handler& h) {
       h.parallel_for(::sycl::range<1>(len), reduction,
                      [=](::sycl::item<1> it, auto& red) {
                        ForallParam fp;
-                       RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(fp);
+                       RAJA::expt::ParamMultiplexer::params_init(pol, fp);
                        IndexType ii = it.get_id(0);
                        if (ii < len)
                        {
@@ -297,10 +298,10 @@ forall_impl(resources::Sycl& sycl_res,
     });
 
     q->wait();
-    RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params, *res);
+    RAJA::expt::ParamMultiplexer::params_combine(pol, f_params, *res);
     ::sycl::free(res, *q);
   }
-  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve(pol, f_params);
 
   return resources::EventProxy<resources::Sycl>(sycl_res);
 }
@@ -318,7 +319,7 @@ RAJA_INLINE concepts::enable_if_t<
     concepts::negate<
         RAJA::expt::type_traits::is_ForallParamPack_empty<ForallParam>>>
 forall_impl(resources::Sycl& sycl_res,
-            sycl_exec<BlockSize, Async>,
+            sycl_exec<BlockSize, Async> const& pol,
             Iterable&& iter,
             LoopBody&& loop_body,
             ForallParam f_params)
@@ -329,6 +330,7 @@ forall_impl(resources::Sycl& sycl_res,
   using IndexType =
       camp::decay<decltype(std::distance(std::begin(iter), std::end(iter)))>;
   using EXEC_POL = RAJA::sycl_exec<BlockSize, Async>;
+
   //
   // Compute the requested iteration space size
   //
@@ -336,7 +338,7 @@ forall_impl(resources::Sycl& sycl_res,
   Iterator end   = std::end(iter);
   IndexType len  = std::distance(begin, end);
 
-  RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_init(pol, f_params);
 
   // Only launch kernel if we have something to iterate over
   if (len > 0 && BlockSize > 0)
@@ -350,7 +352,7 @@ forall_impl(resources::Sycl& sycl_res,
     ::sycl::queue* q = sycl_res.get_queue();
 
     auto combiner = [](ForallParam x, ForallParam y) {
-      RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(x, y);
+      RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, x, y);
       return x;
     };
 
@@ -371,7 +373,7 @@ forall_impl(resources::Sycl& sycl_res,
     q->memcpy(beg, &begin, sizeof(Iterator)).wait();
 
     ForallParam* res = ::sycl::malloc_shared<ForallParam>(1, *q);
-    RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(*res);
+    RAJA::expt::ParamMultiplexer::params_init(pol, *res);
     auto reduction = ::sycl::reduction(res, f_params, combiner);
 
     q->submit([&](::sycl::handler& h) {
@@ -379,7 +381,7 @@ forall_impl(resources::Sycl& sycl_res,
                       [=](::sycl::item<1> it, auto& red) {
                         Index_type ii = it.get_id(0);
                         ForallParam fp;
-                        RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(fp);
+                        RAJA::expt::ParamMultiplexer::params_init(pol, fp);
                         if (ii < len)
                         {
                           RAJA::expt::invoke_body(fp, *lbody, (*beg)[ii]);
@@ -387,7 +389,7 @@ forall_impl(resources::Sycl& sycl_res,
                         red.combine(fp);
                       });
      }).wait();  // Need to wait for completion to free memory
-    RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(f_params, *res);
+    RAJA::expt::ParamMultiplexer::params_combine(pol, f_params, *res);
     // Free our device memory
     ::sycl::free(res, *q);
     ::sycl::free(lbody, *q);
@@ -395,7 +397,7 @@ forall_impl(resources::Sycl& sycl_res,
 
     RAJA_FT_END;
   }
-  RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(f_params);
+  RAJA::expt::ParamMultiplexer::params_resolve(pol, f_params);
 
   return resources::EventProxy<resources::Sycl>(sycl_res);
 }

--- a/include/RAJA/policy/sycl/launch.hpp
+++ b/include/RAJA/policy/sycl/launch.hpp
@@ -123,7 +123,8 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
     ::sycl::queue* q = res.get<camp::resources::Sycl>().get_queue();
 
     using EXEC_POL = RAJA::sycl_launch_t<async, 0>;
-    RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(launch_reducers);
+    EXEC_POL pol{};
+    RAJA::expt::ParamMultiplexer::params_init(pol, launch_reducers);
 
     //
     // Compute the number of blocks and threads
@@ -149,14 +150,14 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
 
 
       auto combiner = [](ReduceParams x, ReduceParams y) {
-        RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(x, y);
+        RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, x, y);
         return x;
       };
 
       RAJA_FT_BEGIN;
 
       ReduceParams* res = ::sycl::malloc_shared<ReduceParams>(1, *q);
-      RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(*res);
+      RAJA::expt::ParamMultiplexer::params_init(pol, *res);
       auto reduction = ::sycl::reduction(res, launch_reducers, combiner);
 
       q->submit([&](::sycl::handler& h) {
@@ -174,7 +175,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
                    s_vec.get_multi_ptr<::sycl::access::decorated::yes>().get();
 
                ReduceParams fp;
-               RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(fp);
+               RAJA::expt::ParamMultiplexer::params_init(pol, fp);
 
                RAJA::expt::invoke_body(fp, body_in, ctx);
 
@@ -182,13 +183,13 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
              });
        }).wait();  // Need to wait for completion to free memory
 
-      RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(launch_reducers, *res);
+      RAJA::expt::ParamMultiplexer::params_combine(pol, launch_reducers, *res);
       ::sycl::free(res, *q);
 
       RAJA_FT_END;
     }
 
-    RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(launch_reducers);
+    RAJA::expt::ParamMultiplexer::params_resolve(pol, launch_reducers);
 
     return resources::EventProxy<resources::Resource>(res);
   }
@@ -290,7 +291,8 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
     ::sycl::queue* q = res.get<camp::resources::Sycl>().get_queue();
 
     using EXEC_POL = RAJA::sycl_launch_t<async, 0>;
-    RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(launch_reducers);
+    EXEC_POL pol{};
+    RAJA::expt::ParamMultiplexer::params_init(pol, launch_reducers);
 
     //
     // Compute the number of blocks and threads
@@ -316,7 +318,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
 
 
       auto combiner = [](ReduceParams x, ReduceParams y) {
-        RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(x, y);
+        RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, x, y);
         return x;
       };
 
@@ -332,7 +334,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
       q->memcpy(lbody, &body_in, sizeof(LOOP_BODY)).wait();
 
       ReduceParams* res = ::sycl::malloc_shared<ReduceParams>(1, *q);
-      RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(*res);
+      RAJA::expt::ParamMultiplexer::params_init(pol, *res);
       auto reduction = ::sycl::reduction(res, launch_reducers, combiner);
 
       q->submit([&](::sycl::handler& h) {
@@ -350,7 +352,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
                    s_vec.get_multi_ptr<::sycl::access::decorated::yes>().get();
 
                ReduceParams fp;
-               RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(fp);
+               RAJA::expt::ParamMultiplexer::params_init(pol, fp);
 
                RAJA::expt::invoke_body(fp, *lbody, ctx);
 
@@ -358,14 +360,14 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
              });
        }).wait();  // Need to wait for completion to free memory
 
-      RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(launch_reducers, *res);
+      RAJA::expt::ParamMultiplexer::params_combine(pol, launch_reducers, *res);
       ::sycl::free(res, *q);
       ::sycl::free(lbody, *q);
 
       RAJA_FT_END;
     }
 
-    RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(launch_reducers);
+    RAJA::expt::ParamMultiplexer::params_resolve(pol, launch_reducers);
 
     return resources::EventProxy<resources::Resource>(res);
   }

--- a/include/RAJA/policy/sycl/launch.hpp
+++ b/include/RAJA/policy/sycl/launch.hpp
@@ -124,7 +124,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
 
     using EXEC_POL = RAJA::sycl_launch_t<async, 0>;
     EXEC_POL pol {};
-    RAJA::expt::ParamMultiplexer::params_init(pol, launch_reducers);
+    RAJA::expt::ParamMultiplexer::parampack_init(pol, launch_reducers);
 
     //
     // Compute the number of blocks and threads
@@ -150,14 +150,14 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
 
 
       auto combiner = [](ReduceParams x, ReduceParams y) {
-        RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, x, y);
+        RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, x, y);
         return x;
       };
 
       RAJA_FT_BEGIN;
 
       ReduceParams* res = ::sycl::malloc_shared<ReduceParams>(1, *q);
-      RAJA::expt::ParamMultiplexer::params_init(pol, *res);
+      RAJA::expt::ParamMultiplexer::parampack_init(pol, *res);
       auto reduction = ::sycl::reduction(res, launch_reducers, combiner);
 
       q->submit([&](::sycl::handler& h) {
@@ -175,7 +175,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
                    s_vec.get_multi_ptr<::sycl::access::decorated::yes>().get();
 
                ReduceParams fp;
-               RAJA::expt::ParamMultiplexer::params_init(pol, fp);
+               RAJA::expt::ParamMultiplexer::parampack_init(pol, fp);
 
                RAJA::expt::invoke_body(fp, body_in, ctx);
 
@@ -183,13 +183,14 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
              });
        }).wait();  // Need to wait for completion to free memory
 
-      RAJA::expt::ParamMultiplexer::params_combine(pol, launch_reducers, *res);
+      RAJA::expt::ParamMultiplexer::parampack_combine(pol, launch_reducers,
+                                                      *res);
       ::sycl::free(res, *q);
 
       RAJA_FT_END;
     }
 
-    RAJA::expt::ParamMultiplexer::params_resolve(pol, launch_reducers);
+    RAJA::expt::ParamMultiplexer::parampack_resolve(pol, launch_reducers);
 
     return resources::EventProxy<resources::Resource>(res);
   }
@@ -292,7 +293,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
 
     using EXEC_POL = RAJA::sycl_launch_t<async, 0>;
     EXEC_POL pol {};
-    RAJA::expt::ParamMultiplexer::params_init(pol, launch_reducers);
+    RAJA::expt::ParamMultiplexer::parampack_init(pol, launch_reducers);
 
     //
     // Compute the number of blocks and threads
@@ -318,7 +319,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
 
 
       auto combiner = [](ReduceParams x, ReduceParams y) {
-        RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, x, y);
+        RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, x, y);
         return x;
       };
 
@@ -334,7 +335,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
       q->memcpy(lbody, &body_in, sizeof(LOOP_BODY)).wait();
 
       ReduceParams* res = ::sycl::malloc_shared<ReduceParams>(1, *q);
-      RAJA::expt::ParamMultiplexer::params_init(pol, *res);
+      RAJA::expt::ParamMultiplexer::parampack_init(pol, *res);
       auto reduction = ::sycl::reduction(res, launch_reducers, combiner);
 
       q->submit([&](::sycl::handler& h) {
@@ -352,7 +353,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
                    s_vec.get_multi_ptr<::sycl::access::decorated::yes>().get();
 
                ReduceParams fp;
-               RAJA::expt::ParamMultiplexer::params_init(pol, fp);
+               RAJA::expt::ParamMultiplexer::parampack_init(pol, fp);
 
                RAJA::expt::invoke_body(fp, *lbody, ctx);
 
@@ -360,14 +361,15 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
              });
        }).wait();  // Need to wait for completion to free memory
 
-      RAJA::expt::ParamMultiplexer::params_combine(pol, launch_reducers, *res);
+      RAJA::expt::ParamMultiplexer::parampack_combine(pol, launch_reducers,
+                                                      *res);
       ::sycl::free(res, *q);
       ::sycl::free(lbody, *q);
 
       RAJA_FT_END;
     }
 
-    RAJA::expt::ParamMultiplexer::params_resolve(pol, launch_reducers);
+    RAJA::expt::ParamMultiplexer::parampack_resolve(pol, launch_reducers);
 
     return resources::EventProxy<resources::Resource>(res);
   }

--- a/include/RAJA/policy/sycl/launch.hpp
+++ b/include/RAJA/policy/sycl/launch.hpp
@@ -123,7 +123,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
     ::sycl::queue* q = res.get<camp::resources::Sycl>().get_queue();
 
     using EXEC_POL = RAJA::sycl_launch_t<async, 0>;
-    RAJA::expt::ParamMultiplexer::init<EXEC_POL>(launch_reducers);
+    RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(launch_reducers);
 
     //
     // Compute the number of blocks and threads
@@ -149,14 +149,14 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
 
 
       auto combiner = [](ReduceParams x, ReduceParams y) {
-        RAJA::expt::ParamMultiplexer::combine<EXEC_POL>(x, y);
+        RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(x, y);
         return x;
       };
 
       RAJA_FT_BEGIN;
 
       ReduceParams* res = ::sycl::malloc_shared<ReduceParams>(1, *q);
-      RAJA::expt::ParamMultiplexer::init<EXEC_POL>(*res);
+      RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(*res);
       auto reduction = ::sycl::reduction(res, launch_reducers, combiner);
 
       q->submit([&](::sycl::handler& h) {
@@ -174,7 +174,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
                    s_vec.get_multi_ptr<::sycl::access::decorated::yes>().get();
 
                ReduceParams fp;
-               RAJA::expt::ParamMultiplexer::init<EXEC_POL>(fp);
+               RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(fp);
 
                RAJA::expt::invoke_body(fp, body_in, ctx);
 
@@ -182,13 +182,13 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
              });
        }).wait();  // Need to wait for completion to free memory
 
-      RAJA::expt::ParamMultiplexer::combine<EXEC_POL>(launch_reducers, *res);
+      RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(launch_reducers, *res);
       ::sycl::free(res, *q);
 
       RAJA_FT_END;
     }
 
-    RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(launch_reducers);
+    RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(launch_reducers);
 
     return resources::EventProxy<resources::Resource>(res);
   }
@@ -290,7 +290,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
     ::sycl::queue* q = res.get<camp::resources::Sycl>().get_queue();
 
     using EXEC_POL = RAJA::sycl_launch_t<async, 0>;
-    RAJA::expt::ParamMultiplexer::init<EXEC_POL>(launch_reducers);
+    RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(launch_reducers);
 
     //
     // Compute the number of blocks and threads
@@ -316,7 +316,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
 
 
       auto combiner = [](ReduceParams x, ReduceParams y) {
-        RAJA::expt::ParamMultiplexer::combine<EXEC_POL>(x, y);
+        RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(x, y);
         return x;
       };
 
@@ -332,7 +332,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
       q->memcpy(lbody, &body_in, sizeof(LOOP_BODY)).wait();
 
       ReduceParams* res = ::sycl::malloc_shared<ReduceParams>(1, *q);
-      RAJA::expt::ParamMultiplexer::init<EXEC_POL>(*res);
+      RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(*res);
       auto reduction = ::sycl::reduction(res, launch_reducers, combiner);
 
       q->submit([&](::sycl::handler& h) {
@@ -350,7 +350,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
                    s_vec.get_multi_ptr<::sycl::access::decorated::yes>().get();
 
                ReduceParams fp;
-               RAJA::expt::ParamMultiplexer::init<EXEC_POL>(fp);
+               RAJA::expt::ParamMultiplexer::params_init<EXEC_POL>(fp);
 
                RAJA::expt::invoke_body(fp, *lbody, ctx);
 
@@ -358,14 +358,14 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
              });
        }).wait();  // Need to wait for completion to free memory
 
-      RAJA::expt::ParamMultiplexer::combine<EXEC_POL>(launch_reducers, *res);
+      RAJA::expt::ParamMultiplexer::params_combine<EXEC_POL>(launch_reducers, *res);
       ::sycl::free(res, *q);
       ::sycl::free(lbody, *q);
 
       RAJA_FT_END;
     }
 
-    RAJA::expt::ParamMultiplexer::resolve<EXEC_POL>(launch_reducers);
+    RAJA::expt::ParamMultiplexer::params_resolve<EXEC_POL>(launch_reducers);
 
     return resources::EventProxy<resources::Resource>(res);
   }

--- a/include/RAJA/policy/sycl/launch.hpp
+++ b/include/RAJA/policy/sycl/launch.hpp
@@ -123,7 +123,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
     ::sycl::queue* q = res.get<camp::resources::Sycl>().get_queue();
 
     using EXEC_POL = RAJA::sycl_launch_t<async, 0>;
-    EXEC_POL pol{};
+    EXEC_POL pol {};
     RAJA::expt::ParamMultiplexer::params_init(pol, launch_reducers);
 
     //
@@ -150,7 +150,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
 
 
       auto combiner = [](ReduceParams x, ReduceParams y) {
-        RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, x, y);
+        RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, x, y);
         return x;
       };
 
@@ -291,7 +291,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
     ::sycl::queue* q = res.get<camp::resources::Sycl>().get_queue();
 
     using EXEC_POL = RAJA::sycl_launch_t<async, 0>;
-    EXEC_POL pol{};
+    EXEC_POL pol {};
     RAJA::expt::ParamMultiplexer::params_init(pol, launch_reducers);
 
     //
@@ -318,7 +318,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
 
 
       auto combiner = [](ReduceParams x, ReduceParams y) {
-        RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, x, y);
+        RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, x, y);
         return x;
       };
 

--- a/include/RAJA/policy/sycl/params/kernel_name.hpp
+++ b/include/RAJA/policy/sycl/params/kernel_name.hpp
@@ -14,7 +14,7 @@ namespace detail
 
 // Init
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> init(
+camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_init(
     KernelName&)
 {
   // TODO: Define kernel naming
@@ -23,12 +23,12 @@ camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> init(
 // Combine
 template<typename EXEC_POL, typename T>
 camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> SYCL_EXTERNAL
-combine(KernelName&, T)
+param_combine(KernelName&, T)
 {}
 
 // Resolve
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> resolve(
+camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_resolve(
     KernelName&)
 {
   // TODO: Define kernel naming

--- a/include/RAJA/policy/sycl/params/kernel_name.hpp
+++ b/include/RAJA/policy/sycl/params/kernel_name.hpp
@@ -24,8 +24,7 @@ camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_init(
 // Combine
 template<typename EXEC_POL, typename T>
 camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> SYCL_EXTERNAL
-param_combine(EXEC_POL const&,
-    KernelName&, T)
+param_combine(EXEC_POL const&, KernelName&, T)
 {}
 
 // Resolve

--- a/include/RAJA/policy/sycl/params/kernel_name.hpp
+++ b/include/RAJA/policy/sycl/params/kernel_name.hpp
@@ -15,6 +15,7 @@ namespace detail
 // Init
 template<typename EXEC_POL>
 camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_init(
+    EXEC_POL const&,
     KernelName&)
 {
   // TODO: Define kernel naming
@@ -23,12 +24,14 @@ camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_init(
 // Combine
 template<typename EXEC_POL, typename T>
 camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> SYCL_EXTERNAL
-param_combine(KernelName&, T)
+param_combine(EXEC_POL const&,
+    KernelName&, T)
 {}
 
 // Resolve
 template<typename EXEC_POL>
 camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_resolve(
+    EXEC_POL const&,
     KernelName&)
 {
   // TODO: Define kernel naming

--- a/include/RAJA/policy/sycl/params/reduce.hpp
+++ b/include/RAJA/policy/sycl/params/reduce.hpp
@@ -15,6 +15,7 @@ namespace detail
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_init(
+    EXEC_POL const&,
     Reducer<OP, T, VOp>& red)
 {
   red.m_valop.val = OP::identity();
@@ -23,6 +24,7 @@ camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_init(
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_combine(
+    EXEC_POL const&,
     Reducer<OP, T, VOp>& out,
     const Reducer<OP, T, VOp>& in)
 {
@@ -32,6 +34,7 @@ camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_combine(
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_resolve(
+    EXEC_POL const&,
     Reducer<OP, T, VOp>& red)
 {
   red.combineTarget(red.m_valop.val);

--- a/include/RAJA/policy/sycl/params/reduce.hpp
+++ b/include/RAJA/policy/sycl/params/reduce.hpp
@@ -14,7 +14,7 @@ namespace detail
 
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> init(
+camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_init(
     Reducer<OP, T, VOp>& red)
 {
   red.m_valop.val = OP::identity();
@@ -22,7 +22,7 @@ camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> init(
 
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> combine(
+camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_combine(
     Reducer<OP, T, VOp>& out,
     const Reducer<OP, T, VOp>& in)
 {
@@ -31,7 +31,7 @@ camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> combine(
 
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> resolve(
+camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_resolve(
     Reducer<OP, T, VOp>& red)
 {
   red.combineTarget(red.m_valop.val);

--- a/include/RAJA/util/macros.hpp
+++ b/include/RAJA/util/macros.hpp
@@ -141,7 +141,7 @@ RAJA_HOST_DEVICE RAJA_INLINE void RAJA_UNUSED_VAR(T&&...) noexcept
  */
 #if defined(RAJA_ENABLE_OPENMP)
 #define RAJA_OMP_DECLARE_REDUCTION_COMBINE                                     \
-  RAJA_UNUSED_VAR(EXEC_POL{}); \
+  RAJA_UNUSED_VAR(EXEC_POL {});                                                \
   _Pragma(" omp declare reduction( combine \
         : typename std::remove_reference<decltype(f_params)>::type \
         : RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, omp_out, omp_in) ) ")  // initializer(omp_priv = omp_in) ")

--- a/include/RAJA/util/macros.hpp
+++ b/include/RAJA/util/macros.hpp
@@ -144,7 +144,7 @@ RAJA_HOST_DEVICE RAJA_INLINE void RAJA_UNUSED_VAR(T&&...) noexcept
   RAJA_UNUSED_VAR(EXEC_POL {});                                                \
   _Pragma(" omp declare reduction( combine \
         : typename std::remove_reference<decltype(f_params)>::type \
-        : RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, omp_out, omp_in) ) ")  // initializer(omp_priv = omp_in) ")
+        : RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL{}, omp_out, omp_in) ) ")  // initializer(omp_priv = omp_in) ")
 #endif
 
 

--- a/include/RAJA/util/macros.hpp
+++ b/include/RAJA/util/macros.hpp
@@ -141,9 +141,10 @@ RAJA_HOST_DEVICE RAJA_INLINE void RAJA_UNUSED_VAR(T&&...) noexcept
  */
 #if defined(RAJA_ENABLE_OPENMP)
 #define RAJA_OMP_DECLARE_REDUCTION_COMBINE                                     \
+  RAJA_UNUSED_VAR(EXEC_POL{}); \
   _Pragma(" omp declare reduction( combine \
         : typename std::remove_reference<decltype(f_params)>::type \
-        : RAJA::expt::ParamMultiplexer::combine<EXEC_POL>(omp_out, omp_in) ) ")  // initializer(omp_priv = omp_in) ")
+        : RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, omp_out, omp_in) ) ")  // initializer(omp_priv = omp_in) ")
 #endif
 
 


### PR DESCRIPTION
# Rename param implementation

Prepend param_ to the init, combine, and resolve overloads used to implement the params interface.
This avoids having to make a call to a specific function in detail and should allow the interface to be more extensible. Perhaps even to the point of letting users add params that could look at things like the cuda/hip launch parameters.
Also pass the policy by value to avoid having to specifying the template parameter explicitly.

- This PR is a refactoring
- It does the following (modify list as needed):
  - refactors params to be more easily greppable and more extensible
