### PR TITLE
Work on unifing params style

### DIFF
--- a/benchmark/raja_view_blur.cpp
+++ b/benchmark/raja_view_blur.cpp
@@ -111,7 +111,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   //launch to intialize the stream
   RAJA::forall<device_pol>
-    (RAJA::RangeSegment(0,1), [=] RAJA_HOST_DEVICE (int i) {
+    (RAJA::RangeSegment(0,1), [=] RAJA_HOST_DEVICE (int RAJA_UNUSED_ARG(i)) {
   });
 
   int * array      = def_host_res.allocate<int>(N * N);

--- a/include/RAJA/pattern/params/forall.hpp
+++ b/include/RAJA/pattern/params/forall.hpp
@@ -43,10 +43,10 @@ struct ForallParamPack
 private:
   // Init
   template<typename EXEC_POL, camp::idx_t... Seq, typename... Args>
-  static constexpr void params_init(EXEC_POL const& pol,
-                                    camp::idx_seq<Seq...>,
-                                    ForallParamPack& f_params,
-                                    Args&&... args)
+  static constexpr void parampack_init(EXEC_POL const& pol,
+                                       camp::idx_seq<Seq...>,
+                                       ForallParamPack& f_params,
+                                       Args&&... args)
   {
     CAMP_EXPAND(param_init(pol, camp::get<Seq>(f_params.param_tup),
                            std::forward<Args>(args)...));
@@ -54,7 +54,7 @@ private:
 
   // Combine
   template<typename EXEC_POL, camp::idx_t... Seq>
-  RAJA_HOST_DEVICE static constexpr void params_combine(
+  RAJA_HOST_DEVICE static constexpr void parampack_combine(
       EXEC_POL const& pol,
       camp::idx_seq<Seq...>,
       ForallParamPack& out,
@@ -65,7 +65,7 @@ private:
   }
 
   template<typename EXEC_POL, camp::idx_t... Seq>
-  RAJA_HOST_DEVICE static constexpr void params_combine(
+  RAJA_HOST_DEVICE static constexpr void parampack_combine(
       EXEC_POL const& pol,
       camp::idx_seq<Seq...>,
       ForallParamPack& f_params)
@@ -75,10 +75,10 @@ private:
 
   // Resolve
   template<typename EXEC_POL, camp::idx_t... Seq, typename... Args>
-  static constexpr void params_resolve(EXEC_POL const& pol,
-                                       camp::idx_seq<Seq...>,
-                                       ForallParamPack& f_params,
-                                       Args&&... args)
+  static constexpr void parampack_resolve(EXEC_POL const& pol,
+                                          camp::idx_seq<Seq...>,
+                                          ForallParamPack& f_params,
+                                          Args&&... args)
   {
     CAMP_EXPAND(param_resolve(pol, camp::get<Seq>(f_params.param_tup),
                               std::forward<Args>(args)...));
@@ -155,23 +155,11 @@ struct ParamMultiplexer
            typename... Params,
            typename... Args,
            typename FP = ForallParamPack<Params...>>
-  static void constexpr params_init(EXEC_POL const& pol,
-                                    ForallParamPack<Params...>& f_params,
-                                    Args&&... args)
-  {
-    FP::params_init(pol, typename FP::params_seq(), f_params,
-                    std::forward<Args>(args)...);
-  }
-
-  template<typename EXEC_POL,
-           typename... Params,
-           typename... Args,
-           typename FP = ForallParamPack<Params...>>
-  static void constexpr params_combine(EXEC_POL const& pol,
+  static void constexpr parampack_init(EXEC_POL const& pol,
                                        ForallParamPack<Params...>& f_params,
                                        Args&&... args)
   {
-    FP::params_combine(pol, typename FP::params_seq(), f_params,
+    FP::parampack_init(pol, typename FP::params_seq(), f_params,
                        std::forward<Args>(args)...);
   }
 
@@ -179,12 +167,24 @@ struct ParamMultiplexer
            typename... Params,
            typename... Args,
            typename FP = ForallParamPack<Params...>>
-  static void constexpr params_resolve(EXEC_POL const& pol,
-                                       ForallParamPack<Params...>& f_params,
-                                       Args&&... args)
+  static void constexpr parampack_combine(EXEC_POL const& pol,
+                                          ForallParamPack<Params...>& f_params,
+                                          Args&&... args)
   {
-    FP::params_resolve(pol, typename FP::params_seq(), f_params,
-                       std::forward<Args>(args)...);
+    FP::parampack_combine(pol, typename FP::params_seq(), f_params,
+                          std::forward<Args>(args)...);
+  }
+
+  template<typename EXEC_POL,
+           typename... Params,
+           typename... Args,
+           typename FP = ForallParamPack<Params...>>
+  static void constexpr parampack_resolve(EXEC_POL const& pol,
+                                          ForallParamPack<Params...>& f_params,
+                                          Args&&... args)
+  {
+    FP::parampack_resolve(pol, typename FP::params_seq(), f_params,
+                          std::forward<Args>(args)...);
   }
 };
 

--- a/include/RAJA/pattern/params/forall.hpp
+++ b/include/RAJA/pattern/params/forall.hpp
@@ -49,7 +49,7 @@ private:
                                     Args&&... args)
   {
     CAMP_EXPAND(param_init(pol, camp::get<Seq>(f_params.param_tup),
-                                std::forward<Args>(args)...));
+                           std::forward<Args>(args)...));
   }
 
   // Combine
@@ -61,7 +61,7 @@ private:
       const ForallParamPack& in)
   {
     CAMP_EXPAND(param_combine(pol, camp::get<Seq>(out.param_tup),
-                                   camp::get<Seq>(in.param_tup)));
+                              camp::get<Seq>(in.param_tup)));
   }
 
   template<typename EXEC_POL, camp::idx_t... Seq>
@@ -81,7 +81,7 @@ private:
                                        Args&&... args)
   {
     CAMP_EXPAND(param_resolve(pol, camp::get<Seq>(f_params.param_tup),
-                                   std::forward<Args>(args)...));
+                              std::forward<Args>(args)...));
   }
 
   // Used to construct the argument TYPES that will be invoked with the lambda.

--- a/include/RAJA/pattern/params/forall.hpp
+++ b/include/RAJA/pattern/params/forall.hpp
@@ -1,20 +1,9 @@
 #ifndef FORALL_PARAM_HPP
 #define FORALL_PARAM_HPP
 
-#include "RAJA/policy/sequential/params/reduce.hpp"
-#include "RAJA/policy/sequential/params/kernel_name.hpp"
-#include "RAJA/policy/openmp/params/reduce.hpp"
-#include "RAJA/policy/openmp/params/kernel_name.hpp"
-#include "RAJA/policy/openmp_target/params/reduce.hpp"
-#include "RAJA/policy/openmp_target/params/kernel_name.hpp"
-#include "RAJA/policy/cuda/params/reduce.hpp"
-#include "RAJA/policy/cuda/params/kernel_name.hpp"
-#include "RAJA/policy/hip/params/reduce.hpp"
-#include "RAJA/policy/hip/params/kernel_name.hpp"
-#include "RAJA/policy/sycl/params/reduce.hpp"
-#include "RAJA/policy/sycl/params/kernel_name.hpp"
-
 #include "RAJA/util/CombiningAdapter.hpp"
+
+#include "RAJA/pattern/params/params_base.hpp"
 
 namespace RAJA
 {

--- a/include/RAJA/policy/cuda.hpp
+++ b/include/RAJA/policy/cuda.hpp
@@ -41,6 +41,8 @@
 #include "RAJA/policy/cuda/synchronize.hpp"
 #include "RAJA/policy/cuda/launch.hpp"
 #include "RAJA/policy/cuda/WorkGroup.hpp"
+#include "RAJA/policy/cuda/params/reduce.hpp"
+#include "RAJA/policy/cuda/params/kernel_name.hpp"
 
 #endif  // closing endif for if defined(RAJA_ENABLE_CUDA)
 

--- a/include/RAJA/policy/cuda/forall.hpp
+++ b/include/RAJA/policy/cuda/forall.hpp
@@ -445,7 +445,7 @@ __launch_bounds__(BlockSize, BlocksPerSM) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
 }
 
 ///
@@ -474,7 +474,7 @@ __global__ void forallp_cuda_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
 }
 
 template<
@@ -565,7 +565,7 @@ __launch_bounds__(BlockSize, BlocksPerSM) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
 }
 
 ///
@@ -597,7 +597,7 @@ __global__ void forallp_cuda_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
 }
 
 }  // namespace impl

--- a/include/RAJA/policy/cuda/forall.hpp
+++ b/include/RAJA/policy/cuda/forall.hpp
@@ -445,7 +445,7 @@ __launch_bounds__(BlockSize, BlocksPerSM) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, f_params);
 }
 
 ///
@@ -474,7 +474,7 @@ __global__ void forallp_cuda_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, f_params);
 }
 
 template<
@@ -565,7 +565,7 @@ __launch_bounds__(BlockSize, BlocksPerSM) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, f_params);
 }
 
 ///
@@ -597,7 +597,7 @@ __global__ void forallp_cuda_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, f_params);
 }
 
 }  // namespace impl
