### PR TITLE
Update SYCL compiler build instructions for LC

### DIFF
--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -31,10 +31,10 @@ rocmcc_5_7_1_hip_desul_atomics:
     SPEC: " ~shared +rocm ~openmp +tests +desul amdgpu_target=gfx906 %llvm-amdgpu@=5.7.1 ^hip@5.7.1"
   extends: .job_on_corona
 
-clang_19_0_0_sycl_gcc_10_3_1_rocmcc_6_3_1_hip:
+clang_22_0_0_sycl_gcc_10_3_1_rocmcc_6_4_2_hip:
   variables:
-    SPEC: " ~shared +sycl ~openmp +tests cxxflags==\"-w -fsycl -fsycl-unnamed-lambda -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906\" %sycl-clang-19-gcc-10"
-    MODULE_LIST: "rocm/6.3.1"
-    SYCL_PATH: "/usr/workspace/raja-dev/clang_sycl_e42590ef4b94_hip_gcc10.3.1_rocm6.3.1/"
+    SPEC: " ~shared +sycl ~openmp +tests cxxflags==\"-w -fsycl -fsycl-unnamed-lambda -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906\" %sycl-clang-22-gcc-10"
+    MODULE_LIST: "rocm/6.4.2"
+    SYCL_PATH: "/usr/workspace/raja-dev/clang_sycl_16b7bcb09915_hip_gcc10.3.1_rocm6.4.2"
     LD_LIBRARY_PATH: "${SYCL_PATH}/lib:${SYCL_PATH}/lib64:${LD_LIBRARY_PATH}"
   extends: .job_on_corona

--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -31,10 +31,10 @@ rocmcc_5_7_1_hip_desul_atomics:
     SPEC: " ~shared +rocm ~openmp +tests +desul amdgpu_target=gfx906 %llvm-amdgpu@=5.7.1 ^hip@5.7.1"
   extends: .job_on_corona
 
-clang_22_0_0_sycl_gcc_10_3_1_rocmcc_6_4_2_hip:
+clang_19_0_0_sycl_gcc_10_3_1_rocmcc_6_3_1_hip:
   variables:
-    SPEC: " ~shared +sycl ~openmp +tests cxxflags==\"-w -fsycl -fsycl-unnamed-lambda -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906\" %sycl-clang-22-gcc-10"
-    MODULE_LIST: "rocm/6.4.2"
-    SYCL_PATH: "/usr/workspace/raja-dev/clang_sycl_16b7bcb09915_hip_gcc10.3.1_rocm6.4.2"
+    SPEC: " ~shared +sycl ~openmp +tests cxxflags==\"-w -fsycl -fsycl-unnamed-lambda -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906\" %sycl-clang-19-gcc-10"
+    MODULE_LIST: "rocm/6.3.1"
+    SYCL_PATH: "/usr/workspace/raja-dev/clang_sycl_e42590ef4b94_hip_gcc10.3.1_rocm6.3.1/"
     LD_LIBRARY_PATH: "${SYCL_PATH}/lib:${SYCL_PATH}/lib64:${LD_LIBRARY_PATH}"
   extends: .job_on_corona

--- a/docs/sphinx/dev_guide/ci_tasks.rst
+++ b/docs/sphinx/dev_guide/ci_tasks.rst
@@ -194,7 +194,7 @@ Building the Compiler
    badge next to each commit. Look for a commit that passes.
 
 
-#. On LC machines, it is following the good neighbor policy to do your build a compute node.
+#. On LC machines, it is following the good neighbor policy to do your build on a compute node.
 
    Use an appropriate bank to get an interactive node, e.g on Corona::
 

--- a/docs/sphinx/dev_guide/ci_tasks.rst
+++ b/docs/sphinx/dev_guide/ci_tasks.rst
@@ -194,6 +194,12 @@ Building the Compiler
    badge next to each commit. Look for a commit that passes.
 
 
+#. On LC machines, it is following the good neighbor policy to do your build a compute node.
+
+   Use an appropriate bank to get an interactive node, e.g on Corona::
+
+    flux alloc -t 60 -N 1 --bank=wbronze
+
 #. Load the module of the version of GCC headers that you want to use. We typically use the system default, which on corona at time of writing is gcc/10.3.1-magic::
 
     GCC_VERSION=10.3.1
@@ -219,14 +225,11 @@ Building the Compiler
 
 #. Build the compiler. 
 
-   Note that in this example, we are using rocm5.7.1, but one can change the
-   version they wish to use simply by changing the paths in the configure step
-
    a. Configure
 
      .. code-block:: bash
 
