### PR TITLE
Add test to compare the old style reducers with kernel naming

### DIFF
--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceBitAnd.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceBitAnd.hpp
@@ -43,7 +43,7 @@ void ForallReduceBitAndBasicTestImpl(const SEG_TYPE& seg,
 
   RAJA::ReduceBitAnd<REDUCE_POLICY, DATA_TYPE> simpand(21);
 
-  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, RAJA::Name("Reduce Bit And"), [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     simpand &= working_array[idx];
   });
 

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceBitOr.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceBitOr.hpp
@@ -70,7 +70,7 @@ void ForallReduceBitOrBasicTestImpl(const SEG_TYPE& seg,
   RAJA::ReduceBitOr<REDUCE_POLICY, DATA_TYPE> redor(0);
   RAJA::ReduceBitOr<REDUCE_POLICY, DATA_TYPE> redor2(2);
 
-  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, RAJA::Name("Reduce Bit Or"), [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     redor  |= working_array[idx];
     redor2 |= working_array[idx];
   });

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceMax.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceMax.hpp
@@ -51,7 +51,7 @@ void ForallReduceMaxBasicTestImpl(const SEG_TYPE& seg,
   RAJA::ReduceMax<REDUCE_POLICY, DATA_TYPE> maxinit(big_max);
   RAJA::ReduceMax<REDUCE_POLICY, DATA_TYPE> max(max_init);
 
-  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, RAJA::Name("Reduce Max"), [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     maxinit.max( working_array[idx] );
     max.max( working_array[idx] );
   });

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceMaxLoc.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceMaxLoc.hpp
@@ -60,7 +60,7 @@ void ForallReduceMaxLocBasicTestImpl(const SEG_TYPE& seg,
   RAJA::ReduceMaxLoc<REDUCE_POLICY, DATA_TYPE, IDX_TYPE> maxinit(big_max, maxloc_init);
   RAJA::ReduceMaxLoc<REDUCE_POLICY, DATA_TYPE, IDX_TYPE> max(max_init, maxloc_init);
 
-  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, RAJA::Name("Reduce Max Loc"), [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     maxinit.maxloc( working_array[idx], idx );
     max.maxloc( working_array[idx], idx );
   });

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceMin.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceMin.hpp
@@ -52,7 +52,7 @@ void ForallReduceMinBasicTestImpl(const SEG_TYPE& seg,
   RAJA::ReduceMin<REDUCE_POLICY, DATA_TYPE> mininit(small_min);
   RAJA::ReduceMin<REDUCE_POLICY, DATA_TYPE> min(min_init);
 
-  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, RAJA::Name("Reduce Min"), [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     mininit.min( working_array[idx] );
     min.min( working_array[idx] );
   });

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceMinLoc.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceMinLoc.hpp
@@ -60,7 +60,7 @@ void ForallReduceMinLocBasicTestImpl(const SEG_TYPE& seg,
   RAJA::ReduceMinLoc<REDUCE_POLICY, DATA_TYPE, IDX_TYPE> mininit(small_min, minloc_init);
   RAJA::ReduceMinLoc<REDUCE_POLICY, DATA_TYPE, IDX_TYPE> min(min_init, minloc_init);
 
-  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, RAJA::Name("Reduce Min Loc"), [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     mininit.minloc( working_array[idx], idx );
     min.minloc( working_array[idx], idx );
   });

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceSum.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-ReduceSum.hpp
@@ -50,7 +50,7 @@ void ForallReduceSumBasicTestImpl(const SEG_TYPE& seg,
   RAJA::ReduceSum<REDUCE_POLICY, DATA_TYPE> sum(0);
   RAJA::ReduceSum<REDUCE_POLICY, DATA_TYPE> sum2(2);
 
-  RAJA::forall<EXEC_POLICY>(seg, [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
+  RAJA::forall<EXEC_POLICY>(seg, RAJA::Name("Reduce Sum"), [=] RAJA_HOST_DEVICE(IDX_TYPE idx) {
     sum  += working_array[idx];
     sum2 += working_array[idx];
   });

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceBitAnd.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceBitAnd.hpp
@@ -46,7 +46,8 @@ void ForallReduceBitAndBasicTestImpl(const SEG_TYPE& seg,
   DATA_TYPE simpand(21);
 
   RAJA::forall<EXEC_POLICY>(seg,
-    RAJA::expt::Reduce<RAJA::operators::bit_and>(&simpand),
+    RAJA::expt::Reduce<RAJA::operators::bit_and>(&simpand), 
+			    RAJA::Name("expt Reduce Bit And"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_BITAND & _simpand) {
       _simpand &= working_array[idx];
   });

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceBitOr.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceBitOr.hpp
@@ -47,6 +47,7 @@ void ForallReduceBitOrBasicTestImpl(const SEG_TYPE& seg,
 
   RAJA::forall<EXEC_POLICY>(seg,
     RAJA::expt::Reduce<RAJA::operators::bit_or>(&simpor),
+			    RAJA::Name("expt Reduce Bit Or"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_BITOR & _simpor) {
       _simpor |= working_array[idx];
   });

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMax.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMax.hpp
@@ -56,7 +56,7 @@ void ForallReduceMaxBasicTestImpl(const SEG_TYPE& seg,
   RAJA::forall<EXEC_POLICY>(seg, 
     RAJA::expt::Reduce<RAJA::operators::maximum>(&maxinit),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&max),
-    RAJA::Name("RAJA Reduce Max"),
+    RAJA::Name("expt Reduce Max"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_MAX &mi, REF_MAX &m) {
       mi.max(working_array[idx]);
       m.max(working_array[idx]);

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMaxLoc.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMaxLoc.hpp
@@ -65,7 +65,7 @@ void ForallReduceMaxLocBasicTestImpl(const SEG_TYPE& seg,
   RAJA::forall<EXEC_POLICY>(seg, 
     RAJA::expt::Reduce<RAJA::operators::maximum>(&maxinit),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&max),
-    RAJA::Name("RAJA Reduce MaxLoc"),
+    RAJA::Name("expt Reduce MaxLoc"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &mi, VL_LAMBDA_TYPE &m) {
       mi.maxloc( working_array[idx], idx );
       m.maxloc( working_array[idx], idx );

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMaxLocAlt.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMaxLocAlt.hpp
@@ -65,7 +65,7 @@ void ForallReduceMaxLocAltBasicTestImpl(const SEG_TYPE& seg,
   RAJA::forall<EXEC_POLICY>(seg, 
     RAJA::expt::Reduce<RAJA::operators::maximum>(&maxinit),
     RAJA::expt::Reduce<RAJA::operators::maximum>(&max),
-    RAJA::Name("RAJA Reduce MaxLoc"),
+    RAJA::Name("expt Reduce MaxLoc"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &mi, VL_LAMBDA_TYPE &m) {
       mi.maxloc( working_array[idx], idx );
       m.maxloc( working_array[idx], idx );

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMin.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMin.hpp
@@ -56,7 +56,7 @@ void ForallReduceMinBasicTestImpl(const SEG_TYPE& seg,
   RAJA::forall<EXEC_POLICY>(seg, 
     RAJA::expt::Reduce<RAJA::operators::minimum>(&mininit),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
-    RAJA::Name("RAJA Reduce Min"),
+    RAJA::Name("expt Reduce Min"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_MIN &mi, REF_MIN &m) {
       mi.min(working_array[idx]);
       m.min(working_array[idx]);

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLoc.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLoc.hpp
@@ -64,7 +64,7 @@ void ForallReduceMinLocBasicTestImpl(const SEG_TYPE& seg,
   RAJA::forall<EXEC_POLICY>(seg, 
     RAJA::expt::Reduce<RAJA::operators::minimum>(&mininit),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
-    RAJA::Name("RAJA Reduce MinLoc"),
+    RAJA::Name("expt Reduce MinLoc"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &mi, VL_LAMBDA_TYPE &m) {
       mi.minloc( working_array[idx], idx );
       m.minloc( working_array[idx], idx );
@@ -82,6 +82,7 @@ void ForallReduceMinLocBasicTestImpl(const SEG_TYPE& seg,
   DATA_TYPE factor = 2;
   RAJA::forall<EXEC_POLICY>(seg,
     RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
+			    RAJA::Name("ReduceMinLoc"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &m) {
       m.minloc( working_array[idx] * factor, idx);
   });

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLocAlt.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceMinLocAlt.hpp
@@ -64,7 +64,7 @@ void ForallReduceMinLocAltBasicTestImpl(const SEG_TYPE& seg,
   RAJA::forall<EXEC_POLICY>(seg, 
     RAJA::expt::Reduce<RAJA::operators::minimum>(&mininit),
     RAJA::expt::Reduce<RAJA::operators::minimum>(&min),
-    RAJA::Name("RAJA Reduce MinLoc"),
+    RAJA::Name("expt Reduce MinLoc"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, VL_LAMBDA_TYPE &mi, VL_LAMBDA_TYPE &m) {
       mi.minloc( working_array[idx], idx );
       m.minloc( working_array[idx], idx );

--- a/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceSum.hpp
+++ b/test/functional/forall/reduce-basic/tests/test-forall-basic-expt-ReduceSum.hpp
@@ -54,7 +54,7 @@ void ForallReduceSumBasicTestImpl(const SEG_TYPE& seg,
   RAJA::forall<EXEC_POLICY>(seg, 
     RAJA::expt::Reduce<RAJA::operators::plus>(&sum),
     RAJA::expt::Reduce<RAJA::operators::plus>(&sum2),
-    RAJA::Name("RAJA Reduce Sum"),
+    RAJA::Name("expt Reduce Sum"),
     [=] RAJA_HOST_DEVICE(IDX_TYPE idx, REF_SUM &s1, REF_SUM &s2) {
       s1 += working_array[idx];
       s2 += working_array[idx];

--- a/test/functional/launch/reduce-basic/tests/test-launch-basic-ReduceBitAnd.hpp
+++ b/test/functional/launch/reduce-basic/tests/test-launch-basic-ReduceBitAnd.hpp
@@ -50,6 +50,7 @@ void LaunchReduceBitAndBasicTestImpl(const SEG_TYPE& seg,
 
   RAJA::launch<LAUNCH_POLICY>
     (RAJA::LaunchParams(RAJA::Teams(blocks), RAJA::Threads(threads)),
+     RAJA::Name("launch ReduceBitAnd"),
      [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
       RAJA::loop<GLOBAL_THREAD_POLICY>(ctx, seg, [&](IDX_TYPE idx) {
 

--- a/test/functional/launch/reduce-basic/tests/test-launch-basic-ReduceMin.hpp
+++ b/test/functional/launch/reduce-basic/tests/test-launch-basic-ReduceMin.hpp
@@ -59,6 +59,7 @@ void LaunchReduceMinBasicTestImpl(const SEG_TYPE& seg,
 
   RAJA::launch<LAUNCH_POLICY>
     (RAJA::LaunchParams(RAJA::Teams(blocks), RAJA::Threads(threads)),
+     RAJA::Name("launch ReduceMin"),
      [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
       RAJA::loop<GLOBAL_THREAD_POLICY>(ctx, seg, [&](IDX_TYPE idx) {
 

--- a/test/functional/launch/reduce-basic/tests/test-launch-basic-ReduceSum.hpp
+++ b/test/functional/launch/reduce-basic/tests/test-launch-basic-ReduceSum.hpp
@@ -58,6 +58,7 @@ void LaunchReduceSumBasicTestImpl(const SEG_TYPE& seg,
 
   RAJA::launch<LAUNCH_POLICY>
     (RAJA::LaunchParams(RAJA::Teams(blocks), RAJA::Threads(threads)),
+     RAJA::Name("launch ReduceSum"),
      [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
       RAJA::loop<GLOBAL_THREAD_POLICY>(ctx, seg, [&](IDX_TYPE idx) {
           sum  += working_array[idx];


### PR DESCRIPTION
# Summary

This PR adds kernel names to ensure RAJA::Name works with established reducer framework

@LLNL/raja-core  -- I mostly want to test across platforms to ensure compatibility with RAJA::Name and the production reducers.  