### PR TITLE
Cache-able Cuda/Hip Idx/Dim

### DIFF
--- a/include/RAJA/policy/cuda/policy.hpp
+++ b/include/RAJA/policy/cuda/policy.hpp
@@ -652,6 +652,143 @@ struct IndexSize
   {}
 };
 
+// Class to help cache thread indices or not based on template arg
+template<bool cache_threadIdx>
+struct ThreadIndices
+{
+  template<named_dim dim>
+  RAJA_DEVICE constexpr cuda_dim_member_t get_threadIdx() const
+  {
+    return ::RAJA::internal::CudaDimHelper<dim>::get(threadIdx);
+  }
+};
+
+template<>
+struct ThreadIndices<true>
+{
+  dim3 m_threadIdx;
+
+  RAJA_HOST_DEVICE ThreadIndices()
+#if defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
+      : m_threadIdx(threadIdx)
+#endif
+  {}
+
+  template<named_dim dim>
+  RAJA_DEVICE constexpr cuda_dim_member_t get_threadIdx() const
+  {
+    return ::RAJA::internal::CudaDimHelper<dim>::get(m_threadIdx);
+  }
+};
+
+// Class to help cache block indices or not based on template arg
+template<bool cache_blockIdx>
+struct BlockIndices
+{
+  template<named_dim dim>
+  RAJA_DEVICE constexpr cuda_dim_member_t get_blockIdx() const
+  {
+    return ::RAJA::internal::CudaDimHelper<dim>::get(blockIdx);
+  }
+};
+
+template<>
+struct BlockIndices<true>
+{
+  dim3 m_blockIdx;
+
+  RAJA_HOST_DEVICE BlockIndices()
+#if defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
+      : m_blockIdx(blockIdx)
+#endif
+  {}
+
+  template<named_dim dim>
+  RAJA_DEVICE constexpr cuda_dim_member_t get_blockIdx() const
+  {
+    return ::RAJA::internal::CudaDimHelper<dim>::get(m_blockIdx);
+  }
+};
+
+// Class to help cache block dimensions or not based on template arg
+template<bool cache_blockDim>
+struct BlockDimensions
+{
+  template<named_dim dim>
+  RAJA_DEVICE constexpr cuda_dim_member_t get_blockDim() const
+  {
+    return ::RAJA::internal::CudaDimHelper<dim>::get(blockDim);
+  }
+};
+
+template<>
+struct BlockDimensions<true>
+{
+  dim3 m_blockDim;
+
+  RAJA_HOST_DEVICE BlockDimensions()
+#if defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
+      : m_blockDim(blockDim)
+#endif
+  {}
+
+  template<named_dim dim>
+  RAJA_DEVICE constexpr cuda_dim_member_t get_blockDim() const
+  {
+    return ::RAJA::internal::CudaDimHelper<dim>::get(m_blockDim);
+  }
+};
+
+// Class to help cache grid dimensions or not based on template arg
+template<bool cache_gridDim>
+struct GridDimensions
+{
+  template<named_dim dim>
+  RAJA_DEVICE constexpr cuda_dim_member_t get_gridDim() const
+  {
+    return ::RAJA::internal::CudaDimHelper<dim>::get(gridDim);
+  }
+};
+
+template<>
+struct GridDimensions<true>
+{
+  dim3 m_gridDim = gridDim;
+
+  RAJA_HOST_DEVICE GridDimensions()
+#if defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
+      : m_gridDim(gridDim)
+#endif
+  {}
+
+  template<named_dim dim>
+  RAJA_DEVICE constexpr cuda_dim_member_t get_gridDim() const
+  {
+    return ::RAJA::internal::CudaDimHelper<dim>::get(m_gridDim);
+  }
+};
+
+// Class to help cache indices and dimensions or not based on template args
+template<bool cache_threadIdx,
+         bool cache_blockIdx,
+         bool cache_blockDim,
+         bool cache_gridDim>
+struct IndicesAndDims : ThreadIndices<cache_threadIdx>,
+                        BlockIndices<cache_blockIdx>,
+                        BlockDimensions<cache_blockDim>,
+                        GridDimensions<cache_gridDim>
+{};
+
+// Nothing cached
+using NonCachedIndicesAndDims = IndicesAndDims<false, false, false, false>;
+
+// threadIdx and blockDim cached, rest not cached
+using CachedThreadIndicesAndBlockDims =
+    IndicesAndDims<true, false, true, false>;
+
+// threadIdx, blockDim, blockIdx, gridDim cached
+using AllCachedIndicesAndDims = IndicesAndDims<true, true, true, true>;
+
 /// Type representing thread indexing within a grid
 /// It has various specializations that optimize specific patterns
 
