### PR TITLE
Memory arena for launch

### DIFF
--- a/include/RAJA/pattern/launch/launch_core.hpp
+++ b/include/RAJA/pattern/launch/launch_core.hpp
@@ -222,7 +222,7 @@ public:
   {
 
     // Calculate offset in bytes with a char pointer
-    void* mem_ptr = static_cast<char*>(arena_mem_ptr) + shared_arena_offset;
+    void* mem_ptr = static_cast<char*>(mem_arena_ptr) + mem_arena_offset;
 
     arena_mem_offset += bytes * sizeof(T);
 


### PR DESCRIPTION
# Summary
This PR introduces the concept of a memory arena of launch. The underlying idea is to allow users to allocate static shared memory (or could be an external memory type?) and manage it through a bump style allocator.

This PR is a work in progress. 