### PR TITLE
Matrix Transpose Tutorial Cleanup

### DIFF
--- a/exercises/kernel-matrix-transpose-local-array_solution.cpp
+++ b/exercises/kernel-matrix-transpose-local-array_solution.cpp
@@ -399,8 +399,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       //      These loops iterate over the number of
       //      tiles needed to carry out the transpose
       //
-      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::cuda_block_y_loop,
-        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::cuda_block_x_loop,
+      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::cuda_block_y_direct_unchecked,
+        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::cuda_block_x_direct_unchecked,
           // This statement will initalize local array memory inside a
           // kernel. The cpu_tile_mem policy specifies that memory should be
           // allocated on the stack. The entries in the RAJA::ParamList
@@ -494,8 +494,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
       //      These loops iterate over the number of
       //      tiles needed to carry out the transpose
       //
-      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::hip_block_y_loop,
-        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::hip_block_x_loop,
+      RAJA::statement::Tile<1, RAJA::tile_fixed<TILE_DIM>, RAJA::hip_block_y_direct_unchecked,
+        RAJA::statement::Tile<0, RAJA::tile_fixed<TILE_DIM>, RAJA::hip_block_x_direct_unchecked,
           // This statement will initalize local array memory inside a
           // kernel. The cpu_tile_mem policy specifies that memory should be
           // allocated on the stack. The entries in the RAJA::ParamList

--- a/exercises/kernel-matrix-transpose-local-array_solution.cpp
+++ b/exercises/kernel-matrix-transpose-local-array_solution.cpp
@@ -550,6 +550,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   );
 
   CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpy, At, d_At, N_r * N_c * sizeof(int), hipMemcpyDeviceToHost);
+  CAMP_HIP_API_INVOKE_AND_CHECK(hipDeviceSynchronize);
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
 #endif

--- a/exercises/kernel-matrix-transpose-local-array_solution.cpp
+++ b/exercises/kernel-matrix-transpose-local-array_solution.cpp
@@ -431,10 +431,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
               RAJA::statement::ForICount<1, RAJA::statement::Param<0>, RAJA::cuda_thread_x_direct,
                                             RAJA::statement::Lambda<1>
               >
-            >,
-            // Synchronize threads to ensure all reads
-            // from the local array are complete
-            RAJA::statement::CudaSyncThreads
+            >
           >
         >
       >
@@ -526,10 +523,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
               RAJA::statement::ForICount<1, RAJA::statement::Param<0>, RAJA::hip_thread_x_direct,
                                             RAJA::statement::Lambda<1>
               >
-            >,
-            // Synchronize threads to ensure all reads
-            // from the local array are complete
-            RAJA::statement::HipSyncThreads
+            >
           >
         >
       >

--- a/exercises/launch-matrix-transpose-local-array_solution.cpp
+++ b/exercises/launch-matrix-transpose-local-array_solution.cpp
@@ -308,6 +308,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
             });
           });
 
+          ctx.teamSync();
+
           RAJA::loop_icount<cuda_threads_x>(ctx, col_tile, [&] (int col, int tx) {
             RAJA::loop_icount<cuda_threads_y>(ctx, row_tile, [&] (int row, int ty) {
 
@@ -381,6 +383,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
             });
           });
