### PR TITLE
alloc optimization

### DIFF
--- a/.gitlab/custom-variables.yml
+++ b/.gitlab/custom-variables.yml
@@ -47,7 +47,7 @@ variables:
 
   # Tioga (flux) allocation settings
   TIOGA_SHARED_ALLOC: "OFF"
-  TIOGA_JOB_ALLOC: "--queue=pci --nodes=1 --timelimit=30m --begin-time=+5s"
+  TIOGA_JOB_ALLOC: "--queue=pci --nodes=1 --time-limit=30m --begin-time=+5s"
   # Project specific variants for tioga
   PROJECT_TIOGA_VARIANTS: "~shared +openmp +vectorization +tests"
   # Project specific deps for tioga

--- a/.gitlab/custom-variables.yml
+++ b/.gitlab/custom-variables.yml
@@ -54,8 +54,8 @@ variables:
   PROJECT_TIOGA_DEPS: ""
 
   # Tuolumne (flux) allocation settings
-  TUOLUMNE_SHARED_ALLOC: "--exclusive --queue=pci --time-limit=90m --nodes=1 -o per-resource.count=2"
-  TUOLUMNE_JOB_ALLOC: "--nodes=1 --begin-time=+5s"
+  TUOLUMNE_SHARED_ALLOC: "OFF"
+  TUOLUMNE_JOB_ALLOC: "--queue=pci --nodes=1 --time-limit=60m --begin-time=+5s"
   # Project specific variants for tuolumne
   PROJECT_TUOLUMNE_VARIANTS: "~shared +openmp +vectorization +tests"
   # Project specific deps for tuolumne

--- a/.gitlab/custom-variables.yml
+++ b/.gitlab/custom-variables.yml
@@ -20,9 +20,9 @@ variables:
   ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
 
   # Dane (SLURM) allocation settings
-  DANE_SHARED_ALLOC: "--exclusive --reservation=ci --time=120 --nodes=1"
+  DANE_SHARED_ALLOC: "OFF"
   # Note: we repeat the reservation, helpful when jobs are manually re-triggered.
-  DANE_JOB_ALLOC: "--reservation=ci --nodes=1"
+  DANE_JOB_ALLOC: "--reservation=ci --exclusive=user --time=10 --nodes=1"
   # Project specific variants for dane
   PROJECT_DANE_VARIANTS: "~shared +openmp +vectorization +tests"
   # Project specific deps for dane
@@ -38,16 +38,16 @@ variables:
   PROJECT_MATRIX_DEPS: ""
 
   # Corona (flux) allocation settings
-  CORONA_SHARED_ALLOC: "--exclusive --time-limit=60m --nodes=1 -o per-resource.count=2"
-  CORONA_JOB_ALLOC: "--nodes=1 --begin-time=+5s"
+  CORONA_SHARED_ALLOC: "OFF"
+  CORONA_JOB_ALLOC: "--nodes=1 --time-limit=30m --begin-time=+5s"
   # Project specific variants for corona
   PROJECT_CORONA_VARIANTS: "~shared ~openmp +vectorization +tests"
   # Project specific deps for corona
   PROJECT_CORONA_DEPS: ""
 
   # Tioga (flux) allocation settings
-  TIOGA_SHARED_ALLOC: "--exclusive --queue=pci --time-limit=70m --nodes=1 -o per-resource.count=2"
-  TIOGA_JOB_ALLOC: "--nodes=1 --begin-time=+5s"
+  TIOGA_SHARED_ALLOC: "OFF"
+  TIOGA_JOB_ALLOC: "--queue=pci --nodes=1 --timelimit=30m --begin-time=+5s"
   # Project specific variants for tioga
   PROJECT_TIOGA_VARIANTS: "~shared +openmp +vectorization +tests"
   # Project specific deps for tioga
@@ -55,7 +55,7 @@ variables:
 
   # Tuolumne (flux) allocation settings
   TUOLUMNE_SHARED_ALLOC: "OFF"