@@ -666,18 +803,18 @@ struct IndexGlobal
   static constexpr int block_size = BLOCK_SIZE;
   static constexpr int grid_size  = GRID_SIZE;
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-               ::RAJA::internal::CudaDimHelper<dim>::get(threadIdx)) +
+    return static_cast<IdxT>(idxNDims.template get_threadIdx<dim>()) +
            static_cast<IdxT>(block_size) *
-               static_cast<IdxT>(
-                   ::RAJA::internal::CudaDimHelper<dim>::get(blockIdx));
+               static_cast<IdxT>(idxNDims.template get_blockIdx<dim>());
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static constexpr IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static constexpr IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(block_size) * static_cast<IdxT>(grid_size);
   }
@@ -692,15 +829,16 @@ struct IndexGlobal<dim, 1, GRID_SIZE>
   static constexpr int block_size = 1;
   static constexpr int grid_size  = GRID_SIZE;
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::CudaDimHelper<dim>::get(blockIdx));
+    return static_cast<IdxT>(idxNDims.template get_blockIdx<dim>());
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static constexpr IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static constexpr IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(grid_size);
   }
@@ -715,15 +853,16 @@ struct IndexGlobal<dim, BLOCK_SIZE, 1>
   static constexpr int block_size = BLOCK_SIZE;
   static constexpr int grid_size  = 1;
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::CudaDimHelper<dim>::get(threadIdx));
+    return static_cast<IdxT>(idxNDims.template get_threadIdx<dim>());
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static constexpr IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static constexpr IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(block_size);
   }
@@ -736,14 +875,16 @@ struct IndexGlobal<dim, 1, 1>
   static constexpr int block_size = 1;
   static constexpr int grid_size  = 1;
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(0);
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(1);
   }
@@ -758,22 +899,20 @@ struct IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>
   static constexpr int block_size = named_usage::unspecified;
   static constexpr int grid_size  = GRID_SIZE;
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-               ::RAJA::internal::CudaDimHelper<dim>::get(threadIdx)) +
-           static_cast<IdxT>(
-               ::RAJA::internal::CudaDimHelper<dim>::get(blockDim)) *
-               static_cast<IdxT>(
-                   ::RAJA::internal::CudaDimHelper<dim>::get(blockIdx));
+    return static_cast<IdxT>(idxNDims.template get_threadIdx<dim>()) +
+           static_cast<IdxT>(idxNDims.template get_blockDim<dim>()) *
+               static_cast<IdxT>(idxNDims.template get_blockIdx<dim>());
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-               ::RAJA::internal::CudaDimHelper<dim>::get(blockDim)) *
+    return static_cast<IdxT>(idxNDims.template get_blockDim<dim>()) *
            static_cast<IdxT>(grid_size);
   }
 };
@@ -785,18 +924,18 @@ struct IndexGlobal<dim, named_usage::unspecified, 1>
   static constexpr int block_size = named_usage::unspecified;
   static constexpr int grid_size  = 1;
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::CudaDimHelper<dim>::get(threadIdx));
+    return static_cast<IdxT>(idxNDims.template get_threadIdx<dim>());
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::CudaDimHelper<dim>::get(blockDim));
+    return static_cast<IdxT>(idxNDims.template get_blockDim<dim>());
   }
 };
 
@@ -809,22 +948,21 @@ struct IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>
   static constexpr int block_size = BLOCK_SIZE;
   static constexpr int grid_size  = named_usage::unspecified;
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-               ::RAJA::internal::CudaDimHelper<dim>::get(threadIdx)) +
+    return static_cast<IdxT>(idxNDims.template get_threadIdx<dim>()) +
            static_cast<IdxT>(block_size) *
