### PR TITLE
Add kahan_sum_volatile

### DIFF
--- a/include/RAJA/util/reduce.hpp
+++ b/include/RAJA/util/reduce.hpp
@@ -253,13 +253,23 @@ private:
   Storage m_storage;
 };
 
+enum struct KahanSumImplementation
+{
+  Default,
+  Volatile
+};
+
 /*!
     \brief Reduce class that does a reduction with a left fold.
 
     \note KahanSum does not take an binary operation as the only valid operation
           is plus.
+
+    \note sum_impl can be used to have the implementation use volatile on some
+          intermediate values to force compilers to not optimize out the
+          compensated summation if fast-math is enabled.
 */
-template<typename T>
+template<typename T, KahanSumImplementation sum_impl = KahanSumImplementation::Default>
 struct KahanSum
 {
   static_assert(std::is_floating_point_v<T>, "T must be a floating point type");
@@ -304,13 +314,26 @@ struct KahanSum
   */
   RAJA_HOST_DEVICE RAJA_INLINE constexpr void combine(T val)
   {
-    // volatile used to prevent compiler optimizations that assume
-    // floating-point operations are associative
-    T y                 = val - m_accumulated_carry;
-    volatile T t        = m_accumulated_value + y;
-    volatile T z        = t - m_accumulated_value;
-    m_accumulated_carry = z - y;
-    m_accumulated_value = t;
+    if constexpr (sum_impl == KahanSumImplementation::Default) {
+
+      T y                 = val - m_accumulated_carry;
+      T t                 = m_accumulated_value + y;
+      T z                 = t - m_accumulated_value;
+      m_accumulated_carry = z - y;
+      m_accumulated_value = t;
+
+    } else if constexpr (sum_impl == KahanSumImplementation::Volatile) {
+
+      // volatile used to prevent compiler optimizations that assume
+      // floating-point operations are associative
+      T y                 = val - m_accumulated_carry;
+      volatile T t        = m_accumulated_value + y;
+      volatile T z        = t - m_accumulated_value;
+      m_accumulated_carry = z - y;
+      m_accumulated_value = t;
+
+    }
+
   }
 
   /*!
@@ -401,7 +424,7 @@ RAJA_HOST_DEVICE RAJA_INLINE constexpr concepts::
 
 /*!
   \brief Accumulate given range to a single value
-  using a left fold algorithm in O(N) operations and O(1) extra memory
+  using a kahan summation algorithm in O(N) operations and O(1) extra memory
     see https://en.cppreference.com/w/cpp/algorithm/accumulate
 */
 template<typename Container, typename T = detail::ContainerVal<Container>>
@@ -416,6 +439,34 @@ RAJA_HOST_DEVICE RAJA_INLINE constexpr concepts::
   auto end_it   = end(c);
 
   KahanSum<T> reducer(std::move(init));
+
+  for (; begin_it != end_it; ++begin_it)
+  {
+    reducer.combine(*begin_it);
+  }
+
+  return reducer.get_and_reset();
+}
+
+/*!
+  \brief Accumulate given range to a single value
+  using a kahan summation algorithm in O(N) operations and O(1) extra memory
+    see https://en.cppreference.com/w/cpp/algorithm/accumulate
+  \note Uses volatile on intermediate products to keep compiler from optimizing
+  out the compensated summation with fast-math.
+*/
+template<typename Container, typename T = detail::ContainerVal<Container>>
+RAJA_HOST_DEVICE RAJA_INLINE constexpr concepts::
+    enable_if_t<T, type_traits::is_range<Container>, std::is_floating_point<T>>
+    kahan_sum_volatile(Container&& c, T init = T())
+{
+  using std::begin;
+  using std::end;
+
+  auto begin_it = begin(c);
+  auto end_it   = end(c);
+
+  KahanSum<T, KahanSumImplementation::Volatile> reducer(std::move(init));
 
   for (; begin_it != end_it; ++begin_it)
   {

--- a/include/RAJA/util/reduce.hpp
+++ b/include/RAJA/util/reduce.hpp
@@ -269,7 +269,8 @@ enum struct KahanSumImplementation
           intermediate values to force compilers to not optimize out the
           compensated summation if fast-math is enabled.
 */
-template<typename T, KahanSumImplementation sum_impl = KahanSumImplementation::Default>
+template<typename T,
+         KahanSumImplementation sum_impl = KahanSumImplementation::Default>
 struct KahanSum
 {
   static_assert(std::is_floating_point_v<T>, "T must be a floating point type");
@@ -314,15 +315,17 @@ struct KahanSum
   */
   RAJA_HOST_DEVICE RAJA_INLINE constexpr void combine(T val)
   {
-    if constexpr (sum_impl == KahanSumImplementation::Default) {
+    if constexpr (sum_impl == KahanSumImplementation::Default)
+    {
 
       T y                 = val - m_accumulated_carry;
       T t                 = m_accumulated_value + y;
       T z                 = t - m_accumulated_value;
       m_accumulated_carry = z - y;
       m_accumulated_value = t;
-
-    } else if constexpr (sum_impl == KahanSumImplementation::Volatile) {
+    }
+    else if constexpr (sum_impl == KahanSumImplementation::Volatile)
+    {
 
       // volatile used to prevent compiler optimizations that assume
       // floating-point operations are associative
@@ -331,9 +334,7 @@ struct KahanSum
       volatile T z        = t - m_accumulated_value;
       m_accumulated_carry = z - y;
       m_accumulated_value = t;
-
     }
-
   }
 
   /*!

--- a/test/unit/algorithm/tests/test-algorithm-util-reduce.hpp
+++ b/test/unit/algorithm/tests/test-algorithm-util-reduce.hpp
@@ -30,6 +30,9 @@ struct Accumulate;
 template < typename test_policy, typename platform = test_platform<test_policy> >
 struct KahanSum;
 
+template < typename test_policy, typename platform = test_platform<test_policy> >
+struct KahanSumVolatile;
+
 
 template < typename test_policy >
 struct BinaryTreeReduce<test_policy, RunOnHost>
@@ -88,6 +91,26 @@ struct KahanSum<test_policy, RunOnHost>
   void operator()(T* reduced_value, Args&&... args)
   {
     *reduced_value = RAJA::kahan_sum(std::forward<Args>(args)...);
+  }
+};
+
+template < typename test_policy >
+struct KahanSumVolatile<test_policy, RunOnHost>
+  : ForoneSynchronize<test_policy>
+{
+  using reduce_category = unordered_reduce_tag;
+  using reduce_interface = sum_interface_tag;
+  using reduce_types = floating_point_types_tag;
+
+  const char* name()
+  {
+    return "RAJA::kahan_sum_volatile";
+  }
+
+  template < typename T, typename... Args >
+  void operator()(T* reduced_value, Args&&... args)
+  {
+    *reduced_value = RAJA::kahan_sum_volatile(std::forward<Args>(args)...);
   }
 };
 
@@ -214,6 +237,42 @@ struct KahanSum<test_policy, RunOnDevice>
   {
     forone<test_policy>( [=] RAJA_DEVICE() {
       *reduced_value = RAJA::kahan_sum(c, init);
+    });
+  }
+};
+
+template < typename test_policy >
+struct KahanSumVolatile<test_policy, RunOnDevice>
+  : ForoneSynchronize<test_policy>
+{
+  using reduce_category = unordered_reduce_tag;
+  using reduce_interface = sum_interface_tag;
+  using reduce_types = floating_point_types_tag;
+
+  std::string m_name;
+
+  KahanSumVolatile()
+    : m_name(std::string("RAJA::kahan_sum_volatile<") + test_policy_info<test_policy>::name() + std::string(">"))
+  { }
+
+  const char* name()
+  {
+    return m_name.c_str();
+  }
+
+  template < typename T, typename Container >
+  void operator()(T* reduced_value, Container&& c)
+  {
+    forone<test_policy>( [=] RAJA_DEVICE() {
+      *reduced_value = RAJA::kahan_sum_volatile(c);
+    });
+  }
+
+  template < typename T, typename Container >
+  void operator()(T* reduced_value, Container&& c, RAJA::detail::ContainerVal<Container> init)
+  {
+    forone<test_policy>( [=] RAJA_DEVICE() {
+      *reduced_value = RAJA::kahan_sum_volatile(c, init);
     });
   }
 };


### PR DESCRIPTION
# Summary

Default kahan_sum to not use volatile so the compiler can optimize, and add kahan_sum_volatile. This lets you get an optimized kahan sum and have the option to use a workaround for when fast-math allows the compensated sum to be optimized out.