### PR TITLE
Fix conflict in roctx and caliper plugin

### DIFF
--- a/include/RAJA/policy/cuda/params/kernel_name.hpp
+++ b/include/RAJA/policy/cuda/params/kernel_name.hpp
@@ -12,6 +12,10 @@
 #include "RAJA/policy/cuda/MemUtils_CUDA.hpp"
 #include "RAJA/pattern/params/kernel_name.hpp"
 
+#if defined(RAJA_ENABLE_CALIPER)
+#include "RAJA/util/CaliperPlugin.hpp"
+#endif
+
 namespace RAJA
 {
 namespace expt
@@ -27,7 +31,10 @@ param_init(EXEC_POL const&,
            const RAJA::cuda::detail::cudaInfo&)
 {
 #if defined(RAJA_ENABLE_NVTX)
-  if (kn.name != nullptr && expt::detail::RAJA_caliper_profile == false)
+  if (kn.name != nullptr
+#if defined(RAJA_ENABLE_CALIPER)
+      && RAJA::util::RAJA_caliper_profile == false
+#endif
   {
     nvtxRangePush(kn.name);
   }
@@ -51,7 +58,10 @@ param_resolve(EXEC_POL const&,
               const RAJA::cuda::detail::cudaInfo&)
 {
 #if defined(RAJA_ENABLE_NVTX)
-  if (kn.name != nullptr && expt::detail::RAJA_caliper_profile == false)
+  if (kn.name != nullptr
+#if defined(RAJA_ENABLE_CALIPER)
+      && RAJA::util::RAJA_caliper_profile == false
+#endif
   {
     nvtxRangePop();
   }

--- a/include/RAJA/policy/hip/params/kernel_name.hpp
+++ b/include/RAJA/policy/hip/params/kernel_name.hpp
@@ -11,6 +11,10 @@
 #include "roctx.h"
 #endif
 
+#if defined(RAJA_ENABLE_CALIPER)
+#include "RAJA/util/CaliperPlugin.hpp"
+#endif
+
 namespace RAJA
 {
 namespace expt
@@ -26,7 +30,11 @@ param_init(EXEC_POL const&,
            const RAJA::hip::detail::hipInfo&)
 {
 #if defined(RAJA_ENABLE_ROCTX)
-  if (kn.name != nullptr && expt::detail::RAJA_caliper_profile == false)
+  if (kn.name != nullptr
+#if defined(RAJA_ENABLE_CALIPER)
+      && RAJA::util::RAJA_caliper_profile == false
+#endif
+  )
   {
     roctxRangePush(kn.name);
   }
@@ -50,7 +58,11 @@ param_resolve(EXEC_POL const&,
               const RAJA::hip::detail::hipInfo&)
 {
 #if defined(RAJA_ENABLE_ROCTX)
-  if (kn.name != nullptr && expt::detail::RAJA_caliper_profile == false)
+  if (kn.name != nullptr
+#if defined(RAJA_ENABLE_CALIPER)
+      && RAJA::util::RAJA_caliper_profile == false
+#endif
+  )
   {
     roctxRangePop();
   }

--- a/include/RAJA/util/CaliperPlugin.hpp
+++ b/include/RAJA/util/CaliperPlugin.hpp
@@ -19,6 +19,17 @@ namespace RAJA
 namespace util
 {
 
+// Internal variable to toggle Caliper profiling on and off
+// Users have access to a global function.
+inline bool RAJA_caliper_profile = false;
+
+// Experimental global function to toggle Caliper
+// profiling on and off
+inline void SetRAJACaliperProfiling(bool enable)
+{
+  RAJA_caliper_profile = enable;
+}
+
 class CaliperPlugin : public ::RAJA::util::PluginStrategy
 {
 public:

--- a/src/plugins/caliper-plugin.cpp
+++ b/src/plugins/caliper-plugin.cpp
@@ -14,17 +14,6 @@ namespace RAJA
 namespace util
 {
 
-// Internal variable to toggle Caliper profiling on and off
-// Users have access to a global function.
-inline bool RAJA_caliper_profile = false;
-
-// Experimental global function to toggle Caliper
-// profiling on and off
-inline void SetRAJACaliperProfiling(bool enable)
-{
-  RAJA_caliper_profile = enable;
-}
-
 CaliperPlugin::CaliperPlugin()
 {
   const std::string varName = "RAJA_CALIPER";


### PR DESCRIPTION
This is a bugfix that occurs when building with both caliper and one of the ROCTX/NVTX options. 