-               static_cast<IdxT>(
-                   ::RAJA::internal::CudaDimHelper<dim>::get(blockIdx));
+               static_cast<IdxT>(idxNDims.template get_blockIdx<dim>());
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(block_size) *
-           static_cast<IdxT>(
-               ::RAJA::internal::CudaDimHelper<dim>::get(gridDim));
+           static_cast<IdxT>(idxNDims.template get_gridDim<dim>());
   }
 };
 
@@ -835,18 +973,18 @@ struct IndexGlobal<dim, 1, named_usage::unspecified>
   static constexpr int block_size = 1;
   static constexpr int grid_size  = named_usage::unspecified;
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::CudaDimHelper<dim>::get(blockIdx));
+    return static_cast<IdxT>(idxNDims.template get_blockIdx<dim>());
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::CudaDimHelper<dim>::get(gridDim));
+    return static_cast<IdxT>(idxNDims.template get_gridDim<dim>());
   }
 };
 
@@ -857,24 +995,21 @@ struct IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>
   static constexpr int block_size = named_usage::unspecified;
   static constexpr int grid_size  = named_usage::unspecified;
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-               ::RAJA::internal::CudaDimHelper<dim>::get(threadIdx)) +
-           static_cast<IdxT>(
-               ::RAJA::internal::CudaDimHelper<dim>::get(blockDim)) *
-               static_cast<IdxT>(
-                   ::RAJA::internal::CudaDimHelper<dim>::get(blockIdx));
+    return static_cast<IdxT>(idxNDims.template get_threadIdx<dim>()) +
+           static_cast<IdxT>(idxNDims.template get_blockDim<dim>()) *
+               static_cast<IdxT>(idxNDims.template get_blockIdx<dim>());
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-               ::RAJA::internal::CudaDimHelper<dim>::get(blockDim)) *
-           static_cast<IdxT>(
-               ::RAJA::internal::CudaDimHelper<dim>::get(gridDim));
+    return static_cast<IdxT>(idxNDims.template get_blockDim<dim>()) *
+           static_cast<IdxT>(idxNDims.template get_gridDim<dim>());
   }
 };
 
@@ -888,15 +1023,16 @@ struct IndexGlobal<dim, named_usage::ignored, GRID_SIZE>
   static constexpr int block_size = named_usage::ignored;
   static constexpr int grid_size  = GRID_SIZE;
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::CudaDimHelper<dim>::get(blockIdx));
+    return static_cast<IdxT>(idxNDims.template get_blockIdx<dim>());
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static constexpr IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static constexpr IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(grid_size);
   }
@@ -909,14 +1045,16 @@ struct IndexGlobal<dim, named_usage::ignored, 1>
   static constexpr int block_size = named_usage::ignored;
   static constexpr int grid_size  = 1;
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(0);
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(1);
   }
@@ -929,18 +1067,18 @@ struct IndexGlobal<dim, named_usage::ignored, named_usage::unspecified>
   static constexpr int block_size = named_usage::ignored;
   static constexpr int grid_size  = named_usage::unspecified;
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::CudaDimHelper<dim>::get(blockIdx));
+    return static_cast<IdxT>(idxNDims.template get_blockIdx<dim>());
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::CudaDimHelper<dim>::get(gridDim));
+    return static_cast<IdxT>(idxNDims.template get_gridDim<dim>());
   }
 };
 
@@ -954,15 +1092,16 @@ struct IndexGlobal<dim, BLOCK_SIZE, named_usage::ignored>
   static constexpr int block_size = BLOCK_SIZE;
   static constexpr int grid_size  = named_usage::ignored;
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::CudaDimHelper<dim>::get(threadIdx));
+    return static_cast<IdxT>(idxNDims.template get_threadIdx<dim>());
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static constexpr IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static constexpr IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(block_size);
   }
@@ -975,14 +1114,16 @@ struct IndexGlobal<dim, 1, named_usage::ignored>
   static constexpr int block_size = 1;
   static constexpr int grid_size  = named_usage::ignored;
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(0);
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(1);
   }