-  TUOLUMNE_JOB_ALLOC: "--queue=pci --nodes=1 --time-limit=60m --begin-time=+5s"
+  TUOLUMNE_JOB_ALLOC: "--queue=pci --nodes=1 --time-limit=45m --begin-time=+5s"
   # Project specific variants for tuolumne
   PROJECT_TUOLUMNE_VARIANTS: "~shared +openmp +vectorization +tests"
   # Project specific deps for tuolumne

--- a/.gitlab/custom-variables.yml
+++ b/.gitlab/custom-variables.yml
@@ -31,7 +31,7 @@ variables:
   # Matrix (SLURM) allocation settings
   MATRIX_SHARED_ALLOC: "OFF"
   # Note: we repeat the reservation, helpful when jobs are manually re-triggered.
-  MATRIX_JOB_ALLOC: "--partition=pci --exclusive=user --time=10 --nodes=1"
+  MATRIX_JOB_ALLOC: "--partition=pci --exclusive=user --time=60 --nodes=1"
   # Project specific variants for matrix
   PROJECT_MATRIX_VARIANTS: "~shared +cuda cuda_arch=90 +tests"
   # Project specific deps for matrix

--- a/.gitlab/custom-variables.yml
+++ b/.gitlab/custom-variables.yml
@@ -29,9 +29,9 @@ variables:
   PROJECT_DANE_DEPS: ""
 
   # Matrix (SLURM) allocation settings
-  MATRIX_SHARED_ALLOC: "--exclusive --partition=pci --time=60 --nodes=1"
+  MATRIX_SHARED_ALLOC: "OFF"
   # Note: we repeat the reservation, helpful when jobs are manually re-triggered.
-  MATRIX_JOB_ALLOC: "--partition=pci --nodes=1"
+  MATRIX_JOB_ALLOC: "--partition=pci --exclusive=user --time=10 --nodes=1"
   # Project specific variants for matrix
   PROJECT_MATRIX_VARIANTS: "~shared +cuda cuda_arch=90 +tests"
   # Project specific deps for matrix

--- a/.gitlab/custom-variables.yml
+++ b/.gitlab/custom-variables.yml
@@ -31,7 +31,7 @@ variables:
   # Matrix (SLURM) allocation settings
   MATRIX_SHARED_ALLOC: "OFF"
   # Note: we repeat the reservation, helpful when jobs are manually re-triggered.
-  MATRIX_JOB_ALLOC: "--partition=pci --exclusive=user --time=60 --nodes=1"
+  MATRIX_JOB_ALLOC: "--partition=pci --exclusive=user --time=20 --nodes=1"
   # Project specific variants for matrix
   PROJECT_MATRIX_VARIANTS: "~shared +cuda cuda_arch=90 +tests"
   # Project specific deps for matrix

--- a/.gitlab/jobs/matrix.yml
+++ b/.gitlab/jobs/matrix.yml
@@ -35,7 +35,7 @@ clang_18_1_8_gcc_13_cuda_12_6_0:
 # clang_18_1_8_cuda_12_6_0
 clang_18_1_8_cuda_12_6_0:
   variables:
-    SPEC: " ~shared +cuda cuda_arch=90 %llvm@=18.1.8 ^cuda@12.6.0+allow-unsupported-compilers"
+    SPEC: " ~shared +cuda cuda_arch=90 +tests %llvm@=18.1.8 ^cuda@12.6.0+allow-unsupported-compilers"
   extends: .job_on_matrix
   allow_failure: true
 


### PR DESCRIPTION
This PR switches off shared allocation for CI jobs. Each job has its own allocation and time limit.
This adds more jobs to the CI queue, but simplifies the interpretation of failures.

For Dane and Matrix, we use `--exclusive=user` allocation, which may lead to oversubscription between jobs of the same user, which is good in CI context (except for performance analysis). We hope to improve the throughput with this option, however, it may require finer tuning of allocations to specify that they require less than a full node.

Finally, this PR turns tests back on for the matrix job.