### PR TITLE
Squash unused arg/var warnings.

### DIFF
--- a/include/RAJA/policy/hip/forall.hpp
+++ b/include/RAJA/policy/hip/forall.hpp
@@ -614,13 +614,14 @@ RAJA_INLINE concepts::enable_if_t<
     resources::EventProxy<resources::Hip>,
     RAJA::expt::type_traits::is_ForallParamPack<ForallParam>,
     RAJA::expt::type_traits::is_ForallParamPack_empty<ForallParam>>
-forall_impl(
-    resources::Hip hip_res,
-    ::RAJA::policy::hip::
-        hip_exec<IterationMapping, IterationGetter, Concretizer, Async> const& pol,
-    Iterable&& iter,
-    LoopBody&& loop_body,
-    ForallParam)
+forall_impl(resources::Hip hip_res,
+            ::RAJA::policy::hip::hip_exec<IterationMapping,
+                                          IterationGetter,
+                                          Concretizer,
+                                          Async> const& pol,
+            Iterable&& iter,
+            LoopBody&& loop_body,
+            ForallParam)
 {
   using Iterator  = camp::decay<decltype(std::begin(iter))>;
   using LOOP_BODY = camp::decay<LoopBody>;

--- a/include/RAJA/policy/simd/params/kernel_name.hpp
+++ b/include/RAJA/policy/simd/params/kernel_name.hpp
@@ -28,9 +28,8 @@ param_combine(EXEC_POL const&, KernelName&, T)
 
 // Resolve
 template<typename EXEC_POL>
-camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::simd_exec>> param_resolve(
-    EXEC_POL const&,
-    KernelName&)
+camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::simd_exec>>
+param_resolve(EXEC_POL const&, KernelName&)
 {
   // TODO: Define kernel naming
 }

--- a/include/RAJA/policy/simd/params/reduce.hpp
+++ b/include/RAJA/policy/simd/params/reduce.hpp
@@ -21,19 +21,18 @@ camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::simd_exec>> param_init(
 
 // Combine
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::simd_exec>> param_combine(
-    EXEC_POL const&,
-    Reducer<OP, T, VOp>& out,
-    const Reducer<OP, T, VOp>& in)
+camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::simd_exec>>
+param_combine(EXEC_POL const&,
+              Reducer<OP, T, VOp>& out,
+              const Reducer<OP, T, VOp>& in)
 {
   out.m_valop.val = OP {}(out.m_valop.val, in.m_valop.val);
 }
 
 // Resolve
 template<typename EXEC_POL, typename OP, typename T, typename VOp>
-camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::simd_exec>> param_resolve(
-    EXEC_POL const&,
-    Reducer<OP, T, VOp>& red)
+camp::concepts::enable_if<std::is_same<EXEC_POL, RAJA::simd_exec>>
+param_resolve(EXEC_POL const&, Reducer<OP, T, VOp>& red)
 {
   red.combineTarget(red.m_valop.val);
 }

--- a/include/RAJA/policy/sycl/launch.hpp
+++ b/include/RAJA/policy/sycl/launch.hpp
@@ -43,7 +43,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
       RAJA::expt::type_traits::is_ForallParamPack_empty<ReduceParams>>
   exec(RAJA::resources::Resource res,
        const LaunchParams& params,
-       const char* kernel_name,
+       const char* RAJA_UNUSED_ARG(ernel_name),
        BODY_IN&& body_in,
        ReduceParams& RAJA_UNUSED_ARG(launch_reducers))
   {
@@ -114,7 +114,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
           RAJA::expt::type_traits::is_ForallParamPack_empty<ReduceParams>>>
   exec(RAJA::resources::Resource res,
        const LaunchParams& launch_params,
-       const char* kernel_name,
+       const char* RAJA_UNUSED_ARG(kernel_name),
        BODY_IN&& body_in,
        ReduceParams launch_reducers)
   {

--- a/include/RAJA/policy/sycl/launch.hpp
+++ b/include/RAJA/policy/sycl/launch.hpp
@@ -43,7 +43,7 @@ struct LaunchExecute<RAJA::sycl_launch_t<async, 0>>
       RAJA::expt::type_traits::is_ForallParamPack_empty<ReduceParams>>
   exec(RAJA::resources::Resource res,
        const LaunchParams& params,
-       const char* RAJA_UNUSED_ARG(ernel_name),
+       const char* RAJA_UNUSED_ARG(kernel_name),
        BODY_IN&& body_in,
        ReduceParams& RAJA_UNUSED_ARG(launch_reducers))
   {

--- a/include/RAJA/util/macros.hpp
+++ b/include/RAJA/util/macros.hpp
@@ -152,6 +152,7 @@ RAJA_HOST_DEVICE
 inline void RAJA_ABORT_OR_THROW(const char* str)
 {
 #if defined(__SYCL_DEVICE_ONLY__)
+  RAJA_UNUSED_VAR(str);
   // segfault here ran into linking problems
   *((volatile char*)0) = 0;  // write to address 0
 #else


### PR DESCRIPTION
# Summary

- This PR squashes compiler warnings when SYCL is enabled.
- It also runs clang-format on the code to pass that check