### PR TITLE
Remove references to non-existent RAJA Google Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,6 @@ Communicate with Us
 The most effective way to communicate with the core RAJA development team
 is via our mailing list: **raja-dev@llnl.gov** 
 
-You are also welcome to join our [RAJA Google Group](https://groups.google.com/forum/#!forum/raja-users).
-
 If you have questions, find a bug, or have ideas about expanding the
 functionality or applicability of RAJA and are interested in contributing
 to its development, please do not hesitate to contact us. We are very

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -111,8 +111,6 @@ interested in improving RAJA and exploring new ways to use it.
 
 The best way to communicate with us is via our email list: ``raja-dev@llnl.gov``
 
-You are also welcome to join our `Google Group <https://groups.google.com/forum/#!forum/raja-users>`_
-
 A brief description of how to start a contribution to RAJA can be found in
 :ref:`contributing-label`.
 


### PR DESCRIPTION
Remove references to non-existent RAJA Google group from documentation.

Fixes #1872 