### PR TITLE
Remove warning supressions

### DIFF
--- a/include/RAJA/pattern/thread.hpp
+++ b/include/RAJA/pattern/thread.hpp
@@ -71,7 +71,6 @@ namespace RAJA
  * Returns 1 if OMP is not active.
  * @return Maximum number of threads
  */
-RAJA_SUPPRESS_HD_WARN
 template<typename Policy>
 RAJA_INLINE RAJA_HOST_DEVICE int get_max_threads()
 {
@@ -85,7 +84,6 @@ RAJA_INLINE RAJA_HOST_DEVICE int get_max_threads()
  * in sequential part of a program or OMP is not active
  * @return Current thread number
  */
-RAJA_SUPPRESS_HD_WARN
 template<typename Policy>
 RAJA_INLINE RAJA_HOST_DEVICE int get_thread_num()
 {

--- a/include/RAJA/policy/atomic_auto.hpp
+++ b/include/RAJA/policy/atomic_auto.hpp
@@ -26,8 +26,6 @@
 #include "RAJA/policy/sequential/atomic.hpp"
 #endif
 
-namespace RAJA
-{
 /*!
  * Provides priority between atomic policies that should do the "right thing"
  *
@@ -41,17 +39,125 @@ namespace RAJA
  * because we assume there is no thread safety issues (no parallel model)
  */
 #if defined(__CUDA_ARCH__) && defined(RAJA_CUDA_ACTIVE)
-using auto_atomic = RAJA::cuda_atomic;
+#define RAJA_AUTO_ATOMIC                                                       \
+  RAJA::cuda_atomic {}
 #elif defined(__HIP_DEVICE_COMPILE__) && defined(RAJA_HIP_ACTIVE)
-using auto_atomic = RAJA::hip_atomic;
+#define RAJA_AUTO_ATOMIC                                                       \
+  RAJA::hip_atomic {}
 #elif defined(__SYCL_DEVICE_ONLY__)
-using auto_atomic = RAJA::sycl_atomic;
-#elif defined(RAJA_OPENMP_ACTIVE)
-using auto_atomic = RAJA::omp_atomic;
+#define RAJA_AUTO_ATOMIC                                                       \
+  RAJA::sycl_atomic {}
+#elif defined(RAJA_ENABLE_OPENMP)
+#define RAJA_AUTO_ATOMIC                                                       \
+  RAJA::omp_atomic {}
 #else
-using auto_atomic = RAJA::seq_atomic;
+#define RAJA_AUTO_ATOMIC                                                       \
+  RAJA::seq_atomic {}
 #endif
 
+
+namespace RAJA
+{
+
+//! Atomic policy that automatically does "the right thing"
+struct auto_atomic
+{};
+
+template<typename T>
+RAJA_INLINE RAJA_HOST_DEVICE T atomicLoad(auto_atomic, T* acc)
+{
+  return atomicLoad(RAJA_AUTO_ATOMIC, acc);
+}
+
+template<typename T>
+RAJA_INLINE RAJA_HOST_DEVICE void atomicStore(auto_atomic, T* acc, T value)
+{
+  atomicStore(RAJA_AUTO_ATOMIC, acc, value);
+}
+
+template<typename T>
+RAJA_INLINE RAJA_HOST_DEVICE T atomicAdd(auto_atomic, T* acc, T value)
+{
+  return atomicAdd(RAJA_AUTO_ATOMIC, acc, value);
+}
+
+template<typename T>
+RAJA_INLINE RAJA_HOST_DEVICE T atomicSub(auto_atomic, T* acc, T value)
+{
+  return atomicSub(RAJA_AUTO_ATOMIC, acc, value);
+}
+
+template<typename T>
+RAJA_INLINE RAJA_HOST_DEVICE T atomicMin(auto_atomic, T* acc, T value)
+{
+  return atomicMin(RAJA_AUTO_ATOMIC, acc, value);
+}
+
+template<typename T>
+RAJA_INLINE RAJA_HOST_DEVICE T atomicMax(auto_atomic, T* acc, T value)
+{
+  return atomicMax(RAJA_AUTO_ATOMIC, acc, value);
+}
+
+template<typename T>
+RAJA_INLINE RAJA_HOST_DEVICE T atomicInc(auto_atomic, T* acc)
+{
+  return atomicInc(RAJA_AUTO_ATOMIC, acc);
+}
+
+template<typename T>
+RAJA_INLINE RAJA_HOST_DEVICE T atomicInc(auto_atomic, T* acc, T compare)
+{
+  return atomicInc(RAJA_AUTO_ATOMIC, acc, compare);
+}
+
+template<typename T>
+RAJA_INLINE RAJA_HOST_DEVICE T atomicDec(auto_atomic, T* acc)
+{
+  return atomicDec(RAJA_AUTO_ATOMIC, acc);
+}
+
+template<typename T>
+RAJA_INLINE RAJA_HOST_DEVICE T atomicDec(auto_atomic, T* acc, T compare)
+{
+  return atomicDec(RAJA_AUTO_ATOMIC, acc, compare);
+}
+
+template<typename T>
+RAJA_INLINE RAJA_HOST_DEVICE T atomicAnd(auto_atomic, T* acc, T value)
+{
+  return atomicAnd(RAJA_AUTO_ATOMIC, acc, value);
+}
+
+template<typename T>
+RAJA_INLINE RAJA_HOST_DEVICE T atomicOr(auto_atomic, T* acc, T value)
+{
+  return atomicOr(RAJA_AUTO_ATOMIC, acc, value);
+}
+
+template<typename T>
+RAJA_INLINE RAJA_HOST_DEVICE T atomicXor(auto_atomic, T* acc, T value)
+{
+  return atomicXor(RAJA_AUTO_ATOMIC, acc, value);
+}
+
+template<typename T>
+RAJA_INLINE RAJA_HOST_DEVICE T atomicExchange(auto_atomic, T* acc, T value)
+{
+  return atomicExchange(RAJA_AUTO_ATOMIC, acc, value);
+}
+
+template<typename T>
+RAJA_INLINE RAJA_HOST_DEVICE T
+atomicCAS(auto_atomic, T* acc, T compare, T value)
+{
+  return atomicCAS(RAJA_AUTO_ATOMIC, acc, compare, value);
+}
+
+
 }  // namespace RAJA
+
+// make sure this define doesn't bleed out of this header
+#undef RAJA_AUTO_ATOMIC
 
 #endif

--- a/include/RAJA/policy/openmp/thread.hpp
+++ b/include/RAJA/policy/openmp/thread.hpp
@@ -29,14 +29,12 @@
 namespace RAJA
 {
 
-RAJA_SUPPRESS_HD_WARN
 template<>
 RAJA_HOST_DEVICE RAJA_INLINE int get_max_threads(omp_thread)
 {
   return omp_get_max_threads();
 }
 
-RAJA_SUPPRESS_HD_WARN
 template<>
 RAJA_HOST_DEVICE RAJA_INLINE int get_thread_num(omp_thread)
 {

--- a/include/RAJA/policy/sequential/thread.hpp
+++ b/include/RAJA/policy/sequential/thread.hpp
@@ -26,15 +26,12 @@
 
 namespace RAJA
 {
-
-RAJA_SUPPRESS_HD_WARN
 template<>
 RAJA_HOST_DEVICE RAJA_INLINE int get_max_threads(seq_thread)
 {
   return 1;
 }
 
-RAJA_SUPPRESS_HD_WARN
 template<>
 RAJA_HOST_DEVICE RAJA_INLINE int get_thread_num(seq_thread)
 {

--- a/include/RAJA/policy/thread_auto.hpp
+++ b/include/RAJA/policy/thread_auto.hpp
@@ -49,11 +49,9 @@ using active_auto_thread = RAJA::seq_thread;
 
 }  // namespace detail
 
-RAJA_SUPPRESS_HD_WARN
 template<typename AtomicPolicy>
 RAJA_HOST_DEVICE RAJA_INLINE int get_max_threads(AtomicPolicy);
 
-RAJA_SUPPRESS_HD_WARN
 template<typename AtomicPolicy>
 RAJA_HOST_DEVICE RAJA_INLINE int get_thread_num(AtomicPolicy);
 

--- a/include/RAJA/policy/thread_auto.hpp
+++ b/include/RAJA/policy/thread_auto.hpp
@@ -29,6 +29,7 @@
 #include "RAJA/policy/sequential/policy.hpp"
 
 namespace RAJA
+{
 
 namespace detail
 {

--- a/include/RAJA/policy/thread_auto.hpp
+++ b/include/RAJA/policy/thread_auto.hpp
@@ -29,7 +29,6 @@
 #include "RAJA/policy/sequential/policy.hpp"
 
 namespace RAJA
-{
 
 namespace detail
 {


### PR DESCRIPTION
The merge #1947 merge broke builds on LC matrix and other CUDA builds.

Remove the suppression warnings.

This fixes #1954 