@@ -995,18 +1136,18 @@ struct IndexGlobal<dim, named_usage::unspecified, named_usage::ignored>
   static constexpr int block_size = named_usage::unspecified;
   static constexpr int grid_size  = named_usage::ignored;
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::CudaDimHelper<dim>::get(threadIdx));
+    return static_cast<IdxT>(idxNDims.template get_threadIdx<dim>());
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::CudaDimHelper<dim>::get(blockDim));
+    return static_cast<IdxT>(idxNDims.template get_blockDim<dim>());
   }
 };
 
@@ -1018,14 +1159,16 @@ struct IndexGlobal<dim, named_usage::ignored, named_usage::ignored>
   static constexpr int block_size = named_usage::ignored;
   static constexpr int grid_size  = named_usage::ignored;
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(0);
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(1);
   }
@@ -1036,17 +1179,19 @@ template<typename x_index>
 struct IndexFlatten<x_index>
 {
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
 
-    return x_index::template index<IdxT>();
+    return x_index::template index<IdxT>(idxNDims);
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return x_index::template size<IdxT>();
+    return x_index::template size<IdxT>(idxNDims);
   }
 };
 
@@ -1055,18 +1200,22 @@ template<typename x_index, typename y_index>
 struct IndexFlatten<x_index, y_index>
 {
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
 
-    return x_index::template index<IdxT>() +
-           x_index::template size<IdxT>() * (y_index::template index<IdxT>());
+    return x_index::template index<IdxT>(idxNDims) +
+           x_index::template size<IdxT>(idxNDims) *
+               (y_index::template index<IdxT>(idxNDims));
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return x_index::template size<IdxT>() * y_index::template size<IdxT>();
+    return x_index::template size<IdxT>(idxNDims) *
+           y_index::template size<IdxT>(idxNDims);
   }
 };
 
@@ -1075,38 +1224,43 @@ template<typename x_index, typename y_index, typename z_index>
 struct IndexFlatten<x_index, y_index, z_index>
 {
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
 
-    return x_index::template index<IdxT>() +
-           x_index::template size<IdxT>() *
-               (y_index::template index<IdxT>() +
-                y_index::template size<IdxT>() *
-                    z_index::template index<IdxT>());
+    return x_index::template index<IdxT>(idxNDims) +
+           x_index::template size<IdxT>(idxNDims) *
+               (y_index::template index<IdxT>(idxNDims) +
+                y_index::template size<IdxT>(idxNDims) *
+                    z_index::template index<IdxT>(idxNDims));
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return x_index::template size<IdxT>() * y_index::template size<IdxT>() *
-           z_index::template size<IdxT>();
+    return x_index::template size<IdxT>(idxNDims) *
+           y_index::template size<IdxT>(idxNDims) *
+           z_index::template size<IdxT>(idxNDims);
   }
 };
 
 template<size_t divisor, typename indexer>
 struct IndexDivide
 {
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return indexer::template index<IdxT>() / static_cast<IdxT>(divisor);
+    return indexer::template index<IdxT>(idxNDims) / static_cast<IdxT>(divisor);
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return RAJA_DIVIDE_CEILING_INT(indexer::template size<IdxT>(),
+    return RAJA_DIVIDE_CEILING_INT(indexer::template size<IdxT>(idxNDims),
                                    static_cast<IdxT>(divisor));
   }
 };
@@ -1114,14 +1268,16 @@ struct IndexDivide
 template<size_t divisor, typename indexer>
 struct IndexModulo
 {
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return indexer::template index<IdxT>() % static_cast<IdxT>(divisor);
+    return indexer::template index<IdxT>(idxNDims) % static_cast<IdxT>(divisor);
   }
 
-  template<typename IdxT = cuda_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = cuda_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(divisor);
   }

--- a/include/RAJA/policy/hip/policy.hpp
+++ b/include/RAJA/policy/hip/policy.hpp
@@ -644,6 +644,143 @@ struct IndexSize
   {}
 };
 