@@ -764,7 +764,7 @@ forall_impl(resources::Cuda cuda_res,
     launch_info.res      = cuda_res;
 
     {
-      RAJA::expt::ParamMultiplexer::params_init(pol, f_params, launch_info);
+      RAJA::expt::ParamMultiplexer::parampack_init(pol, f_params, launch_info);
 
       //
       // Privatize the loop_body, using make_launch_body to setup reductions
@@ -781,7 +781,8 @@ forall_impl(resources::Cuda cuda_res,
       RAJA::cuda::launch(func, dims.blocks, dims.threads, args, shmem, cuda_res,
                          Async);
 
-      RAJA::expt::ParamMultiplexer::params_resolve(pol, f_params, launch_info);
+      RAJA::expt::ParamMultiplexer::parampack_resolve(pol, f_params,
+                                                      launch_info);
     }
 
     RAJA_FT_END;

--- a/include/RAJA/policy/cuda/forall.hpp
+++ b/include/RAJA/policy/cuda/forall.hpp
@@ -627,7 +627,7 @@ forall_impl(resources::Cuda cuda_res,
                                                      IterationGetter,
                                                      Concretizer,
                                                      BlocksPerSM,
-                                                     Async> const&,
+                                                     Async> const& pol,
             Iterable&& iter,
             LoopBody&& loop_body,
             ForallParam)
@@ -636,8 +636,7 @@ forall_impl(resources::Cuda cuda_res,
   using LOOP_BODY = camp::decay<LoopBody>;
   using IndexType =
       camp::decay<decltype(std::distance(std::begin(iter), std::end(iter)))>;
-  using EXEC_POL = ::RAJA::policy::cuda::cuda_exec_explicit<
-      IterationMapping, IterationGetter, Concretizer, BlocksPerSM, Async>;
+  using EXEC_POL     = camp::decay<decltype(pol)>;
   using UniqueMarker = ::camp::list<IterationMapping, IterationGetter,
                                     LOOP_BODY, Iterator, ForallParam>;
   using DimensionCalculator =
@@ -721,8 +720,7 @@ forall_impl(resources::Cuda cuda_res,
   using LOOP_BODY = camp::decay<LoopBody>;
   using IndexType =
       camp::decay<decltype(std::distance(std::begin(iter), std::end(iter)))>;
-  using EXEC_POL = ::RAJA::policy::cuda::cuda_exec_explicit<
-      IterationMapping, IterationGetter, Concretizer, BlocksPerSM, Async>;
+  using EXEC_POL = camp::decay<decltype(pol)>;
   using UniqueMarker =
       ::camp::list<IterationMapping, IterationGetter, camp::num<BlocksPerSM>,
                    LOOP_BODY, Iterator, ForallParam>;

--- a/include/RAJA/policy/cuda/intrinsics.hpp
+++ b/include/RAJA/policy/cuda/intrinsics.hpp
@@ -102,7 +102,7 @@ struct AccessorDeviceScopeUseBlockFence
 
     for (size_t i = 0; i < u.array_size(); ++i)
     {
-      u.array[i] = atomicAdd(&ptr[i], integer_type(0));
+      u.array[i] = ::atomicAdd(&ptr[i], integer_type(0));
     }
 
     return u.get_value();
@@ -121,7 +121,7 @@ struct AccessorDeviceScopeUseBlockFence
 
     for (size_t i = 0; i < u.array_size(); ++i)
     {
-      atomicExch(&ptr[i], u.array[i]);
+      ::atomicExch(&ptr[i], u.array[i]);
     }
   }
 

--- a/include/RAJA/policy/cuda/launch.hpp
+++ b/include/RAJA/policy/cuda/launch.hpp
@@ -61,8 +61,8 @@ __global__ void launch_new_reduce_global_fcn(BODY body_in,
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine(RAJA::cuda_flatten_global_xyz_direct{},
-      reduce_params);
+  RAJA::expt::ParamMultiplexer::params_combine(
+      RAJA::cuda_flatten_global_xyz_direct {}, reduce_params);
 }
 
 template<bool async>
@@ -186,8 +186,8 @@ struct LaunchExecute<
       {
         using EXEC_POL = RAJA::policy::cuda::cuda_launch_explicit_t<
             async, named_usage::unspecified, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL{}, launch_reducers,
-                                                     launch_info);
+        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL {}, launch_reducers,
+                                                  launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -203,8 +203,8 @@ struct LaunchExecute<
         RAJA::cuda::launch(func, gridSize, blockSize, args, shared_mem_size,
                            cuda_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve(EXEC_POL{}, launch_reducers,
-                                                        launch_info);
+        RAJA::expt::ParamMultiplexer::params_resolve(
+            EXEC_POL {}, launch_reducers, launch_info);
       }
 
       RAJA_FT_END;
@@ -252,8 +252,8 @@ __launch_bounds__(num_threads, BLOCKS_PER_SM) __global__
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine(RAJA::cuda_flatten_global_xyz_direct{},
-      reduce_params);
+  RAJA::expt::ParamMultiplexer::params_combine(
+      RAJA::cuda_flatten_global_xyz_direct {}, reduce_params);
 }
 
 template<bool async, int nthreads, size_t BLOCKS_PER_SM>
@@ -375,12 +375,12 @@ struct LaunchExecute<
       launch_info.res          = cuda_res;
 
       {
-        // Use a generic block size policy here to match that used in params_combine
-        using EXEC_POL =
-            RAJA::policy::cuda::cuda_launch_explicit_t<
-                async, named_usage::unspecified, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL{}, launch_reducers,
-                                                     launch_info);
+        // Use a generic block size policy here to match that used in
+        // params_combine
+        using EXEC_POL = RAJA::policy::cuda::cuda_launch_explicit_t<
+            async, named_usage::unspecified, named_usage::unspecified>;
+        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL {}, launch_reducers,
+                                                  launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -396,8 +396,8 @@ struct LaunchExecute<
         RAJA::cuda::launch(func, gridSize, blockSize, args, shared_mem_size,
                            cuda_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve(EXEC_POL{}, launch_reducers,
-                                                        launch_info);
+        RAJA::expt::ParamMultiplexer::params_resolve(
+            EXEC_POL {}, launch_reducers, launch_info);
       }
 
       RAJA_FT_END;

--- a/include/RAJA/policy/cuda/launch.hpp
+++ b/include/RAJA/policy/cuda/launch.hpp
@@ -61,7 +61,7 @@ __global__ void launch_new_reduce_global_fcn(BODY body_in,
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine(
+  RAJA::expt::ParamMultiplexer::parampack_combine(
       RAJA::cuda_flatten_global_xyz_direct {}, reduce_params);
 }
 
@@ -186,8 +186,8 @@ struct LaunchExecute<
       {
         using EXEC_POL = RAJA::policy::cuda::cuda_launch_explicit_t<
             async, named_usage::unspecified, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL {}, launch_reducers,
-                                                  launch_info);
+        RAJA::expt::ParamMultiplexer::parampack_init(
+            EXEC_POL {}, launch_reducers, launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -203,7 +203,7 @@ struct LaunchExecute<
         RAJA::cuda::launch(func, gridSize, blockSize, args, shared_mem_size,
                            cuda_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve(
+        RAJA::expt::ParamMultiplexer::parampack_resolve(
             EXEC_POL {}, launch_reducers, launch_info);
       }
 
@@ -252,7 +252,7 @@ __launch_bounds__(num_threads, BLOCKS_PER_SM) __global__
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine(
+  RAJA::expt::ParamMultiplexer::parampack_combine(
       RAJA::cuda_flatten_global_xyz_direct {}, reduce_params);
 }
 
@@ -376,11 +376,11 @@ struct LaunchExecute<
 
       {
         // Use a generic block size policy here to match that used in
-        // params_combine
+        // parampack_combine
         using EXEC_POL = RAJA::policy::cuda::cuda_launch_explicit_t<
             async, named_usage::unspecified, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL {}, launch_reducers,
-                                                  launch_info);
+        RAJA::expt::ParamMultiplexer::parampack_init(
+            EXEC_POL {}, launch_reducers, launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -396,7 +396,7 @@ struct LaunchExecute<
         RAJA::cuda::launch(func, gridSize, blockSize, args, shared_mem_size,
                            cuda_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve(
+        RAJA::expt::ParamMultiplexer::parampack_resolve(
             EXEC_POL {}, launch_reducers, launch_info);
       }
 

--- a/include/RAJA/policy/cuda/params/kernel_name.hpp
+++ b/include/RAJA/policy/cuda/params/kernel_name.hpp
@@ -17,6 +17,7 @@ namespace detail
 // Init
 template<typename EXEC_POL>
 camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_init(
+    EXEC_POL const&,
     KernelName& kn,
     const RAJA::cuda::detail::cudaInfo&)
 {
@@ -31,12 +32,13 @@ camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_init(
 template<typename EXEC_POL>
 RAJA_HOST_DEVICE camp::concepts::enable_if<
     type_traits::is_cuda_policy<EXEC_POL>>
-param_combine(KernelName&)
+param_combine(EXEC_POL const&, KernelName&)
 {}
 
 // Resolve
 template<typename EXEC_POL>
 camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_resolve(
+    EXEC_POL const&,
     KernelName&,
     const RAJA::cuda::detail::cudaInfo&)
 {

--- a/include/RAJA/policy/cuda/params/kernel_name.hpp
+++ b/include/RAJA/policy/cuda/params/kernel_name.hpp
@@ -16,10 +16,8 @@ namespace detail
 
 // Init
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_init(
-    EXEC_POL const&,
-    KernelName& kn,
-    const RAJA::cuda::detail::cudaInfo&)
+camp::concepts::enable_if<RAJA::type_traits::is_cuda_policy<EXEC_POL>>
+param_init(EXEC_POL const&, KernelName& kn, const RAJA::cuda::detail::cudaInfo&)
 {
 #if defined(RAJA_ENABLE_NV_TOOLS_EXT)
   nvtxRangePush(kn.name);
@@ -31,16 +29,14 @@ camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_init(
 // Combine
 template<typename EXEC_POL>
 RAJA_HOST_DEVICE camp::concepts::enable_if<
-    type_traits::is_cuda_policy<EXEC_POL>>
+    RAJA::type_traits::is_cuda_policy<EXEC_POL>>
 param_combine(EXEC_POL const&, KernelName&)
 {}
 
 // Resolve
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_resolve(
-    EXEC_POL const&,
-    KernelName&,
-    const RAJA::cuda::detail::cudaInfo&)
+camp::concepts::enable_if<RAJA::type_traits::is_cuda_policy<EXEC_POL>>
+param_resolve(EXEC_POL const&, KernelName&, const RAJA::cuda::detail::cudaInfo&)
 {
 #if defined(RAJA_ENABLE_NV_TOOLS_EXT)
   nvtxRangePop();

--- a/include/RAJA/policy/cuda/params/reduce.hpp
+++ b/include/RAJA/policy/cuda/params/reduce.hpp
@@ -19,10 +19,10 @@ namespace detail
 
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_init(
-    EXEC_POL const&,
-    Reducer<OP, T, VOp>& red,
-    RAJA::cuda::detail::cudaInfo& ci)
+camp::concepts::enable_if<RAJA::type_traits::is_cuda_policy<EXEC_POL>>
+param_init(EXEC_POL const&,
+           Reducer<OP, T, VOp>& red,
+           RAJA::cuda::detail::cudaInfo& ci)
 {
   red.devicetarget =
       RAJA::cuda::pinned_mempool_type::getInstance().template malloc<T>(1);
@@ -34,7 +34,7 @@ camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_init(
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 RAJA_HOST_DEVICE camp::concepts::enable_if<
-    type_traits::is_cuda_policy<EXEC_POL>>
+    RAJA::type_traits::is_cuda_policy<EXEC_POL>>
 param_combine(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   RAJA::cuda::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter, OP>(
@@ -43,10 +43,10 @@ param_combine(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_resolve(
-    EXEC_POL const&,
-    Reducer<OP, T, VOp>& red,
-    RAJA::cuda::detail::cudaInfo& ci)
+camp::concepts::enable_if<RAJA::type_traits::is_cuda_policy<EXEC_POL>>
+param_resolve(EXEC_POL const&,
+              Reducer<OP, T, VOp>& red,
+              RAJA::cuda::detail::cudaInfo& ci)
 {
   // complete reduction
   ci.res.wait();

--- a/include/RAJA/policy/cuda/params/reduce.hpp
+++ b/include/RAJA/policy/cuda/params/reduce.hpp
@@ -35,8 +35,7 @@ camp::concepts::enable_if<type_traits::is_cuda_policy<EXEC_POL>> param_init(
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 RAJA_HOST_DEVICE camp::concepts::enable_if<
     type_traits::is_cuda_policy<EXEC_POL>>
-param_combine(EXEC_POL const&,
-    Reducer<OP, T, VOp>& red)
+param_combine(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   RAJA::cuda::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter, OP>(
       red.devicetarget, red.getVal(), red.device_mem, red.device_count);

--- a/include/RAJA/policy/hip.hpp
+++ b/include/RAJA/policy/hip.hpp
@@ -40,6 +40,8 @@
 #include "RAJA/policy/hip/synchronize.hpp"
 #include "RAJA/policy/hip/launch.hpp"
 #include "RAJA/policy/hip/WorkGroup.hpp"
+#include "RAJA/policy/hip/params/reduce.hpp"
+#include "RAJA/policy/hip/params/kernel_name.hpp"
 
 
 #endif  // closing endif for if defined(RAJA_HIP_ACTIVE)

--- a/include/RAJA/policy/hip/forall.hpp
+++ b/include/RAJA/policy/hip/forall.hpp
@@ -443,7 +443,7 @@ __launch_bounds__(BlockSize, 1) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
 }
 
 ///
@@ -471,7 +471,7 @@ __global__ void forallp_hip_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
 }
 
 template<
@@ -559,7 +559,7 @@ __launch_bounds__(BlockSize, 1) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
 }
 
 ///
@@ -590,7 +590,7 @@ __global__ void forallp_hip_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, f_params);
+  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
 }
 
 }  // namespace impl
@@ -696,13 +696,14 @@ RAJA_INLINE concepts::enable_if_t<
     RAJA::expt::type_traits::is_ForallParamPack<ForallParam>,
     concepts::negate<
         RAJA::expt::type_traits::is_ForallParamPack_empty<ForallParam>>>
-forall_impl(
-    resources::Hip hip_res,
-    ::RAJA::policy::hip::
-        hip_exec<IterationMapping, IterationGetter, Concretizer, Async> const& pol,
-    Iterable&& iter,
-    LoopBody&& loop_body,
-    ForallParam f_params)
+forall_impl(resources::Hip hip_res,
+            ::RAJA::policy::hip::hip_exec<IterationMapping,
+                                          IterationGetter,
+                                          Concretizer,
+                                          Async> const& pol,
+            Iterable&& iter,
+            LoopBody&& loop_body,
+            ForallParam f_params)
 {
   using Iterator  = camp::decay<decltype(std::begin(iter))>;
   using LOOP_BODY = camp::decay<LoopBody>;

--- a/include/RAJA/policy/hip/forall.hpp
+++ b/include/RAJA/policy/hip/forall.hpp
@@ -617,7 +617,7 @@ RAJA_INLINE concepts::enable_if_t<
 forall_impl(
     resources::Hip hip_res,
     ::RAJA::policy::hip::
-        hip_exec<IterationMapping, IterationGetter, Concretizer, Async> const&,
+        hip_exec<IterationMapping, IterationGetter, Concretizer, Async> const& pol,
     Iterable&& iter,
     LoopBody&& loop_body,
     ForallParam)
@@ -626,9 +626,7 @@ forall_impl(
   using LOOP_BODY = camp::decay<LoopBody>;
   using IndexType =
       camp::decay<decltype(std::distance(std::begin(iter), std::end(iter)))>;
-  using EXEC_POL =
-      ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter,
-                                    Concretizer, Async>;
+  using EXEC_POL     = camp::decay<decltype(pol)>;
   using UniqueMarker = ::camp::list<IterationMapping, IterationGetter,
                                     LOOP_BODY, Iterator, ForallParam>;
   using DimensionCalculator =
@@ -709,9 +707,7 @@ forall_impl(resources::Hip hip_res,
   using LOOP_BODY = camp::decay<LoopBody>;
   using IndexType =
       camp::decay<decltype(std::distance(std::begin(iter), std::end(iter)))>;
-  using EXEC_POL =
-      ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter,
-                                    Concretizer, Async>;
+  using EXEC_POL     = camp::decay<decltype(pol)>;
   using UniqueMarker = ::camp::list<IterationMapping, IterationGetter,
                                     LOOP_BODY, Iterator, ForallParam>;
   using DimensionCalculator =

--- a/include/RAJA/policy/hip/forall.hpp
+++ b/include/RAJA/policy/hip/forall.hpp
@@ -443,7 +443,7 @@ __launch_bounds__(BlockSize, 1) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, f_params);
 }
 
 ///
@@ -471,7 +471,7 @@ __global__ void forallp_hip_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, f_params);
 }
 
 template<
@@ -559,7 +559,7 @@ __launch_bounds__(BlockSize, 1) __global__
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, f_params);
 }
 
 ///
@@ -590,7 +590,7 @@ __global__ void forallp_hip_kernel(LOOP_BODY loop_body,
   {
     RAJA::expt::invoke_body(f_params, body, idx[ii]);
   }
-  RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, f_params);
 }
 
 }  // namespace impl
@@ -752,7 +752,7 @@ forall_impl(resources::Hip hip_res,
     launch_info.res      = hip_res;
 
     {
-      RAJA::expt::ParamMultiplexer::params_init(pol, f_params, launch_info);
+      RAJA::expt::ParamMultiplexer::parampack_init(pol, f_params, launch_info);
 
       //
       // Privatize the loop_body, using make_launch_body to setup reductions
@@ -769,7 +769,8 @@ forall_impl(resources::Hip hip_res,
       RAJA::hip::launch(func, dims.blocks, dims.threads, args, shmem, hip_res,
                         Async);
 
-      RAJA::expt::ParamMultiplexer::params_resolve(pol, f_params, launch_info);
+      RAJA::expt::ParamMultiplexer::parampack_resolve(pol, f_params,
+                                                      launch_info);
     }
 
     RAJA_FT_END;

--- a/include/RAJA/policy/hip/intrinsics.hpp
+++ b/include/RAJA/policy/hip/intrinsics.hpp
@@ -107,7 +107,7 @@ struct AccessorDeviceScopeUseBlockFence
       u.array[i] = __hip_atomic_load(&ptr[i], __ATOMIC_RELAXED,
                                      __HIP_MEMORY_SCOPE_AGENT);
 #else
-      u.array[i] = atomicAdd(&ptr[i], integer_type(0));
+      u.array[i] = ::atomicAdd(&ptr[i], integer_type(0));
 #endif
     }
 
@@ -132,7 +132,7 @@ struct AccessorDeviceScopeUseBlockFence
       __hip_atomic_store(&ptr[i], u.array[i], __ATOMIC_RELAXED,
                          __HIP_MEMORY_SCOPE_AGENT);
 #else
-      atomicExch(&ptr[i], u.array[i]);
+      ::atomicExch(&ptr[i], u.array[i]);
 #endif
     }
   }

--- a/include/RAJA/policy/hip/launch.hpp
+++ b/include/RAJA/policy/hip/launch.hpp
@@ -61,8 +61,8 @@ __global__ void launch_new_reduce_global_fcn(BODY body_in,
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine(RAJA::hip_flatten_global_xyz_direct{},
-      reduce_params);
+  RAJA::expt::ParamMultiplexer::params_combine(
+      RAJA::hip_flatten_global_xyz_direct {}, reduce_params);
 }
 
 template<bool async>
@@ -184,8 +184,8 @@ struct LaunchExecute<
       {
         using EXEC_POL =
             RAJA::policy::hip::hip_launch_t<async, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL{}, launch_reducers,
-                                                     launch_info);
+        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL {}, launch_reducers,
+                                                  launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -201,8 +201,8 @@ struct LaunchExecute<
         RAJA::hip::launch(func, gridSize, blockSize, args, shared_mem_size,
                           hip_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve(EXEC_POL{}, launch_reducers,
-                                                        launch_info);
+        RAJA::expt::ParamMultiplexer::params_resolve(
+            EXEC_POL {}, launch_reducers, launch_info);
       }
 
       RAJA_FT_END;
@@ -247,8 +247,8 @@ __launch_bounds__(num_threads, 1) __global__
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine(RAJA::hip_flatten_global_xyz_direct{},
-      reduce_params);
+  RAJA::expt::ParamMultiplexer::params_combine(
+      RAJA::hip_flatten_global_xyz_direct {}, reduce_params);
 }
 
 template<bool async, int nthreads>
@@ -371,8 +371,8 @@ struct LaunchExecute<RAJA::policy::hip::hip_launch_t<async, nthreads>>
       {
         using EXEC_POL =
             RAJA::policy::hip::hip_launch_t<async, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL{}, launch_reducers,
-                                                     launch_info);
+        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL {}, launch_reducers,
+                                                  launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -388,8 +388,8 @@ struct LaunchExecute<RAJA::policy::hip::hip_launch_t<async, nthreads>>
         RAJA::hip::launch(func, gridSize, blockSize, args, shared_mem_size,
                           hip_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve(EXEC_POL{}, launch_reducers,
-                                                        launch_info);
+        RAJA::expt::ParamMultiplexer::params_resolve(
+            EXEC_POL {}, launch_reducers, launch_info);
       }
 
       RAJA_FT_END;

--- a/include/RAJA/policy/hip/launch.hpp
+++ b/include/RAJA/policy/hip/launch.hpp
@@ -146,6 +146,9 @@ struct LaunchExecute<
        ReduceParams& launch_reducers)
   {
     using BODY = camp::decay<BODY_IN>;
+    using EXEC_POL =
+        RAJA::policy::hip::hip_launch_t<async, named_usage::unspecified>;
+    EXEC_POL pol {};
 
     auto func = reinterpret_cast<const void*>(
         &launch_new_reduce_global_fcn<BODY, camp::decay<ReduceParams>>);
@@ -182,10 +185,9 @@ struct LaunchExecute<
       launch_info.res          = hip_res;
 
       {
-        using EXEC_POL =
-            RAJA::policy::hip::hip_launch_t<async, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::parampack_init(
-            EXEC_POL {}, launch_reducers, launch_info);
+
+        RAJA::expt::ParamMultiplexer::parampack_init(pol, launch_reducers,
+                                                     launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -201,8 +203,8 @@ struct LaunchExecute<
         RAJA::hip::launch(func, gridSize, blockSize, args, shared_mem_size,
                           hip_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::parampack_resolve(
-            EXEC_POL {}, launch_reducers, launch_info);
+        RAJA::expt::ParamMultiplexer::parampack_resolve(pol, launch_reducers,
+                                                        launch_info);
       }
 
       RAJA_FT_END;
@@ -332,6 +334,11 @@ struct LaunchExecute<RAJA::policy::hip::hip_launch_t<async, nthreads>>
        ReduceParams& launch_reducers)
   {
     using BODY = camp::decay<BODY_IN>;
+    // Use a generic block size policy here to match that used in
+    // parampack_combine
+    using EXEC_POL =
+        RAJA::policy::hip::hip_launch_t<async, named_usage::unspecified>;
+    EXEC_POL pol {};
 
     auto func = reinterpret_cast<const void*>(
         &launch_new_reduce_global_fcn_fixed<BODY, nthreads,
@@ -369,10 +376,9 @@ struct LaunchExecute<RAJA::policy::hip::hip_launch_t<async, nthreads>>
       launch_info.res          = hip_res;
 
       {
-        using EXEC_POL =
-            RAJA::policy::hip::hip_launch_t<async, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::parampack_init(
-            EXEC_POL {}, launch_reducers, launch_info);
+
+        RAJA::expt::ParamMultiplexer::parampack_init(pol, launch_reducers,
+                                                     launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -388,8 +394,8 @@ struct LaunchExecute<RAJA::policy::hip::hip_launch_t<async, nthreads>>
         RAJA::hip::launch(func, gridSize, blockSize, args, shared_mem_size,
                           hip_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::parampack_resolve(
-            EXEC_POL {}, launch_reducers, launch_info);
+        RAJA::expt::ParamMultiplexer::parampack_resolve(pol, launch_reducers,
+                                                        launch_info);
       }
 
       RAJA_FT_END;

--- a/include/RAJA/policy/hip/launch.hpp
+++ b/include/RAJA/policy/hip/launch.hpp
@@ -61,7 +61,7 @@ __global__ void launch_new_reduce_global_fcn(BODY body_in,
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine(
+  RAJA::expt::ParamMultiplexer::parampack_combine(
       RAJA::hip_flatten_global_xyz_direct {}, reduce_params);
 }
 
@@ -184,8 +184,8 @@ struct LaunchExecute<
       {
         using EXEC_POL =
             RAJA::policy::hip::hip_launch_t<async, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL {}, launch_reducers,
-                                                  launch_info);
+        RAJA::expt::ParamMultiplexer::parampack_init(
+            EXEC_POL {}, launch_reducers, launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -201,7 +201,7 @@ struct LaunchExecute<
         RAJA::hip::launch(func, gridSize, blockSize, args, shared_mem_size,
                           hip_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve(
+        RAJA::expt::ParamMultiplexer::parampack_resolve(
             EXEC_POL {}, launch_reducers, launch_info);
       }
 
@@ -247,7 +247,7 @@ __launch_bounds__(num_threads, 1) __global__
   RAJA::expt::invoke_body(reduce_params, body, ctx);
 
   // Using a flatten global policy as we may use all dimensions
-  RAJA::expt::ParamMultiplexer::params_combine(
+  RAJA::expt::ParamMultiplexer::parampack_combine(
       RAJA::hip_flatten_global_xyz_direct {}, reduce_params);
 }
 
@@ -371,8 +371,8 @@ struct LaunchExecute<RAJA::policy::hip::hip_launch_t<async, nthreads>>
       {
         using EXEC_POL =
             RAJA::policy::hip::hip_launch_t<async, named_usage::unspecified>;
-        RAJA::expt::ParamMultiplexer::params_init(EXEC_POL {}, launch_reducers,
-                                                  launch_info);
+        RAJA::expt::ParamMultiplexer::parampack_init(
+            EXEC_POL {}, launch_reducers, launch_info);
 
         //
         // Privatize the loop_body, using make_launch_body to setup reductions
@@ -388,7 +388,7 @@ struct LaunchExecute<RAJA::policy::hip::hip_launch_t<async, nthreads>>
         RAJA::hip::launch(func, gridSize, blockSize, args, shared_mem_size,
                           hip_res, async, kernel_name);
 
-        RAJA::expt::ParamMultiplexer::params_resolve(
+        RAJA::expt::ParamMultiplexer::parampack_resolve(
             EXEC_POL {}, launch_reducers, launch_info);
       }
 

--- a/include/RAJA/policy/hip/params/kernel_name.hpp
+++ b/include/RAJA/policy/hip/params/kernel_name.hpp
@@ -20,10 +20,8 @@ namespace detail
 
 // Init
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_init(
-    EXEC_POL const&,
-    KernelName& kn,
-    const RAJA::hip::detail::hipInfo&)
+camp::concepts::enable_if<RAJA::type_traits::is_hip_policy<EXEC_POL>>
+param_init(EXEC_POL const&, KernelName& kn, const RAJA::hip::detail::hipInfo&)
 {
 #if defined(RAJA_ENABLE_ROCTX)
   roctxRangePush(kn.name);
@@ -34,16 +32,15 @@ camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_init(
 
 // Combine
 template<typename EXEC_POL>
-RAJA_HOST_DEVICE camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>>
+RAJA_HOST_DEVICE camp::concepts::enable_if<
+    RAJA::type_traits::is_hip_policy<EXEC_POL>>
 param_combine(EXEC_POL const&, KernelName&)
 {}
 
 // Resolve
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_resolve(
-    EXEC_POL const&,
-    KernelName&,
-    const RAJA::hip::detail::hipInfo&)
+camp::concepts::enable_if<RAJA::type_traits::is_hip_policy<EXEC_POL>>
+param_resolve(EXEC_POL const&, KernelName&, const RAJA::hip::detail::hipInfo&)
 {
 #if defined(RAJA_ENABLE_ROCTX)
   roctxRangePop();

--- a/include/RAJA/policy/hip/params/kernel_name.hpp
+++ b/include/RAJA/policy/hip/params/kernel_name.hpp
@@ -35,8 +35,7 @@ camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_init(
 // Combine
 template<typename EXEC_POL>
 RAJA_HOST_DEVICE camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>>
-param_combine(EXEC_POL const&,
-    KernelName&)
+param_combine(EXEC_POL const&, KernelName&)
 {}
 
 // Resolve

--- a/include/RAJA/policy/hip/params/reduce.hpp
+++ b/include/RAJA/policy/hip/params/reduce.hpp
@@ -17,10 +17,10 @@ namespace detail
 
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_init(
-    EXEC_POL const&,
-    Reducer<OP, T, VOp>& red,
-    RAJA::hip::detail::hipInfo& hi)
+camp::concepts::enable_if<RAJA::type_traits::is_hip_policy<EXEC_POL>>
+param_init(EXEC_POL const&,
+           Reducer<OP, T, VOp>& red,
+           RAJA::hip::detail::hipInfo& hi)
 {
   red.devicetarget =
       RAJA::hip::pinned_mempool_type::getInstance().template malloc<T>(1);
@@ -31,7 +31,8 @@ camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_init(
 
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-RAJA_HOST_DEVICE camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>>
+RAJA_HOST_DEVICE camp::concepts::enable_if<
+    RAJA::type_traits::is_hip_policy<EXEC_POL>>
 param_combine(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter, OP>(
@@ -40,10 +41,10 @@ param_combine(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_resolve(
-    EXEC_POL const&,
-    Reducer<OP, T, VOp>& red,
-    RAJA::hip::detail::hipInfo& hi)
+camp::concepts::enable_if<RAJA::type_traits::is_hip_policy<EXEC_POL>>
+param_resolve(EXEC_POL const&,
+              Reducer<OP, T, VOp>& red,
+              RAJA::hip::detail::hipInfo& hi)
 {
   // complete reduction
   hi.res.wait();

--- a/include/RAJA/policy/hip/params/reduce.hpp
+++ b/include/RAJA/policy/hip/params/reduce.hpp
@@ -32,8 +32,7 @@ camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>> param_init(
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 RAJA_HOST_DEVICE camp::concepts::enable_if<type_traits::is_hip_policy<EXEC_POL>>
-param_combine(EXEC_POL const&,
-    Reducer<OP, T, VOp>& red)
+param_combine(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   RAJA::hip::impl::expt::grid_reduce<typename EXEC_POL::IterationGetter, OP>(
       red.devicetarget, red.getVal(), red.device_mem, red.device_count);

--- a/include/RAJA/policy/openmp.hpp
+++ b/include/RAJA/policy/openmp.hpp
@@ -44,6 +44,8 @@
 #include "RAJA/policy/openmp/synchronize.hpp"
 #include "RAJA/policy/openmp/launch.hpp"
 #include "RAJA/policy/openmp/WorkGroup.hpp"
+#include "RAJA/policy/openmp/params/reduce.hpp"
+#include "RAJA/policy/openmp/params/kernel_name.hpp"
 
 
 #endif  // closing endif for if defined(RAJA_ENABLE_OPENMP)

--- a/include/RAJA/policy/openmp/launch.hpp
+++ b/include/RAJA/policy/openmp/launch.hpp
@@ -72,7 +72,7 @@ struct LaunchExecute<RAJA::omp_launch_t>
     using EXEC_POL = RAJA::omp_launch_t;
     EXEC_POL pol {};
 
-    expt::ParamMultiplexer::params_init(pol, f_params);
+    expt::ParamMultiplexer::parampack_init(pol, f_params);
 
     // reducer object must be named f_params as expected by macro below
     RAJA_OMP_DECLARE_REDUCTION_COMBINE;
@@ -93,7 +93,7 @@ struct LaunchExecute<RAJA::omp_launch_t>
       ctx.shared_mem_ptr = nullptr;
     }
 
-    expt::ParamMultiplexer::params_resolve(pol, f_params);
+    expt::ParamMultiplexer::parampack_resolve(pol, f_params);
 
     return resources::EventProxy<resources::Resource>(res);
   }

--- a/include/RAJA/policy/openmp/launch.hpp
+++ b/include/RAJA/policy/openmp/launch.hpp
@@ -68,7 +68,6 @@ struct LaunchExecute<RAJA::omp_launch_t>
        BODY const& body,
        ReduceParams& f_params)
   {
-
     using EXEC_POL = RAJA::omp_launch_t;
     EXEC_POL pol {};
 

--- a/include/RAJA/policy/openmp/launch.hpp
+++ b/include/RAJA/policy/openmp/launch.hpp
@@ -70,7 +70,7 @@ struct LaunchExecute<RAJA::omp_launch_t>
   {
 
     using EXEC_POL = RAJA::omp_launch_t;
-    EXEC_POL pol{};
+    EXEC_POL pol {};
 
     expt::ParamMultiplexer::params_init(pol, f_params);
 

--- a/include/RAJA/policy/openmp/params/forall.hpp
+++ b/include/RAJA/policy/openmp/params/forall.hpp
@@ -34,7 +34,7 @@ forall_impl(const ExecPol& p,
             ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -44,7 +44,7 @@ forall_impl(const ExecPol& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -64,7 +64,7 @@ forall_impl(const ExecPol<ChunkSize>& p,
             ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -74,7 +74,7 @@ forall_impl(const ExecPol<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -94,7 +94,7 @@ forall_impl(const ExecPol<ChunkSize>& p,
             ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -105,7 +105,7 @@ forall_impl(const ExecPol<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -118,7 +118,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Runtime& p,
                              ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -128,7 +128,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Runtime& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -141,7 +141,7 @@ RAJA_INLINE void forall_impl_nowait(const ::RAJA::policy::omp::Auto& p,
                                     ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -154,7 +154,7 @@ RAJA_INLINE void forall_impl_nowait(const ::RAJA::policy::omp::Auto& p,
     }
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -171,7 +171,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
                              ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -181,7 +181,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -198,7 +198,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
                              ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -209,7 +209,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -226,7 +226,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
                              ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -236,7 +236,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -253,7 +253,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
                              ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -264,7 +264,7 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
     RAJA::expt::invoke_body(f_params, loop_body, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -282,7 +282,7 @@ RAJA_INLINE void forall_impl_nowait(
     ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -295,7 +295,7 @@ RAJA_INLINE void forall_impl_nowait(
     }
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 //
@@ -313,7 +313,7 @@ RAJA_INLINE void forall_impl_nowait(
     ForallParam&& f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   RAJA_EXTRACT_BED_IT(iter);
@@ -326,7 +326,7 @@ RAJA_INLINE void forall_impl_nowait(
     }
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
 }
 
 }  //  namespace internal

--- a/include/RAJA/policy/openmp/params/forall.hpp
+++ b/include/RAJA/policy/openmp/params/forall.hpp
@@ -33,7 +33,8 @@ forall_impl(const ExecPol& p,
             Func&& loop_body,
             ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  using EXEC_POL = camp::decay<decltype(p)>;
+
   RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
@@ -63,7 +64,8 @@ forall_impl(const ExecPol<ChunkSize>& p,
             Func&& loop_body,
             ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  using EXEC_POL = camp::decay<decltype(p)>;
+
   RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
@@ -93,7 +95,8 @@ forall_impl(const ExecPol<ChunkSize>& p,
             Func&& loop_body,
             ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  using EXEC_POL = camp::decay<decltype(p)>;
+
   RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
@@ -117,7 +120,8 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Runtime& p,
                              Func&& loop_body,
                              ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  using EXEC_POL = camp::decay<decltype(p)>;
+
   RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
@@ -140,7 +144,8 @@ RAJA_INLINE void forall_impl_nowait(const ::RAJA::policy::omp::Auto& p,
                                     Func&& loop_body,
                                     ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  using EXEC_POL = camp::decay<decltype(p)>;
+
   RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
@@ -170,7 +175,8 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
                              Func&& loop_body,
                              ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  using EXEC_POL = camp::decay<decltype(p)>;
+
   RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
@@ -197,7 +203,8 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Dynamic<ChunkSize>& p,
                              Func&& loop_body,
                              ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  using EXEC_POL = camp::decay<decltype(p)>;
+
   RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
@@ -225,7 +232,8 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
                              Func&& loop_body,
                              ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  using EXEC_POL = camp::decay<decltype(p)>;
+
   RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
@@ -252,7 +260,8 @@ RAJA_INLINE void forall_impl(const ::RAJA::policy::omp::Guided<ChunkSize>& p,
                              Func&& loop_body,
                              ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  using EXEC_POL = camp::decay<decltype(p)>;
+
   RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
@@ -281,7 +290,8 @@ RAJA_INLINE void forall_impl_nowait(
     Func&& loop_body,
     ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  using EXEC_POL = camp::decay<decltype(p)>;
+
   RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
@@ -312,7 +322,8 @@ RAJA_INLINE void forall_impl_nowait(
     Func&& loop_body,
     ForallParam&& f_params)
 {
-  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  using EXEC_POL = camp::decay<decltype(p)>;
+
   RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 

--- a/include/RAJA/policy/openmp/params/kernel_name.hpp
+++ b/include/RAJA/policy/openmp/params/kernel_name.hpp
@@ -23,17 +23,14 @@ camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_init(
 
 // Combine
 template<typename EXEC_POL, typename T>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_combine(
-    EXEC_POL const&,
-    KernelName&,
-    T& /*place holder argument*/)
+camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>>
+param_combine(EXEC_POL const&, KernelName&, T& /*place holder argument*/)
 {}
 
 // Resolve
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_resolve(
-    EXEC_POL const&,
-    KernelName&)
+camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>>
+param_resolve(EXEC_POL const&, KernelName&)
 {
   // TODO: Define kernel naming
 }

--- a/include/RAJA/policy/openmp/params/kernel_name.hpp
+++ b/include/RAJA/policy/openmp/params/kernel_name.hpp
@@ -14,22 +14,21 @@ namespace detail
 
 // Init
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_init(
-    EXEC_POL const&,
-    KernelName&)
+camp::concepts::enable_if<RAJA::type_traits::is_openmp_policy<EXEC_POL>>
+param_init(EXEC_POL const&, KernelName&)
 {
   // TODO: Define kernel naming
 }
 
 // Combine
 template<typename EXEC_POL, typename T>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>>
+camp::concepts::enable_if<RAJA::type_traits::is_openmp_policy<EXEC_POL>>
 param_combine(EXEC_POL const&, KernelName&, T& /*place holder argument*/)
 {}
 
 // Resolve
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>>
+camp::concepts::enable_if<RAJA::type_traits::is_openmp_policy<EXEC_POL>>
 param_resolve(EXEC_POL const&, KernelName&)
 {
   // TODO: Define kernel naming

--- a/include/RAJA/policy/openmp/params/reduce.hpp
+++ b/include/RAJA/policy/openmp/params/reduce.hpp
@@ -23,19 +23,18 @@ camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_init(
 
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_combine(
-    EXEC_POL const&,
-    Reducer<OP, T, VOp>& out,
-    const Reducer<OP, T, VOp>& in)
+camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>>
+param_combine(EXEC_POL const&,
+              Reducer<OP, T, VOp>& out,
+              const Reducer<OP, T, VOp>& in)
 {
   out.m_valop.val = OP {}(out.m_valop.val, in.m_valop.val);
 }
 
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_resolve(
-    EXEC_POL const&,
-    Reducer<OP, T, VOp>& red)
+camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>>
+param_resolve(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   red.combineTarget(red.m_valop.val);
 }

--- a/include/RAJA/policy/openmp/params/reduce.hpp
+++ b/include/RAJA/policy/openmp/params/reduce.hpp
@@ -14,16 +14,15 @@ namespace detail
 
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>> param_init(
-    EXEC_POL const&,
-    Reducer<OP, T, VOp>& red)
+camp::concepts::enable_if<RAJA::type_traits::is_openmp_policy<EXEC_POL>>
+param_init(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   red.m_valop.val = OP::identity();
 }
 
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>>
+camp::concepts::enable_if<RAJA::type_traits::is_openmp_policy<EXEC_POL>>
 param_combine(EXEC_POL const&,
               Reducer<OP, T, VOp>& out,
               const Reducer<OP, T, VOp>& in)
@@ -33,7 +32,7 @@ param_combine(EXEC_POL const&,
 
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_openmp_policy<EXEC_POL>>
+camp::concepts::enable_if<RAJA::type_traits::is_openmp_policy<EXEC_POL>>
 param_resolve(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   red.combineTarget(red.m_valop.val);

--- a/include/RAJA/policy/openmp_target.hpp
+++ b/include/RAJA/policy/openmp_target.hpp
@@ -32,6 +32,8 @@
 #include "RAJA/policy/openmp_target/reduce.hpp"
 //#include "RAJA/policy/openmp_target/multi_reduce.hpp"
 #include "RAJA/policy/openmp_target/WorkGroup.hpp"
+#include "RAJA/policy/openmp_target/params/reduce.hpp"
+#include "RAJA/policy/openmp_target/params/kernel_name.hpp"
 
 
 #endif  // closing endif for if defined(RAJA_ENABLE_OPENMP) &&

--- a/include/RAJA/policy/openmp_target/forall.hpp
+++ b/include/RAJA/policy/openmp_target/forall.hpp
@@ -49,7 +49,7 @@ forall_impl(resources::Omp omp_res,
             ForallParam f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   using Body = typename std::remove_reference<decltype(loop_body)>::type;
@@ -88,7 +88,7 @@ forall_impl(resources::Omp omp_res,
     RAJA::expt::invoke_body(f_params, ib, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
   return resources::EventProxy<resources::Omp>(omp_res);
 }
 
@@ -157,7 +157,7 @@ forall_impl(resources::Omp omp_res,
             ForallParam f_params)
 {
   using EXEC_POL = typename std::decay_t<decltype(p)>;
-  RAJA::expt::ParamMultiplexer::params_init(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
   using Body = typename std::remove_reference<decltype(loop_body)>::type;
@@ -174,7 +174,7 @@ forall_impl(resources::Omp omp_res,
     RAJA::expt::invoke_body(f_params, ib, begin_it[i]);
   }
 
-  RAJA::expt::ParamMultiplexer::params_resolve(p, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
   return resources::EventProxy<resources::Omp>(omp_res);
 }
 

--- a/include/RAJA/policy/openmp_target/forall.hpp
+++ b/include/RAJA/policy/openmp_target/forall.hpp
@@ -48,7 +48,8 @@ forall_impl(resources::Omp omp_res,
             Func&& loop_body,
             ForallParam f_params)
 {
-  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  using EXEC_POL = camp::decay<decltype(p)>;
+
   RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
@@ -89,6 +90,7 @@ forall_impl(resources::Omp omp_res,
   }
 
   RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
+
   return resources::EventProxy<resources::Omp>(omp_res);
 }
 
@@ -156,7 +158,8 @@ forall_impl(resources::Omp omp_res,
             Func&& loop_body,
             ForallParam f_params)
 {
-  using EXEC_POL = typename std::decay_t<decltype(p)>;
+  using EXEC_POL = camp::decay<decltype(p)>;
+
   RAJA::expt::ParamMultiplexer::parampack_init(p, f_params);
   RAJA_OMP_DECLARE_REDUCTION_COMBINE;
 
@@ -175,6 +178,7 @@ forall_impl(resources::Omp omp_res,
   }
 
   RAJA::expt::ParamMultiplexer::parampack_resolve(p, f_params);
+
   return resources::EventProxy<resources::Omp>(omp_res);
 }
 

--- a/include/RAJA/policy/openmp_target/params/kernel_name.hpp
+++ b/include/RAJA/policy/openmp_target/params/kernel_name.hpp
@@ -14,7 +14,7 @@ namespace detail
 
 // Init
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
+camp::concepts::enable_if<RAJA::type_traits::is_target_openmp_policy<EXEC_POL>>
 param_init(EXEC_POL const&, KernelName&)
 {
   // TODO: Define kernel naming
@@ -22,13 +22,13 @@ param_init(EXEC_POL const&, KernelName&)
 
 // Combine
 template<typename EXEC_POL, typename T>
-camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
+camp::concepts::enable_if<RAJA::type_traits::is_target_openmp_policy<EXEC_POL>>
 param_combine(EXEC_POL const&, KernelName&, T& /*place holder argument*/)
 {}
 
 // Resolve
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
+camp::concepts::enable_if<RAJA::type_traits::is_target_openmp_policy<EXEC_POL>>
 param_resolve(EXEC_POL const&, KernelName&)
 {
   // TODO: Define kernel naming

--- a/include/RAJA/policy/openmp_target/params/kernel_name.hpp
+++ b/include/RAJA/policy/openmp_target/params/kernel_name.hpp
@@ -14,9 +14,8 @@ namespace detail
 
 // Init
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> param_init(
-    EXEC_POL const&,
-    KernelName&)
+camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
+param_init(EXEC_POL const&, KernelName&)
 {
   // TODO: Define kernel naming
 }
@@ -24,15 +23,13 @@ camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> param_
 // Combine
 template<typename EXEC_POL, typename T>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
-param_combine(EXEC_POL const&,
-    KernelName&, T& /*place holder argument*/)
+param_combine(EXEC_POL const&, KernelName&, T& /*place holder argument*/)
 {}
 
 // Resolve
 template<typename EXEC_POL>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
-param_resolve(EXEC_POL const&,
-    KernelName&)
+param_resolve(EXEC_POL const&, KernelName&)
 {
   // TODO: Define kernel naming
 }

--- a/include/RAJA/policy/openmp_target/params/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/params/reduce.hpp
@@ -14,9 +14,8 @@ namespace detail
 
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> param_init(
-    EXEC_POL const&,
-    Reducer<OP, T, VOp>& red)
+camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
+param_init(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   red.m_valop.val = OP::identity();
 }
@@ -25,7 +24,8 @@ camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>> param_
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
 param_combine(EXEC_POL const&,
-    Reducer<OP, T, VOp>& out, const Reducer<OP, T, VOp>& in)
+              Reducer<OP, T, VOp>& out,
+              const Reducer<OP, T, VOp>& in)
 {
   out.m_valop.val = OP {}(out.m_valop.val, in.m_valop.val);
 }
@@ -33,8 +33,7 @@ param_combine(EXEC_POL const&,
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
 camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
-param_resolve(EXEC_POL const&,
-    Reducer<OP, T, VOp>& red)
+param_resolve(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   red.combineTarget(red.m_valop.val);
 }

--- a/include/RAJA/policy/openmp_target/params/reduce.hpp
+++ b/include/RAJA/policy/openmp_target/params/reduce.hpp
@@ -14,7 +14,7 @@ namespace detail
 
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
+camp::concepts::enable_if<RAJA::type_traits::is_target_openmp_policy<EXEC_POL>>
 param_init(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   red.m_valop.val = OP::identity();
@@ -22,7 +22,7 @@ param_init(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
+camp::concepts::enable_if<RAJA::type_traits::is_target_openmp_policy<EXEC_POL>>
 param_combine(EXEC_POL const&,
               Reducer<OP, T, VOp>& out,
               const Reducer<OP, T, VOp>& in)
@@ -32,7 +32,7 @@ param_combine(EXEC_POL const&,
 
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_target_openmp_policy<EXEC_POL>>
+camp::concepts::enable_if<RAJA::type_traits::is_target_openmp_policy<EXEC_POL>>
 param_resolve(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   red.combineTarget(red.m_valop.val);

--- a/include/RAJA/policy/sequential.hpp
+++ b/include/RAJA/policy/sequential.hpp
@@ -33,5 +33,7 @@
 #include "RAJA/policy/sequential/sort.hpp"
 #include "RAJA/policy/sequential/launch.hpp"
 #include "RAJA/policy/sequential/WorkGroup.hpp"
+#include "RAJA/policy/sequential/params/reduce.hpp"
+#include "RAJA/policy/sequential/params/kernel_name.hpp"
 
 #endif  // closing endif for header file include guard

--- a/include/RAJA/policy/sequential/forall.hpp
+++ b/include/RAJA/policy/sequential/forall.hpp
@@ -69,7 +69,7 @@ forall_impl(Resource res,
             Func&& body,
             ForallParam f_params)
 {
-  expt::ParamMultiplexer::params_init(pol, f_params);
+  expt::ParamMultiplexer::parampack_init(pol, f_params);
 
   RAJA_EXTRACT_BED_IT(iter);
 
@@ -78,7 +78,7 @@ forall_impl(Resource res,
     expt::invoke_body(f_params, body, *(begin_it + i));
   }
 
-  expt::ParamMultiplexer::params_resolve(pol, f_params);
+  expt::ParamMultiplexer::parampack_resolve(pol, f_params);
   return resources::EventProxy<Resource>(res);
 }
 

--- a/include/RAJA/policy/sequential/forall.hpp
+++ b/include/RAJA/policy/sequential/forall.hpp
@@ -55,15 +55,12 @@ namespace sequential
 //////////////////////////////////////////////////////////////////////
 //
 
-template<typename Iterable,
-         typename Func,
-         typename Resource,
-         typename ForallParam>
+template<typename Iterable, typename Func, typename ForallParam>
 RAJA_INLINE concepts::enable_if_t<
-    resources::EventProxy<Resource>,
+    resources::EventProxy<resources::Host>,
     expt::type_traits::is_ForallParamPack<ForallParam>,
     concepts::negate<expt::type_traits::is_ForallParamPack_empty<ForallParam>>>
-forall_impl(Resource res,
+forall_impl(resources::Host host_res,
             const seq_exec& pol,
             Iterable&& iter,
             Func&& body,
@@ -79,18 +76,16 @@ forall_impl(Resource res,
   }
 
   expt::ParamMultiplexer::parampack_resolve(pol, f_params);
-  return resources::EventProxy<Resource>(res);
+
+  return resources::EventProxy<resources::Host>(host_res);
 }
 
-template<typename Iterable,
-         typename Func,
-         typename Resource,
-         typename ForallParam>
+template<typename Iterable, typename Func, typename ForallParam>
 RAJA_INLINE concepts::enable_if_t<
-    resources::EventProxy<Resource>,
+    resources::EventProxy<resources::Host>,
     expt::type_traits::is_ForallParamPack<ForallParam>,
     expt::type_traits::is_ForallParamPack_empty<ForallParam>>
-forall_impl(Resource res,
+forall_impl(resources::Host host_res,
             const seq_exec&,
             Iterable&& iter,
             Func&& body,
@@ -102,7 +97,8 @@ forall_impl(Resource res,
   {
     body(*(begin_it + i));
   }
-  return resources::EventProxy<Resource>(res);
+
+  return resources::EventProxy<resources::Host>(host_res);
 }
 
 }  // namespace sequential

--- a/include/RAJA/policy/sequential/launch.hpp
+++ b/include/RAJA/policy/sequential/launch.hpp
@@ -77,7 +77,7 @@ struct LaunchExecute<RAJA::seq_launch_t>
        BODY const& body,
        ReduceParams& launch_reducers)
   {
-    expt::ParamMultiplexer::params_init(seq_exec{}, launch_reducers);
+    expt::ParamMultiplexer::params_init(seq_exec {}, launch_reducers);
 
     LaunchContext ctx;
     char* kernel_local_mem = new char[launch_params.shared_mem_size];
@@ -88,7 +88,7 @@ struct LaunchExecute<RAJA::seq_launch_t>
     delete[] kernel_local_mem;
     ctx.shared_mem_ptr = nullptr;
 
-    expt::ParamMultiplexer::params_resolve(seq_exec{}, launch_reducers);
+    expt::ParamMultiplexer::params_resolve(seq_exec {}, launch_reducers);
 
     return resources::EventProxy<resources::Resource>(res);
   }

--- a/include/RAJA/policy/sequential/launch.hpp
+++ b/include/RAJA/policy/sequential/launch.hpp
@@ -77,7 +77,10 @@ struct LaunchExecute<RAJA::seq_launch_t>
        BODY const& body,
        ReduceParams& launch_reducers)
   {
-    expt::ParamMultiplexer::parampack_init(seq_exec {}, launch_reducers);
+    using EXEC_POL = RAJA::seq_exec;
+    EXEC_POL pol {};
+
+    expt::ParamMultiplexer::parampack_init(pol, launch_reducers);
 
     LaunchContext ctx;
     char* kernel_local_mem = new char[launch_params.shared_mem_size];
@@ -88,7 +91,7 @@ struct LaunchExecute<RAJA::seq_launch_t>
     delete[] kernel_local_mem;
     ctx.shared_mem_ptr = nullptr;
 
-    expt::ParamMultiplexer::parampack_resolve(seq_exec {}, launch_reducers);
+    expt::ParamMultiplexer::parampack_resolve(pol, launch_reducers);
 
     return resources::EventProxy<resources::Resource>(res);
   }

--- a/include/RAJA/policy/sequential/launch.hpp
+++ b/include/RAJA/policy/sequential/launch.hpp
@@ -77,7 +77,7 @@ struct LaunchExecute<RAJA::seq_launch_t>
        BODY const& body,
        ReduceParams& launch_reducers)
   {
-    expt::ParamMultiplexer::params_init(seq_exec {}, launch_reducers);
+    expt::ParamMultiplexer::parampack_init(seq_exec {}, launch_reducers);
 
     LaunchContext ctx;
     char* kernel_local_mem = new char[launch_params.shared_mem_size];
@@ -88,7 +88,7 @@ struct LaunchExecute<RAJA::seq_launch_t>
     delete[] kernel_local_mem;
     ctx.shared_mem_ptr = nullptr;
 
-    expt::ParamMultiplexer::params_resolve(seq_exec {}, launch_reducers);
+    expt::ParamMultiplexer::parampack_resolve(seq_exec {}, launch_reducers);
 
     return resources::EventProxy<resources::Resource>(res);
   }

--- a/include/RAJA/policy/sequential/params/kernel_name.hpp
+++ b/include/RAJA/policy/sequential/params/kernel_name.hpp
@@ -23,8 +23,7 @@ camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::seq_exec>> param_init(
 template<typename EXEC_POL, typename T>
 RAJA_HOST_DEVICE camp::concepts::enable_if<
     std::is_same<EXEC_POL, RAJA::seq_exec>>
-param_combine(EXEC_POL const&,
-    KernelName&, T)
+param_combine(EXEC_POL const&, KernelName&, T)
 {}
 
 // Resolve

--- a/include/RAJA/policy/simd.hpp
+++ b/include/RAJA/policy/simd.hpp
@@ -25,5 +25,7 @@
 #include "RAJA/policy/sequential/launch.hpp"
 #include "RAJA/policy/simd/kernel/For.hpp"
 #include "RAJA/policy/simd/kernel/ForICount.hpp"
+#include "RAJA/policy/simd/params/reduce.hpp"
+#include "RAJA/policy/simd/params/kernel_name.hpp"
 
 #endif  // closing endif for header file include guard

--- a/include/RAJA/policy/simd/forall.hpp
+++ b/include/RAJA/policy/simd/forall.hpp
@@ -58,7 +58,7 @@ forall_impl(RAJA::resources::Host host_res,
             Func&& loop_body,
             ForallParam f_params)
 {
-  expt::ParamMultiplexer::params_init(seq_exec {}, f_params);
+  expt::ParamMultiplexer::parampack_init(seq_exec {}, f_params);
 
   auto begin    = std::begin(iter);
   auto end      = std::end(iter);
@@ -69,7 +69,7 @@ forall_impl(RAJA::resources::Host host_res,
     expt::invoke_body(f_params, loop_body, *(begin + i));
   }
 
-  expt::ParamMultiplexer::params_resolve(seq_exec {}, f_params);
+  expt::ParamMultiplexer::parampack_resolve(seq_exec {}, f_params);
   return RAJA::resources::EventProxy<resources::Host>(host_res);
 }
 

--- a/include/RAJA/policy/simd/forall.hpp
+++ b/include/RAJA/policy/simd/forall.hpp
@@ -58,7 +58,7 @@ forall_impl(RAJA::resources::Host host_res,
             Func&& loop_body,
             ForallParam f_params)
 {
-  expt::ParamMultiplexer::params_init(seq_exec{}, f_params);
+  expt::ParamMultiplexer::params_init(seq_exec {}, f_params);
 
   auto begin    = std::begin(iter);
   auto end      = std::end(iter);
@@ -69,7 +69,7 @@ forall_impl(RAJA::resources::Host host_res,
     expt::invoke_body(f_params, loop_body, *(begin + i));
   }
 
-  expt::ParamMultiplexer::params_resolve(seq_exec{}, f_params);
+  expt::ParamMultiplexer::params_resolve(seq_exec {}, f_params);
   return RAJA::resources::EventProxy<resources::Host>(host_res);
 }
 

--- a/include/RAJA/policy/simd/forall.hpp
+++ b/include/RAJA/policy/simd/forall.hpp
@@ -52,25 +52,25 @@ RAJA_INLINE concepts::enable_if_t<
     resources::EventProxy<resources::Host>,
     expt::type_traits::is_ForallParamPack<ForallParam>,
     concepts::negate<expt::type_traits::is_ForallParamPack_empty<ForallParam>>>
-forall_impl(RAJA::resources::Host host_res,
-            const simd_exec& RAJA_UNUSED_ARG(pol),
+forall_impl(resources::Host host_res,
+            const simd_exec& pol,
             Iterable&& iter,
-            Func&& loop_body,
+            Func&& body,
             ForallParam f_params)
 {
-  expt::ParamMultiplexer::parampack_init(seq_exec {}, f_params);
+  expt::ParamMultiplexer::parampack_init(pol, f_params);
 
-  auto begin    = std::begin(iter);
-  auto end      = std::end(iter);
-  auto distance = std::distance(begin, end);
+  RAJA_EXTRACT_BED_IT(iter);
+
   RAJA_SIMD
-  for (decltype(distance) i = 0; i < distance; ++i)
+  for (decltype(distance_it) i = 0; i < distance_it; ++i)
   {
-    expt::invoke_body(f_params, loop_body, *(begin + i));
+    expt::invoke_body(f_params, body, *(begin_it + i));
   }
 
-  expt::ParamMultiplexer::parampack_resolve(seq_exec {}, f_params);
-  return RAJA::resources::EventProxy<resources::Host>(host_res);
+  expt::ParamMultiplexer::parampack_resolve(pol, f_params);
+
+  return resources::EventProxy<resources::Host>(host_res);
 }
 
 template<typename Iterable, typename Func, typename ForallParam>
@@ -78,22 +78,21 @@ RAJA_INLINE concepts::enable_if_t<
     resources::EventProxy<resources::Host>,
     expt::type_traits::is_ForallParamPack<ForallParam>,
     expt::type_traits::is_ForallParamPack_empty<ForallParam>>
-forall_impl(RAJA::resources::Host host_res,
+forall_impl(resources::Host host_res,
             const simd_exec&,
             Iterable&& iter,
-            Func&& loop_body,
+            Func&& body,
             ForallParam)
 {
-  auto begin    = std::begin(iter);
-  auto end      = std::end(iter);
-  auto distance = std::distance(begin, end);
+  RAJA_EXTRACT_BED_IT(iter);
+
   RAJA_SIMD
-  for (decltype(distance) i = 0; i < distance; ++i)
+  for (decltype(distance_it) i = 0; i < distance_it; ++i)
   {
-    loop_body(*(begin + i));
+    body(*(begin_it + i));
   }
 
-  return RAJA::resources::EventProxy<resources::Host>(host_res);
+  return resources::EventProxy<resources::Host>(host_res);
 }
 
 }  // namespace simd

--- a/include/RAJA/policy/simd/params/kernel_name.hpp
+++ b/include/RAJA/policy/simd/params/kernel_name.hpp
@@ -1,0 +1,43 @@
+#ifndef SIMD_KERNELNAME_HPP
+#define SIMD_KERNELNAME_HPP
+
+#include "RAJA/pattern/params/kernel_name.hpp"
+
+namespace RAJA
+{
+namespace expt
+{
+namespace detail
+{
+
+// Init
+template<typename EXEC_POL>
+camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::simd_exec>> param_init(
+    EXEC_POL const&,
+    KernelName&)
+{
+  // TODO: Define kernel naming
+}
+
+// Combine
+template<typename EXEC_POL, typename T>
+RAJA_HOST_DEVICE camp::concepts::enable_if<
+    std::is_same<EXEC_POL, RAJA::simd_exec>>
+param_combine(EXEC_POL const&, KernelName&, T)
+{}
+
+// Resolve
+template<typename EXEC_POL>
+camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::simd_exec>> param_resolve(
+    EXEC_POL const&,
+    KernelName&)
+{
+  // TODO: Define kernel naming
+}
+
+}  //  namespace detail
+}  //  namespace expt
+}  //  namespace RAJA
+
+
+#endif  //  NEW_REDUCE_SIMD_REDUCE_HPP

--- a/include/RAJA/policy/simd/params/reduce.hpp
+++ b/include/RAJA/policy/simd/params/reduce.hpp
@@ -1,0 +1,45 @@
+#ifndef NEW_REDUCE_SIMD_REDUCE_HPP
+#define NEW_REDUCE_SIMD_REDUCE_HPP
+
+#include "RAJA/pattern/params/reducer.hpp"
+
+namespace RAJA
+{
+namespace expt
+{
+namespace detail
+{
+
+// Init
+template<typename EXEC_POL, typename OP, typename T, typename VOp>
+camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::simd_exec>> param_init(
+    EXEC_POL const&,
+    Reducer<OP, T, VOp>& red)
+{
+  red.m_valop.val = OP::identity();
+}
+
+// Combine
+template<typename EXEC_POL, typename OP, typename T, typename VOp>
+camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::simd_exec>> param_combine(
+    EXEC_POL const&,
+    Reducer<OP, T, VOp>& out,
+    const Reducer<OP, T, VOp>& in)
+{
+  out.m_valop.val = OP {}(out.m_valop.val, in.m_valop.val);
+}
+
+// Resolve
+template<typename EXEC_POL, typename OP, typename T, typename VOp>
+camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::simd_exec>> param_resolve(
+    EXEC_POL const&,
+    Reducer<OP, T, VOp>& red)
+{
+  red.combineTarget(red.m_valop.val);
+}
+
+}  //  namespace detail
+}  //  namespace expt
+}  //  namespace RAJA
+
+#endif  //  NEW_REDUCE_SIMD_REDUCE_HPP

--- a/include/RAJA/policy/sycl.hpp
+++ b/include/RAJA/policy/sycl.hpp
@@ -36,6 +36,8 @@
 //#include "RAJA/policy/sycl/synchronize.hpp"
 #include "RAJA/policy/sycl/launch.hpp"
 //#include "RAJA/policy/sycl/WorkGroup.hpp"
+#include "RAJA/policy/sycl/params/reduce.hpp"
+#include "RAJA/policy/sycl/params/kernel_name.hpp"
 
 #endif  // closing endif for if defined(RAJA_ENABLE_SYCL)
 

--- a/include/RAJA/policy/sycl/forall.hpp
+++ b/include/RAJA/policy/sycl/forall.hpp
@@ -275,7 +275,7 @@ forall_impl(resources::Sycl& sycl_res,
     ::sycl::queue* q = sycl_res.get_queue();
 
     auto combiner = [](ForallParam x, ForallParam y) {
-      RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, x, y);
+      RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, x, y);
       return x;
     };
 
@@ -352,7 +352,7 @@ forall_impl(resources::Sycl& sycl_res,
     ::sycl::queue* q = sycl_res.get_queue();
 
     auto combiner = [](ForallParam x, ForallParam y) {
-      RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, x, y);
+      RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, x, y);
       return x;
     };
 

--- a/include/RAJA/policy/sycl/forall.hpp
+++ b/include/RAJA/policy/sycl/forall.hpp
@@ -260,7 +260,7 @@ forall_impl(resources::Sycl& sycl_res,
   Iterator end   = std::end(iter);
   IndexType len  = std::distance(begin, end);
 
-  RAJA::expt::ParamMultiplexer::params_init(pol, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(pol, f_params);
 
   // Only launch kernel if we have something to iterate over
   if (len > 0 && BlockSize > 0)
@@ -275,19 +275,19 @@ forall_impl(resources::Sycl& sycl_res,
     ::sycl::queue* q = sycl_res.get_queue();
 
     auto combiner = [](ForallParam x, ForallParam y) {
-      RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, x, y);
+      RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, x, y);
       return x;
     };
 
     ForallParam* res = ::sycl::malloc_shared<ForallParam>(1, *q);
-    RAJA::expt::ParamMultiplexer::params_init(pol, *res);
+    RAJA::expt::ParamMultiplexer::parampack_init(pol, *res);
     auto reduction = ::sycl::reduction(res, f_params, combiner);
 
     q->submit([&](::sycl::handler& h) {
       h.parallel_for(::sycl::range<1>(len), reduction,
                      [=](::sycl::item<1> it, auto& red) {
                        ForallParam fp;
-                       RAJA::expt::ParamMultiplexer::params_init(pol, fp);
+                       RAJA::expt::ParamMultiplexer::parampack_init(pol, fp);
                        IndexType ii = it.get_id(0);
                        if (ii < len)
                        {
@@ -298,10 +298,10 @@ forall_impl(resources::Sycl& sycl_res,
     });
 
     q->wait();
-    RAJA::expt::ParamMultiplexer::params_combine(pol, f_params, *res);
+    RAJA::expt::ParamMultiplexer::parampack_combine(pol, f_params, *res);
     ::sycl::free(res, *q);
   }
-  RAJA::expt::ParamMultiplexer::params_resolve(pol, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(pol, f_params);
 
   return resources::EventProxy<resources::Sycl>(sycl_res);
 }
@@ -338,7 +338,7 @@ forall_impl(resources::Sycl& sycl_res,
   Iterator end   = std::end(iter);
   IndexType len  = std::distance(begin, end);
 
-  RAJA::expt::ParamMultiplexer::params_init(pol, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_init(pol, f_params);
 
   // Only launch kernel if we have something to iterate over
   if (len > 0 && BlockSize > 0)
@@ -352,7 +352,7 @@ forall_impl(resources::Sycl& sycl_res,
     ::sycl::queue* q = sycl_res.get_queue();
 
     auto combiner = [](ForallParam x, ForallParam y) {
-      RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, x, y);
+      RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, x, y);
       return x;
     };
 
@@ -373,7 +373,7 @@ forall_impl(resources::Sycl& sycl_res,
     q->memcpy(beg, &begin, sizeof(Iterator)).wait();
 
     ForallParam* res = ::sycl::malloc_shared<ForallParam>(1, *q);
-    RAJA::expt::ParamMultiplexer::params_init(pol, *res);
+    RAJA::expt::ParamMultiplexer::parampack_init(pol, *res);
     auto reduction = ::sycl::reduction(res, f_params, combiner);
 
     q->submit([&](::sycl::handler& h) {
@@ -381,7 +381,7 @@ forall_impl(resources::Sycl& sycl_res,
                       [=](::sycl::item<1> it, auto& red) {
                         Index_type ii = it.get_id(0);
                         ForallParam fp;
-                        RAJA::expt::ParamMultiplexer::params_init(pol, fp);
+                        RAJA::expt::ParamMultiplexer::parampack_init(pol, fp);
                         if (ii < len)
                         {
                           RAJA::expt::invoke_body(fp, *lbody, (*beg)[ii]);
@@ -389,7 +389,7 @@ forall_impl(resources::Sycl& sycl_res,
                         red.combine(fp);
                       });
      }).wait();  // Need to wait for completion to free memory
-    RAJA::expt::ParamMultiplexer::params_combine(pol, f_params, *res);
+    RAJA::expt::ParamMultiplexer::parampack_combine(pol, f_params, *res);
     // Free our device memory
     ::sycl::free(res, *q);
     ::sycl::free(lbody, *q);
@@ -397,7 +397,7 @@ forall_impl(resources::Sycl& sycl_res,
 
     RAJA_FT_END;
   }
-  RAJA::expt::ParamMultiplexer::params_resolve(pol, f_params);
+  RAJA::expt::ParamMultiplexer::parampack_resolve(pol, f_params);
 
   return resources::EventProxy<resources::Sycl>(sycl_res);
 }

--- a/include/RAJA/policy/sycl/forall.hpp
+++ b/include/RAJA/policy/sycl/forall.hpp
@@ -251,7 +251,7 @@ forall_impl(resources::Sycl& sycl_res,
   using LOOP_BODY = camp::decay<LoopBody>;
   using IndexType =
       camp::decay<decltype(std::distance(std::begin(iter), std::end(iter)))>;
-  using EXEC_POL = typename std::decay_t<decltype(pol)>;
+  using EXEC_POL = camp::decay<decltype(pol)>;
 
   //
   // Compute the requested iteration space size
@@ -329,7 +329,7 @@ forall_impl(resources::Sycl& sycl_res,
   using LOOP_BODY = camp::decay<LoopBody>;
   using IndexType =
       camp::decay<decltype(std::distance(std::begin(iter), std::end(iter)))>;
-  using EXEC_POL = RAJA::sycl_exec<BlockSize, Async>;
+  using EXEC_POL = camp::decay<decltype(pol)>;
 
   //
   // Compute the requested iteration space size

--- a/include/RAJA/policy/sycl/launch.hpp
+++ b/include/RAJA/policy/sycl/launch.hpp
@@ -124,7 +124,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
 
     using EXEC_POL = RAJA::sycl_launch_t<async, 0>;
     EXEC_POL pol {};
-    RAJA::expt::ParamMultiplexer::params_init(pol, launch_reducers);
+    RAJA::expt::ParamMultiplexer::parampack_init(pol, launch_reducers);
 
     //
     // Compute the number of blocks and threads
@@ -150,14 +150,14 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
 
 
       auto combiner = [](ReduceParams x, ReduceParams y) {
-        RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, x, y);
+        RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, x, y);
         return x;
       };
 
       RAJA_FT_BEGIN;
 
       ReduceParams* res = ::sycl::malloc_shared<ReduceParams>(1, *q);
-      RAJA::expt::ParamMultiplexer::params_init(pol, *res);
+      RAJA::expt::ParamMultiplexer::parampack_init(pol, *res);
       auto reduction = ::sycl::reduction(res, launch_reducers, combiner);
 
       q->submit([&](::sycl::handler& h) {
@@ -175,7 +175,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
                    s_vec.get_multi_ptr<::sycl::access::decorated::yes>().get();
 
                ReduceParams fp;
-               RAJA::expt::ParamMultiplexer::params_init(pol, fp);
+               RAJA::expt::ParamMultiplexer::parampack_init(pol, fp);
 
                RAJA::expt::invoke_body(fp, body_in, ctx);
 
@@ -183,13 +183,14 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
              });
        }).wait();  // Need to wait for completion to free memory
 
-      RAJA::expt::ParamMultiplexer::params_combine(pol, launch_reducers, *res);
+      RAJA::expt::ParamMultiplexer::parampack_combine(pol, launch_reducers,
+                                                      *res);
       ::sycl::free(res, *q);
 
       RAJA_FT_END;
     }
 
-    RAJA::expt::ParamMultiplexer::params_resolve(pol, launch_reducers);
+    RAJA::expt::ParamMultiplexer::parampack_resolve(pol, launch_reducers);
 
     return resources::EventProxy<resources::Resource>(res);
   }
@@ -292,7 +293,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
 
     using EXEC_POL = RAJA::sycl_launch_t<async, 0>;
     EXEC_POL pol {};
-    RAJA::expt::ParamMultiplexer::params_init(pol, launch_reducers);
+    RAJA::expt::ParamMultiplexer::parampack_init(pol, launch_reducers);
 
     //
     // Compute the number of blocks and threads
@@ -318,7 +319,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
 
 
       auto combiner = [](ReduceParams x, ReduceParams y) {
-        RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, x, y);
+        RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL {}, x, y);
         return x;
       };
 
@@ -334,7 +335,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
       q->memcpy(lbody, &body_in, sizeof(LOOP_BODY)).wait();
 
       ReduceParams* res = ::sycl::malloc_shared<ReduceParams>(1, *q);
-      RAJA::expt::ParamMultiplexer::params_init(pol, *res);
+      RAJA::expt::ParamMultiplexer::parampack_init(pol, *res);
       auto reduction = ::sycl::reduction(res, launch_reducers, combiner);
 
       q->submit([&](::sycl::handler& h) {
@@ -352,7 +353,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
                    s_vec.get_multi_ptr<::sycl::access::decorated::yes>().get();
 
                ReduceParams fp;
-               RAJA::expt::ParamMultiplexer::params_init(pol, fp);
+               RAJA::expt::ParamMultiplexer::parampack_init(pol, fp);
 
                RAJA::expt::invoke_body(fp, *lbody, ctx);
 
@@ -360,14 +361,15 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
              });
        }).wait();  // Need to wait for completion to free memory
 
-      RAJA::expt::ParamMultiplexer::params_combine(pol, launch_reducers, *res);
+      RAJA::expt::ParamMultiplexer::parampack_combine(pol, launch_reducers,
+                                                      *res);
       ::sycl::free(res, *q);
       ::sycl::free(lbody, *q);
 
       RAJA_FT_END;
     }
 
-    RAJA::expt::ParamMultiplexer::params_resolve(pol, launch_reducers);
+    RAJA::expt::ParamMultiplexer::parampack_resolve(pol, launch_reducers);
 
     return resources::EventProxy<resources::Resource>(res);
   }

--- a/include/RAJA/policy/sycl/launch.hpp
+++ b/include/RAJA/policy/sycl/launch.hpp
@@ -118,12 +118,12 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
        BODY_IN&& body_in,
        ReduceParams launch_reducers)
   {
+    using EXEC_POL = RAJA::sycl_launch_t<async, 0>;
+    EXEC_POL pol {};
 
     /*Get the queue from concrete resource */
     ::sycl::queue* q = res.get<camp::resources::Sycl>().get_queue();
 
-    using EXEC_POL = RAJA::sycl_launch_t<async, 0>;
-    EXEC_POL pol {};
     RAJA::expt::ParamMultiplexer::parampack_init(pol, launch_reducers);
 
     //
@@ -287,12 +287,12 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
        BODY_IN&& body_in,
        ReduceParams launch_reducers)
   {
+    using EXEC_POL = RAJA::sycl_launch_t<async, 0>;
+    EXEC_POL pol {};
 
     /*Get the queue from concrete resource */
     ::sycl::queue* q = res.get<camp::resources::Sycl>().get_queue();
 
-    using EXEC_POL = RAJA::sycl_launch_t<async, 0>;
-    EXEC_POL pol {};
     RAJA::expt::ParamMultiplexer::parampack_init(pol, launch_reducers);
 
     //

--- a/include/RAJA/policy/sycl/launch.hpp
+++ b/include/RAJA/policy/sycl/launch.hpp
@@ -123,7 +123,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
     ::sycl::queue* q = res.get<camp::resources::Sycl>().get_queue();
 
     using EXEC_POL = RAJA::sycl_launch_t<async, 0>;
-    EXEC_POL pol{};
+    EXEC_POL pol {};
     RAJA::expt::ParamMultiplexer::params_init(pol, launch_reducers);
 
     //
@@ -150,7 +150,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
 
 
       auto combiner = [](ReduceParams x, ReduceParams y) {
-        RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, x, y);
+        RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, x, y);
         return x;
       };
 
@@ -291,7 +291,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
     ::sycl::queue* q = res.get<camp::resources::Sycl>().get_queue();
 
     using EXEC_POL = RAJA::sycl_launch_t<async, 0>;
-    EXEC_POL pol{};
+    EXEC_POL pol {};
     RAJA::expt::ParamMultiplexer::params_init(pol, launch_reducers);
 
     //
@@ -318,7 +318,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
 
 
       auto combiner = [](ReduceParams x, ReduceParams y) {
-        RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, x, y);
+        RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL {}, x, y);
         return x;
       };
 

--- a/include/RAJA/policy/sycl/params/kernel_name.hpp
+++ b/include/RAJA/policy/sycl/params/kernel_name.hpp
@@ -14,24 +14,22 @@ namespace detail
 
 // Init
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_init(
-    EXEC_POL const&,
-    KernelName&)
+camp::concepts::enable_if<RAJA::type_traits::is_sycl_policy<EXEC_POL>>
+param_init(EXEC_POL const&, KernelName&)
 {
   // TODO: Define kernel naming
 }
 
 // Combine
 template<typename EXEC_POL, typename T>
-camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> SYCL_EXTERNAL
-param_combine(EXEC_POL const&, KernelName&, T)
+camp::concepts::enable_if<RAJA::type_traits::is_sycl_policy<EXEC_POL>>
+    SYCL_EXTERNAL param_combine(EXEC_POL const&, KernelName&, T)
 {}
 
 // Resolve
 template<typename EXEC_POL>
-camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_resolve(
-    EXEC_POL const&,
-    KernelName&)
+camp::concepts::enable_if<RAJA::type_traits::is_sycl_policy<EXEC_POL>>
+param_resolve(EXEC_POL const&, KernelName&)
 {
   // TODO: Define kernel naming
 }

--- a/include/RAJA/policy/sycl/params/kernel_name.hpp
+++ b/include/RAJA/policy/sycl/params/kernel_name.hpp
@@ -24,8 +24,7 @@ camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_init(
 // Combine
 template<typename EXEC_POL, typename T>
 camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> SYCL_EXTERNAL
-param_combine(EXEC_POL const&,
-    KernelName&, T)
+param_combine(EXEC_POL const&, KernelName&, T)
 {}
 
 // Resolve

--- a/include/RAJA/policy/sycl/params/reduce.hpp
+++ b/include/RAJA/policy/sycl/params/reduce.hpp
@@ -14,28 +14,26 @@ namespace detail
 
 // Init
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_init(
-    EXEC_POL const&,
-    Reducer<OP, T, VOp>& red)
+camp::concepts::enable_if<RAJA::type_traits::is_sycl_policy<EXEC_POL>>
+param_init(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   red.m_valop.val = OP::identity();
 }
 
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_combine(
-    EXEC_POL const&,
-    Reducer<OP, T, VOp>& out,
-    const Reducer<OP, T, VOp>& in)
+camp::concepts::enable_if<RAJA::type_traits::is_sycl_policy<EXEC_POL>>
+param_combine(EXEC_POL const&,
+              Reducer<OP, T, VOp>& out,
+              const Reducer<OP, T, VOp>& in)
 {
   out.m_valop.val = OP {}(out.m_valop.val, in.m_valop.val);
 }
 
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<type_traits::is_sycl_policy<EXEC_POL>> param_resolve(
-    EXEC_POL const&,
-    Reducer<OP, T, VOp>& red)
+camp::concepts::enable_if<RAJA::type_traits::is_sycl_policy<EXEC_POL>>
+param_resolve(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   red.combineTarget(red.m_valop.val);
 }

--- a/include/RAJA/util/macros.hpp
+++ b/include/RAJA/util/macros.hpp
@@ -141,7 +141,7 @@ RAJA_HOST_DEVICE RAJA_INLINE void RAJA_UNUSED_VAR(T&&...) noexcept
  */
 #if defined(RAJA_ENABLE_OPENMP)
 #define RAJA_OMP_DECLARE_REDUCTION_COMBINE                                     \
-  RAJA_UNUSED_VAR(EXEC_POL{}); \
+  RAJA_UNUSED_VAR(EXEC_POL {});                                                \
   _Pragma(" omp declare reduction( combine \
         : typename std::remove_reference<decltype(f_params)>::type \
         : RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, omp_out, omp_in) ) ")  // initializer(omp_priv = omp_in) ")

--- a/include/RAJA/util/macros.hpp
+++ b/include/RAJA/util/macros.hpp
@@ -144,7 +144,7 @@ RAJA_HOST_DEVICE RAJA_INLINE void RAJA_UNUSED_VAR(T&&...) noexcept
   RAJA_UNUSED_VAR(EXEC_POL {});                                                \
   _Pragma(" omp declare reduction( combine \
         : typename std::remove_reference<decltype(f_params)>::type \
-        : RAJA::expt::ParamMultiplexer::params_combine(EXEC_POL{}, omp_out, omp_in) ) ")  // initializer(omp_priv = omp_in) ")
+        : RAJA::expt::ParamMultiplexer::parampack_combine(EXEC_POL{}, omp_out, omp_in) ) ")  // initializer(omp_priv = omp_in) ")
 #endif
 
 

--- a/test/functional/kernel/basic-fission-fusion-loop/tests/basic-fission-fusion-loop-impl.hpp
+++ b/test/functional/kernel/basic-fission-fusion-loop/tests/basic-fission-fusion-loop-impl.hpp
@@ -80,7 +80,7 @@ void KernelBasicFissionFusionLoopTestImpl(
          0,
          sizeof(DATA_TYPE) * RAJA::stripIndexType(data_len));
 
-  RAJA::forall<RAJA::seq_exec>(working_res, seg_idx, [=](IDX_TYPE i) {
+  RAJA::forall<RAJA::seq_exec>(seg_idx, [=](IDX_TYPE i) {
     check_array_y[RAJA::stripIndexType(i)] += 1;
     check_array_y[RAJA::stripIndexType(i)] += 2;
   });

--- a/test/functional/kernel/conditional-fission-fusion-loop/tests/conditional-fission-fusion-loop-impl.hpp
+++ b/test/functional/kernel/conditional-fission-fusion-loop/tests/conditional-fission-fusion-loop-impl.hpp
@@ -85,7 +85,7 @@ void KernelConditionalFissionFusionLoopTestImpl(
            0,
            sizeof(DATA_TYPE) * RAJA::stripIndexType(data_len));
 
-    RAJA::forall<RAJA::seq_exec>(working_res, seg_idx, [=](IDX_TYPE i) {
+    RAJA::forall<RAJA::seq_exec>(seg_idx, [=](IDX_TYPE i) {
       check_array_y[RAJA::stripIndexType(i)] = 3 + 3 * param;
     });
 

--- a/test/functional/launch/tile_icount_tcount_direct/tests/test-launch-nested-Tile-iCount-tCount-Direct.hpp
+++ b/test/functional/launch/tile_icount_tcount_direct/tests/test-launch-nested-Tile-iCount-tCount-Direct.hpp
@@ -15,8 +15,8 @@ template <typename INDEX_TYPE, typename WORKING_RES, typename LAUNCH_POLICY,
 void LaunchNestedTileDirectTestImpl(INDEX_TYPE M)
 {
 
-  constexpr int threads_x   = 4;
-  constexpr int blocks_x    = 4;
+  constexpr INDEX_TYPE threads_x   = 4;
+  constexpr INDEX_TYPE blocks_x    = 4;
 
   RAJA::TypedRangeSegment<INDEX_TYPE> r1(0, M*threads_x+1);
 

--- a/test/functional/launch/tile_icount_tcount_direct_unchecked/tests/test-launch-nested-Tile-iCount-tCount-DirectUnchecked.hpp
+++ b/test/functional/launch/tile_icount_tcount_direct_unchecked/tests/test-launch-nested-Tile-iCount-tCount-DirectUnchecked.hpp
@@ -15,8 +15,8 @@ template <typename INDEX_TYPE, typename WORKING_RES, typename LAUNCH_POLICY,
 void LaunchNestedTileDirectUncheckedTestImpl(INDEX_TYPE M)
 {
 
-  constexpr int threads_x   = 4;
-  const     int blocks_x    = M*4;
+  constexpr INDEX_TYPE threads_x = 4;
+  const     INDEX_TYPE blocks_x  = M*4;
 
   RAJA::TypedRangeSegment<INDEX_TYPE> r1(0, threads_x*blocks_x);
 

--- a/test/functional/launch/tile_icount_tcount_loop/tests/test-launch-nested-Tile-iCount-tCount-Loop.hpp
+++ b/test/functional/launch/tile_icount_tcount_loop/tests/test-launch-nested-Tile-iCount-tCount-Loop.hpp
@@ -15,11 +15,11 @@ template <typename INDEX_TYPE, typename WORKING_RES, typename LAUNCH_POLICY,
 void LaunchNestedTileLoopTestImpl(INDEX_TYPE M)
 {
 
-  constexpr int tile_size   = 4;
+  constexpr INDEX_TYPE tile_size   = 4;
 
   //following grid will require loop policies
-  constexpr int threads_x   = 3;
-  constexpr int blocks_x    = 1;
+  constexpr INDEX_TYPE threads_x   = 3;
+  constexpr INDEX_TYPE blocks_x    = 1;
 
   RAJA::TypedRangeSegment<INDEX_TYPE> r1(0, M*tile_size+1);
 


### PR DESCRIPTION
# Unify style and improve include structure

Make the style of the param implementations more uniform. This also changes the include structure to be more in line with other parts of the code.
This should make it a little easier to make changes and simplify the diff of subsequent PRs.

Also add separate simd implementations of reduce and kernel name so the simd policy may be used similar to sequential policies in the param interface.

- This PR is a refactoring
- It does the following (modify list as needed):
  - refactors param implementations

