### PR TITLE
Fix shadow warnings.

### DIFF
--- a/examples/plugin/test-plugin.cpp
+++ b/examples/plugin/test-plugin.cpp
@@ -7,13 +7,14 @@
 
 #include "RAJA/RAJA.hpp"
 
-int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
+int main(int RAJA_UNUSED_ARG(argc), char** RAJA_UNUSED_ARG(argv[]))
 {
   double* a = new double[10];
 
-  for (int ii = 0; ii < 10; ii++) {
-    RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0,10), [=] (int i) {
-        a[i] = 0;
+  for (int ii = 0; ii < 10; ii++)
+  {
+    RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, 10), [=](int i) {
+      a[i] = 0;
     });
   }
 }

--- a/examples/plugin/test-plugin.cpp
+++ b/examples/plugin/test-plugin.cpp
@@ -11,7 +11,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 {
   double* a = new double[10];
 
-  for (int i = 0; i < 10; i++) {
+  for (int ii = 0; ii < 10; ii++) {
     RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0,10), [=] (int i) {
         a[i] = 0;
     });

--- a/exercises/kernel-matrix-transpose-local-array.cpp
+++ b/exercises/kernel-matrix-transpose-local-array.cpp
@@ -390,15 +390,15 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
                      RAJA::TypedRangeSegment<int>(0, N_r)),
     RAJA::make_tuple((int)0, (int)0, Tile_Array),
 
