### PR TITLE
Fix files so GitHub can detect RAJA license type

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,13 +1,13 @@
 Intellectual Property Notice
 ------------------------------
 
-RAJA is produced at the Lawrence Livermore National Laboratory
+RAJA is produced at the Lawrence Livermore National Laboratory.
 
 Unlimited Open Source - BSD Distribution
 LLNL-CODE-689114
 OCEC-16-063
 
-This file is part of RAJA
+This file is part of RAJA.
 For details, see https://github.com/llnl/RAJA
 
 RAJA licensed under the BSD 3-Clause license

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,11 +1,22 @@
 Intellectual Property Notice
 ------------------------------
 
+RAJA is produced at the Lawrence Livermore National Laboratory
+
+Unlimited Open Source - BSD Distribution
+LLNL-CODE-689114
+OCEC-16-063
+
+This file is part of RAJA
+For details, see https://github.com/llnl/RAJA
+
 RAJA licensed under the BSD 3-Clause license
 (BSD-3-Clause or https://opensource.org/licenses/BSD-3-Clause).
 
 Copyrights and patents in the RAJA project are retained by contributors.
 No copyright assignment is required to contribute to RAJA.
+
+See https://github.com/llnl/RAJA/contributors for the list of contributors.
 
 Additional BSD Notice
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,18 +1,7 @@
+BSD 3-Clause License
+
 Copyright (c) 2016-2026, Lawrence Livermore National Security, LLC.
-
-Produced at the Lawrence Livermore National Laboratory
-
-Unlimited Open Source - BSD Distribution
-LLNL-CODE-689114
-OCEC-16-063
-
 All rights reserved.
-
-This file is part of RAJA
-
-For details, see https://github.com/llnl/RAJA
-
-Please also read RAJA/COPYRIGHT
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
# Summary

- This PR fixes the issue that GitHub cannot detect the RAJA license type.
- The issue arose after a recent PR that reworked how the copyright dates propagate through the repo (mea culpa).