+// Class to help cache thread indices or not based on template arg
+template<bool cache_threadIdx>
+struct ThreadIndices
+{
+  template<named_dim dim>
+  RAJA_DEVICE constexpr hip_dim_member_t get_threadIdx() const
+  {
+    return ::RAJA::internal::HipDimHelper<dim>::get(threadIdx);
+  }
+};
+
+template<>
+struct ThreadIndices<true>
+{
+  dim3 m_threadIdx;
+
+  RAJA_HOST_DEVICE ThreadIndices()
+#if defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
+      : m_threadIdx(threadIdx)
+#endif
+  {}
+
+  template<named_dim dim>
+  RAJA_DEVICE constexpr hip_dim_member_t get_threadIdx() const
+  {
+    return ::RAJA::internal::HipDimHelper<dim>::get(m_threadIdx);
+  }
+};
+
+// Class to help cache block indices or not based on template arg
+template<bool cache_blockIdx>
+struct BlockIndices
+{
+  template<named_dim dim>
+  RAJA_DEVICE constexpr hip_dim_member_t get_blockIdx() const
+  {
+    return ::RAJA::internal::HipDimHelper<dim>::get(blockIdx);
+  }
+};
+
+template<>
+struct BlockIndices<true>
+{
+  dim3 m_blockIdx;
+
+  RAJA_HOST_DEVICE BlockIndices()
+#if defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
+      : m_blockIdx(blockIdx)
+#endif
+  {}
+
+  template<named_dim dim>
+  RAJA_DEVICE constexpr hip_dim_member_t get_blockIdx() const
+  {
+    return ::RAJA::internal::HipDimHelper<dim>::get(m_blockIdx);
+  }
+};
+
+// Class to help cache block dimensions or not based on template arg
+template<bool cache_blockDim>
+struct BlockDimensions
+{
+  template<named_dim dim>
+  RAJA_DEVICE constexpr hip_dim_member_t get_blockDim() const
+  {
+    return ::RAJA::internal::HipDimHelper<dim>::get(blockDim);
+  }
+};
+
+template<>
+struct BlockDimensions<true>
+{
+  dim3 m_blockDim;
+
+  RAJA_HOST_DEVICE BlockDimensions()
+#if defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
+      : m_blockDim(blockDim)
+#endif
+  {}
+
+  template<named_dim dim>
+  RAJA_DEVICE constexpr hip_dim_member_t get_blockDim() const
+  {
+    return ::RAJA::internal::HipDimHelper<dim>::get(m_blockDim);
+  }
+};
+
+// Class to help cache grid dimensions or not based on template arg
+template<bool cache_gridDim>
+struct GridDimensions
+{
+  template<named_dim dim>
+  RAJA_DEVICE constexpr hip_dim_member_t get_gridDim() const
+  {
+    return ::RAJA::internal::HipDimHelper<dim>::get(gridDim);
+  }
+};
+
+template<>
+struct GridDimensions<true>
+{
+  dim3 m_gridDim = gridDim;
+
+  RAJA_HOST_DEVICE GridDimensions()
+#if defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
+      : m_gridDim(gridDim)
+#endif
+  {}
+
+  template<named_dim dim>
+  RAJA_DEVICE constexpr hip_dim_member_t get_gridDim() const
+  {
+    return ::RAJA::internal::HipDimHelper<dim>::get(m_gridDim);
+  }
+};
+
+// Class to help cache indices and dimensions or not based on template args
+template<bool cache_threadIdx,
+         bool cache_blockIdx,
+         bool cache_blockDim,
+         bool cache_gridDim>
+struct IndicesAndDims : ThreadIndices<cache_threadIdx>,
+                        BlockIndices<cache_blockIdx>,
+                        BlockDimensions<cache_blockDim>,
+                        GridDimensions<cache_gridDim>
+{};
+
+// Nothing cached
+using NonCachedIndicesAndDims = IndicesAndDims<false, false, false, false>;
+
+// threadIdx and blockDim cached, rest not cached
+using CachedThreadIndicesAndBlockDims =
+    IndicesAndDims<true, false, true, false>;
+
+// threadIdx, blockDim, blockIdx, gridDim cached
+using AllCachedIndicesAndDims = IndicesAndDims<true, true, true, true>;
+
 /// Type representing thread indexing within a grid
 /// It has various specializations that optimize specific patterns
 
