### PR TITLE
Increase LC matrix CI job allocation time

### DIFF
--- a/.gitlab/custom-variables.yml
+++ b/.gitlab/custom-variables.yml
@@ -31,7 +31,7 @@ variables:
   # Matrix (SLURM) allocation settings
   MATRIX_SHARED_ALLOC: "OFF"
   # Note: we repeat the reservation, helpful when jobs are manually re-triggered.
-  MATRIX_JOB_ALLOC: "--partition=pci --exclusive=user --time=20 --nodes=1"
+  MATRIX_JOB_ALLOC: "--partition=pci --exclusive=user --time=30 --nodes=1"
   # Project specific variants for matrix
   PROJECT_MATRIX_VARIANTS: "~shared +cuda cuda_arch=90 +tests"
   # Project specific deps for matrix


### PR DESCRIPTION
# CI Tests on LC Matrix system experienced frequent timeouts

Increased the job allocation allocation from 20 to 30 minutes.   Manually running showed build/test was taking ~20 minutes.
