### PR TITLE
Fix CUDA architecture check for Blackwell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,23 +106,30 @@ include(cmake/SetupBasics.cmake)
 # Find third-party packages
 include(cmake/SetupPackages.cmake)
 
+# Set CUDA compute architecture
 if (RAJA_ENABLE_CUDA)
-  if (DEFINED CMAKE_CUDA_ARCHITECTURES)
-    if ("${CMAKE_CUDA_ARCHITECTURES}" STRLESS "35")
-      message( FATAL_ERROR "RAJA requires minimum CUDA compute architecture of 35")
-    endif()
-  else()
-    message(STATUS "CUDA compute architecture set to RAJA default 35 since it was not specified")
-    set(CMAKE_CUDA_ARCHITECTURES "35" CACHE STRING "Set CMAKE_CUDA_ARCHITECTURES to RAJA minimum supported" FORCE)
-  endif()
+  if (DEFINED CMAKE_CUDA_ARCHITECTURES AND NOT "${CMAKE_CUDA_ARCHITECTURES}" STREQUAL "")
+    foreach (arch IN LISTS CMAKE_CUDA_ARCHITECTURES)
+      if (arch LESS 35)
+        message(FATAL_ERROR
+          "RAJA requires minimum CUDA compute architecture of 35, but got ${arch}")
+      endif ()
+    endforeach ()
+  else ()
+    message(STATUS
+      "CUDA compute architecture set to RAJA default 35 since it was not specified")
+    set(CMAKE_CUDA_ARCHITECTURES "35" CACHE STRING
+      "Set CMAKE_CUDA_ARCHITECTURES to RAJA minimum supported" FORCE)
+  endif ()
+
   message(STATUS "CMAKE_CUDA_ARCHITECTURES set to ${CMAKE_CUDA_ARCHITECTURES}")
-  if ( (CMAKE_CXX_COMPILER_ID MATCHES GNU) AND (CMAKE_SYSTEM_PROCESSOR MATCHES ppc64le) )
+
+  if (CMAKE_CXX_COMPILER_ID MATCHES GNU AND CMAKE_SYSTEM_PROCESSOR MATCHES ppc64le)
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
-      set (CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -mno-float128")
+      set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -mno-float128")
     endif ()
   endif ()
-endif()
-
+endif ()
 
 # Setup vendor-specific compiler flags
 include(cmake/SetupCompilers.cmake)


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Improve robustness of the minimum CUDA architecture check 

# Context:

The old check `"${CMAKE_CUDA_ARCHITECTURES}" STRLESS "35"` fails on Blackwell cards (`sm_100` and `sm_120`)  since they come first than `sm_35` lexicographically.  This PR does the comparison numerically.

Pulled branch on fork into RAJA repo and made companion PR for merging: https://github.com/LLNL/RAJA/pull/1892