@@ -658,18 +795,18 @@ struct IndexGlobal
   static constexpr int block_size = BLOCK_SIZE;
   static constexpr int grid_size  = GRID_SIZE;
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-               ::RAJA::internal::HipDimHelper<dim>::get(threadIdx)) +
+    return static_cast<IdxT>(idxNDims.template get_threadIdx<dim>()) +
            static_cast<IdxT>(block_size) *
-               static_cast<IdxT>(
-                   ::RAJA::internal::HipDimHelper<dim>::get(blockIdx));
+               static_cast<IdxT>(idxNDims.template get_blockIdx<dim>());
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static constexpr IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static constexpr IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(block_size) * static_cast<IdxT>(grid_size);
   }
@@ -684,15 +821,16 @@ struct IndexGlobal<dim, 1, GRID_SIZE>
   static constexpr int block_size = 1;
   static constexpr int grid_size  = GRID_SIZE;
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::HipDimHelper<dim>::get(blockIdx));
+    return static_cast<IdxT>(idxNDims.template get_blockIdx<dim>());
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static constexpr IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static constexpr IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(grid_size);
   }
@@ -707,15 +845,16 @@ struct IndexGlobal<dim, BLOCK_SIZE, 1>
   static constexpr int block_size = BLOCK_SIZE;
   static constexpr int grid_size  = 1;
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::HipDimHelper<dim>::get(threadIdx));
+    return static_cast<IdxT>(idxNDims.template get_threadIdx<dim>());
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static constexpr IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static constexpr IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(block_size);
   }
@@ -728,14 +867,16 @@ struct IndexGlobal<dim, 1, 1>
   static constexpr int block_size = 1;
   static constexpr int grid_size  = 1;
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(0);
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(1);
   }
@@ -750,22 +891,20 @@ struct IndexGlobal<dim, named_usage::unspecified, GRID_SIZE>
   static constexpr int block_size = named_usage::unspecified;
   static constexpr int grid_size  = GRID_SIZE;
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-               ::RAJA::internal::HipDimHelper<dim>::get(threadIdx)) +
-           static_cast<IdxT>(
-               ::RAJA::internal::HipDimHelper<dim>::get(blockDim)) *
-               static_cast<IdxT>(
-                   ::RAJA::internal::HipDimHelper<dim>::get(blockIdx));
+    return static_cast<IdxT>(idxNDims.template get_threadIdx<dim>()) +
+           static_cast<IdxT>(idxNDims.template get_blockDim<dim>()) *
+               static_cast<IdxT>(idxNDims.template get_blockIdx<dim>());
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-               ::RAJA::internal::HipDimHelper<dim>::get(blockDim)) *
+    return static_cast<IdxT>(idxNDims.template get_blockDim<dim>()) *
            static_cast<IdxT>(grid_size);
   }
 };
@@ -777,18 +916,18 @@ struct IndexGlobal<dim, named_usage::unspecified, 1>
   static constexpr int block_size = named_usage::unspecified;
   static constexpr int grid_size  = 1;
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::HipDimHelper<dim>::get(threadIdx));
+    return static_cast<IdxT>(idxNDims.template get_threadIdx<dim>());
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::HipDimHelper<dim>::get(blockDim));
+    return static_cast<IdxT>(idxNDims.template get_blockDim<dim>());
   }
 };
 
@@ -801,21 +940,21 @@ struct IndexGlobal<dim, BLOCK_SIZE, named_usage::unspecified>
   static constexpr int block_size = BLOCK_SIZE;
   static constexpr int grid_size  = named_usage::unspecified;
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-               ::RAJA::internal::HipDimHelper<dim>::get(threadIdx)) +
+    return static_cast<IdxT>(idxNDims.template get_threadIdx<dim>()) +
            static_cast<IdxT>(block_size) *
-               static_cast<IdxT>(
-                   ::RAJA::internal::HipDimHelper<dim>::get(blockIdx));
+               static_cast<IdxT>(idxNDims.template get_blockIdx<dim>());
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(block_size) *
-           static_cast<IdxT>(::RAJA::internal::HipDimHelper<dim>::get(gridDim));
+           static_cast<IdxT>(idxNDims.template get_gridDim<dim>());
   }
 };
 