+
+          ctx.teamSync();
 
           RAJA::loop_icount<hip_threads_x>(ctx, col_tile, [&] (int col, int tx) {
             RAJA::loop_icount<hip_threads_y>(ctx, row_tile, [&] (int row, int ty) {

--- a/exercises/launch-matrix-transpose-local-array_solution.cpp
+++ b/exercises/launch-matrix-transpose-local-array_solution.cpp
@@ -278,8 +278,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const int n_blocks_c = RAJA_DIVIDE_CEILING_INT(N_c, c_block_sz);
   const int n_blocks_r = RAJA_DIVIDE_CEILING_INT(N_r, r_block_sz);
 
-  using cuda_teams_y = RAJA::LoopPolicy<RAJA::cuda_block_y_direct>;
-  using cuda_teams_x = RAJA::LoopPolicy<RAJA::cuda_block_x_direct>;
+  using cuda_teams_y = RAJA::LoopPolicy<RAJA::cuda_block_y_direct_unchecked>;
+  using cuda_teams_x = RAJA::LoopPolicy<RAJA::cuda_block_x_direct_unchecked>;
 
   using cuda_threads_y = RAJA::LoopPolicy<RAJA::cuda_thread_y_direct>;
   using cuda_threads_x = RAJA::LoopPolicy<RAJA::cuda_thread_x_direct>;
@@ -352,8 +352,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
   const int n_blocks_c = RAJA_DIVIDE_CEILING_INT(N_c, c_block_sz);
   const int n_blocks_r = RAJA_DIVIDE_CEILING_INT(N_r, r_block_sz);
 
-  using hip_teams_y = RAJA::LoopPolicy<RAJA::hip_block_y_direct>;
-  using hip_teams_x = RAJA::LoopPolicy<RAJA::hip_block_x_direct>;
+  using hip_teams_y = RAJA::LoopPolicy<RAJA::hip_block_y_direct_unchecked>;
+  using hip_teams_x = RAJA::LoopPolicy<RAJA::hip_block_x_direct_unchecked>;
 
   using hip_threads_y = RAJA::LoopPolicy<RAJA::hip_thread_y_direct>;
   using hip_threads_x = RAJA::LoopPolicy<RAJA::hip_thread_x_direct>;

--- a/exercises/launch-matrix-transpose-local-array_solution.cpp
+++ b/exercises/launch-matrix-transpose-local-array_solution.cpp
@@ -182,9 +182,11 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     RAJA::LaunchParams(), //LaunchParams may be empty when only running on the cpu
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx) {
 
-      RAJA::tile<loop_pol_1>(ctx, TILE_DIM, RAJA::TypedRangeSegment<int>(0, N_r), [&] (RAJA::TypedRangeSegment<int> const &row_tile) {
+      RAJA::tile<loop_pol_1>(ctx, TILE_DIM, RAJA::TypedRangeSegment<int>(0, N_r),
+        [&] (RAJA::TypedRangeSegment<int> const &row_tile) {
 
-        RAJA::tile<loop_pol_1>(ctx, TILE_DIM, RAJA::TypedRangeSegment<int>(0, N_c), [&] (RAJA::TypedRangeSegment<int> const &col_tile) {
+        RAJA::tile<loop_pol_1>(ctx, TILE_DIM, RAJA::TypedRangeSegment<int>(0, N_c),
+          [&] (RAJA::TypedRangeSegment<int> const &col_tile) {
 
           RAJA_TEAM_SHARED double Tile_Array[TILE_DIM][TILE_DIM];
 
@@ -232,9 +234,11 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
     RAJA::LaunchParams(), //LaunchParams may be empty when only running on the cpu
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx) {
 
-      RAJA::tile<omp_pol_2>(ctx, TILE_DIM, RAJA::TypedRangeSegment<int>(0, N_r), [&] (RAJA::TypedRangeSegment<int> const &row_tile) {
+      RAJA::tile<omp_pol_2>(ctx, TILE_DIM, RAJA::TypedRangeSegment<int>(0, N_r),
+        [&] (RAJA::TypedRangeSegment<int> const &row_tile) {
 
-        RAJA::tile<loop_pol_2>(ctx, TILE_DIM, RAJA::TypedRangeSegment<int>(0, N_c), [&] (RAJA::TypedRangeSegment<int> const &col_tile) {
+        RAJA::tile<loop_pol_2>(ctx, TILE_DIM, RAJA::TypedRangeSegment<int>(0, N_c),
+          [&] (RAJA::TypedRangeSegment<int> const &col_tile) {
 
           RAJA_TEAM_SHARED double Tile_Array[TILE_DIM][TILE_DIM];
 
@@ -285,12 +289,14 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   RAJA::launch<cuda_launch_policy>(
     RAJA::LaunchParams(RAJA::Teams(n_blocks_c, n_blocks_r),
-                     RAJA::Threads(c_block_sz, r_block_sz)),
+                       RAJA::Threads(c_block_sz, r_block_sz)),
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx) {
 
-      RAJA::tile<cuda_teams_y>(ctx, TILE_DIM, RAJA::TypedRangeSegment<int>(0, N_r), [&] (RAJA::TypedRangeSegment<int> const &row_tile) {
+      RAJA::tile<cuda_teams_y>(ctx, TILE_DIM, RAJA::TypedRangeSegment<int>(0, N_r),
+        [&] (RAJA::TypedRangeSegment<int> const &row_tile) {
 
-        RAJA::tile<cuda_teams_x>(ctx, TILE_DIM, RAJA::TypedRangeSegment<int>(0, N_c), [&] (RAJA::TypedRangeSegment<int> const &col_tile) {
+        RAJA::tile<cuda_teams_x>(ctx, TILE_DIM, RAJA::TypedRangeSegment<int>(0, N_c),
+          [&] (RAJA::TypedRangeSegment<int> const &col_tile) {
 
           RAJA_TEAM_SHARED double Tile_Array[TILE_DIM][TILE_DIM];
 
@@ -302,16 +308,16 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
             });
           });
 
-         RAJA::loop_icount<cuda_threads_x>(ctx, col_tile, [&] (int col, int tx) {
-           RAJA::loop_icount<cuda_threads_y>(ctx, row_tile, [&] (int row, int ty) {
+          RAJA::loop_icount<cuda_threads_x>(ctx, col_tile, [&] (int col, int tx) {
+            RAJA::loop_icount<cuda_threads_y>(ctx, row_tile, [&] (int row, int ty) {
 
-             Atview(col, row) = Tile_Array[ty][tx];
+              Atview(col, row) = Tile_Array[ty][tx];
 
-           });
-         });
+            });
+          });
 
-       });
-     });
+        });
+      });
 
    });
 
@@ -357,12 +363,14 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
   RAJA::launch<hip_launch_policy>
      (RAJA::LaunchParams(RAJA::Teams(n_blocks_c, n_blocks_r),
-                     RAJA::Threads(c_block_sz, r_block_sz)),
+                         RAJA::Threads(c_block_sz, r_block_sz)),
     [=] RAJA_HOST_DEVICE (RAJA::LaunchContext ctx) {
 
-      RAJA::tile<hip_teams_y>(ctx, TILE_DIM, RAJA::TypedRangeSegment<int>(0, N_r), [&] (RAJA::TypedRangeSegment<int> const &row_tile) {
+      RAJA::tile<hip_teams_y>(ctx, TILE_DIM, RAJA::TypedRangeSegment<int>(0, N_r),
+        [&] (RAJA::TypedRangeSegment<int> const &row_tile) {
 
-        RAJA::tile<hip_teams_x>(ctx, TILE_DIM, RAJA::TypedRangeSegment<int>(0, N_c), [&] (RAJA::TypedRangeSegment<int> const &col_tile) {
+        RAJA::tile<hip_teams_x>(ctx, TILE_DIM, RAJA::TypedRangeSegment<int>(0, N_c),
+          [&] (RAJA::TypedRangeSegment<int> const &col_tile) {
 
           RAJA_TEAM_SHARED double Tile_Array[TILE_DIM][TILE_DIM];
 
@@ -375,15 +383,15 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
           });
 
           RAJA::loop_icount<hip_threads_x>(ctx, col_tile, [&] (int col, int tx) {
-           RAJA::loop_icount<hip_threads_y>(ctx, row_tile, [&] (int row, int ty) {
+            RAJA::loop_icount<hip_threads_y>(ctx, row_tile, [&] (int row, int ty) {
 
-             d_Atview(col, row) = Tile_Array[ty][tx];
+              d_Atview(col, row) = Tile_Array[ty][tx];
 
-           });
-         });
+            });
+          });
 
-       });
-     });
+        });
+      });
 
    });
 

--- a/exercises/launch-matrix-transpose-local-array_solution.cpp
+++ b/exercises/launch-matrix-transpose-local-array_solution.cpp
@@ -310,8 +310,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
           ctx.teamSync();
 
-          RAJA::loop_icount<cuda_threads_x>(ctx, col_tile, [&] (int col, int tx) {
-            RAJA::loop_icount<cuda_threads_y>(ctx, row_tile, [&] (int row, int ty) {
+          RAJA::loop_icount<cuda_threads_y>(ctx, col_tile, [&] (int col, int tx) {
+            RAJA::loop_icount<cuda_threads_x>(ctx, row_tile, [&] (int row, int ty) {
 
               Atview(col, row) = Tile_Array[ty][tx];
 
@@ -386,8 +386,8 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
 
           ctx.teamSync();
 
-          RAJA::loop_icount<hip_threads_x>(ctx, col_tile, [&] (int col, int tx) {
-            RAJA::loop_icount<hip_threads_y>(ctx, row_tile, [&] (int row, int ty) {
+          RAJA::loop_icount<hip_threads_y>(ctx, col_tile, [&] (int col, int tx) {
+            RAJA::loop_icount<hip_threads_x>(ctx, row_tile, [&] (int row, int ty) {
 
               d_Atview(col, row) = Tile_Array[ty][tx];
 

--- a/exercises/launch-matrix-transpose-local-array_solution.cpp
+++ b/exercises/launch-matrix-transpose-local-array_solution.cpp
@@ -400,6 +400,7 @@ int main(int RAJA_UNUSED_ARG(argc), char **RAJA_UNUSED_ARG(argv[]))
    });
 
   CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpy, At, d_At, N_r * N_c * sizeof(int), hipMemcpyDeviceToHost);
+  CAMP_HIP_API_INVOKE_AND_CHECK(hipDeviceSynchronize);
   checkResult<int>(Atview, N_c, N_r);
   // printResult<int>(Atview, N_c, N_r);
 #endif


### PR DESCRIPTION
# Summary

Fix the cuda and hip matrix tutorial. Fix spacing, add proper synchronization, map threads properly in teams implementation.

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes #1916 