-     srun -n1  python3 buildbot/configure.py --hip -o buildrocm${ROCM_VERSION} \
+     python3 buildbot/configure.py --hip -o buildrocm${ROCM_VERSION} \
      --cmake-gen "Unix Makefiles" \
      --cmake-opt=-DSYCL_BUILD_PI_HIP_ROCM_DIR=/opt/rocm-${ROCM_VERSION} \
      --cmake-opt=-DSYCL_BUILD_PI_HIP_ROCM_INCLUDE_DIR=/opt/rocm-${ROCM_VERSION}/include \
@@ -241,40 +244,20 @@ Building the Compiler
 
    #. Build::
 
-      srun -n1 python buildbot/compile.py -o buildrocm${ROCM_VERSION}		     
+      python buildbot/compile.py -o buildrocm${ROCM_VERSION}		     
 
    #. Install::
 	
       cp -rp buildrocm${ROCM_VERSION}/install ${INSTALL_PREFIX}
       cd ..
 
-#. Install the oneDPL library.
-
-   The oneDPL library contains efficient SYCL implementations for scan, sort and other algorithms.
-
-   a. Clone::
-
-      git clone https://github.com/uxlfoundation/oneDPL
-
-   #. Configure::
-	
-      srun -n1 cmake -S oneDPL -B build-oneDPL-rocm${ROCM_VERSION} -DCMAKE_CXX_COMPILER=${INSTALL_PREFIX}/bin/clang++ -DONEDPL_BACKEND=dpcpp_only -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}
-      
-   #. Build::
-
-      srun -n1 cmake --build build-oneDPL-rocm${ROCM_VERSION}
-
-   #. Install::
-
-      srun -n1 cmake --install build-oneDPL-rocm${ROCM_VERSION}	
-
 #. Set the permissions of the folder, and everything in it to 750::
 
-      chmod 750 /usr/workspace/raja-dev/<foldername>/ -R  
+      chmod 750 ${INSTALL_PREFIX} -R  
 
 #. Change the group of the folder and everything in it to raja-dev::
 
-      chgrp raja-dev /usr/workspace/raja-dev/<foldername>/ -R
+      chgrp raja-dev ${INSTALL_PREFIX} -R
 
 #. Test the compiler
 
@@ -292,13 +275,19 @@ Using the compiler
 
     cd /path/to/raja
 
+#. Determine where you installed the compiler.
+
+   This is the ``INSTALL_PREFIX`` used above.  For example::
+
+    SYCL_INSTALL_PREFIX=/usr/workspace/raja-dev/clang_sycl_16b7bcb09915_hip_gcc10.3.1_rocm6.4.2
+
 #. Run the test config script::
 
-    ./scripts/lc-builds/corona_sycl.sh ${INSTALL_PREFIX}
+    ./scripts/lc-builds/corona_sycl.sh ${SYCL_INSTALL_PREFIX}
 
 #. As indicated in the output of the ``corona_sycl.sh`` script the SYCL compiler libraries need to be on the ``LD_LIBRARY_PATH``::
    
-    export LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib:${INSTALL_PREFIX}/lib64:$LD_LIBRARY_PATH    
+    export LD_LIBRARY_PATH=${SYCL_INSTALL_PREFIX}/lib:${SYCL_INSTALL_PREFIX}/lib64:$LD_LIBRARY_PATH    
 
 #. cd into the generated build directory::
 

--- a/docs/sphinx/dev_guide/ci_tasks.rst
+++ b/docs/sphinx/dev_guide/ci_tasks.rst
@@ -191,26 +191,31 @@ Building the Compiler
    that the head of the SYCL branch will fail to build. In the event that it
    does not build, try checking out an earlier commit. On the Intel/LLVM GitHub
    page, one can see which of their commits builds by checking the status
-   badge next to each commit. Look for a commit that passes. 
+   badge next to each commit. Look for a commit that passes.
 
-#. Load the module of the version of GCC headers that you want to use. For example, we typically use the system default, which on corona is gcc/10.3.1-magic::
 
-    module load gcc/10.3.1-magic
+#. Load the module of the version of GCC headers that you want to use. We typically use the system default, which on corona at time of writing is gcc/10.3.1-magic::
 
-#. Load the module of the version of ROCm that you want to use. For example::
+    GCC_VERSION=10.3.1
+    module load gcc/${GCC_VERSION}-magic
 
