### PR TITLE
Fix handling of the CUDA language standard

### DIFF
--- a/cmake/SetupCompilers.cmake
+++ b/cmake/SetupCompilers.cmake
@@ -37,7 +37,6 @@ if ( MSVC )
 endif()
 
 if (RAJA_ENABLE_CUDA)
-  set(CMAKE_CUDA_STANDARD 17)
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -restrict --expt-extended-lambda --expt-relaxed-constexpr -Xcudafe \"--display_error_number\"")
 
   if (NOT RAJA_HOST_CONFIG_LOADED)

--- a/docs/sphinx/user_guide/config_options.rst
+++ b/docs/sphinx/user_guide/config_options.rst
@@ -116,7 +116,7 @@ The following tables describe which variables set RAJA options and
 and their default settings. 
 
 .. note:: Items marked with a double asterisk (**) indicate variables that 
-          are supported directly in CMake and are also supported in RAJA as
+          are supported directly in BLT/CMake and are also supported in RAJA as
           CMake dependent options, for finer-grained configuration control.
           The RAJA CMake dependent variable form adds the prefix ``RAJA_``.
 


### PR DESCRIPTION
* The CUDA language standard is hardcoded to c++17, preventing anyone from building with a newer language standard. This fix allows the user to specify CMAKE_CUDA_STANDARD, and if it is not specified, BLT will set it based on the value in BLT_CXX_STD.
* Also clarifies the docs about config options