-    [=](int col, int row, int tx, int ty, TILE_MEM &Tile_Array) {
+    [=](int col, int row, int tx, int ty, TILE_MEM &_Tile_Array) {
 
-      Tile_Array(ty, tx) = Aview(row, col);
+      _Tile_Array(ty, tx) = Aview(row, col);
 
     },
 
-    [=](int col, int row, int tx, int ty, TILE_MEM &Tile_Array) {
+    [=](int col, int row, int tx, int ty, TILE_MEM &_Tile_Array) {
 
-      Atview(col, row) = Tile_Array(ty, tx);
+      Atview(col, row) = _Tile_Array(ty, tx);
 
     }
   );

--- a/exercises/kernel-matrix-transpose-local-array_solution.cpp
+++ b/exercises/kernel-matrix-transpose-local-array_solution.cpp
@@ -230,12 +230,12 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
     RAJA::make_tuple((int)0, (int)0, Tile_Array),
 
-    [=](int col, int row, int tx, int ty, TILE_MEM &Tile_Array) {
-      Tile_Array(ty, tx) = Aview(row, col);
+    [=](int col, int row, int tx, int ty, TILE_MEM &_Tile_Array) {
+      _Tile_Array(ty, tx) = Aview(row, col);
     },
 
-    [=](int col, int row, int tx, int ty, TILE_MEM &Tile_Array) {
-      Atview(col, row) = Tile_Array(ty, tx);
+    [=](int col, int row, int tx, int ty, TILE_MEM &_Tile_Array) {
+      Atview(col, row) = _Tile_Array(ty, tx);
     }
 
   );
@@ -299,15 +299,15 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
                      RAJA::TypedRangeSegment<int>(0, N_r)),
     RAJA::make_tuple((int)0, (int)0, Tile_Array),
 
-    [=](int col, int row, int tx, int ty, TILE_MEM &Tile_Array) {
+    [=](int col, int row, int tx, int ty, TILE_MEM &_Tile_Array) {
 
-      Tile_Array(ty, tx) = Aview(row, col);
+      _Tile_Array(ty, tx) = Aview(row, col);
 
     },
 
-    [=](int col, int row, int tx, int ty, TILE_MEM &Tile_Array) {
+    [=](int col, int row, int tx, int ty, TILE_MEM &_Tile_Array) {
 
-      Atview(col, row) = Tile_Array(ty, tx);
+      Atview(col, row) = _Tile_Array(ty, tx);
 
     }
   );
@@ -368,15 +368,15 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
                      RAJA::TypedRangeSegment<int>(0, N_r)),
     RAJA::make_tuple((int)0, (int)0, Tile_Array),
 
-    [=](int col, int row, int tx, int ty, TILE_MEM &Tile_Array) {
+    [=](int col, int row, int tx, int ty, TILE_MEM &_Tile_Array) {
 
-      Tile_Array(ty, tx) = Aview(row, col);
+      _Tile_Array(ty, tx) = Aview(row, col);
 
     },
 
-    [=](int col, int row, int tx, int ty, TILE_MEM &Tile_Array) {
+    [=](int col, int row, int tx, int ty, TILE_MEM &_Tile_Array) {
 
-      Atview(col, row) = Tile_Array(ty, tx);
+      Atview(col, row) = _Tile_Array(ty, tx);
 
     }
   );
@@ -602,12 +602,12 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
     RAJA::make_tuple(Tile_Array),
 
-    [=](int col, int row, int tx, int ty, TILE_MEM &Tile_Array) {
-        Tile_Array(ty, tx) = Aview(row, col);
+    [=](int col, int row, int tx, int ty, TILE_MEM &_Tile_Array) {
+        _Tile_Array(ty, tx) = Aview(row, col);
     },
 
-    [=](int col, int row, int tx, int ty, TILE_MEM &Tile_Array) {
-      Atview(col, row) = Tile_Array(ty, tx);
+    [=](int col, int row, int tx, int ty, TILE_MEM &_Tile_Array) {
+      Atview(col, row) = _Tile_Array(ty, tx);
     }
   );
   // _raja_mattranspose_lambdaargs_start

--- a/exercises/view-layout.cpp
+++ b/exercises/view-layout.cpp
@@ -467,8 +467,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   int imin = -5;
   int imax = 6;
 
-  for (int i = imin; i < imax; ++i) {
-    ao_ref[ i-imin ] = i;
+  for (int ii = imin; ii < imax; ++ii) {
+    ao_ref[ ii-imin ] = i;
   }
   // _cstyle_offlayout1D_end
 
@@ -485,8 +485,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   RAJA::View< int, RAJA::OffsetLayout<1, int> > aoview_1Doff(ao,
                                                              offlayout_1D);
 
-  for (int i = imin; i < imax; ++i) {
-    aoview_1Doff(i) = i;
+  for (int ii = imin; ii < imax; ++ii) {
+    aoview_1Doff(ii) = ii;
   }
   // _raja_offlayout1D_end
 
@@ -510,9 +510,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   int jmax = 5;
 
   iter = 0;
-  for (int i = imin; i < imax; ++i) {
-    for (int j = jmin; j < jmax; ++j) {
-      ao_ref[ (j-jmin) + (i-imin) * (jmax-jmin)  ] = iter;
+  for (int ii = imin; ii < imax; ++ii) {
+    for (int jj = jmin; jj < jmax; ++jj) {
+      ao_ref[ (jj-jmin) + (ii-imin) * (jmax-jmin)  ] = iter;
       iter++;
     }
   }
@@ -547,9 +547,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   // _cstyle_permofflayout2D_start
   iter = 0;
-  for (int j = jmin; j < jmax; ++j) {
-    for (int i = imin; i < imax; ++i) {
-      ao_ref[ (i-imin) + (j-jmin) * (imax-imin)  ] = iter; 
+  for (int jj = jmin; jj < jmax; ++jj) {
+    for (int ii = imin; ii < imax; ++ii) {
+      ao_ref[ (ii-imin) + (jj-jmin) * (imax-imin)  ] = iter; 
       iter++;
     }
   }
@@ -572,9 +572,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
                                                             permofflayout_2D);
 
   iter = 0;
-  for (int j = jmin; j < jmax; ++j) {
-    for (int i = imin; i < imax; ++i) {
-      aoview_2Dpermoff(i, j) = iter;
+  for (int jj = jmin; jj < jmax; ++jj) {
+    for (int ii = imin; ii < imax; ++ii) {
+      aoview_2Dpermoff(ii, jj) = iter;
       iter++;
     }
   }

--- a/exercises/view-layout_solution.cpp
+++ b/exercises/view-layout_solution.cpp
@@ -478,8 +478,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   int imin = -5;
   int imax = 6;
 
-  for (int i = imin; i < imax; ++i) {
-    ao_ref[ i-imin ] = i;
+  for (int ii = imin; ii < imax; ++ii) {
+    ao_ref[ ii-imin ] = i;
   }
   // _cstyle_offlayout1D_end
 
@@ -496,8 +496,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   RAJA::View< int, RAJA::OffsetLayout<1, int> > aoview_1Doff(ao,
                                                              offlayout_1D);
 
-  for (int i = imin; i < imax; ++i) {
-    aoview_1Doff(i) = i;
+  for (int ii = imin; ii < imax; ++ii) {
+    aoview_1Doff(ii) = ii;
   }
   // _raja_offlayout1D_end
 
@@ -521,9 +521,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   int jmax = 5;
 
   iter = 0;
-  for (int i = imin; i < imax; ++i) {
-    for (int j = jmin; j < jmax; ++j) {
-      ao_ref[ (j-jmin) + (i-imin) * (jmax-jmin)  ] = iter;
+  for (int ii = imin; ii < imax; ++ii) {
+    for (int jj = jmin; jj < jmax; ++jj) {
+      ao_ref[ (jj-jmin) + (ii-imin) * (jmax-jmin)  ] = iter;
       iter++;
     }
   }
@@ -542,9 +542,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   RAJA::View< int, RAJA::OffsetLayout<2, int> > aoview_2Doff(ao,
                                                              offlayout_2D);
   iter = 0;
-  for (int i = imin; i < imax; ++i) {
-    for (int j = jmin; j < jmax; ++j) {
-      aoview_2Doff(i, j) = iter;
+  for (int ii = imin; ii < imax; ++ii) {
+    for (int jj = jmin; jj < jmax; ++jj) {
+      aoview_2Doff(ii, jj) = iter;
       iter++;
     }
   }
@@ -565,9 +565,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   // _cstyle_permofflayout2D_start
   iter = 0;
-  for (int j = jmin; j < jmax; ++j) {
-    for (int i = imin; i < imax; ++i) {
-      ao_ref[ (i-imin) + (j-jmin) * (imax-imin)  ] = iter; 
+  for (int jj = jmin; jj < jmax; ++jj) {
+    for (int ii = imin; ii < imax; ++ii) {
+      ao_ref[ (ii-imin) + (jj-jmin) * (imax-imin)  ] = iter; 
       iter++;
     }
   }
@@ -590,9 +590,9 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
                                                             permofflayout_2D);
 
   iter = 0;
-  for (int j = jmin; j < jmax; ++j) {
-    for (int i = imin; i < imax; ++i) {
-      aoview_2Dpermoff(i, j) = iter;
+  for (int jj = jmin; jj < jmax; ++jj) {
+    for (int ii = imin; ii < imax; ++ii) {
+      aoview_2Dpermoff(ii, jj) = iter;
       iter++;
     }
   }

--- a/include/RAJA/policy/MultiPolicy.hpp
+++ b/include/RAJA/policy/MultiPolicy.hpp
@@ -52,24 +52,24 @@ namespace multi
 template<typename Selector, typename... Policies>
 class MultiPolicy
 {
-  Selector s;
+  Selector _selector;
 
 public:
   MultiPolicy() = delete;  // No default construction
 
-  MultiPolicy(Selector _s) : s(_s), _policies({Policies {}...}) {}
+  MultiPolicy(Selector s) : _selector(s), _policies({Policies {}...}) {}
 
-  MultiPolicy(Selector _s, Policies... policies) : s(_s), _policies({policies...})
+  MultiPolicy(Selector s, Policies... policies) : _selector(s), _policies({policies...})
   {}
 
-  MultiPolicy(const MultiPolicy& p) : s(p.s), _policies(p._policies) {}
+  MultiPolicy(const MultiPolicy& p) : _selector(p._selector), _policies(p._policies) {}
 
   template<typename Iterable, typename Body>
   int invoke(Iterable&& i, Body&& b)
   {
-    size_t index = s(i);
+    size_t index = _selector(i);
     _policies.invoke(index, i, b);
-    return s(i);
+    return _selector(i);
   }
 
   detail::

--- a/include/RAJA/policy/MultiPolicy.hpp
+++ b/include/RAJA/policy/MultiPolicy.hpp
@@ -57,9 +57,9 @@ class MultiPolicy
 public:
   MultiPolicy() = delete;  // No default construction
 
-  MultiPolicy(Selector s_in) : s(s_in), _policies({Policies {}...}) {}
+  MultiPolicy(Selector _s) : s(_s), _policies({Policies {}...}) {}
 
-  MultiPolicy(Selector s_in, Policies... policies) : s(s_in), _policies({policies...})
+  MultiPolicy(Selector _s, Policies... policies) : s(_s), _policies({policies...})
   {}
 
   MultiPolicy(const MultiPolicy& p) : s(p.s), _policies(p._policies) {}

--- a/include/RAJA/policy/MultiPolicy.hpp
+++ b/include/RAJA/policy/MultiPolicy.hpp
@@ -59,10 +59,15 @@ public:
 
   MultiPolicy(Selector s) : _selector(s), _policies({Policies {}...}) {}
 
-  MultiPolicy(Selector s, Policies... policies) : _selector(s), _policies({policies...})
+  MultiPolicy(Selector s, Policies... policies)
+      : _selector(s),
+        _policies({policies...})
   {}
 
-  MultiPolicy(const MultiPolicy& p) : _selector(p._selector), _policies(p._policies) {}
+  MultiPolicy(const MultiPolicy& p)
+      : _selector(p._selector),
+        _policies(p._policies)
+  {}
 
   template<typename Iterable, typename Body>
   int invoke(Iterable&& i, Body&& b)

--- a/include/RAJA/policy/MultiPolicy.hpp
+++ b/include/RAJA/policy/MultiPolicy.hpp
@@ -57,9 +57,9 @@ class MultiPolicy
 public:
   MultiPolicy() = delete;  // No default construction
 
-  MultiPolicy(Selector s) : s(s), _policies({Policies {}...}) {}
+  MultiPolicy(Selector s_in) : s(s_in), _policies({Policies {}...}) {}
 
-  MultiPolicy(Selector s, Policies... policies) : s(s), _policies({policies...})
+  MultiPolicy(Selector s_in, Policies... policies) : s(s_in), _policies({policies...})
   {}
 
   MultiPolicy(const MultiPolicy& p) : s(p.s), _policies(p._policies) {}

--- a/include/RAJA/util/View.hpp
+++ b/include/RAJA/util/View.hpp
@@ -168,8 +168,8 @@ struct MultiView
         data(data_ptr)
   {}
 
-  RAJA_INLINE constexpr MultiView(pointer_type data_ptr, layout_type&& layout)
-      : layout(layout),
+  RAJA_INLINE constexpr MultiView(pointer_type data_ptr, layout_type&& ly)
+      : layout(ly),
         data(data_ptr)
   {}
 

--- a/test/functional/forall/resource-segment/tests/test-forall-resource-RangeStrideSegment.hpp
+++ b/test/functional/forall/resource-segment/tests/test-forall-resource-RangeStrideSegment.hpp
@@ -36,10 +36,10 @@ void ForallResourceRangeStrideSegmentTestImpl(INDEX_TYPE first, INDEX_TYPE last,
   working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * RAJA::stripIndexType(N));
   working_res.wait();
 
-  INDEX_TYPE idx = first;
+  INDEX_TYPE index = first;
   for (INDEX_TYPE i = INDEX_TYPE(0); i < N; ++i) {
-    test_array[ RAJA::stripIndexType((idx-first)/stride) ] = idx;
-    idx += stride; 
+    test_array[ RAJA::stripIndexType((index-first)/stride) ] = index;
+    index += stride; 
   }
 
   RAJA::forall<EXEC_POLICY>(working_res, r1, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {

--- a/test/functional/forall/segment-view/tests/test-forall-RangeStrideSegmentView.hpp
+++ b/test/functional/forall/segment-view/tests/test-forall-RangeStrideSegmentView.hpp
@@ -31,10 +31,10 @@ void ForallRangeStrideSegmentViewTestImpl(INDEX_TYPE first, INDEX_TYPE last,
 
   working_res.memcpy(working_array, test_array, sizeof(INDEX_TYPE) * N);
 
-  INDEX_TYPE idx = first;
+  INDEX_TYPE index = first;
   for (INDEX_TYPE i = 0; i < N; ++i) {
-    test_array[ (idx-first)/stride ] = idx;
-    idx += stride;
+    test_array[ (index-first)/stride ] = index;
+    index += stride;
   }
 
   using view_type = RAJA::View< INDEX_TYPE, RAJA::Layout<1, INDEX_TYPE, 0> >;

--- a/test/functional/forall/segment/tests/test-forall-RangeStrideSegment.hpp
+++ b/test/functional/forall/segment/tests/test-forall-RangeStrideSegment.hpp
@@ -42,10 +42,10 @@ void ForallRangeStrideSegmentTestImpl(INDEX_TYPE first, INDEX_TYPE last,
 
   if ( RAJA::stripIndexType(N) > 0 ) {
 
-    INDEX_TYPE idx = first;
+    INDEX_TYPE index = first;
     for (INDEX_TYPE i = INDEX_TYPE(0); i < N; ++i) {
-      test_array[ RAJA::stripIndexType((idx-first)/stride) ] = idx;
-      idx += stride; 
+      test_array[ RAJA::stripIndexType((index-first)/stride) ] = index;
+      index += stride; 
     }
 
     RAJA::forall<EXEC_POLICY>(r1, [=] RAJA_HOST_DEVICE(INDEX_TYPE idx) {

--- a/test/functional/kernel/multi-reduce-nested/tests/test-kernel-nested-MultiReduce.hpp
+++ b/test/functional/kernel/multi-reduce-nested/tests/test-kernel-nested-MultiReduce.hpp
@@ -173,8 +173,8 @@ KernelMultiReduceNestedTestImpl(const SEGMENTS_TYPE& segments,
       }
 
       RAJA::kernel_resource<EXEC_POLICY>(segments, working_res,
-          [=] RAJA_HOST_DEVICE (IDX_TYPE k, IDX_TYPE j, IDX_TYPE i) {
-        IDX_TYPE ii = (dimi * dimj * k) + (dimi * j) + i;
+          [=] RAJA_HOST_DEVICE (IDX_TYPE K, IDX_TYPE J, IDX_TYPE I) {
+        IDX_TYPE ii = (dimi * dimj * K) + (dimi * J) + I;
         for (IDX_TYPE idx = working_range[ii]; idx < working_range[ii+1]; ++idx) {
           ABSTRACTION::reduce(red[working_bins[idx]],  working_array[idx]);
         }
@@ -212,8 +212,8 @@ KernelMultiReduceNestedTestImpl(const SEGMENTS_TYPE& segments,
       red.reset();
 
       RAJA::kernel_resource<EXEC_POLICY>(segments, working_res,
-          [=] RAJA_HOST_DEVICE (IDX_TYPE k, IDX_TYPE j, IDX_TYPE i) {
-        IDX_TYPE ii = (dimi * dimj * k) + (dimi * j) + i;
+          [=] RAJA_HOST_DEVICE (IDX_TYPE K, IDX_TYPE J, IDX_TYPE I) {
+        IDX_TYPE ii = (dimi * dimj * K) + (dimi * J) + I;
         for (IDX_TYPE idx = working_range[ii]; idx < working_range[ii+1]; ++idx) {
           ABSTRACTION::reduce(red[working_bins[idx]],  working_array[idx]);
         }

--- a/test/functional/kernel/tile-variants/tests/test-kernel-tile-LocalArray2D.hpp
+++ b/test/functional/kernel/tile-variants/tests/test-kernel-tile-LocalArray2D.hpp
@@ -73,12 +73,12 @@ void KernelTileLocalArray2DTestImpl(const int rows, const int cols)
   RAJA::TypedRangeSegment<INDEX_TYPE> colrange( 0, cols );
 
   RAJA::kernel_param<EXEC_POLICY> ( RAJA::make_tuple( colrange, rowrange ), RAJA::make_tuple( (INDEX_TYPE)0, (INDEX_TYPE)0, Tile_Array ),
-    [=] RAJA_HOST_DEVICE ( INDEX_TYPE cc, INDEX_TYPE rr, INDEX_TYPE tx, INDEX_TYPE ty, TILE_MEM &Tile_Array ) {
-      Tile_Array( ty, tx ) = WorkView( rr, cc );
+    [=] RAJA_HOST_DEVICE ( INDEX_TYPE cc, INDEX_TYPE rr, INDEX_TYPE tx, INDEX_TYPE ty, TILE_MEM &_Tile_Array ) {
+      _Tile_Array( ty, tx ) = WorkView( rr, cc );
     },
 
-    [=] RAJA_HOST_DEVICE ( INDEX_TYPE cc, INDEX_TYPE rr, INDEX_TYPE tx, INDEX_TYPE ty, TILE_MEM &Tile_Array ) {
-      WorkTView( cc, rr ) = Tile_Array( ty, tx );
+    [=] RAJA_HOST_DEVICE ( INDEX_TYPE cc, INDEX_TYPE rr, INDEX_TYPE tx, INDEX_TYPE ty, TILE_MEM &_Tile_Array ) {
+      WorkTView( cc, rr ) = _Tile_Array( ty, tx );
     }
   );
 

--- a/test/functional/launch/multi-reduce-nested/tests/test-launch-nested-MultiReduce.hpp
+++ b/test/functional/launch/multi-reduce-nested/tests/test-launch-nested-MultiReduce.hpp
@@ -244,8 +244,8 @@ LaunchMultiReduceNestedTestImpl(const SEGMENTS_TYPE& segments,
       }
 
       Launch<EXEC_POL_DATA, IDX_TYPE>(segments,
-          [=] RAJA_HOST_DEVICE (IDX_TYPE k, IDX_TYPE j, IDX_TYPE i) {
-        IDX_TYPE ii = (dimi * dimj * k) + (dimi * j) + i;
+          [=] RAJA_HOST_DEVICE (IDX_TYPE K, IDX_TYPE J, IDX_TYPE I) {
+        IDX_TYPE ii = (dimi * dimj * K) + (dimi * J) + I;
         for (IDX_TYPE idx = working_range[ii]; idx < working_range[ii+1]; ++idx) {
           ABSTRACTION::reduce(red[working_bins[idx]],  working_array[idx]);
         }
@@ -283,8 +283,8 @@ LaunchMultiReduceNestedTestImpl(const SEGMENTS_TYPE& segments,
       red.reset();
 
       Launch<EXEC_POL_DATA, IDX_TYPE>(segments,
-          [=] RAJA_HOST_DEVICE (IDX_TYPE k, IDX_TYPE j, IDX_TYPE i) {
-        IDX_TYPE ii = (dimi * dimj * k) + (dimi * j) + i;
+          [=] RAJA_HOST_DEVICE (IDX_TYPE K, IDX_TYPE J, IDX_TYPE I) {
+        IDX_TYPE ii = (dimi * dimj * K) + (dimi * J) + I;
         for (IDX_TYPE idx = working_range[ii]; idx < working_range[ii+1]; ++idx) {
           ABSTRACTION::reduce(red[working_bins[idx]],  working_array[idx]);
         }

--- a/test/functional/launch/segment/tests/test-launch-RangeStrideSegment.hpp
+++ b/test/functional/launch/segment/tests/test-launch-RangeStrideSegment.hpp
@@ -44,10 +44,10 @@ void LaunchRangeStrideSegmentTestImpl(INDEX_TYPE first, INDEX_TYPE last,
 
   if ( RAJA::stripIndexType(N) > 0 ) {
 
-    INDEX_TYPE idx = first;
+    INDEX_TYPE index = first;
     for (INDEX_TYPE i = INDEX_TYPE(0); i < N; ++i) {
-      test_array[ RAJA::stripIndexType((idx-first)/stride) ] = idx;
-      idx += stride;
+      test_array[ RAJA::stripIndexType((index-first)/stride) ] = index;
+      index += stride;
     }
 
     RAJA::launch<LAUNCH_POLICY>(

--- a/test/functional/tensor/register/tests/test-tensor-register-Add.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-Add.hpp
@@ -13,11 +13,11 @@
 template <typename REGISTER_TYPE>
 void AddImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // Allocate
 
@@ -50,13 +50,13 @@ void AddImpl()
   // operator +
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t y;
+    reg_t y;
     y.load_packed(input1_dptr);
 
-    register_t z = x + y;
+    reg_t z = x + y;
 
     z.store_packed(output0_dptr);
   });
@@ -72,13 +72,13 @@ void AddImpl()
   // operator +=
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t y;
+    reg_t y;
     y.load_packed(input1_dptr);
 
-    register_t z = x;
+    reg_t z = x;
 
     z += y;
 
@@ -97,10 +97,10 @@ void AddImpl()
   // operator + scalar
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t z = x + 7;
+    reg_t z = x + 7;
 
     z.store_packed(output0_dptr);
   });
@@ -117,10 +117,10 @@ void AddImpl()
   // operator += scalar
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t z = x;
+    reg_t z = x;
 
     z += 3;
 

--- a/test/functional/tensor/register/tests/test-tensor-register-Divide.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-Divide.hpp
@@ -13,11 +13,11 @@
 template <typename REGISTER_TYPE>
 void DivideImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // Allocate
 
@@ -50,13 +50,13 @@ void DivideImpl()
   // operator /
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t y;
+    reg_t y;
     y.load_packed(input1_dptr);
 
-    register_t z = x / y;
+    reg_t z = x / y;
 
     z.store_packed(output0_dptr);
   });
@@ -72,13 +72,13 @@ void DivideImpl()
   // operator /=
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t y;
+    reg_t y;
     y.load_packed(input1_dptr);
 
-    register_t z = x;
+    reg_t z = x;
 
     z /= y;
 
@@ -97,10 +97,10 @@ void DivideImpl()
   // operator / scalar
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t z = x / 7;
+    reg_t z = x / 7;
 
     z.store_packed(output0_dptr);
   });
@@ -117,10 +117,10 @@ void DivideImpl()
   // operator += scalar
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t z = x;
+    reg_t z = x;
 
     z /= 3;
 
@@ -141,13 +141,13 @@ void DivideImpl()
 
     tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-      register_t x;
+      reg_t x;
       x.load_packed_n(input0_dptr, N);
 
-      register_t y;
+      reg_t y;
       y.load_packed_n(input1_dptr, N);
 
-      register_t z = x.divide_n(y,N);
+      reg_t z = x.divide_n(y,N);
 
       z.store_packed(output0_dptr);
     });

--- a/test/functional/tensor/register/tests/test-tensor-register-DotProduct.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-DotProduct.hpp
@@ -13,11 +13,11 @@
 template <typename REGISTER_TYPE>
 void DotProductImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // Allocate
 
@@ -49,10 +49,10 @@ void DotProductImpl()
 
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t y;
+    reg_t y;
     y.load_packed(input1_dptr);
 
 

--- a/test/functional/tensor/register/tests/test-tensor-register-FMA.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-FMA.hpp
@@ -13,11 +13,11 @@
 template <typename REGISTER_TYPE>
 void FMAImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // Allocate
 
@@ -56,16 +56,16 @@ void FMAImpl()
   // operator z = a*b+c
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t a;
+    reg_t a;
     a.load_packed(input0_dptr);
 
-    register_t b;
+    reg_t b;
     b.load_packed(input1_dptr);
 
-    register_t c;
+    reg_t c;
     c.load_packed(input2_dptr);
 
-    register_t z = a.multiply_add(b,c);
+    reg_t z = a.multiply_add(b,c);
 
     z.store_packed(output0_dptr);
   });

--- a/test/functional/tensor/register/tests/test-tensor-register-FMS.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-FMS.hpp
@@ -13,11 +13,11 @@
 template <typename REGISTER_TYPE>
 void FMSImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // Allocate
 
@@ -56,16 +56,16 @@ void FMSImpl()
   // operator z = a*b-c
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t a;
+    reg_t a;
     a.load_packed(input0_dptr);
 
-    register_t b;
+    reg_t b;
     b.load_packed(input1_dptr);
 
-    register_t c;
+    reg_t c;
     c.load_packed(input2_dptr);
 
-    register_t z = a.multiply_subtract(b,c);
+    reg_t z = a.multiply_subtract(b,c);
 
     z.store_packed(output0_dptr);
   });

--- a/test/functional/tensor/register/tests/test-tensor-register-Gather.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-Gather.hpp
@@ -13,14 +13,14 @@
 template <typename REGISTER_TYPE>
 void GatherImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // get the integer indexing types
-  using int_register_t = typename register_t::int_vector_type;
+  using int_register_t = typename reg_t::int_vector_type;
   using index_t = typename int_register_t::element_type;
 
   // Allocate
@@ -63,7 +63,7 @@ void GatherImpl()
     idx.load_packed(input1_dptr);
 
     // gather elements from a given offsets in idx
-    register_t a;
+    reg_t a;
     a.gather(input0_dptr, idx);
 
     // write out gathered elements in packed order
@@ -91,7 +91,7 @@ void GatherImpl()
       idx.load_packed_n(input1_dptr, N);
 
       // gather elements from a given offsets in idx
-      register_t a;
+      reg_t a;
       a.gather_n(input0_dptr, idx, N);
 
       // write out gathered elements in packed order

--- a/test/functional/tensor/register/tests/test-tensor-register-GetSet.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-GetSet.hpp
@@ -13,11 +13,11 @@
 template <typename REGISTER_TYPE>
 void GetSetImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // Allocate
   std::vector<element_t> input0_vec(num_elem);
@@ -38,7 +38,7 @@ void GetSetImpl()
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
     // fill x using set
-    register_t x;
+    reg_t x;
     for(camp::idx_t i = 0;i < num_elem; ++ i){
       x.set(input0_dptr[i], i);
     }
@@ -63,12 +63,12 @@ void GetSetImpl()
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
     // fill x using set
-    register_t x;
+    reg_t x;
     for(camp::idx_t i = 0;i < num_elem; ++ i){
       x.set(input0_dptr[i], i);
     }
 
-    register_t cc(x);
+    reg_t cc(x);
 
     // extract from x using get
     for(camp::idx_t i = 0;i < num_elem; ++ i){
@@ -92,12 +92,12 @@ void GetSetImpl()
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
     // fill x using set
-    register_t x;
+    reg_t x;
     for(camp::idx_t i = 0;i < num_elem; ++ i){
       x.set(input0_dptr[i], i);
     }
 
-    register_t cc;
+    reg_t cc;
     cc.copy(x);
 
     // extract from x using get
@@ -122,12 +122,12 @@ void GetSetImpl()
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
     // fill x using set
-    register_t x;
+    reg_t x;
     for(camp::idx_t i = 0;i < num_elem; ++ i){
       x.set(input0_dptr[i], i);
     }
 
-    register_t cc = x;
+    reg_t cc = x;
 
     // extract from x using get
     for(camp::idx_t i = 0;i < num_elem; ++ i){
@@ -151,7 +151,7 @@ void GetSetImpl()
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
 
-    register_t cc = (element_t) 5;
+    reg_t cc = (element_t) 5;
 
     // extract from x using get
     for(camp::idx_t i = 0;i < num_elem; ++ i){
@@ -176,7 +176,7 @@ void GetSetImpl()
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
 
-    register_t cc = (element_t) 0;
+    reg_t cc = (element_t) 0;
     cc = (element_t) 11.0;
 
     // extract from x using get
@@ -199,7 +199,7 @@ void GetSetImpl()
   //
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t cc = (element_t) 0;
+    reg_t cc = (element_t) 0;
     cc.broadcast(13.0);
 
     // extract from x using get

--- a/test/functional/tensor/register/tests/test-tensor-register-Load.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-Load.hpp
@@ -13,11 +13,11 @@
 template <typename REGISTER_TYPE>
 void LoadImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // Allocate
   std::vector<element_t> input0_vec(10*num_elem);
@@ -41,7 +41,7 @@ void LoadImpl()
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
     // fill x using set
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
     // extract from x using get
@@ -64,7 +64,7 @@ void LoadImpl()
     tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
       // fill x using set
-      register_t x;
+      reg_t x;
       x.load_packed_n(input0_dptr, N);
 
       // extract from x using get
@@ -93,7 +93,7 @@ void LoadImpl()
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
     // fill x using set
-    register_t x;
+    reg_t x;
     x.load_strided(input0_dptr, 2);
 
     // extract from x using get
@@ -116,7 +116,7 @@ void LoadImpl()
     tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
       // fill x using set
-      register_t x;
+      reg_t x;
       x.load_strided_n(input0_dptr, 2, N);
 
       // extract from x using get

--- a/test/functional/tensor/register/tests/test-tensor-register-Max.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-Max.hpp
@@ -13,11 +13,11 @@
 template <typename REGISTER_TYPE>
 void MaxImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // Allocate
 
@@ -53,10 +53,10 @@ void MaxImpl()
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
     // load input vectors
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t y;
+    reg_t y;
     y.load_packed(input1_dptr);
 
 
@@ -65,7 +65,7 @@ void MaxImpl()
 
 
     // compute element-wise
-    register_t z = x.vmax(y);
+    reg_t z = x.vmax(y);
     z.store_packed(output1_dptr);
   });
 
@@ -100,7 +100,7 @@ void MaxImpl()
 
     tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-      register_t x;
+      reg_t x;
       x.load_packed(input0_dptr);
 
       output0_dptr[0] = x.max_n(N);
@@ -111,13 +111,13 @@ void MaxImpl()
 
 
     // compute expected value for reduction
-    element_t expected = RAJA::operators::limits<element_t>::min();
+    element_t expected2 = RAJA::operators::limits<element_t>::min();
     for(camp::idx_t i = 0;i < N;++i){
-      expected = expected < input0_vec[i] ? input0_vec[i] : expected;
+      expected2 = expected2 < input0_vec[i] ? input0_vec[i] : expected2;
     }
 
     // check reduction
-    ASSERT_SCALAR_EQ(expected, output0_vec[0]);
+    ASSERT_SCALAR_EQ(expected2, output0_vec[0]);
 
   }
 

--- a/test/functional/tensor/register/tests/test-tensor-register-Min.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-Min.hpp
@@ -13,11 +13,11 @@
 template <typename REGISTER_TYPE>
 void MinImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // Allocate
 
@@ -52,10 +52,10 @@ void MinImpl()
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
     // load input vectors
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t y;
+    reg_t y;
     y.load_packed(input1_dptr);
 
 
@@ -64,7 +64,7 @@ void MinImpl()
 
 
     // compute element-wise
-    register_t z = x.vmin(y);
+    reg_t z = x.vmin(y);
     z.store_packed(output1_dptr);
   });
 
@@ -99,7 +99,7 @@ void MinImpl()
 
     tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-      register_t x;
+      reg_t x;
       x.load_packed(input0_dptr);
 
       output0_dptr[0] = x.min_n(N);
@@ -110,13 +110,13 @@ void MinImpl()
 
 
     // compute expected value for reduction
-    element_t expected = RAJA::operators::limits<element_t>::max();
+    element_t expected2 = RAJA::operators::limits<element_t>::max();
     for(camp::idx_t i = 0;i < N;++i){
-      expected = expected > input0_vec[i] ? input0_vec[i] : expected;
+      expected2 = expected2 > input0_vec[i] ? input0_vec[i] : expected2;
     }
 
     // check reduction
-    ASSERT_SCALAR_EQ(expected, output0_vec[0]);
+    ASSERT_SCALAR_EQ(expected2, output0_vec[0]);
 
   }
 

--- a/test/functional/tensor/register/tests/test-tensor-register-Multiply.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-Multiply.hpp
@@ -13,11 +13,11 @@
 template <typename REGISTER_TYPE>
 void MultiplyImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // Allocate
 
@@ -50,13 +50,13 @@ void MultiplyImpl()
   // operator *
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t y;
+    reg_t y;
     y.load_packed(input1_dptr);
 
-    register_t z = x * y;
+    reg_t z = x * y;
 
     z.store_packed(output0_dptr);
   });
@@ -72,13 +72,13 @@ void MultiplyImpl()
   // operator *=
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t y;
+    reg_t y;
     y.load_packed(input1_dptr);
 
-    register_t z = x;
+    reg_t z = x;
 
     z *= y;
 
@@ -97,10 +97,10 @@ void MultiplyImpl()
   // operator * scalar
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t z = x * 7;
+    reg_t z = x * 7;
 
     z.store_packed(output0_dptr);
   });
@@ -117,10 +117,10 @@ void MultiplyImpl()
   // operator *= scalar
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t z = x;
+    reg_t z = x;
 
     z *= 3;
 

--- a/test/functional/tensor/register/tests/test-tensor-register-Scatter.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-Scatter.hpp
@@ -13,14 +13,14 @@
 template <typename REGISTER_TYPE>
 void ScatterImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // get the integer indexing types
-  using int_register_t = typename register_t::int_vector_type;
+  using int_register_t = typename reg_t::int_vector_type;
   using index_t = typename int_register_t::element_type;
 
   // Allocate
@@ -69,7 +69,7 @@ void ScatterImpl()
     int_register_t idx;
     idx.load_packed(input1_dptr);
 
-    register_t a;
+    reg_t a;
     a.load_packed(input0_dptr);
 
     a.scatter(output0_dptr, idx);
@@ -111,7 +111,7 @@ void ScatterImpl()
       int_register_t idx;
       idx.load_packed(input1_dptr);
 
-      register_t a;
+      reg_t a;
       a.load_packed(input0_dptr);
 
       a.scatter_n(output0_dptr, idx, N);

--- a/test/functional/tensor/register/tests/test-tensor-register-SegmentedBroadcastInner.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-SegmentedBroadcastInner.hpp
@@ -13,11 +13,11 @@
 template <typename REGISTER_TYPE>
 void SegmentedBroadcastInnerImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // Allocate
 
@@ -51,10 +51,10 @@ void SegmentedBroadcastInnerImpl()
       // Execute segmented broadcast
       tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-        register_t x;
+        reg_t x;
         x.load_packed(input0_dptr);
 
-        register_t y = x.segmented_broadcast_inner(segbits, input_segment);
+        reg_t y = x.segmented_broadcast_inner(segbits, input_segment);
 
         y.store_packed(output0_dptr);
 

--- a/test/functional/tensor/register/tests/test-tensor-register-SegmentedBroadcastOuter.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-SegmentedBroadcastOuter.hpp
@@ -13,11 +13,11 @@
 template <typename REGISTER_TYPE>
 void SegmentedBroadcastOuterImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // Allocate
 
@@ -50,10 +50,10 @@ void SegmentedBroadcastOuterImpl()
       // Execute segmented broadcast
       tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-        register_t x;
+        reg_t x;
         x.load_packed(input0_dptr);
 
-        register_t y = x.segmented_broadcast_outer(segbits, input_segment);
+        reg_t y = x.segmented_broadcast_outer(segbits, input_segment);
 
         y.store_packed(output0_dptr);
 

--- a/test/functional/tensor/register/tests/test-tensor-register-SegmentedDotProduct.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-SegmentedDotProduct.hpp
@@ -13,11 +13,11 @@
 template <typename REGISTER_TYPE>
 void SegmentedDotProductImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // Allocate
 
@@ -54,13 +54,13 @@ void SegmentedDotProductImpl()
 
       tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-        register_t x;
+        reg_t x;
         x.load_packed(input0_dptr);
 
-        register_t y;
+        reg_t y;
         y.load_packed(input1_dptr);
 
-        register_t dp = x.segmented_dot(segbits, output_segment, y);
+        reg_t dp = x.segmented_dot(segbits, output_segment, y);
         dp.store_packed(output0_dptr);
 
       });

--- a/test/functional/tensor/register/tests/test-tensor-register-SegmentedSumInner.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-SegmentedSumInner.hpp
@@ -13,11 +13,11 @@
 template <typename REGISTER_TYPE>
 void SegmentedSumInnerImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // Allocate
 
@@ -48,10 +48,10 @@ void SegmentedSumInnerImpl()
       // Execute segmented broadcast
       tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-        register_t x;
+        reg_t x;
         x.load_packed(input0_dptr);
 
-        register_t y = x.segmented_sum_inner(segbits, output_segment);
+        reg_t y = x.segmented_sum_inner(segbits, output_segment);
 
         y.store_packed(output0_dptr);
 

--- a/test/functional/tensor/register/tests/test-tensor-register-SegmentedSumOuter.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-SegmentedSumOuter.hpp
@@ -13,11 +13,11 @@
 template <typename REGISTER_TYPE>
 void SegmentedSumOuterImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // Allocate
 
@@ -47,10 +47,10 @@ void SegmentedSumOuterImpl()
       // Execute segmented broadcast
       tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-        register_t x;
+        reg_t x;
         x.load_packed(input0_dptr);
 
-        register_t y = x.segmented_sum_outer(segbits, output_segment);
+        reg_t y = x.segmented_sum_outer(segbits, output_segment);
 
         y.store_packed(output0_dptr);
 

--- a/test/functional/tensor/register/tests/test-tensor-register-Store.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-Store.hpp
@@ -13,11 +13,11 @@
 template <typename REGISTER_TYPE>
 void StoreImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // Allocate
   std::vector<element_t> input0_vec(num_elem);
@@ -46,7 +46,7 @@ void StoreImpl()
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
     // fill x
-    register_t x;
+    reg_t x;
     for(camp::idx_t i = 0;i < num_elem; ++ i){
       x.set(input0_dptr[i], i);
     }
@@ -76,7 +76,7 @@ void StoreImpl()
     tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
       // fill x
-      register_t x;
+      reg_t x;
       for(camp::idx_t i = 0;i < num_elem; ++ i){
         x.set(input0_dptr[i], i);
       }
@@ -110,7 +110,7 @@ void StoreImpl()
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
     // fill x
-    register_t x;
+    reg_t x;
     for(camp::idx_t i = 0;i < num_elem; ++ i){
       x.set(input0_dptr[i], i);
     }
@@ -141,7 +141,7 @@ void StoreImpl()
     tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
       // fill x
-      register_t x;
+      reg_t x;
       for(camp::idx_t i = 0;i < num_elem; ++ i){
         x.set(input0_dptr[i], i);
       }

--- a/test/functional/tensor/register/tests/test-tensor-register-Subtract.hpp
+++ b/test/functional/tensor/register/tests/test-tensor-register-Subtract.hpp
@@ -13,11 +13,11 @@
 template <typename REGISTER_TYPE>
 void SubtractImpl()
 {
-  using register_t = REGISTER_TYPE;
-  using element_t = typename register_t::element_type;
-  using policy_t = typename register_t::register_policy;
+  using reg_t = REGISTER_TYPE;
+  using element_t = typename reg_t::element_type;
+  using policy_t = typename reg_t::register_policy;
 
-  static constexpr camp::idx_t num_elem = register_t::s_num_elem;
+  static constexpr camp::idx_t num_elem = reg_t::s_num_elem;
 
   // Allocate
 
@@ -50,13 +50,13 @@ void SubtractImpl()
   // operator -
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t y;
+    reg_t y;
     y.load_packed(input1_dptr);
 
-    register_t z = x - y;
+    reg_t z = x - y;
 
     z.store_packed(output0_dptr);
   });
@@ -72,13 +72,13 @@ void SubtractImpl()
   // operator -=
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t y;
+    reg_t y;
     y.load_packed(input1_dptr);
 
-    register_t z = x;
+    reg_t z = x;
 
     z -= y;
 
@@ -97,10 +97,10 @@ void SubtractImpl()
   // operator - scalar
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t z = x - 7;
+    reg_t z = x - 7;
 
     z.store_packed(output0_dptr);
   });
@@ -117,10 +117,10 @@ void SubtractImpl()
   // operator -= scalar
   tensor_do<policy_t>([=] RAJA_HOST_DEVICE (){
 
-    register_t x;
+    reg_t x;
     x.load_packed(input0_dptr);
 
-    register_t z = x;
+    reg_t z = x;
 
     z -= 3;
 

--- a/test/functional/tensor/vector/tests/test-tensor-vector-FmaFms.hpp
+++ b/test/functional/tensor/vector/tests/test-tensor-vector-FmaFms.hpp
@@ -62,15 +62,15 @@ void FmaFmsImpl()
 
       // try FMA (A*B+C)
 
-      vector_t fma = vec_A.multiply_add(vec_B, vec_C);
+      vector_t _fma = vec_A.multiply_add(vec_B, vec_C);
       for(camp::idx_t i = 0;i < N;++ i){
-        fma_ptr[i] = fma.get(i);
+        fma_ptr[i] = _fma.get(i);
       }
 
       // try FMS (A*B-C)
-      vector_t fms = vec_A.multiply_subtract(vec_B, vec_C);
+      vector_t _fms = vec_A.multiply_subtract(vec_B, vec_C);
       for(camp::idx_t i = 0;i < N;++ i){
-        fms_ptr[i] = fms.get(i);
+        fms_ptr[i] = _fms.get(i);
       }
     }
   });

--- a/test/include/RAJA_test-reduceloc-types.hpp
+++ b/test/include/RAJA_test-reduceloc-types.hpp
@@ -20,7 +20,7 @@ struct Index2D {
    RAJA::Index_type idx, idy;
    constexpr Index2D() : idx(-1), idy(-1) {}
    constexpr Index2D(RAJA::Index_type init) : idx(init), idy(init) {}
-   constexpr Index2D(RAJA::Index_type idx, RAJA::Index_type idy) : idx(idx), idy(idy) {}
+   constexpr Index2D(RAJA::Index_type ix, RAJA::Index_type iy) : idx(ix), idy(iy) {}
    template<typename T>
    RAJA_HOST_DEVICE void operator=(T rhs) { idx = rhs; idx = rhs; }
 };

--- a/test/unit/index/test-indexset.cpp
+++ b/test/unit/index/test-indexset.cpp
@@ -186,8 +186,8 @@ TEST(IndexSetUnitTest, ConditionalEvenIndices)
   ref_even_indices.push_back(16);
 
   RAJA::RAJAVec<int> even_indices;
-  getIndicesConditional(even_indices, iset, [] (int idx) {
-    return !(idx % 2);
+  getIndicesConditional(even_indices, iset, [] (int i) {
+    return !(i % 2);
   });
 
   EXPECT_EQ(even_indices.size(), ref_even_indices.size());

--- a/test/unit/workgroup/tests/test-workgroup-Enqueue-Multiple.hpp
+++ b/test/unit/workgroup/tests/test-workgroup-Enqueue-Multiple.hpp
@@ -59,10 +59,10 @@ void operator()(
     ASSERT_EQ(pool.num_loops(), (size_t)0);
     ASSERT_EQ(pool.storage_bytes(), (size_t)0);
 
-    for (size_t i = 0; i < rep; ++i) {
+    for (size_t ii = 0; ii < rep; ++ii) {
 
       {
-        for (size_t i = 0; i < num; ++i) {
+        for (size_t jj = 0; jj < num; ++jj) {
           pool.enqueue(range_segment{0, 1}, callable{&success, IndexType(0)});
         }
 

--- a/test/unit/workgroup/tests/test-workgroup-Enqueue-Single.hpp
+++ b/test/unit/workgroup/tests/test-workgroup-Enqueue-Single.hpp
@@ -58,10 +58,10 @@ void operator()(RAJA::xargs<Args...>, bool do_instantiate, size_t rep, size_t nu
     ASSERT_EQ(pool.num_loops(), (size_t)0);
     ASSERT_EQ(pool.storage_bytes(), (size_t)0);
 
-    for (size_t i = 0; i < rep; ++i) {
+    for (size_t ii = 0; ii < rep; ++ii) {
 
       {
-        for (size_t i = 0; i < num; ++i) {
+        for (size_t jj = 0; jj < num; ++jj) {
           pool.enqueue(range_segment{0, 1}, callable{&success, IndexType(0)});
         }
 


### PR DESCRIPTION
# Summary

- This PR is a refactoring/bugfix
- It does the following:
  - Refactors code where variable names are repeated in nested scopes. This was brought to our attention by using `-Wshadow` with gcc here https://github.com/LLNL/RAJA/issues/1893.