### PR TITLE
Attempt to fix pragma warnings

### DIFF
--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -443,15 +443,15 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #else // CUDA compiler active, with GCC host compiler
 #if defined(__NVCC_DIAG_PRAGMA_SUPPORT__) // CUDA >= 11.5
 #define RAJA_UNROLL \
-        _Pragma ("nv_diagnostic push") \
-        _Pragma ("nv_diag_suppress 1675") \
-        _Pragma ("GCC unroll 10000") \
-        _Pragma ("nv_diagnostic pop")
+        RAJA_PRAGMA (nv_diagnostic push) \
+        RAJA_PRAGMA (nv_diag_suppress 1675) \
+        RAJA_PRAGMA (GCC unroll 10000) \
+        RAJA_PRAGMA (nv_diagnostic pop)
 #define RAJA_UNROLL_COUNT(N) \
-        _Pragma ("nv_diagnostic push") \
-        _Pragma ("nv_diag_suppress 1675") \
-        _Pragma ("GCC unroll N") \
-        _Pragma ("nv_diagnostic pop")
+        RAJA_PRAGMA (nv_diagnostic push) \
+        RAJA_PRAGMA (nv_diag_suppress 1675) \
+        RAJA_PRAGMA (GCC unroll N) \
+        RAJA_PRAGMA (nv_diagnostic pop)
 #else // CUDA < 11.5
 // Choosing not to unroll CPU code to avoid warnings of
 // unrecognized pragmas from NVCC.

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -447,13 +447,14 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
         _Pragma ("nv_diag_suppress 1675") \
         _Pragma ("GCC unroll 10000") \
         _Pragma ("nv_diagnostic pop")
-// CUDA < 11.5
 #define RAJA_UNROLL_COUNT(N) \
         _Pragma ("nv_diagnostic push") \
         _Pragma ("nv_diag_suppress 1675") \
         _Pragma ("GCC unroll N") \
         _Pragma ("nv_diagnostic pop")
-#else
+#else // CUDA < 11.5
+// Choosing not to unroll CPU code to avoid warnings of
+// unrecognized pragmas from NVCC.
 #define RAJA_UNROLL
 #define RAJA_UNROLL_COUNT(N)
 #endif // __NVCC_DIAG_PRAGMA_SUPPORT__

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -440,8 +440,8 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_UNROLL RAJA_PRAGMA(GCC unroll 10000)
 #define RAJA_UNROLL_COUNT(N) RAJA_PRAGMA(GCC unroll N)
 #else
-#define RAJA_UNROLL RAJA_PRAGMA(unroll)
-#define RAJA_UNROLL_COUNT(N) RAJA_PRAGMA(unroll N)
+#define RAJA_UNROLL
+#define RAJA_UNROLL_COUNT(N)
 #endif
 
 #if defined(RAJA_ENABLE_CUDA) || defined(RAJA_ENABLE_HIP)

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -436,12 +436,27 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 #define RAJA_MAX_ALIGN 16
 #define RAJA_FORCEINLINE_RECURSIVE
 #define RAJA_INLINE inline  __attribute__((always_inline))
-#if !defined(__NVCC__)
+
+#if !defined(__NVCC__) // purely GCC, CUDA compiler not active
 #define RAJA_UNROLL RAJA_PRAGMA(GCC unroll 10000)
 #define RAJA_UNROLL_COUNT(N) RAJA_PRAGMA(GCC unroll N)
+#else // CUDA compiler active, with GCC host compiler
+#if defined(__NVCC_DIAG_PRAGMA_SUPPORT__) // CUDA >= 11.5
+#define RAJA_UNROLL \
+        _Pragma ("nv_diagnostic push") \
+        _Pragma ("nv_diag_suppress 1675") \
+        _Pragma ("GCC unroll 10000") \
+        _Pragma ("nv_diagnostic pop")
+// CUDA < 11.5
+#define RAJA_UNROLL_COUNT(N) \
+        _Pragma ("nv_diagnostic push") \
+        _Pragma ("nv_diag_suppress 1675") \
+        _Pragma ("GCC unroll N") \
+        _Pragma ("nv_diagnostic pop")
 #else
 #define RAJA_UNROLL
 #define RAJA_UNROLL_COUNT(N)
+#endif // __NVCC_DIAG_PRAGMA_SUPPORT__
 #endif
 
 #if defined(RAJA_ENABLE_CUDA) || defined(RAJA_ENABLE_HIP)


### PR DESCRIPTION
Explores discussion in https://github.com/LLNL/RAJA/issues/1830

I've verified that this change does indeed remove the warnings seen in mfem mini apps performance ex1. 
