### PR TITLE
Task/rhornung67/squash warnings

### DIFF
--- a/examples/gpu-launch-context-indices.cpp
+++ b/examples/gpu-launch-context-indices.cpp
@@ -106,7 +106,7 @@ int run_example()
         // the launch context. With the "all cached" policy, those values are
         // cached in `ctx` the first time they are needed.
 
-        RAJA::loop<teams_x>(ctx, RAJA::RangeSegment(0, GRID_DIM), [&](int bx) {
+        RAJA::loop<teams_x>(ctx, RAJA::RangeSegment(0, GRID_DIM), [&](int RAJA_UNUSED_ARG(bx)) {
 
           // Iterate over more logical thread-iterations than the physical
           // thread dimension to exercise the *_thread_x_loop mapping.

--- a/include/RAJA/config.hpp.in
+++ b/include/RAJA/config.hpp.in
@@ -391,6 +391,8 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 //
 //     RAJA_INLINE - macro to enforce method inlining
 //
+//     RAJA_NOINLINE - macro to enforce noninline method
+//
 //     RAJA_ALIGN_DATA(<variable>) - macro to express alignment of data,
 //                              loop bounds, etc.
 //
@@ -399,6 +401,12 @@ const int DATA_ALIGN = @RAJA_DATA_ALIGN@;
 //
 //     RAJA_ALIGNED_ATTR(<alignment>) - macro to express type or variable alignments
 //
+
+#if defined(_MSC_VER)
+#define RAJA_NOINLINE __declspec(noinline)
+#else
+#define RAJA_NOINLINE __attribute__((noinline))
+#endif
 
 #if (defined(_WIN32) || defined(_WIN64)) && !defined(RAJA_WIN_STATIC_BUILD)
 #ifdef RAJA_EXPORTS

--- a/test/unit/workgroup/tests/test-util-workgroup-WorkStorage.hpp
+++ b/test/unit/workgroup/tests/test-util-workgroup-WorkStorage.hpp
@@ -20,16 +20,17 @@
 #include <array>
 #include <cstddef>
 #include <type_traits>
+#include <cstring>
 
 
 template < typename T >
 struct TestCallable
 {
-  static __attribute__((noinline)) void copy_value(void* dst,
-                                                   void const* src,
-                                                   size_t size)
+  static RAJA_NOINLINE void copy_value(void* dst,
+                                       void const* src,
+                                       size_t size)
   {
-    __builtin_memmove(dst, src, size);
+    std::memmove(dst, src, size);
   }
 
   TestCallable(T _val)

--- a/test/unit/workgroup/tests/test-util-workgroup-WorkStorage.hpp
+++ b/test/unit/workgroup/tests/test-util-workgroup-WorkStorage.hpp
@@ -57,7 +57,7 @@ struct TestCallable
   RAJA_HOST_DEVICE void operator()(
       void* val_ptr, bool* move_constructed_ptr, bool* moved_from_ptr) const
   {
-    static_assert(std::is_trivially_copyable<T>::value,
+    static_assert(std::is_trivially_copyable_v<T>,
                   "TestCallable requires trivially copyable values");
     copy_value(val_ptr, &val, sizeof(T));
     *move_constructed_ptr = move_constructed;

--- a/test/unit/workgroup/tests/test-util-workgroup-WorkStorage.hpp
+++ b/test/unit/workgroup/tests/test-util-workgroup-WorkStorage.hpp
@@ -26,6 +26,9 @@
 template < typename T >
 struct TestCallable
 {
+  static_assert(std::is_trivially_copyable_v<T>,
+                "TestCallable requires trivially copyable values");
+
   static RAJA_NOINLINE void copy_value(void* dst,
                                        void const* src,
                                        size_t size)
@@ -57,8 +60,6 @@ struct TestCallable
   RAJA_HOST_DEVICE void operator()(
       void* val_ptr, bool* move_constructed_ptr, bool* moved_from_ptr) const
   {
-    static_assert(std::is_trivially_copyable_v<T>,
-                  "TestCallable requires trivially copyable values");
     copy_value(val_ptr, &val, sizeof(T));
     *move_constructed_ptr = move_constructed;
     *moved_from_ptr = moved_from;

--- a/test/unit/workgroup/tests/test-util-workgroup-WorkStorage.hpp
+++ b/test/unit/workgroup/tests/test-util-workgroup-WorkStorage.hpp
@@ -19,11 +19,19 @@
 #include <random>
 #include <array>
 #include <cstddef>
+#include <type_traits>
 
 
 template < typename T >
 struct TestCallable
 {
+  static __attribute__((noinline)) void copy_value(void* dst,
+                                                   void const* src,
+                                                   size_t size)
+  {
+    __builtin_memmove(dst, src, size);
+  }
+
   TestCallable(T _val)
     : val(_val)
   { }
@@ -48,7 +56,9 @@ struct TestCallable
   RAJA_HOST_DEVICE void operator()(
       void* val_ptr, bool* move_constructed_ptr, bool* moved_from_ptr) const
   {
-    *static_cast<T*>(val_ptr) = val;
+    static_assert(std::is_trivially_copyable<T>::value,
+                  "TestCallable requires trivially copyable values");
+    copy_value(val_ptr, &val, sizeof(T));
     *move_constructed_ptr = move_constructed;
     *moved_from_ptr = moved_from;
   }

--- a/test/unit/workgroup/tests/test-util-workgroup-WorkStorage.hpp
+++ b/test/unit/workgroup/tests/test-util-workgroup-WorkStorage.hpp
@@ -30,7 +30,7 @@ struct TestCallable
                                        void const* src,
                                        size_t size)
   {
-    std::memmove(dst, src, size);
+    std::memcpy(dst, src, size);
   }
 
   TestCallable(T _val)


### PR DESCRIPTION
# Summary

- This PR squashes several GNU and Clang compiler warnings. Specifically, 
   - Fixed one unused variable warning in an example code.
   - FIx compiler warning about possible out-of-bounds write in a workgroup test helper. The test helper routine had been writing back through a typed T* obtained
    from a void*, which the compiler was complaining about. This is changed
    to copy the trivially-copyable value through a small noinline untyped
    byte-copy helper instead. This preserves the test behavior and removes
    the warning.

Note: Codex CLI was consulted in resolving the second warning.