-    module load rocm/5.7.1 
+#. Load the module of the version of ROCm that you want to use::
+    ROCM_VERSION=6.4.2
+    module load rocm/${ROCM_VERSION}
 
+#. Load Python module you want to use.  At time of writing, the LLVM configure requires at least version 3.7. we use Corona default::
+    PYTHON_VERSION=3.9.12
+    module load python/${PYTHON_VERSION}
+    
 #. Clone the SYCL branch of Intel's LLVM compiler::
 
     git clone https://github.com/intel/llvm -b sycl
 
-#. cd into the LLVM folder:: 
-    
-    cd llvm
+#. cd into the LLVM folder and extract the GIT SHA for naming the install directories.  The install directory uses the naming convention ``clang_sycl_<git sha>_hip_gcc<version>_rocm<version>``::
 
-   In the event that the head of the sycl branch does not build, run
-   ``git checkout <git sha>`` to checkout a version that does build.
+    cd llvm
+    GIT_SHA=$(git rev-parse --short=12 HEAD)
+    INSTALL_PREFIX=/usr/workspace/raja-dev/clang_sycl_${GIT_SHA}_hip_gcc${GCC_VERSION}_rocm${ROCM_VERSION}
 
 #. Build the compiler. 
 
@@ -219,50 +224,69 @@ Building the Compiler
 
    a. Configure
 
-     .. code-block:: bash 
-
-        srun -n1 /usr/bin/python3 buildbot/configure.py --hip -o buildrocm5.7.1 \
-        --cmake-gen "Unix Makefiles" \
-        --cmake-opt=-DSYCL_BUILD_PI_HIP_ROCM_DIR=/opt/rocm-5.7.1 \
-        --cmake-opt=-DSYCL_BUILD_PI_HIP_ROCM_INCLUDE_DIR=/opt/rocm-5.7.1/include \
-        --cmake-opt=-DSYCL_BUILD_PI_HIP_ROCM_LIB_DIR=/opt/rocm-5.7.1/lib \
-        --cmake-opt=-DSYCL_BUILD_PI_HIP_INCLUDE_DIR=/opt/rocm-5.7.1/include \
-        --cmake-opt=-DSYCL_BUILD_PI_HIP_HSA_INCLUDE_DIR=/opt/rocm-5.7.1/hsa/include/hsa \
-        --cmake-opt=-DSYCL_BUILD_PI_HIP_LIB_DIR=/opt/rocm-5.7.1/lib \
-        --cmake-opt=-DUR_HIP_ROCM_DIR=/opt/rocm-5.7.1 \
-        --cmake-opt=-DUR_HIP_INCLUDE_DIR=/opt/rocm-5.7.1/include \
-        --cmake-opt=-DUR_HIP_HSA_INCLUDE_DIR=/opt/rocm-5.7.1/hsa/include/hsa \
-        --cmake-opt=-DUR_HIP_LIB_DIR=/opt/rocm-5.7.1/lib
-
-   b. Build
-
      .. code-block:: bash
 
