### PR TITLE
Fix Race Conditions in Tests

### DIFF
--- a/include/RAJA/index/ListSegment.hpp
+++ b/include/RAJA/index/ListSegment.hpp
@@ -151,7 +151,7 @@ public:
     if (m_size > 0)
     {
 
-      camp::resources::Resource host_res {camp::resources::Host()};
+      camp::resources::Resource host_res {camp::resources::Host::get_default()};
 
       value_type* tmp = host_res.allocate<value_type>(m_size);
 
@@ -168,6 +168,7 @@ public:
       m_resource = new camp::resources::Resource(resource);
       m_data     = m_resource->allocate<value_type>(m_size);
       m_resource->memcpy(m_data, tmp, sizeof(value_type) * m_size);
+      m_resource->wait();
       m_owned = Owned;
 
       host_res.deallocate(tmp);
@@ -368,7 +369,7 @@ private:
 
       m_resource = new camp::resources::Resource(resource_);
 
-      camp::resources::Resource host_res {camp::resources::Host()};
+      camp::resources::Resource host_res {camp::resources::Host::get_default()};
 
       value_type* tmp = host_res.allocate<value_type>(m_size);
 
@@ -379,6 +380,7 @@ private:
 
       m_data = m_resource->allocate<value_type>(m_size);
       m_resource->memcpy(m_data, tmp, sizeof(value_type) * m_size);
+      m_resource->wait();
 
       host_res.deallocate(tmp);
 

--- a/test/functional/dynamic_forall/resource-segment/tests/test-dynamic-forall-resource-RangeSegment.hpp
+++ b/test/functional/dynamic_forall/resource-segment/tests/test-dynamic-forall-resource-RangeSegment.hpp
@@ -18,7 +18,7 @@ void DynamicForallResourceRangeSegmentTestImpl(INDEX_TYPE first, INDEX_TYPE last
   RAJA::TypedRangeSegment<INDEX_TYPE> r1(RAJA::stripIndexType(first), RAJA::stripIndexType(last));
   INDEX_TYPE N = INDEX_TYPE(r1.end() - r1.begin());
 
-  WORKING_RES working_res;
+  WORKING_RES working_res{WORKING_RES::get_default()};
   camp::resources::Resource erased_working_res{working_res};
   INDEX_TYPE* working_array;
   INDEX_TYPE* check_array;
@@ -39,6 +39,7 @@ void DynamicForallResourceRangeSegmentTestImpl(INDEX_TYPE first, INDEX_TYPE last
   });
 
   working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * RAJA::stripIndexType(N));
+  working_res.wait();
 
   for (INDEX_TYPE i = INDEX_TYPE(0); i < N; i++) {
     ASSERT_EQ(test_array[RAJA::stripIndexType(i)], check_array[RAJA::stripIndexType(i)]);

--- a/test/functional/forall/atomic-basic/tests/test-forall-atomic-basic.hpp
+++ b/test/functional/forall/atomic-basic/tests/test-forall-atomic-basic.hpp
@@ -54,7 +54,7 @@ struct RSMultiplexer < IdxType, RAJA::TypedListSegment<IdxType> >
 
 template <typename ExecPolicy,
           typename AtomicPolicy,
-          typename WORKINGRES,
+          typename WorkingRes,
           typename IdxType,
           typename SegmentType,
           typename T>
@@ -63,7 +63,7 @@ void ForallAtomicBasicTestImpl( IdxType seglimit )
   // initialize an array
   const int len = 12;
 
-  camp::resources::Resource work_res{WORKINGRES()};
+  camp::resources::Resource work_res{WorkingRes::get_default()};
 
   SegmentType seg = 
     RSMultiplexer<IdxType, SegmentType>().makeseg(seglimit, work_res);

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefCAS.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefCAS.hpp
@@ -92,15 +92,10 @@ testAtomicRefCASOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list,
       T val = otherop(i);
       list[i] = val;
   });
-#if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(cudaDeviceSynchronize());
-#endif
-#if defined(RAJA_ENABLE_HIP)
-  hipErrchk(hipDeviceSynchronize());
-#endif
 
   work_res.memcpy( hcount, count, sizeof(T) );
   work_res.memcpy( hlist, list, sizeof(T) * N );
