### PR TITLE
Enable optional omp 5.1 atomic min/max

### DIFF
--- a/cmake/SetupRajaOptions.cmake
+++ b/cmake/SetupRajaOptions.cmake
@@ -18,6 +18,8 @@ option(RAJA_ENABLE_VECTORIZATION "Build experimental vectorization support" On)
 
 option(RAJA_ENABLE_OPENMP_TASK "Build OpenMP task variants of certain algorithms" Off)
 
+option(RAJA_ENABLE_OPENMP_5_1_ATOMICS "Enable OpenMP 5.1 atomics for min/max operations" On)
+
 option(RAJA_ENABLE_REPRODUCERS "Build issue reproducers" Off)
 
 option(RAJA_ENABLE_EXERCISES "Build exercises " On)

--- a/cmake/SetupRajaOptions.cmake
+++ b/cmake/SetupRajaOptions.cmake
@@ -18,7 +18,7 @@ option(RAJA_ENABLE_VECTORIZATION "Build experimental vectorization support" On)
 
 option(RAJA_ENABLE_OPENMP_TASK "Build OpenMP task variants of certain algorithms" Off)
 
-option(RAJA_ENABLE_OPENMP_5_1_ATOMICS "Enable OpenMP 5.1 atomics for min/max operations" On)
+option(RAJA_ALLOW_OPENMP_5_1_ATOMICS "Enable OpenMP 5.1 atomics for min/max operations" On)
 
 option(RAJA_ENABLE_REPRODUCERS "Build issue reproducers" Off)
 

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -177,6 +177,7 @@ static_assert(RAJA_HAS_SOME_CXX14,
 #cmakedefine RAJA_ENABLE_SYCL
 
 #cmakedefine RAJA_ENABLE_OMP_TASK
+#cmakedefine RAJA_ENABLE_OPENMP_5_1_ATOMICS
 #cmakedefine RAJA_ENABLE_VECTORIZATION
 
 #cmakedefine RAJA_ENABLE_CALIPER
@@ -256,7 +257,12 @@ static_assert.
 
 namespace RAJA {
 
-#if defined(RAJA_ENABLE_OPENMP) && !defined(__HIP_DEVICE_COMPILE__)
+// Enables OpenMP 5.1 atomics for min/max operations  
+#if defined(RAJA_ENABLE_OPENMP) && defined(RAJA_ENABLE_OPENMP_5_1_ATOMICS)
+#define RAJA_OPENMP_5_1_ATOMICS
+#endif
+  
+#if defined(RAJA_ENABLE_OPENMP) && !defined(__HIP_DEVICE_COMPILE__)  
 #if defined(_OPENMP)
 #if (_OPENMP >= 200805)
 #if defined(RAJA_ENABLE_OPENMP_TASK)

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -262,7 +262,7 @@ namespace RAJA {
 #define RAJA_OPENMP_5_1_ATOMICS
 #endif
   
-#if defined(RAJA_ENABLE_OPENMP) && !defined(__HIP_DEVICE_COMPILE__)  
+#if defined(RAJA_ENABLE_OPENMP) && !defined(__HIP_DEVICE_COMPILE__)
 #if defined(_OPENMP)
 #if (_OPENMP >= 200805)
 #if defined(RAJA_ENABLE_OPENMP_TASK)

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -177,7 +177,7 @@ static_assert(RAJA_HAS_SOME_CXX14,
 #cmakedefine RAJA_ENABLE_SYCL
 
 #cmakedefine RAJA_ENABLE_OMP_TASK
-#cmakedefine RAJA_ENABLE_OPENMP_5_1_ATOMICS
+#cmakedefine RAJA_ALLOW_OPENMP_5_1_ATOMICS
 #cmakedefine RAJA_ENABLE_VECTORIZATION
 
 #cmakedefine RAJA_ENABLE_CALIPER
@@ -258,8 +258,8 @@ static_assert.
 namespace RAJA {
 
 // Enables OpenMP 5.1 atomics for min/max operations  
-#if defined(RAJA_ENABLE_OPENMP) && _OPENMP >= 202011 && defined(RAJA_ENABLE_OPENMP_5_1_ATOMICS)
-#define RAJA_ENABLE_OPENMP_5_1_ATOMICS_INTERNAL
+#if defined(RAJA_ENABLE_OPENMP) && _OPENMP >= 202011 && defined(RAJA_ALLOW_OPENMP_5_1_ATOMICS)
+#define RAJA_USE_OPENMP_5_1_ATOMICS
 #endif
   
 #if defined(RAJA_ENABLE_OPENMP) && !defined(__HIP_DEVICE_COMPILE__)

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -258,8 +258,8 @@ static_assert.
 namespace RAJA {
 
 // Enables OpenMP 5.1 atomics for min/max operations  
-#if defined(RAJA_ENABLE_OPENMP) && defined(RAJA_ENABLE_OPENMP_5_1_ATOMICS)
-#define RAJA_OPENMP_5_1_ATOMICS
+#if defined(RAJA_ENABLE_OPENMP) && _OPENMP >= 202011 && defined(RAJA_ENABLE_OPENMP_5_1_ATOMICS)
+#define RAJA_ENABLE_OPENMP_5_1_ATOMICS_INTERNAL
 #endif
   
 #if defined(RAJA_ENABLE_OPENMP) && !defined(__HIP_DEVICE_COMPILE__)

--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -88,7 +88,7 @@ RAJA_SUPPRESS_HD_WARN
 template<typename T>
 RAJA_HOST_DEVICE RAJA_INLINE T atomicMin(omp_atomic, T* acc, T value)
 {
-#if _OPENMP >= 202011
+#if _OPENMP >= 202011 && defined(RAJA_OPENMP_5_1_ATOMICS)
   T old;
 #pragma omp atomic capture compare
   {
@@ -109,7 +109,7 @@ RAJA_SUPPRESS_HD_WARN
 template<typename T>
 RAJA_HOST_DEVICE RAJA_INLINE T atomicMax(omp_atomic, T* acc, T value)
 {
-#if _OPENMP >= 202011
+#if _OPENMP >= 202011 && defined(RAJA_OPENMP_5_1_ATOMICS)
   T old;
 #pragma omp atomic capture compare
   {

--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -88,7 +88,7 @@ RAJA_SUPPRESS_HD_WARN
 template<typename T>
 RAJA_HOST_DEVICE RAJA_INLINE T atomicMin(omp_atomic, T* acc, T value)
 {
-#if defined(RAJA_ENABLE_OPENMP_5_1_ATOMICS_INTERNAL)
+#if defined(RAJA_USE_OPENMP_5_1_ATOMICS)
   T old;
 #pragma omp atomic capture compare
   {
@@ -109,7 +109,7 @@ RAJA_SUPPRESS_HD_WARN
 template<typename T>
 RAJA_HOST_DEVICE RAJA_INLINE T atomicMax(omp_atomic, T* acc, T value)
 {
-#if defined(RAJA_ENABLE_OPENMP_5_1_ATOMICS_INTERNAL)
+#if defined(RAJA_USE_OPENMP_5_1_ATOMICS)
   T old;
 #pragma omp atomic capture compare
   {

--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -88,7 +88,7 @@ RAJA_SUPPRESS_HD_WARN
 template<typename T>
 RAJA_HOST_DEVICE RAJA_INLINE T atomicMin(omp_atomic, T* acc, T value)
 {
-#if _OPENMP >= 202011 && defined(RAJA_OPENMP_5_1_ATOMICS)
+#if defined(RAJA_ENABLE_OPENMP_5_1_ATOMICS_INTERNAL)
   T old;
 #pragma omp atomic capture compare
   {
@@ -109,7 +109,7 @@ RAJA_SUPPRESS_HD_WARN
 template<typename T>
 RAJA_HOST_DEVICE RAJA_INLINE T atomicMax(omp_atomic, T* acc, T value)
 {
-#if _OPENMP >= 202011 && defined(RAJA_OPENMP_5_1_ATOMICS)
+#if defined(RAJA_ENABLE_OPENMP_5_1_ATOMICS_INTERNAL)
   T old;
 #pragma omp atomic capture compare
   {


### PR DESCRIPTION
This PR enables a workaround for issue https://github.com/LLNL/RAJA/issues/1812. 