### PR TITLE
ci: Disable draft PR filter (temporary)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,13 +83,14 @@ include:
       github_project_org: $GITHUB_PROJECT_ORG
       github_token: $GITHUB_TOKEN
 
+  # TODO(john) Re-enable this check when the draft-PR check is fixed
   # Draft PR filter
-  - component: $CI_SERVER_FQDN/radiuss/radiuss-shared-ci/utility-draft-pr-filter@v2025.12.0
-    inputs:
-      github_token: $GITHUB_TOKEN
-      github_project_name: $GITHUB_PROJECT_NAME
-      github_project_org: $GITHUB_PROJECT_ORG
-      always_run_pattern: "^develop$|^main$|^v[0-9.]*-RC$"
+  # - component: $CI_SERVER_FQDN/radiuss/radiuss-shared-ci/utility-draft-pr-filter@v2025.12.0
+  #   inputs:
+  #     github_token: $GITHUB_TOKEN
+  #     github_project_name: $GITHUB_PROJECT_NAME
+  #     github_project_org: $GITHUB_PROJECT_ORG
+  #     always_run_pattern: "^develop$|^main$|^v[0-9.]*-RC$"
 
   # Local custom variables (used for component inputs and forwarded to child pipelines)
   - local: '.gitlab/custom-variables.yml'


### PR DESCRIPTION
The draft PR filter is currently broken in our gitlab CI, so this PR will temporarily disable the filter while we work on a permanent solution