+  work_res.wait();
 
   EXPECT_LE(otherop.final_min, hcount[0]);
   EXPECT_GE(otherop.final_max, hcount[0]);
@@ -113,30 +108,22 @@ testAtomicRefCASOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list,
 
 template <typename ExecPolicy,
           typename AtomicPolicy,
-          typename WORKINGRES,
+          typename WorkingRes,
           typename IdxType,
           typename T>
 void ForallAtomicRefCASTestImpl( IdxType N )
 {
   RAJA::TypedRangeSegment<IdxType> seg(0, N);
 
-  camp::resources::Resource work_res{WORKINGRES()};
+  camp::resources::Resource work_res{WorkingRes::get_default()};
 
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
 
   T * count   = work_res.allocate<T>(1);
   T * list    = work_res.allocate<T>(N);
 
   T * hcount   = host_res.allocate<T>(1);
   T * hlist    = host_res.allocate<T>(N);
-
-#if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(cudaDeviceSynchronize());
-#endif
-
-#if defined(RAJA_ENABLE_HIP)
-  hipErrchk(hipDeviceSynchronize());
-#endif
 
   testAtomicRefCASOp<ExecPolicy, AtomicPolicy, IdxType, T, 
                        CASOtherOp                  >(seg, count, list, hcount, hlist, work_res, N);

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefLoadStore.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefLoadStore.hpp
@@ -94,15 +94,10 @@ testAtomicRefLoadStoreOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list
       T val = otherop(i);
       list[i] = val;
   });
-#if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(cudaDeviceSynchronize());
-#endif
-#if defined(RAJA_ENABLE_HIP)
-  hipErrchk(hipDeviceSynchronize());
-#endif
 
   work_res.memcpy( hcount, count, sizeof(T) );
   work_res.memcpy( hlist, list, sizeof(T) * N );
+  work_res.wait();
 
   EXPECT_LE(otherop.final_min, hcount[0]);
   EXPECT_GE(otherop.final_max, hcount[0]);
@@ -115,30 +110,22 @@ testAtomicRefLoadStoreOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list
 
 template <typename ExecPolicy,
           typename AtomicPolicy,
-          typename WORKINGRES,
+          typename WorkingRes,
           typename IdxType,
           typename T>
 void ForallAtomicRefLoadStoreTestImpl( IdxType N )
 {
   RAJA::TypedRangeSegment<IdxType> seg(0, N);
 
-  camp::resources::Resource work_res{WORKINGRES()};
+  camp::resources::Resource work_res{WorkingRes::get_default()};
 
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
 
   T * count   = work_res.allocate<T>(1);
   T * list    = work_res.allocate<T>(N);
 
   T * hcount   = host_res.allocate<T>(1);
   T * hlist    = host_res.allocate<T>(N);
-
-#if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(cudaDeviceSynchronize());
-#endif
-
-#if defined(RAJA_ENABLE_HIP)
-  hipErrchk(hipDeviceSynchronize());
-#endif
 
   testAtomicRefLoadStoreOp<ExecPolicy, AtomicPolicy, IdxType, T, 
                        LoadOtherOp     >(seg, count, list, hcount, hlist, work_res, N);

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefMinMax.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefMinMax.hpp
@@ -94,15 +94,10 @@ testAtomicRefMinMaxOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list,
       T val = otherop(i);
       list[i] = val;
   });
-#if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(cudaDeviceSynchronize());
-#endif
-#if defined(RAJA_ENABLE_HIP)
-  hipErrchk(hipDeviceSynchronize());
-#endif
 
   work_res.memcpy( hcount, count, sizeof(T) );
   work_res.memcpy( hlist, list, sizeof(T) * N );
+  work_res.wait();
 
   EXPECT_LE(otherop.final_min, hcount[0]);
   EXPECT_GE(otherop.final_max, hcount[0]);
