### PR TITLE
Use project specific variable to specify github status token

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,7 +81,7 @@ include:
     inputs:
       github_project_name: $GITHUB_PROJECT_NAME
       github_project_org: $GITHUB_PROJECT_ORG
-      github_token: $GITHUB_TOKEN
+      github_token: $RSCI_GITHUB_STATUS_TOKEN
 
   # Draft PR filter
   - component: $CI_SERVER_FQDN/radiuss/radiuss-shared-ci/utility-draft-pr-filter@v2025.12.0

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,14 +83,13 @@ include:
       github_project_org: $GITHUB_PROJECT_ORG
       github_token: $GITHUB_TOKEN
 
-  # TODO(john) Re-enable this check when the draft-PR check is fixed
   # Draft PR filter
-  # - component: $CI_SERVER_FQDN/radiuss/radiuss-shared-ci/utility-draft-pr-filter@v2025.12.0
-  #   inputs:
-  #     github_token: $GITHUB_TOKEN
-  #     github_project_name: $GITHUB_PROJECT_NAME
-  #     github_project_org: $GITHUB_PROJECT_ORG
-  #     always_run_pattern: "^develop$|^main$|^v[0-9.]*-RC$"
+  - component: $CI_SERVER_FQDN/radiuss/radiuss-shared-ci/utility-draft-pr-filter@v2025.12.0
+    inputs:
+      github_token: $RSCI_GITHUB_STATUS_TOKEN
+      github_project_name: $GITHUB_PROJECT_NAME
+      github_project_org: $GITHUB_PROJECT_ORG
+      always_run_pattern: "^develop$|^main$|^v[0-9.]*-RC$"
 
   # Local custom variables (used for component inputs and forwarded to child pipelines)
   - local: '.gitlab/custom-variables.yml'


### PR DESCRIPTION
Fix issue with draft PR filter.

The issue identified is that token cannot be accessed correctly when defined at group level anymore.
Instead, we defined the token at project level, and seize the occasion to give it a name that is more specific.

We turn the draft filter back on.