@@ -826,17 +965,18 @@ struct IndexGlobal<dim, 1, named_usage::unspecified>
   static constexpr int block_size = 1;
   static constexpr int grid_size  = named_usage::unspecified;
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::HipDimHelper<dim>::get(blockIdx));
+    return static_cast<IdxT>(idxNDims.template get_blockIdx<dim>());
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(::RAJA::internal::HipDimHelper<dim>::get(gridDim));
+    return static_cast<IdxT>(idxNDims.template get_gridDim<dim>());
   }
 };
 
@@ -847,23 +987,21 @@ struct IndexGlobal<dim, named_usage::unspecified, named_usage::unspecified>
   static constexpr int block_size = named_usage::unspecified;
   static constexpr int grid_size  = named_usage::unspecified;
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-               ::RAJA::internal::HipDimHelper<dim>::get(threadIdx)) +
-           static_cast<IdxT>(
-               ::RAJA::internal::HipDimHelper<dim>::get(blockDim)) *
-               static_cast<IdxT>(
-                   ::RAJA::internal::HipDimHelper<dim>::get(blockIdx));
+    return static_cast<IdxT>(idxNDims.template get_threadIdx<dim>()) +
+           static_cast<IdxT>(idxNDims.template get_blockDim<dim>()) *
+               static_cast<IdxT>(idxNDims.template get_blockIdx<dim>());
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-               ::RAJA::internal::HipDimHelper<dim>::get(blockDim)) *
-           static_cast<IdxT>(::RAJA::internal::HipDimHelper<dim>::get(gridDim));
+    return static_cast<IdxT>(idxNDims.template get_blockDim<dim>()) *
+           static_cast<IdxT>(idxNDims.template get_gridDim<dim>());
   }
 };
 
@@ -877,15 +1015,16 @@ struct IndexGlobal<dim, named_usage::ignored, GRID_SIZE>
   static constexpr int block_size = named_usage::ignored;
   static constexpr int grid_size  = GRID_SIZE;
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::HipDimHelper<dim>::get(blockIdx));
+    return static_cast<IdxT>(idxNDims.template get_blockIdx<dim>());
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static constexpr IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static constexpr IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(grid_size);
   }
@@ -898,14 +1037,16 @@ struct IndexGlobal<dim, named_usage::ignored, 1>
   static constexpr int block_size = named_usage::ignored;
   static constexpr int grid_size  = 1;
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(0);
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(1);
   }
@@ -918,17 +1059,18 @@ struct IndexGlobal<dim, named_usage::ignored, named_usage::unspecified>
   static constexpr int block_size = named_usage::ignored;
   static constexpr int grid_size  = named_usage::unspecified;
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::HipDimHelper<dim>::get(blockIdx));
+    return static_cast<IdxT>(idxNDims.template get_blockIdx<dim>());
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(::RAJA::internal::HipDimHelper<dim>::get(gridDim));
+    return static_cast<IdxT>(idxNDims.template get_gridDim<dim>());
   }
 };
 
@@ -942,15 +1084,16 @@ struct IndexGlobal<dim, BLOCK_SIZE, named_usage::ignored>
   static constexpr int block_size = BLOCK_SIZE;
   static constexpr int grid_size  = named_usage::ignored;
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::HipDimHelper<dim>::get(threadIdx));
+    return static_cast<IdxT>(idxNDims.template get_threadIdx<dim>());
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static constexpr IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static constexpr IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(block_size);
   }
@@ -963,14 +1106,16 @@ struct IndexGlobal<dim, 1, named_usage::ignored>
   static constexpr int block_size = 1;
   static constexpr int grid_size  = named_usage::ignored;
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(0);
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(1);
   }
@@ -983,18 +1128,18 @@ struct IndexGlobal<dim, named_usage::unspecified, named_usage::ignored>
   static constexpr int block_size = named_usage::unspecified;
   static constexpr int grid_size  = named_usage::ignored;
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::HipDimHelper<dim>::get(threadIdx));
+    return static_cast<IdxT>(idxNDims.template get_threadIdx<dim>());
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return static_cast<IdxT>(
-        ::RAJA::internal::HipDimHelper<dim>::get(blockDim));
+    return static_cast<IdxT>(idxNDims.template get_blockDim<dim>());
   }
 };
 
