### PR TITLE
Use C++17 aligned memory allocation

### DIFF
--- a/cmake/SetupRajaConfig.cmake
+++ b/cmake/SetupRajaConfig.cmake
@@ -49,10 +49,10 @@ else ()
     set(RAJA_USE_CLOCK   OFF CACHE BOOL "Use clock from time.h for timer"    )
 endif ()
 
-include(CheckSymbolExists)
-check_symbol_exists(posix_memalign stdlib.h RAJA_HAVE_POSIX_MEMALIGN)
-check_symbol_exists(std::aligned_alloc stdlib.h RAJA_HAVE_ALIGNED_ALLOC)
-check_symbol_exists(_mm_malloc "" RAJA_HAVE_MM_MALLOC)
+include(CheckCXXSymbolExists)
+check_cxx_symbol_exists(posix_memalign cstdlib RAJA_HAVE_POSIX_MEMALIGN)
+check_cxx_symbol_exists(std::aligned_alloc cstdlib RAJA_HAVE_ALIGNED_ALLOC)
+check_cxx_symbol_exists(_mm_malloc cstdlib RAJA_HAVE_MM_MALLOC)
 
 # Set up RAJA_ENABLE prefixed options
 set(RAJA_ENABLE_OPENMP ${ENABLE_OPENMP})

--- a/cmake/SetupRajaConfig.cmake
+++ b/cmake/SetupRajaConfig.cmake
@@ -49,11 +49,6 @@ else ()
     set(RAJA_USE_CLOCK   OFF CACHE BOOL "Use clock from time.h for timer"    )
 endif ()
 
-include(CheckCXXSymbolExists)
-check_cxx_symbol_exists(posix_memalign cstdlib RAJA_HAVE_POSIX_MEMALIGN)
-check_cxx_symbol_exists(std::aligned_alloc cstdlib RAJA_HAVE_ALIGNED_ALLOC)
-check_cxx_symbol_exists(_mm_malloc cstdlib RAJA_HAVE_MM_MALLOC)
-
 # Set up RAJA_ENABLE prefixed options
 set(RAJA_ENABLE_OPENMP ${ENABLE_OPENMP})
 set(RAJA_ENABLE_TARGET_OPENMP ${ENABLE_TARGET_OPENMP})

--- a/include/RAJA/internal/MemUtils_CPU.hpp
+++ b/include/RAJA/internal/MemUtils_CPU.hpp
@@ -44,7 +44,7 @@ namespace RAJA
  * Convenience function to allocate aligned memory using the
  * std::aligned_alloc function but returns a pointer of the allocated
  * type rather than void*
- * 
+ *
  * Memory should be deallocated using standard C++ free.
  */
 template<typename T>

--- a/include/RAJA/internal/MemUtils_CPU.hpp
+++ b/include/RAJA/internal/MemUtils_CPU.hpp
@@ -3,8 +3,8 @@
  *
  * \file
  *
- * \brief   Header file defining prototypes for routines used to manage
- *          memory for CPU reductions and other operations.
+ * \brief   Internal memory functions and classes to manage memory for
+ *          CPU reductions and other operations.
  *
  ******************************************************************************
  */
