### PR TITLE
OpenMP Target build script and config for CCE compiler.

### DIFF
--- a/host-configs/lc-builds/toss4/cce_omptarget_X.cmake
+++ b/host-configs/lc-builds/toss4/cce_omptarget_X.cmake
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+set(RAJA_COMPILER "RAJA_COMPILER_CLANG" CACHE STRING "")
+
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -haccel=amd_${HIP_ARCH}" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -haccel=amd_${HIP_ARCH}" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -haccel=amd_${HIP_ARCH}" CACHE STRING "")
+
+# hcpu flag needs more experimentation, can cause runtime vectorization failures.
+# -hcpu=x86-genoa

--- a/scripts/lc-builds/toss4_cce_omptarget.sh
+++ b/scripts/lc-builds/toss4_cce_omptarget.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+if [[ $# -lt 2 ]]; then
+  echo
+  echo "You must pass 3 or more arguments to the script (in this order): "
+  echo "   1) compiler version number"
+  echo "   2) HIP compute architecture"
+  echo "   3...) optional arguments to cmake"
+  echo
+  echo "For example: "
+  echo "    toss4_cce_omptarget.sh 20.0.0-magic gfx942"
+  exit
+fi
+
+COMP_VER=$1
+HIP_ARCH=$2
+shift 2
+
+HOSTCONFIG="cce_omptarget_X"
+
+BUILD_SUFFIX=lc_toss4-cce-${COMP_VER}-${HIP_ARCH}-omptarget
+
+echo
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
+echo
+
+rm -rf build_${BUILD_SUFFIX} >/dev/null
+mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
+
+
+module load cmake/3.24.2
+
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DHIP_ARCH=${HIP_ARCH} \
+  -DCMAKE_C_COMPILER="/usr/tce/packages/cce/cce-${COMP_VER}/bin/craycc" \
+  -DCMAKE_CXX_COMPILER="/usr/tce/packages/cce/cce-${COMP_VER}/bin/crayCC" \
+  -DBLT_CXX_STD=c++17 \
+  -DENABLE_CLANGFORMAT=Off \
+  -C "../host-configs/lc-builds/toss4/${HOSTCONFIG}.cmake" \
+  -DENABLE_HIP=OFF \
+  -DENABLE_OPENMP=ON \
+  -DRAJA_ENABLE_TARGET_OPENMP=ON \
+  -DENABLE_CUDA=OFF \
+  -DENABLE_BENCHMARKS=On \
+  -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
+  "$@" \
+  ..
+
+echo
+echo "***********************************************************************"
+echo
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA"
+echo
+echo "    srun -n1 make"
+echo
+echo "***********************************************************************"


### PR DESCRIPTION
# Summary

- This PR is a feature
- It does the following:
  - Re-establishes an OpenMP Target build with CCE. We should use this while AMD is working on fixes for this https://github.com/LLNL/RAJA/pull/1937.