-      srun -n1 /usr/bin/python3 buildbot/compile.py -o buildrocm5.7.1
+     srun -n1  python3 buildbot/configure.py --hip -o buildrocm${ROCM_VERSION} \
+     --cmake-gen "Unix Makefiles" \
+     --cmake-opt=-DSYCL_BUILD_PI_HIP_ROCM_DIR=/opt/rocm-${ROCM_VERSION} \
+     --cmake-opt=-DSYCL_BUILD_PI_HIP_ROCM_INCLUDE_DIR=/opt/rocm-${ROCM_VERSION}/include \
+     --cmake-opt=-DSYCL_BUILD_PI_HIP_ROCM_LIB_DIR=/opt/rocm-${ROCM_VERSION}/lib \
+     --cmake-opt=-DSYCL_BUILD_PI_HIP_INCLUDE_DIR=/opt/rocm-${ROCM_VERSION}/include \
+     --cmake-opt=-DSYCL_BUILD_PI_HIP_HSA_INCLUDE_DIR=/opt/rocm-${ROCM_VERSION}/hsa/include/hsa \
+     --cmake-opt=-DSYCL_BUILD_PI_HIP_LIB_DIR=/opt/rocm-${ROCM_VERSION}/lib \
+     --cmake-opt=-DUR_HIP_ROCM_DIR=/opt/rocm-${ROCM_VERSION} \
+     --cmake-opt=-DUR_HIP_INCLUDE_DIR=/opt/rocm-${ROCM_VERSION}/include \
+     --cmake-opt=-DUR_HIP_HSA_INCLUDE_DIR=/opt/rocm-${ROCM_VERSION}/hsa/include/hsa \
+     --cmake-opt=-DUR_HIP_LIB_DIR=/opt/rocm-${ROCM_VERSION}/lib 
+
+   #. Build::
+
+      srun -n1 python buildbot/compile.py -o buildrocm${ROCM_VERSION}		     
+
+   #. Install::
+	
+      cp -rp buildrocm${ROCM_VERSION}/install ${INSTALL_PREFIX}
+      cd ..
+
+#. Install the oneDPL library.
+
+   The oneDPL library contains efficient SYCL implementations for scan, sort and other algorithms.
+
+   a. Clone::
+
+      git clone https://github.com/uxlfoundation/oneDPL
+
+   #. Configure::
+	
+      srun -n1 cmake -S oneDPL -B build-oneDPL-rocm${ROCM_VERSION} -DCMAKE_CXX_COMPILER=${INSTALL_PREFIX}/bin/clang++ -DONEDPL_BACKEND=dpcpp_only -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}
+      
+   #. Build::
+
+      srun -n1 cmake --build build-oneDPL-rocm${ROCM_VERSION}
+
+   #. Install::
+
+      srun -n1 cmake --install build-oneDPL-rocm${ROCM_VERSION}	
+
+#. Set the permissions of the folder, and everything in it to 750::
+
+      chmod 750 /usr/workspace/raja-dev/<foldername>/ -R  
+
+#. Change the group of the folder and everything in it to raja-dev::
+
+      chgrp raja-dev /usr/workspace/raja-dev/<foldername>/ -R
 
 #. Test the compiler
 
    Follow the steps in the `Using the compiler`_ section to test the installation
 
-#. Install
-
-  a. The build step will install the compiler in the folder ``buildrocm<version>/install``. Copy this folder to the ``/usr/workspace/raja-dev/`` directory using the naming scheme ``clang_sycl_<git sha>_hip_gcc<version>_rocm<version>``
-
-  #. Set the permissions of the folder, and everything in it to 750::
-
-      chmod 750 /usr/workspace/raja-dev/<foldername>/ -R  
-
-  #. Change the group of the folder and everything in it to raja-dev::
-
-      chgrp raja-dev /usr/workspace/raja-dev/<foldername>/ -R  
-
-
 Using the compiler
 ^^^^^^^^^^^^^^^^^^
 
-#. Load the version of rocm that you used when building the compiler, for example::
+#. Load the version of ROCm that you used when building the compiler, for example::
 
-    module load rocm/5.7.1
+    ROCM_VERSION=6.4.2 
+    module load rocm/${ROCM_VERSION}
 
 #. Navigate to the root of your local RAJA checkout space::
 
@@ -270,13 +294,15 @@ Using the compiler
 
 #. Run the test config script::
 
-    ./scripts/lc-builds/corona_sycl.sh /usr/workspace/raja-dev/clang_sycl_2f03ef85fee5_hip_gcc10.3.1_rocm5.7.1
+    ./scripts/lc-builds/corona_sycl.sh ${INSTALL_PREFIX}
 
-   Note that at the time of writing, the newest compiler we had built was at ``clang_sycl_2f03ef85fee5_hip_gcc10.3.1_rocm5.7.1``
+#. As indicated in the output of the ``corona_sycl.sh`` script the SYCL compiler libraries need to be on the ``LD_LIBRARY_PATH``::
+   
+    export LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib:${INSTALL_PREFIX}/lib64:$LD_LIBRARY_PATH    
 
 #. cd into the generated build directory::
 
-    cd {build directory}
+    cd build_corona-sycl_${USER}
 
 #. Build the code and run the RAJA tests::
 

--- a/scripts/lc-builds/corona_sycl.sh
+++ b/scripts/lc-builds/corona_sycl.sh
@@ -13,7 +13,7 @@ if [[ $# -lt 1 ]]; then
   echo "   1) SYCL compiler installation path"
   echo
   echo "For example: "
-  echo "    corona_sycl.sh /usr/workspace/raja-dev/clang_sycl_730cd3a5275f_hip_gcc10.3.1_rocm6.0.2"
+  echo "    corona_sycl.sh /usr/workspace/raja-dev/clang_sycl_16b7bcb09915_hip_gcc10.3.1_rocm6.4.2"
   exit
 fi
 


### PR DESCRIPTION
Update developer manual instructions for building Intel LLVM SYCL compiler on LC systems.

- This PR is a refactoring.