@@ -38,72 +38,37 @@
 namespace RAJA
 {
 
-///
-/// Portable aligned memory allocation
-///
-inline void* allocate_aligned(size_t alignment, size_t size)
-{
-#if defined(RAJA_HAVE_POSIX_MEMALIGN)
-  // posix_memalign available
-  void* ret = nullptr;
-  int err   = posix_memalign(&ret, alignment, size);
-  return err ? nullptr : ret;
-#elif defined(RAJA_HAVE_ALIGNED_ALLOC)
-  return std::aligned_alloc(alignment, size);
-#elif defined(RAJA_HAVE_MM_MALLOC)
-  return _mm_malloc(size, alignment);
-#elif defined(RAJA_PLATFORM_WINDOWS)
-  return _aligned_malloc(size, alignment);
-#else
-  char* mem = (char*)malloc(size + alignment + sizeof(void*));
-  if (nullptr == mem) return nullptr;
-  void** ptr = (void**)((std::uintptr_t)(mem + alignment + sizeof(void*)) &
-                        ~(alignment - 1));
-  // Store the original address one position behind what we give the user.
-  ptr[-1] = mem;
-  return ptr;
-#endif
-}
-
-///
-/// Portable aligned memory allocation
-///
+/*!
+ * Typed aligned memory allocation
+ *
+ * Convenience function to allocate aligned memory using the
+ * std::aligned_alloc function but returns a pointer of the allocated
+ * type rather than void*
+ * 
+ * Memory should be deallocated using standard C++ free.
+ */
 template<typename T>
 inline T* allocate_aligned_type(size_t alignment, size_t size)
 {
-  return reinterpret_cast<T*>(allocate_aligned(alignment, size));
+  return reinterpret_cast<T*>(std::aligned_alloc(alignment, size));
 }
 
-///
-/// Portable aligned memory free - required for Windows
-///
-inline void free_aligned(void* ptr)
-{
-#if defined(RAJA_HAVE_POSIX_MEMALIGN) || defined(RAJA_HAVE_ALIGNED_ALLOC)
-  free(ptr);
-#elif defined(RAJA_HAVE_MM_MALLOC)
-  _mm_free(ptr);
-#elif defined(RAJA_PLATFORM_WINDOWS)
-  _aligned_free(ptr);
-#else
-  // Free the address stored one position behind the user data in ptr.
-  // This is valid for pointers allocated with allocate_aligned
-  free(((void**)ptr)[-1]);
-#endif
-}
-
-///
-/// Deleter function object for memory allocated with allocate_aligned
-///
+/*!
+ * Deleter function object for memory allocated with std allocation
+ * methods.
+ *
+ * Can be used with the RAJA::allocate_aligned_type function.
+ */
 struct FreeAligned
 {
-  void operator()(void* ptr) { free_aligned(ptr); }
+  void operator()(void* ptr) { free(ptr); }
 };
 
-///
-/// Deleter function object for memory allocated with allocate_aligned_type
-/// that calls the destructor for the fist size objects in the storage.
-///
+/*!
+ * Deleter function object for memory allocated with
+ * allocate_aligned_type that calls the destructor for the first `size`
+ * objects in the storage.
+ */
 template<typename T, typename index_type>
 struct FreeAlignedType : FreeAligned
 {

--- a/include/RAJA/policy/openmp/multi_reduce.hpp
+++ b/include/RAJA/policy/openmp/multi_reduce.hpp
@@ -191,7 +191,7 @@ private:
     {
       data[bin - 1].~T();
     }
-    RAJA::free_aligned(data);
+    free(data);
     data = nullptr;
   }
 };
@@ -408,7 +408,7 @@ private:
             .~T();
       }
     }
-    RAJA::free_aligned(data);
+    free(data);
     data = nullptr;
   }
 };

--- a/test/old-tests/unit/test-simd.cpp
+++ b/test/old-tests/unit/test-simd.cpp
@@ -46,8 +46,8 @@ TEST(SIMD, Align)
     ASSERT_DOUBLE_EQ((double)y[i], (double)1.0);
   }
 
-  RAJA::free_aligned(a);
-  RAJA::free_aligned(b);
+  free(a);
+  free(b);
 }
 
 #if defined(RAJA_ENABLE_OPENMP)
@@ -85,9 +85,9 @@ TEST(SIMD, OMPAndSimd)
     ASSERT_DOUBLE_EQ((double)c[i], (double)2.0);
   }
 
-  RAJA::free_aligned(a);
-  RAJA::free_aligned(b);
-  RAJA::free_aligned(c);
+  free(a);
+  free(b);
+  free(c);
 }
 
 TEST(SIMD, OMPAndSimd_MultiLambda)
@@ -141,12 +141,12 @@ TEST(SIMD, OMPAndSimd_MultiLambda)
     ASSERT_DOUBLE_EQ((double)c2[i], (double)2.0);
   }
 
-  RAJA::free_aligned(a);
-  RAJA::free_aligned(b);
-  RAJA::free_aligned(c);
+  free(a);
+  free(b);
+  free(c);
 
-  RAJA::free_aligned(a2);
-  RAJA::free_aligned(b2);
-  RAJA::free_aligned(c2);
+  free(a2);
+  free(b2);
+  free(c2);
 }
 #endif


### PR DESCRIPTION
# Use C++17 aligned memory allocation rather than platform/compiler allocators

With the adoption of C++17 requirement for RAJA the standard aligned memory allocator (std::aligned_alloc) is available and can replace platform / compiler specific options.  This PR removes CMake checks for the platform allocators and simplifies the aligned memory allocator wrappers.

- This PR is a refactoring
- It does the following (modify list as needed):
  - Refactors the internal aligned memory allocators to use the std allocators.
  
 Discussion on removal is in a prior cmake fix that has been closed #1985.   This PR replaces that change with a more complete change.