@@ -1006,14 +1151,16 @@ struct IndexGlobal<dim, named_usage::ignored, named_usage::ignored>
   static constexpr int block_size = named_usage::ignored;
   static constexpr int grid_size  = named_usage::ignored;
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(0);
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(1);
   }
@@ -1024,17 +1171,19 @@ template<typename x_index>
 struct IndexFlatten<x_index>
 {
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
 
-    return x_index::template index<IdxT>();
+    return x_index::template index<IdxT>(idxNDims);
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return x_index::template size<IdxT>();
+    return x_index::template size<IdxT>(idxNDims);
   }
 };
 
@@ -1043,18 +1192,22 @@ template<typename x_index, typename y_index>
 struct IndexFlatten<x_index, y_index>
 {
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
 
-    return x_index::template index<IdxT>() +
-           x_index::template size<IdxT>() * (y_index::template index<IdxT>());
+    return x_index::template index<IdxT>(idxNDims) +
+           x_index::template size<IdxT>(idxNDims) *
+               (y_index::template index<IdxT>(idxNDims));
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return x_index::template size<IdxT>() * y_index::template size<IdxT>();
+    return x_index::template size<IdxT>(idxNDims) *
+           y_index::template size<IdxT>(idxNDims);
   }
 };
 
@@ -1063,38 +1216,43 @@ template<typename x_index, typename y_index, typename z_index>
 struct IndexFlatten<x_index, y_index, z_index>
 {
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
 
-    return x_index::template index<IdxT>() +
-           x_index::template size<IdxT>() *
-               (y_index::template index<IdxT>() +
-                y_index::template size<IdxT>() *
-                    z_index::template index<IdxT>());
+    return x_index::template index<IdxT>(idxNDims) +
+           x_index::template size<IdxT>(idxNDims) *
+               (y_index::template index<IdxT>(idxNDims) +
+                y_index::template size<IdxT>(idxNDims) *
+                    z_index::template index<IdxT>(idxNDims));
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return x_index::template size<IdxT>() * y_index::template size<IdxT>() *
-           z_index::template size<IdxT>();
+    return x_index::template size<IdxT>(idxNDims) *
+           y_index::template size<IdxT>(idxNDims) *
+           z_index::template size<IdxT>(idxNDims);
   }
 };
 
 template<size_t divisor, typename indexer>
 struct IndexDivide
 {
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return indexer::template index<IdxT>() / static_cast<IdxT>(divisor);
+    return indexer::template index<IdxT>(idxNDims) / static_cast<IdxT>(divisor);
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return RAJA_DIVIDE_CEILING_INT(indexer::template size<IdxT>(),
+    return RAJA_DIVIDE_CEILING_INT(indexer::template size<IdxT>(idxNDims),
                                    static_cast<IdxT>(divisor));
   }
 };
@@ -1102,14 +1260,16 @@ struct IndexDivide
 template<size_t divisor, typename indexer>
 struct IndexModulo
 {
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT index()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT index(IdxNDims const& idxNDims = IdxNDims {})
   {
-    return indexer::template index<IdxT>() % static_cast<IdxT>(divisor);
+    return indexer::template index<IdxT>(idxNDims) % static_cast<IdxT>(divisor);
   }
 
-  template<typename IdxT = hip_dim_member_t>
-  RAJA_DEVICE static inline IdxT size()
+  template<typename IdxT     = hip_dim_member_t,
+           typename IdxNDims = NonCachedIndicesAndDims>
+  RAJA_DEVICE static inline IdxT size(IdxNDims const& idxNDims = IdxNDims {})
   {
     return static_cast<IdxT>(divisor);
   }


### PR DESCRIPTION
# Summary

Add classes that can cache threadIdx, blockIdx, blockDim, and/or gridDim in cuda and hip and use then in the Index classes.

- This PR is a feature
- It does the following:
  - Adds cache-able idx/dim at the request of @artv3 