### PR TITLE
Use C++ compiler to check for symbols

### DIFF
--- a/cmake/SetupRajaConfig.cmake
+++ b/cmake/SetupRajaConfig.cmake
@@ -49,10 +49,10 @@ else ()
     set(RAJA_USE_CLOCK   OFF CACHE BOOL "Use clock from time.h for timer"    )
 endif ()
 
-include(CheckSymbolExists)
-check_symbol_exists(posix_memalign stdlib.h RAJA_HAVE_POSIX_MEMALIGN)
-check_symbol_exists(std::aligned_alloc stdlib.h RAJA_HAVE_ALIGNED_ALLOC)
-check_symbol_exists(_mm_malloc "" RAJA_HAVE_MM_MALLOC)
+include(CheckCXXSymbolExists)
+check_cxx_symbol_exists(posix_memalign cstdlib RAJA_HAVE_POSIX_MEMALIGN)
+check_cxx_symbol_exists(std::aligned_alloc cstdlib RAJA_HAVE_ALIGNED_ALLOC)
+check_cxx_symbol_exists(_mm_malloc cstdlib RAJA_HAVE_MM_MALLOC)
 
 # Set up RAJA_ENABLE prefixed options
 set(RAJA_ENABLE_OPENMP ${ENABLE_OPENMP})


### PR DESCRIPTION
# Symbol existence checks changed to use C++ compiler rather than the C compiler

check_symbol_exists use the C compiler for the symbol check, check_cxx_symbol_exists is the C++ variant.   The C check was being used to check for a C++ symbol name (std::aligned_alloc) which was failing.   Other checks were refactored to use C++ checks since use is in C++ code.

- This PR is a bugfix