@@ -115,30 +110,22 @@ testAtomicRefMinMaxOp(RAJA::TypedRangeSegment<IdxType> seg, T* count, T* list,
 
 template <typename ExecPolicy,
           typename AtomicPolicy,
-          typename WORKINGRES,
+          typename WorkingRes,
           typename IdxType,
           typename T>
 void ForallAtomicRefMinMaxTestImpl( IdxType N )
 {
   RAJA::TypedRangeSegment<IdxType> seg(0, N);
 
-  camp::resources::Resource work_res{WORKINGRES()};
+  camp::resources::Resource work_res{WorkingRes::get_default()};
 
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
 
   T * count   = work_res.allocate<T>(1);
   T * list    = work_res.allocate<T>(N);
 
   T * hcount   = host_res.allocate<T>(1);
   T * hlist    = host_res.allocate<T>(N);
-
-#if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(cudaDeviceSynchronize());
-#endif
-
-#if defined(RAJA_ENABLE_HIP)
-  hipErrchk(hipDeviceSynchronize());
-#endif
 
   testAtomicRefMinMaxOp<ExecPolicy, AtomicPolicy, IdxType, T, 
                        MaxEqOtherOp   >(seg, count, list, hcount, hlist, work_res, N);

--- a/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefSub.hpp
+++ b/test/functional/forall/atomic-ref/tests/test-forall-AtomicRefSub.hpp
@@ -96,16 +96,11 @@ void testAtomicRefSub(RAJA::TypedRangeSegment<IdxType> seg,
       list[i] = val;
       hit[(IdxType)val] = true;
       });
-#if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(cudaDeviceSynchronize());
-#endif
-#if defined(RAJA_ENABLE_HIP)
-  hipErrchk(hipDeviceSynchronize());
-#endif
 
   work_res.memcpy( hcount, count, sizeof(T) );
   work_res.memcpy( hlist, list, sizeof(T) * N );
   work_res.memcpy( hhit, hit, sizeof(bool) * N );
+  work_res.wait();
 
   EXPECT_EQ(countop.final, hcount[0]);
   for (IdxType i = 0; i < seg.size(); i++) {
@@ -118,16 +113,16 @@ void testAtomicRefSub(RAJA::TypedRangeSegment<IdxType> seg,
 
 template <typename ExecPolicy,
           typename AtomicPolicy,
-          typename WORKINGRES,
+          typename WorkingRes,
           typename IdxType,
           typename T>
 void ForallAtomicRefSubTestImpl( IdxType N )
 {
   RAJA::TypedRangeSegment<IdxType> seg(0, N);
 
-  camp::resources::Resource work_res{WORKINGRES()};
+  camp::resources::Resource work_res{WorkingRes::get_default()};
 
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
 
   T * count   = work_res.allocate<T>(1);
   T * list    = work_res.allocate<T>(N);
@@ -136,14 +131,6 @@ void ForallAtomicRefSubTestImpl( IdxType N )
   T * hcount   = host_res.allocate<T>(1);
   T * hlist    = host_res.allocate<T>(N);
   bool * hhit  = host_res.allocate<bool>(N);
-
-#if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(cudaDeviceSynchronize());
-#endif
-
-#if defined(RAJA_ENABLE_HIP)
-  hipErrchk(hipDeviceSynchronize());
-#endif
 
   testAtomicRefSub<ExecPolicy, AtomicPolicy, IdxType, T, 
                      PreDecCountOp  >(seg, count, list, hit, hcount, hlist, hhit, work_res, N);

--- a/test/functional/forall/atomic-view/tests/test-forall-AtomicMultiView.hpp
+++ b/test/functional/forall/atomic-view/tests/test-forall-AtomicMultiView.hpp
@@ -16,7 +16,7 @@
 
 template <typename ExecPolicy,
           typename AtomicPolicy,
-          typename WORKINGRES,
+          typename WorkingRes,
           typename IdxType,
           typename T>
 void ForallAtomicMultiViewTestImpl( IdxType N )
@@ -30,22 +30,14 @@ void ForallAtomicMultiViewTestImpl( IdxType N )
   RAJA::TypedRangeSegment<IdxType> seg_dstside(0, dst_side);
   RAJA::TypedRangeSegment<IdxType> seg_srcside(0, src_side);
 
-  camp::resources::Resource work_res{WORKINGRES()};
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource work_res{WorkingRes::get_default()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
 
   T *  actualsource = work_res.allocate<T> (N);
   T ** source       = work_res.allocate<T*>(src_side);
   T *  actualdest   = work_res.allocate<T> (N/2);
   T ** dest         = work_res.allocate<T*>(dst_side);
   T *  check_array  = host_res.allocate<T> (N/2);
-
-#if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(cudaDeviceSynchronize());
-#endif
-
-#if defined(RAJA_ENABLE_HIP)
-  hipErrchk(hipDeviceSynchronize());
-#endif
 
   // assumes each source[] will be 2x size of each dest[], src_side x dst_side
   RAJA::forall<ExecPolicy>(seg_srcside, [=] RAJA_HOST_DEVICE(IdxType ii)
@@ -89,14 +81,7 @@ void ForallAtomicMultiViewTestImpl( IdxType N )
   });
 
   work_res.memcpy( check_array, actualdest, sizeof(T) * N/2 );
-
-#if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(cudaDeviceSynchronize());
-#endif
-
-#if defined(RAJA_ENABLE_HIP)
-  hipErrchk(hipDeviceSynchronize());
-#endif
+  work_res.wait();
 
   for (IdxType i = 0; i < N / 2; ++i) {
     EXPECT_EQ((T)2, check_array[i]);

--- a/test/functional/forall/atomic-view/tests/test-forall-AtomicView.hpp
+++ b/test/functional/forall/atomic-view/tests/test-forall-AtomicView.hpp
@@ -14,7 +14,7 @@
 
 template <typename ExecPolicy,
           typename AtomicPolicy,
-          typename WORKINGRES,
+          typename WorkingRes,
           typename IdxType,
           typename T>
 void ForallAtomicViewTestImpl( IdxType N )
@@ -22,34 +22,18 @@ void ForallAtomicViewTestImpl( IdxType N )
   RAJA::TypedRangeSegment<IdxType> seg(0, N);
   RAJA::TypedRangeSegment<IdxType> seg_half(0, N / 2);
 
-  camp::resources::Resource work_res{WORKINGRES()};
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource work_res{WorkingRes::get_default()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
 
   T * hsource = host_res.allocate<T>(N);
   T * source = work_res.allocate<T>(N);
   T * dest = work_res.allocate<T>(N/2);
   T * check_array = host_res.allocate<T>(N/2);
 
-#if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(cudaDeviceSynchronize());
-#endif
-
-#if defined(RAJA_ENABLE_HIP)
-  hipErrchk(hipDeviceSynchronize());
-#endif
-
   RAJA::forall<RAJA::seq_exec>(seg,
                                [=](IdxType i) { hsource[i] = (T)1; });
 
   work_res.memcpy( source, hsource, sizeof(T) * N );
-
-#if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(cudaDeviceSynchronize());
-#endif
-
-#if defined(RAJA_ENABLE_HIP)
-  hipErrchk(hipDeviceSynchronize());
-#endif
 
   // use atomic add to reduce the array
   RAJA::View<T, RAJA::Layout<1>> vec_view(source, N);
@@ -69,14 +53,7 @@ void ForallAtomicViewTestImpl( IdxType N )
   });
 
   work_res.memcpy( check_array, dest, sizeof(T) * N/2 );
-
-#if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(cudaDeviceSynchronize());
-#endif
-
-#if defined(RAJA_ENABLE_HIP)
-  hipErrchk(hipDeviceSynchronize());
-#endif
+  work_res.wait();
 
   for (IdxType i = 0; i < N / 2; ++i) {
     EXPECT_EQ((T)2, check_array[i]);

--- a/test/functional/forall/resource-segment/tests/test-forall-resource-RangeStrideSegment.hpp
+++ b/test/functional/forall/resource-segment/tests/test-forall-resource-RangeStrideSegment.hpp
@@ -16,9 +16,9 @@ void ForallResourceRangeStrideSegmentTestImpl(INDEX_TYPE first, INDEX_TYPE last,
   RAJA::TypedRangeStrideSegment<INDEX_TYPE> r1(RAJA::stripIndexType(first), RAJA::stripIndexType(last), stride);
   INDEX_TYPE N = INDEX_TYPE(r1.size());
 
-  WORKING_RES working_res;
+  WORKING_RES working_res{WORKING_RES::get_default()};
   camp::resources::Resource erased_working_res{working_res};
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
   INDEX_TYPE* working_array;
   INDEX_TYPE* check_array;
   INDEX_TYPE* test_array;
@@ -33,7 +33,8 @@ void ForallResourceRangeStrideSegmentTestImpl(INDEX_TYPE first, INDEX_TYPE last,
     test_array[RAJA::stripIndexType(i)] = INDEX_TYPE(0);
   }
 
-  working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * RAJA::stripIndexType(N)); 
+  working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * RAJA::stripIndexType(N));
+  working_res.wait();
 
   INDEX_TYPE idx = first;
   for (INDEX_TYPE i = INDEX_TYPE(0); i < N; ++i) {
@@ -46,6 +47,7 @@ void ForallResourceRangeStrideSegmentTestImpl(INDEX_TYPE first, INDEX_TYPE last,
   });
 
   working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * RAJA::stripIndexType(N));
+  working_res.wait();
 
   for (INDEX_TYPE i = INDEX_TYPE(0); i < N; i++) {
     ASSERT_EQ(test_array[RAJA::stripIndexType(i)], check_array[RAJA::stripIndexType(i)]);

--- a/test/functional/forall/segment/tests/test-forall-RangeStrideSegment.hpp
+++ b/test/functional/forall/segment/tests/test-forall-RangeStrideSegment.hpp
@@ -19,7 +19,7 @@ void ForallRangeStrideSegmentTestImpl(INDEX_TYPE first, INDEX_TYPE last,
   INDEX_TYPE N = INDEX_TYPE(r1.size());
 
   camp::resources::Resource working_res{WORKING_RES::get_default()};
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
   INDEX_TYPE* working_array;
   INDEX_TYPE* check_array;
   INDEX_TYPE* test_array;
@@ -37,7 +37,8 @@ void ForallRangeStrideSegmentTestImpl(INDEX_TYPE first, INDEX_TYPE last,
 
   memset(static_cast<void*>(test_array), 0, sizeof(INDEX_TYPE) * data_len);
 
-  working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * data_len); 
+  working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * data_len);
+  working_res.wait();
 
   if ( RAJA::stripIndexType(N) > 0 ) {
 
@@ -61,6 +62,7 @@ void ForallRangeStrideSegmentTestImpl(INDEX_TYPE first, INDEX_TYPE last,
   }
 
   working_res.memcpy(check_array, working_array, sizeof(INDEX_TYPE) * data_len);
+  working_res.wait();
 
   for (INDEX_TYPE i = INDEX_TYPE(0); i < N; i++) {
     ASSERT_EQ(test_array[RAJA::stripIndexType(i)], check_array[RAJA::stripIndexType(i)]);

--- a/test/functional/indexset-build/test-aligned-indexset.cpp
+++ b/test/functional/indexset-build/test-aligned-indexset.cpp
@@ -44,7 +44,7 @@ TEST(IndexSetBuild, Aligned)
   indices.push_back(30);
   indices.push_back(31);
 
-  camp::resources::Resource res{camp::resources::Host()};
+  camp::resources::Resource res{camp::resources::Host::get_default()};
  
   RAJA::TypedIndexSet<RAJA::RangeSegment, RAJA::ListSegment> iset;
 

--- a/test/functional/kernel/nested-loop/tests/nested-loop-MultiLambda-impl.hpp
+++ b/test/functional/kernel/nested-loop/tests/nested-loop-MultiLambda-impl.hpp
@@ -46,7 +46,7 @@ void KernelNestedLoopTest(){
   constexpr static int N = 1000;
   constexpr static int DIM = 2;
 
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
   WORKING_RES work_res{WORKING_RES::get_default()};
 
   // Allocate Tests Data

--- a/test/functional/kernel/nested-loop/tests/nested-loop-MultiLambdaParam-impl.hpp
+++ b/test/functional/kernel/nested-loop/tests/nested-loop-MultiLambdaParam-impl.hpp
@@ -49,7 +49,7 @@ void KernelNestedLoopTest(){
   constexpr static int N = 100;
   constexpr static int DIM = 2;
 
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
   WORKING_RES work_res{WORKING_RES::get_default()};
 
   // Allocate Tests Data
@@ -84,6 +84,7 @@ void KernelNestedLoopTest(){
   work_res.memcpy(work_arrA, test_arrA, sizeof(double) * RAJA::stripIndexType(N*N));
   work_res.memcpy(work_arrB, test_arrB, sizeof(double) * RAJA::stripIndexType(N*N));
   work_res.memcpy(work_arrC, test_arrC, sizeof(double) * RAJA::stripIndexType(N*N));
+  work_res.wait();
 
   // Calculate Test data
   for (int row = 0; row < N; ++row) {
@@ -127,6 +128,7 @@ void KernelNestedLoopTest(){
   );
 
   work_res.memcpy(check_arrC, work_arrC, sizeof(double) * RAJA::stripIndexType(N*N));
+  work_res.wait();
 
   RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment{0, N*N}, [=] (RAJA::Index_type i) {
     ASSERT_TRUE( RAJA::test_abs(test_arrC[i] - check_arrC[i]) < 10e-8 );

--- a/test/functional/kernel/region/tests/test-kernel-region-sync.hpp
+++ b/test/functional/kernel/region/tests/test-kernel-region-sync.hpp
@@ -15,7 +15,7 @@
 template <typename INDEX_TYPE, typename WORKING_RES, typename EXEC_POLICY>
 void KernelRegionSyncTestImpl(INDEX_TYPE first, INDEX_TYPE last)
 {
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
   camp::resources::Resource work_res{WORKING_RES::get_default()};
 
   const INDEX_TYPE N = last - first;
@@ -73,6 +73,7 @@ void KernelRegionSyncTestImpl(INDEX_TYPE first, INDEX_TYPE last)
   );
   
   work_res.memcpy(check_array, work_array3, sizeof(INDEX_TYPE) * N);
+  work_res.wait();
 
   for (INDEX_TYPE i = 0; i < N; i++) {
     ASSERT_EQ(check_array[i], 151);

--- a/test/functional/kernel/region/tests/test-kernel-region.hpp
+++ b/test/functional/kernel/region/tests/test-kernel-region.hpp
@@ -11,7 +11,7 @@
 template <typename INDEX_TYPE, typename WORKING_RES, typename EXEC_POLICY>
 void KernelRegionTestImpl(INDEX_TYPE first, INDEX_TYPE last)
 {
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
   camp::resources::Resource work_res{WORKING_RES::get_default()};
 
   const INDEX_TYPE N = last - first;
@@ -57,6 +57,7 @@ void KernelRegionTestImpl(INDEX_TYPE first, INDEX_TYPE last)
   );
   
   work_res.memcpy(check_array, work_array3, sizeof(INDEX_TYPE) * N );
+  work_res.wait();
 
   for (INDEX_TYPE i = 0; i < N; i++) {
     ASSERT_EQ(check_array[i], 151);

--- a/test/functional/launch/segment/tests/test-launch-RangeStrideSegment.hpp
+++ b/test/functional/launch/segment/tests/test-launch-RangeStrideSegment.hpp
@@ -19,7 +19,7 @@ void LaunchRangeStrideSegmentTestImpl(INDEX_TYPE first, INDEX_TYPE last,
   INDEX_TYPE N = INDEX_TYPE(r1.size());
 
   camp::resources::Resource working_res{WORKING_RES::get_default()};
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
   INDEX_TYPE* working_array;
   INDEX_TYPE* check_array;
   INDEX_TYPE* test_array;

--- a/test/functional/scan/tests/test-scan-data.hpp
+++ b/test/functional/scan/tests/test-scan-data.hpp
@@ -18,7 +18,7 @@ void allocScanTestData(int N,
                        T** work_in, T** work_out,
                        T** host_in, T** host_out)
 {
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
 
   *work_in  = work_res.allocate<T>(N);
   *work_out = work_res.allocate<T>(N);
@@ -32,7 +32,7 @@ void deallocScanTestData(camp::resources::Resource work_res,
                          T* work_in, T* work_out,
                          T* host_in, T* host_out)
 {
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
 
   work_res.deallocate(work_in);
   work_res.deallocate(work_out);

--- a/test/include/RAJA_test-forall-data.hpp
+++ b/test/include/RAJA_test-forall-data.hpp
@@ -21,7 +21,7 @@ void allocateForallTestData(size_t N,
                             T** check_array,
                             T** test_array)
 {
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
 
   *work_array = work_res.allocate<T>(RAJA::stripIndexType(N));
 
@@ -38,7 +38,7 @@ void allocateForallTestData(T N,
                             T** check_array,
                             T** test_array)
 {
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
 
   *work_array = work_res.allocate<T>(RAJA::stripIndexType(N));
 
@@ -52,7 +52,7 @@ void deallocateForallTestData(camp::resources::Resource work_res,
                               T* check_array,
                               T* test_array)
 {
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
 
   work_res.deallocate(work_array);
 

--- a/test/integration/plugin/tests/test-plugin-workgroup.hpp
+++ b/test/integration/plugin/tests/test-plugin-workgroup.hpp
@@ -27,7 +27,7 @@ template <typename ExecPolicy,
           typename DispatchTyper,
           typename IndexType,
           typename Allocator,
-          typename WORKINGRES,
+          typename WorkingRes,
           RAJA::Platform PLATFORM>
 struct PluginWorkGroupTestImpl {
 void operator()() const
@@ -58,7 +58,7 @@ void operator()() const
                   Allocator
                 >;
 
-  SetupPluginVars spv(WORKINGRES{});
+  SetupPluginVars spv(WorkingRes::get_default());
 
   CounterData* data = plugin_test_resource->allocate<CounterData>(10);
 
@@ -73,6 +73,7 @@ void operator()() const
       loop_data[i].launch_counter_post    = -1;
     }
     plugin_test_resource->memcpy(data, &loop_data[0], 10*sizeof(CounterData));
+    plugin_test_resource->wait();
   }
 
   WorkPool_type pool(Allocator{});
@@ -84,6 +85,7 @@ void operator()() const
   {
     CounterData plugin_data;
     plugin_test_resource->memcpy(&plugin_data, plugin_test_data, sizeof(CounterData));
+    plugin_test_resource->wait();
     ASSERT_EQ(plugin_data.capture_platform_active, RAJA::Platform::undefined);
     ASSERT_EQ(plugin_data.capture_counter_pre,     10);
     ASSERT_EQ(plugin_data.capture_counter_post,    10);
@@ -95,6 +97,7 @@ void operator()() const
   {
     CounterData loop_data[10];
     plugin_test_resource->memcpy(&loop_data[0], data, 10*sizeof(CounterData));
+    plugin_test_resource->wait();
 
     for (int i = 0; i < 10; i++) {
       ASSERT_EQ(loop_data[i].capture_platform_active, RAJA::Platform::undefined);
@@ -111,6 +114,7 @@ void operator()() const
   {
     CounterData plugin_data;
     plugin_test_resource->memcpy(&plugin_data, plugin_test_data, sizeof(CounterData));
+    plugin_test_resource->wait();
     ASSERT_EQ(plugin_data.capture_platform_active, RAJA::Platform::undefined);
     ASSERT_EQ(plugin_data.capture_counter_pre,     10);
     ASSERT_EQ(plugin_data.capture_counter_post,    10);
@@ -122,6 +126,7 @@ void operator()() const
   {
     CounterData loop_data[10];
     plugin_test_resource->memcpy(&loop_data[0], data, 10*sizeof(CounterData));
+    plugin_test_resource->wait();
 
     for (int i = 0; i < 10; i++) {
       ASSERT_EQ(loop_data[i].capture_platform_active, RAJA::Platform::undefined);
@@ -138,6 +143,7 @@ void operator()() const
   {
     CounterData plugin_data;
     plugin_test_resource->memcpy(&plugin_data, plugin_test_data, sizeof(CounterData));
+    plugin_test_resource->wait();
     ASSERT_EQ(plugin_data.capture_platform_active, RAJA::Platform::undefined);
     ASSERT_EQ(plugin_data.capture_counter_pre,     10);
     ASSERT_EQ(plugin_data.capture_counter_post,    10);
@@ -149,6 +155,7 @@ void operator()() const
   {
     CounterData loop_data[10];
     plugin_test_resource->memcpy(&loop_data, data, 10*sizeof(CounterData));
+    plugin_test_resource->wait();
 
     for (int i = 0; i < 10; i++) {
       ASSERT_EQ(loop_data[i].capture_platform_active, PLATFORM);
@@ -172,7 +179,7 @@ template <size_t BLOCK_SIZE, bool Async,
           typename StoragePolicy,
           typename IndexType,
           typename Allocator,
-          typename WORKINGRES,
+          typename WorkingRes,
           RAJA::Platform PLATFORM
           >
 struct PluginWorkGroupTestImpl<RAJA::hip_work<BLOCK_SIZE, Async>,
@@ -181,7 +188,7 @@ struct PluginWorkGroupTestImpl<RAJA::hip_work<BLOCK_SIZE, Async>,
                                detail::indirect_function_call_dispatch_typer,
                                IndexType,
                                Allocator,
-                               WORKINGRES,
+                               WorkingRes,
                                PLATFORM> {
 void operator()() const
 { }
@@ -191,7 +198,7 @@ template <size_t BLOCK_SIZE, bool Async,
           typename StoragePolicy,
           typename IndexType,
           typename Allocator,
-          typename WORKINGRES,
+          typename WorkingRes,
           RAJA::Platform PLATFORM
           >
 struct PluginWorkGroupTestImpl<RAJA::hip_work<BLOCK_SIZE, Async>,
@@ -200,7 +207,7 @@ struct PluginWorkGroupTestImpl<RAJA::hip_work<BLOCK_SIZE, Async>,
                                detail::indirect_virtual_function_dispatch_typer,
                                IndexType,
                                Allocator,
-                               WORKINGRES,
+                               WorkingRes,
                                PLATFORM> {
 void operator()() const
 { }

--- a/test/integration/plugin/tests/test-plugin.hpp
+++ b/test/integration/plugin/tests/test-plugin.hpp
@@ -43,6 +43,7 @@ struct SetupPluginVars
     data.launch_counter_post    = 0;
 
     m_test_resource.memcpy(plugin_test_data, &data, sizeof(CounterData));
+    m_test_resource.wait();
   }
 
   SetupPluginVars(SetupPluginVars const&) = delete;
@@ -86,6 +87,7 @@ struct PluginTestCallable
     {
       CounterData i_data;
       plugin_test_resource->memcpy(&i_data, m_data_iptr, sizeof(CounterData));
+      plugin_test_resource->wait();
 
       if (m_data.capture_platform_active == RAJA::Platform::undefined &&
           i_data.capture_platform_active != RAJA::Platform::undefined) {

--- a/test/unit/index/test-indexset.cpp
+++ b/test/unit/index/test-indexset.cpp
@@ -17,7 +17,7 @@
 // Resource object used to construct list segment objects with indices
 // living in host (CPU) memory. Used in all tests.
 //
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
 
 
 TEST(IndexSetUnitTest, Empty)

--- a/test/unit/index/test-listsegment.cpp
+++ b/test/unit/index/test-listsegment.cpp
@@ -26,7 +26,7 @@ TYPED_TEST_SUITE(ListSegmentUnitTest, UnitIndexTypes);
 // Resource object used to construct list segment objects with indices
 // living in host (CPU) memory. Used in all tests in this file. 
 //
-camp::resources::Resource host_res{camp::resources::Host()};
+camp::resources::Resource host_res{camp::resources::Host::get_default()};
 
 
 TYPED_TEST(ListSegmentUnitTest, Constructors)

--- a/test/unit/reducer/tests/test-reducer-reset.hpp
+++ b/test/unit/reducer/tests/test-reducer-reset.hpp
@@ -87,7 +87,7 @@ template <  typename ReducePolicy,
 void testReducerReset()
 {
   camp::resources::Resource work_res{WORKING_RES::get_default()};
-  camp::resources::Resource host_res{camp::resources::Host()};
+  camp::resources::Resource host_res{camp::resources::Host::get_default()};
 
   NumericType * resetVal = nullptr;
   NumericType * workVal = nullptr;
@@ -98,15 +98,8 @@ void testReducerReset()
   resetVal = host_res.allocate<NumericType>(1);
 
   work_res.memcpy( workVal, &initVal, sizeof(initVal) );
+  work_res.wait();
   resetVal[0] = (NumericType)10;
-
-  #if defined(RAJA_ENABLE_CUDA)
-  cudaErrchk(cudaDeviceSynchronize());
-  #endif
-
-  #if defined(RAJA_ENABLE_HIP)
-  hipErrchk(hipDeviceSynchronize());
-  #endif
 
   RAJA::ReduceSum<ReducePolicy, NumericType> reduce_sum(initVal);
   RAJA::ReduceMin<ReducePolicy, NumericType> reduce_min(initVal);


### PR DESCRIPTION
# Fix Race Conditions in Tests

There are race conditions caused by inconsistent usage of camp resources (cuda/hip streams) in our tests.
This Addresses these issues by using the default resource which is what is used by RAJA.

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes #1863 
