### PR TITLE
Squash more warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ ENV GTEST_COLOR=1
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
 RUN clang-format --version && \
-    cmake -DENABLE_CLANGFORMAT=ON ../ && \
+    cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DENABLE_CLANGFORMAT=ON ../ && \
     make check
 
 FROM ghcr.io/llnl/radiuss:ubuntu-24.04-clang-19 AS clang19_desul

--- a/include/RAJA/policy/tensor/arch/avx/avx_double.hpp
+++ b/include/RAJA/policy/tensor/arch/avx/avx_double.hpp
@@ -24,6 +24,7 @@
 
 #include "RAJA/config.hpp"
 #include "RAJA/util/macros.hpp"
+#include "RAJA/util/builtin_compat.hpp"
 #include "RAJA/pattern/tensor/internal/RegisterBase.hpp"
 
 // Include SIMD intrinsics header file
@@ -69,6 +70,33 @@ private:
     return _mm256_set_epi64x(3 * stride, 2 * stride, stride, 0);
   }
 
+  RAJA_INLINE
+  static register_type load_register(element_type const* ptr)
+  {
+    return _mm256_loadu_pd(ptr);
+  }
+
+  RAJA_INLINE
+  static void store_register(element_type* ptr, register_type value)
+  {
+    _mm256_storeu_pd(ptr, value);
+  }
+
+  RAJA_INLINE
+  self_type& assign_register(register_type value)
+  {
+    RAJA_BUILTIN_MEMCPY(&m_value, &value, sizeof(m_value));
+    return *this;
+  }
+
+  RAJA_INLINE
+  static element_type lane(register_type value, camp::idx_t i)
+  {
+    element_type lanes[s_num_elem];
+    store_register(lanes, value);
+    return lanes[i];
+  }
+
 public:
   static constexpr camp::idx_t s_num_elem = 4;
 
@@ -97,7 +125,10 @@ public:
    * @brief Copy constructor
    */
   RAJA_INLINE
-  Register(self_type const& c) : base_type(), m_value(c.m_value) {}
+  Register(self_type const& c) : base_type(), m_value(_mm256_setzero_pd())
+  {
+    assign_register(c.m_value);
+  }
 
   /*!
    * @brief Copy assignment constructor
@@ -105,8 +136,7 @@ public:
   RAJA_INLINE
   self_type& operator=(self_type const& c)
   {
-    m_value = c.m_value;
-    return *this;
+    return assign_register(c.m_value);
   }
 
   /*!
@@ -123,7 +153,7 @@ public:
   RAJA_INLINE
   self_type& load_packed(element_type const* ptr)
   {
-    m_value = _mm256_loadu_pd(ptr);
+    m_value = load_register(ptr);
     return *this;
   }
 
@@ -146,10 +176,12 @@ public:
   RAJA_INLINE
   self_type& load_strided(element_type const* ptr, camp::idx_t stride)
   {
+    element_type lanes[s_num_elem];
     for (camp::idx_t i = 0; i < 4; ++i)
     {
-      m_value[i] = ptr[i * stride];
+      lanes[i] = ptr[i * stride];
     }
+    m_value = load_register(lanes);
     return *this;
   }
 
@@ -163,11 +195,12 @@ public:
                             camp::idx_t stride,
                             camp::idx_t N)
   {
-    m_value = _mm256_setzero_pd();
+    element_type lanes[s_num_elem] = {};
     for (camp::idx_t i = 0; i < N; ++i)
     {
-      m_value[i] = ptr[i * stride];
+      lanes[i] = ptr[i * stride];
     };
+    m_value = load_register(lanes);
     return *this;
   }
 
@@ -178,7 +211,7 @@ public:
   RAJA_INLINE
   self_type const& store_packed(element_type* ptr) const
   {
-    _mm256_storeu_pd(ptr, m_value);
+    store_register(ptr, m_value);
     return *this;
   }
 
@@ -200,9 +233,11 @@ public:
   RAJA_INLINE
   self_type const& store_strided(element_type* ptr, camp::idx_t stride) const
   {
+    element_type lanes[s_num_elem];
+    store_register(lanes, m_value);
     for (camp::idx_t i = 0; i < 4; ++i)
     {
-      ptr[i * stride] = m_value[i];
+      ptr[i * stride] = lanes[i];
     }
     return *this;
   }
@@ -216,9 +251,11 @@ public:
                                    camp::idx_t stride,
                                    camp::idx_t N) const
   {
+    element_type lanes[s_num_elem];
+    store_register(lanes, m_value);
     for (camp::idx_t i = 0; i < N; ++i)
     {
-      ptr[i * stride] = m_value[i];
+      ptr[i * stride] = lanes[i];
     }
     return *this;
   }
@@ -229,7 +266,7 @@ public:
    * @return Returns scalar value at i
    */
   RAJA_INLINE
-  element_type get(camp::idx_t i) const { return m_value[i]; }
+  element_type get(camp::idx_t i) const { return lane(m_value, i); }
 
   /*!
    * @brief Set scalar value in vector register
@@ -239,7 +276,10 @@ public:
   RAJA_INLINE
   self_type& set(element_type value, camp::idx_t i)
   {
-    m_value[i] = value;
+    element_type lanes[s_num_elem];
+    store_register(lanes, m_value);
+    lanes[i] = value;
+    m_value = load_register(lanes);
     return *this;
   }
 
@@ -257,8 +297,7 @@ public:
   RAJA_INLINE
   self_type& copy(self_type const& src)
   {
-    m_value = src.m_value;
-    return *this;
+    return assign_register(src.m_value);
   }
 
   RAJA_HOST_DEVICE
@@ -313,7 +352,7 @@ public:
   {
     auto sh1  = _mm256_permute_pd(m_value, 0x5);
     auto red1 = _mm256_add_pd(m_value, sh1);
-    return red1[0] + red1[2];
+    return lane(red1, 0) + lane(red1, 2);
   }
 
   /*!
@@ -335,7 +374,7 @@ public:
     register_type b = _mm256_max_pd(m_value, a);
 
     // now take the maximum of a lower and upper halves
-    return RAJA::max<element_type>(b[0], b[2]);
+    return RAJA::max<element_type>(lane(b, 0), lane(b, 2));
   }
 
   /*!
@@ -359,7 +398,7 @@ public:
       register_type b = _mm256_max_pd(m_value, a);
 
       // now take the maximum of a lower and upper halves
-      return RAJA::max<element_type>(b[0], b[2]);
+      return RAJA::max<element_type>(lane(b, 0), lane(b, 2));
     }
     else if (N == 3)
     {
@@ -377,15 +416,15 @@ public:
       register_type b = _mm256_max_pd(m_value, a);
 
       // now take the maximum of a lower and upper lane
-      return RAJA::max<element_type>(b[0], b[2]);
+      return RAJA::max<element_type>(lane(b, 0), lane(b, 2));
     }
     else if (N == 2)
     {
-      return RAJA::max<element_type>(m_value[0], m_value[1]);
+      return RAJA::max<element_type>(get(0), get(1));
     }
     else if (N == 1)
     {
-      return m_value[0];
+      return get(0);
     }
     return RAJA::operators::limits<double>::min();
   }
@@ -419,7 +458,7 @@ public:
     register_type b = _mm256_min_pd(m_value, a);
 
     // now take the minimum of a lower and upper halves
-    return RAJA::min<element_type>(b[0], b[2]);
+    return RAJA::min<element_type>(lane(b, 0), lane(b, 2));
   }
 
   /*!
@@ -443,7 +482,7 @@ public:
       register_type b = _mm256_min_pd(m_value, a);
 
       // now take the minimum of a lower and upper halves
-      return RAJA::min<element_type>(b[0], b[2]);
+      return RAJA::min<element_type>(lane(b, 0), lane(b, 2));
     }
     else if (N == 3)
     {
@@ -461,15 +500,15 @@ public:
       register_type b = _mm256_min_pd(m_value, a);
 
       // now take the minimum of a lower and upper lane
-      return RAJA::min<element_type>(b[0], b[2]);
+      return RAJA::min<element_type>(lane(b, 0), lane(b, 2));
     }
     else if (N == 2)
     {
-      return RAJA::min<element_type>(m_value[0], m_value[1]);
+      return RAJA::min<element_type>(get(0), get(1));
     }
     else if (N == 1)
     {
-      return m_value[0];
+      return get(0);
     }
     return RAJA::operators::limits<double>::max();
   }

--- a/include/RAJA/policy/tensor/arch/avx/avx_double.hpp
+++ b/include/RAJA/policy/tensor/arch/avx/avx_double.hpp
@@ -279,7 +279,7 @@ public:
     element_type lanes[s_num_elem];
     store_register(lanes, m_value);
     lanes[i] = value;
-    m_value = load_register(lanes);
+    m_value  = load_register(lanes);
     return *this;
   }
 
@@ -295,10 +295,7 @@ public:
   RAJA_HOST_DEVICE
 
   RAJA_INLINE
-  self_type& copy(self_type const& src)
-  {
-    return assign_register(src.m_value);
-  }
+  self_type& copy(self_type const& src) { return assign_register(src.m_value); }
 
   RAJA_HOST_DEVICE
 

--- a/include/RAJA/policy/tensor/arch/avx/avx_float.hpp
+++ b/include/RAJA/policy/tensor/arch/avx/avx_float.hpp
@@ -24,6 +24,7 @@
 
 #include "RAJA/config.hpp"
 #include "RAJA/util/macros.hpp"
+#include "RAJA/util/builtin_compat.hpp"
 #include "RAJA/pattern/tensor/internal/RegisterBase.hpp"
 
 // Include SIMD intrinsics header file
@@ -54,12 +55,67 @@ private:
   register_type m_value;
 
   RAJA_INLINE
+  static register_type make_register(element_type x0,
+                                     element_type x1,
+                                     element_type x2,
+                                     element_type x3,
+                                     element_type x4,
+                                     element_type x5,
+                                     element_type x6,
+                                     element_type x7)
+  {
+    return _mm256_set_ps(x7, x6, x5, x4, x3, x2, x1, x0);
+  }
+
+  RAJA_INLINE
   __m256i createMask(camp::idx_t N) const
   {
     // Generate a mask
     return _mm256_set_epi32(N >= 8 ? -1 : 0, N >= 7 ? -1 : 0, N >= 6 ? -1 : 0,
                             N >= 5 ? -1 : 0, N >= 4 ? -1 : 0, N >= 3 ? -1 : 0,
                             N >= 2 ? -1 : 0, N >= 1 ? -1 : 0);
+  }
+
+  static RAJA_NOINLINE element_type load_scalar(
+      element_type const* ptr)
+  {
+    element_type value;
+    RAJA_BUILTIN_MEMCPY(&value, ptr, sizeof(value));
+    return value;
+  }
+
+  RAJA_INLINE
+  static register_type load_register(element_type const* ptr)
+  {
+    return make_register(load_scalar(ptr + 0),
+                         load_scalar(ptr + 1),
+                         load_scalar(ptr + 2),
+                         load_scalar(ptr + 3),
+                         load_scalar(ptr + 4),
+                         load_scalar(ptr + 5),
+                         load_scalar(ptr + 6),
+                         load_scalar(ptr + 7));
+  }
+
+  RAJA_INLINE
+  static void store_register(element_type* ptr, register_type value)
+  {
+    _mm256_storeu_ps(ptr, value);
+  }
+
+  RAJA_INLINE
+  self_type& assign_register(register_type value)
+  {
+    RAJA_BUILTIN_MEMCPY(&m_value, &value, sizeof(m_value));
+    return *this;
+  }
+
+  RAJA_INLINE
+  static element_type lane(register_type value, camp::idx_t i)
+  {
+    element_type lanes[s_num_elem];
+    store_register(lanes, value);
+    return lanes[i];
   }
 
 public:
@@ -96,7 +152,10 @@ public:
    * @brief Copy constructor
    */
   RAJA_INLINE
-  Register(self_type const& c) : base_type(), m_value(c.m_value) {}
+  Register(self_type const& c) : base_type(), m_value(_mm256_setzero_ps())
+  {
+    assign_register(c.m_value);
+  }
 
   /*!
    * @brief Copy assignment constructor
@@ -104,8 +163,7 @@ public:
   RAJA_INLINE
   self_type& operator=(self_type const& c)
   {
-    m_value = c.m_value;
-    return *this;
+    return assign_register(c.m_value);
   }
 
   /*!
@@ -122,8 +180,7 @@ public:
   RAJA_INLINE
   self_type& load_packed(element_type const* ptr)
   {
-    m_value = _mm256_loadu_ps(ptr);
-    return *this;
+    return assign_register(load_register(ptr));
   }
 
   /*!
@@ -145,11 +202,14 @@ public:
   RAJA_INLINE
   self_type& load_strided(element_type const* ptr, camp::idx_t stride)
   {
-    for (camp::idx_t i = 0; i < 8; ++i)
-    {
-      m_value[i] = ptr[i * stride];
-    }
-    return *this;
+    return assign_register(make_register(load_scalar(ptr + 0 * stride),
+                                         load_scalar(ptr + 1 * stride),
+                                         load_scalar(ptr + 2 * stride),
+                                         load_scalar(ptr + 3 * stride),
+                                         load_scalar(ptr + 4 * stride),
+                                         load_scalar(ptr + 5 * stride),
+                                         load_scalar(ptr + 6 * stride),
+                                         load_scalar(ptr + 7 * stride)));
   }
 
   /*!
@@ -162,12 +222,19 @@ public:
                             camp::idx_t stride,
                             camp::idx_t N)
   {
-    m_value = _mm256_setzero_ps();
-    for (camp::idx_t i = 0; i < N; ++i)
-    {
-      m_value[i] = ptr[i * stride];
-    }
-    return *this;
+    camp::idx_t count = N < s_num_elem ? N : s_num_elem;
+
+    element_type x0 = count > 0 ? load_scalar(ptr + 0 * stride) : 0.0f;
+    element_type x1 = count > 1 ? load_scalar(ptr + 1 * stride) : 0.0f;
+    element_type x2 = count > 2 ? load_scalar(ptr + 2 * stride) : 0.0f;
+    element_type x3 = count > 3 ? load_scalar(ptr + 3 * stride) : 0.0f;
+    element_type x4 = count > 4 ? load_scalar(ptr + 4 * stride) : 0.0f;
+    element_type x5 = count > 5 ? load_scalar(ptr + 5 * stride) : 0.0f;
+    element_type x6 = count > 6 ? load_scalar(ptr + 6 * stride) : 0.0f;
+    element_type x7 = count > 7 ? load_scalar(ptr + 7 * stride) : 0.0f;
+
+    return assign_register(
+        make_register(x0, x1, x2, x3, x4, x5, x6, x7));
   }
 
   /*!
@@ -177,7 +244,7 @@ public:
   RAJA_INLINE
   self_type const& store_packed(element_type* ptr) const
   {
-    _mm256_storeu_ps(ptr, m_value);
+    store_register(ptr, m_value);
     return *this;
   }
 
@@ -199,9 +266,11 @@ public:
   RAJA_INLINE
   self_type const& store_strided(element_type* ptr, camp::idx_t stride) const
   {
+    element_type lanes[s_num_elem];
+    store_register(lanes, m_value);
     for (camp::idx_t i = 0; i < 8; ++i)
     {
-      ptr[i * stride] = m_value[i];
+      ptr[i * stride] = lanes[i];
     }
     return *this;
   }
@@ -215,9 +284,11 @@ public:
                                    camp::idx_t stride,
                                    camp::idx_t N) const
   {
+    element_type lanes[s_num_elem];
+    store_register(lanes, m_value);
     for (camp::idx_t i = 0; i < N; ++i)
     {
-      ptr[i * stride] = m_value[i];
+      ptr[i * stride] = lanes[i];
     }
     return *this;
   }
@@ -228,7 +299,7 @@ public:
    * @return Returns scalar value at i
    */
   RAJA_INLINE
-  element_type get(camp::idx_t i) const { return m_value[i]; }
+  element_type get(camp::idx_t i) const { return lane(m_value, i); }
 
   /*!
    * @brief Set scalar value in vector register
@@ -238,7 +309,10 @@ public:
   RAJA_INLINE
   self_type& set(element_type value, camp::idx_t i)
   {
-    m_value[i] = value;
+    element_type lanes[s_num_elem];
+    store_register(lanes, m_value);
+    lanes[i] = value;
+    m_value = load_register(lanes);
     return *this;
   }
 
@@ -256,8 +330,7 @@ public:
   RAJA_INLINE
   self_type& copy(self_type const& src)
   {
-    m_value = src.m_value;
-    return *this;
+    return assign_register(src.m_value);
   }
 
   RAJA_HOST_DEVICE
@@ -320,7 +393,7 @@ public:
     auto sh2  = _mm256_permute_ps(red1, 0x4E);
     auto red2 = _mm256_add_ps(red1, sh2);
 
-    return red2[0] + red2[4];
+    return lane(red2, 0) + lane(red2, 4);
   }
 
   /*!
@@ -339,7 +412,7 @@ public:
     auto red2 = _mm256_max_ps(red1, sh2);
 
     // combine quads
-    return RAJA::max<element_type>(red2[0], red2[4]);
+    return RAJA::max<element_type>(lane(red2, 0), lane(red2, 4));
   }
 
   /*!
@@ -356,11 +429,11 @@ public:
     }
     if (N == 1)
     {
-      return m_value[0];
+      return get(0);
     }
     if (N == 2)
     {
-      return RAJA::max<element_type>(m_value[0], m_value[1]);
+      return RAJA::max<element_type>(get(0), get(1));
     }
 
     // swap odd-even pairs and add
@@ -377,7 +450,7 @@ public:
     // Some more simple shortcuts
     if (N == 3)
     {
-      return RAJA::max<element_type>(red1[0], m_value[2]);
+      return RAJA::max<element_type>(lane(red1, 0), get(2));
     }
 
 
@@ -387,19 +460,19 @@ public:
 
     if (N == 4)
     {
-      return red2[0];
+      return lane(red2, 0);
     }
     if (N == 5)
     {
-      return RAJA::max<element_type>(red2[0], m_value[4]);
+      return RAJA::max<element_type>(lane(red2, 0), get(4));
     }
     if (N == 6)
     {
-      return RAJA::max<element_type>(red2[0], red1[4]);
+      return RAJA::max<element_type>(lane(red2, 0), lane(red1, 4));
     }
 
     // 7 or 8 lanes
-    return RAJA::max<element_type>(red2[0], red2[4]);
+    return RAJA::max<element_type>(lane(red2, 0), lane(red2, 4));
   }
 
   /*!
@@ -428,7 +501,7 @@ public:
     auto red2 = _mm256_min_ps(red1, sh2);
 
     // combine quads
-    return RAJA::min<element_type>(red2[0], red2[4]);
+    return RAJA::min<element_type>(lane(red2, 0), lane(red2, 4));
   }
 
   /*!
@@ -445,11 +518,11 @@ public:
     }
     if (N == 1)
     {
-      return m_value[0];
+      return get(0);
     }
     if (N == 2)
     {
-      return RAJA::min<element_type>(m_value[0], m_value[1]);
+      return RAJA::min<element_type>(get(0), get(1));
     }
 
     // swap odd-even pairs and add
@@ -466,7 +539,7 @@ public:
     // Some more simple shortcuts
     if (N == 3)
     {
-      return RAJA::min<element_type>(red1[0], m_value[2]);
+      return RAJA::min<element_type>(lane(red1, 0), get(2));
     }
 
 
@@ -476,19 +549,19 @@ public:
 
     if (N == 4)
     {
-      return red2[0];
+      return lane(red2, 0);
     }
     if (N == 5)
     {
-      return RAJA::min<element_type>(red2[0], m_value[4]);
+      return RAJA::min<element_type>(lane(red2, 0), get(4));
     }
     if (N == 6)
     {
-      return RAJA::min<element_type>(red2[0], red1[4]);
+      return RAJA::min<element_type>(lane(red2, 0), lane(red1, 4));
     }
 
     // 7 or 8 lanes
-    return RAJA::min<element_type>(red2[0], red2[4]);
+    return RAJA::min<element_type>(lane(red2, 0), lane(red2, 4));
   }
 
   /*!

--- a/include/RAJA/policy/tensor/arch/avx/avx_float.hpp
+++ b/include/RAJA/policy/tensor/arch/avx/avx_float.hpp
@@ -76,8 +76,7 @@ private:
                             N >= 2 ? -1 : 0, N >= 1 ? -1 : 0);
   }
 
-  static RAJA_NOINLINE element_type load_scalar(
-      element_type const* ptr)
+  static RAJA_NOINLINE element_type load_scalar(element_type const* ptr)
   {
     element_type value;
     RAJA_BUILTIN_MEMCPY(&value, ptr, sizeof(value));
@@ -87,14 +86,10 @@ private:
   RAJA_INLINE
   static register_type load_register(element_type const* ptr)
   {
-    return make_register(load_scalar(ptr + 0),
-                         load_scalar(ptr + 1),
-                         load_scalar(ptr + 2),
-                         load_scalar(ptr + 3),
-                         load_scalar(ptr + 4),
-                         load_scalar(ptr + 5),
-                         load_scalar(ptr + 6),
-                         load_scalar(ptr + 7));
+    return make_register(load_scalar(ptr + 0), load_scalar(ptr + 1),
+                         load_scalar(ptr + 2), load_scalar(ptr + 3),
+                         load_scalar(ptr + 4), load_scalar(ptr + 5),
+                         load_scalar(ptr + 6), load_scalar(ptr + 7));
   }
 
   RAJA_INLINE
@@ -202,14 +197,11 @@ public:
   RAJA_INLINE
   self_type& load_strided(element_type const* ptr, camp::idx_t stride)
   {
-    return assign_register(make_register(load_scalar(ptr + 0 * stride),
-                                         load_scalar(ptr + 1 * stride),
-                                         load_scalar(ptr + 2 * stride),
-                                         load_scalar(ptr + 3 * stride),
-                                         load_scalar(ptr + 4 * stride),
-                                         load_scalar(ptr + 5 * stride),
-                                         load_scalar(ptr + 6 * stride),
-                                         load_scalar(ptr + 7 * stride)));
+    return assign_register(make_register(
+        load_scalar(ptr + 0 * stride), load_scalar(ptr + 1 * stride),
+        load_scalar(ptr + 2 * stride), load_scalar(ptr + 3 * stride),
+        load_scalar(ptr + 4 * stride), load_scalar(ptr + 5 * stride),
+        load_scalar(ptr + 6 * stride), load_scalar(ptr + 7 * stride)));
   }
 
   /*!
@@ -233,8 +225,7 @@ public:
     element_type x6 = count > 6 ? load_scalar(ptr + 6 * stride) : 0.0f;
     element_type x7 = count > 7 ? load_scalar(ptr + 7 * stride) : 0.0f;
 
-    return assign_register(
-        make_register(x0, x1, x2, x3, x4, x5, x6, x7));
+    return assign_register(make_register(x0, x1, x2, x3, x4, x5, x6, x7));
   }
 
   /*!
@@ -312,7 +303,7 @@ public:
     element_type lanes[s_num_elem];
     store_register(lanes, m_value);
     lanes[i] = value;
-    m_value = load_register(lanes);
+    m_value  = load_register(lanes);
     return *this;
   }
 
@@ -328,10 +319,7 @@ public:
   RAJA_HOST_DEVICE
 
   RAJA_INLINE
-  self_type& copy(self_type const& src)
-  {
-    return assign_register(src.m_value);
-  }
+  self_type& copy(self_type const& src) { return assign_register(src.m_value); }
 
   RAJA_HOST_DEVICE
 

--- a/include/RAJA/policy/tensor/arch/avx/avx_int32.hpp
+++ b/include/RAJA/policy/tensor/arch/avx/avx_int32.hpp
@@ -24,6 +24,7 @@
 
 #include "RAJA/config.hpp"
 #include "RAJA/util/macros.hpp"
+#include "RAJA/util/builtin_compat.hpp"
 #include "RAJA/pattern/tensor/internal/RegisterBase.hpp"
 
 // Include SIMD intrinsics header file
@@ -88,6 +89,25 @@ private:
                             N >= 4 ? 3 : 0, N >= 2 ? 2 : 0);
   }
 
+  RAJA_INLINE
+  static register_type load_register(element_type const* ptr)
+  {
+    return _mm256_loadu_si256(reinterpret_cast<__m256i const*>(ptr));
+  }
+
+  RAJA_INLINE
+  static void store_register(element_type* ptr, register_type value)
+  {
+    _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), value);
+  }
+
+  RAJA_INLINE
+  self_type& assign_register(register_type value)
+  {
+    RAJA_BUILTIN_MEMCPY(&m_value, &value, sizeof(m_value));
+    return *this;
+  }
+
 public:
   static constexpr camp::idx_t s_num_elem = 8;
 
@@ -122,7 +142,10 @@ public:
    * @brief Copy constructor
    */
   RAJA_INLINE
-  Register(self_type const& c) : base_type(), m_value(c.m_value) {}
+  Register(self_type const& c) : base_type(), m_value(_mm256_setzero_si256())
+  {
+    assign_register(c.m_value);
+  }
 
   /*!
    * @brief Copy assignment constructor
@@ -130,8 +153,7 @@ public:
   RAJA_INLINE
   self_type& operator=(self_type const& c)
   {
-    m_value = c.m_value;
-    return *this;
+    return assign_register(c.m_value);
   }
 
   /*!
@@ -338,8 +360,7 @@ public:
   RAJA_INLINE
   self_type& copy(self_type const& src)
   {
-    m_value = src.m_value;
-    return *this;
+    return assign_register(src.m_value);
   }
 
   RAJA_HOST_DEVICE

--- a/include/RAJA/policy/tensor/arch/avx/avx_int32.hpp
+++ b/include/RAJA/policy/tensor/arch/avx/avx_int32.hpp
@@ -358,10 +358,7 @@ public:
   RAJA_HOST_DEVICE
 
   RAJA_INLINE
-  self_type& copy(self_type const& src)
-  {
-    return assign_register(src.m_value);
-  }
+  self_type& copy(self_type const& src) { return assign_register(src.m_value); }
 
   RAJA_HOST_DEVICE
 

--- a/include/RAJA/policy/tensor/arch/avx/avx_int64.hpp
+++ b/include/RAJA/policy/tensor/arch/avx/avx_int64.hpp
@@ -24,6 +24,7 @@
 
 #include "RAJA/config.hpp"
 #include "RAJA/util/macros.hpp"
+#include "RAJA/util/builtin_compat.hpp"
 #include "RAJA/pattern/tensor/internal/RegisterBase.hpp"
 
 // Include SIMD intrinsics header file
@@ -54,6 +55,15 @@ private:
   register_type m_value;
 
   RAJA_INLINE
+  static register_type make_register(element_type x0,
+                                     element_type x1,
+                                     element_type x2,
+                                     element_type x3)
+  {
+    return _mm256_set_epi64x(x3, x2, x1, x0);
+  }
+
+  RAJA_INLINE
   __m256i createMask(camp::idx_t N) const
   {
     // Generate a mask
@@ -78,6 +88,36 @@ private:
   RAJA_INLINE __m256i permute(__m256i x) const
   {
     return _mm256_castpd_si256(_mm256_permute_pd(_mm256_castsi256_pd(x), perm));
+  }
+
+  static RAJA_NOINLINE element_type load_scalar(
+      element_type const* ptr)
+  {
+    element_type value;
+    RAJA_BUILTIN_MEMCPY(&value, ptr, sizeof(value));
+    return value;
+  }
+
+  RAJA_INLINE
+  static register_type load_register(element_type const* ptr)
+  {
+    return make_register(load_scalar(ptr + 0),
+                         load_scalar(ptr + 1),
+                         load_scalar(ptr + 2),
+                         load_scalar(ptr + 3));
+  }
+
+  RAJA_INLINE
+  static void store_register(element_type* ptr, register_type value)
+  {
+    _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), value);
+  }
+
+  RAJA_INLINE
+  self_type& assign_register(register_type value)
+  {
+    RAJA_BUILTIN_MEMCPY(&m_value, &value, sizeof(m_value));
+    return *this;
   }
 
 public:
@@ -107,7 +147,10 @@ public:
    * @brief Copy constructor
    */
   RAJA_INLINE
-  Register(self_type const& c) : base_type(), m_value(c.m_value) {}
+  Register(self_type const& c) : base_type(), m_value(_mm256_setzero_si256())
+  {
+    assign_register(c.m_value);
+  }
 
   /*!
    * @brief Copy assignment constructor
@@ -115,8 +158,7 @@ public:
   RAJA_INLINE
   self_type& operator=(self_type const& c)
   {
-    m_value = c.m_value;
-    return *this;
+    return assign_register(c.m_value);
   }
 
   /*!
@@ -133,8 +175,7 @@ public:
   RAJA_INLINE
   self_type& load_packed(element_type const* ptr)
   {
-    m_value = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(ptr));
-    return *this;
+    return assign_register(load_register(ptr));
   }
 
   /*!
@@ -157,11 +198,10 @@ public:
   RAJA_INLINE
   self_type& load_strided(element_type const* ptr, camp::idx_t stride)
   {
-    for (camp::idx_t i = 0; i < 4; ++i)
-    {
-      m_value[i] = ptr[i * stride];
-    }
-    return *this;
+    return assign_register(make_register(load_scalar(ptr + 0 * stride),
+                                         load_scalar(ptr + 1 * stride),
+                                         load_scalar(ptr + 2 * stride),
+                                         load_scalar(ptr + 3 * stride)));
   }
 
   /*!
@@ -174,12 +214,14 @@ public:
                             camp::idx_t stride,
                             camp::idx_t N)
   {
-    m_value = _mm256_setzero_si256();
-    for (camp::idx_t i = 0; i < N; ++i)
-    {
-      m_value[i] = ptr[i * stride];
-    }
-    return *this;
+    camp::idx_t count = N < s_num_elem ? N : s_num_elem;
+
+    element_type x0 = count > 0 ? load_scalar(ptr + 0 * stride) : 0;
+    element_type x1 = count > 1 ? load_scalar(ptr + 1 * stride) : 0;
+    element_type x2 = count > 2 ? load_scalar(ptr + 2 * stride) : 0;
+    element_type x3 = count > 3 ? load_scalar(ptr + 3 * stride) : 0;
+
+    return assign_register(make_register(x0, x1, x2, x3));
   }
 
   /*!
@@ -189,7 +231,7 @@ public:
   RAJA_INLINE
   self_type const& store_packed(element_type* ptr) const
   {
-    _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), m_value);
+    store_register(ptr, m_value);
     return *this;
   }
 
@@ -212,9 +254,11 @@ public:
   RAJA_INLINE
   self_type const& store_strided(element_type* ptr, camp::idx_t stride) const
   {
+    element_type lanes[s_num_elem];
+    store_register(lanes, m_value);
     for (camp::idx_t i = 0; i < 4; ++i)
     {
-      ptr[i * stride] = m_value[i];
+      ptr[i * stride] = lanes[i];
     }
     return *this;
   }
@@ -228,9 +272,11 @@ public:
                                    camp::idx_t stride,
                                    camp::idx_t N) const
   {
+    element_type lanes[s_num_elem];
+    store_register(lanes, m_value);
     for (camp::idx_t i = 0; i < N; ++i)
     {
-      ptr[i * stride] = m_value[i];
+      ptr[i * stride] = lanes[i];
     }
     return *this;
   }
@@ -300,8 +346,7 @@ public:
   RAJA_INLINE
   self_type& copy(self_type const& src)
   {
-    m_value = src.m_value;
-    return *this;
+    return assign_register(src.m_value);
   }
 
   RAJA_HOST_DEVICE

--- a/include/RAJA/policy/tensor/arch/avx/avx_int64.hpp
+++ b/include/RAJA/policy/tensor/arch/avx/avx_int64.hpp
@@ -90,8 +90,7 @@ private:
     return _mm256_castpd_si256(_mm256_permute_pd(_mm256_castsi256_pd(x), perm));
   }
 
-  static RAJA_NOINLINE element_type load_scalar(
-      element_type const* ptr)
+  static RAJA_NOINLINE element_type load_scalar(element_type const* ptr)
   {
     element_type value;
     RAJA_BUILTIN_MEMCPY(&value, ptr, sizeof(value));
@@ -101,10 +100,8 @@ private:
   RAJA_INLINE
   static register_type load_register(element_type const* ptr)
   {
-    return make_register(load_scalar(ptr + 0),
-                         load_scalar(ptr + 1),
-                         load_scalar(ptr + 2),
-                         load_scalar(ptr + 3));
+    return make_register(load_scalar(ptr + 0), load_scalar(ptr + 1),
+                         load_scalar(ptr + 2), load_scalar(ptr + 3));
   }
 
   RAJA_INLINE
@@ -198,10 +195,9 @@ public:
   RAJA_INLINE
   self_type& load_strided(element_type const* ptr, camp::idx_t stride)
   {
-    return assign_register(make_register(load_scalar(ptr + 0 * stride),
-                                         load_scalar(ptr + 1 * stride),
-                                         load_scalar(ptr + 2 * stride),
-                                         load_scalar(ptr + 3 * stride)));
+    return assign_register(make_register(
+        load_scalar(ptr + 0 * stride), load_scalar(ptr + 1 * stride),
+        load_scalar(ptr + 2 * stride), load_scalar(ptr + 3 * stride)));
   }
 
   /*!
@@ -344,10 +340,7 @@ public:
   RAJA_HOST_DEVICE
 
   RAJA_INLINE
-  self_type& copy(self_type const& src)
-  {
-    return assign_register(src.m_value);
-  }
+  self_type& copy(self_type const& src) { return assign_register(src.m_value); }
 
   RAJA_HOST_DEVICE
 

--- a/include/RAJA/policy/tensor/arch/avx2/avx2_double.hpp
+++ b/include/RAJA/policy/tensor/arch/avx2/avx2_double.hpp
@@ -78,8 +78,7 @@ private:
     return _mm256_set_epi64x(3 * stride, 2 * stride, stride, 0);
   }
 
-  static RAJA_NOINLINE element_type load_scalar(
-      element_type const* ptr)
+  static RAJA_NOINLINE element_type load_scalar(element_type const* ptr)
   {
     element_type value;
     RAJA_BUILTIN_MEMCPY(&value, ptr, sizeof(value));
@@ -89,10 +88,8 @@ private:
   RAJA_INLINE
   static register_type load_register(element_type const* ptr)
   {
-    return make_register(load_scalar(ptr + 0),
-                         load_scalar(ptr + 1),
-                         load_scalar(ptr + 2),
-                         load_scalar(ptr + 3));
+    return make_register(load_scalar(ptr + 0), load_scalar(ptr + 1),
+                         load_scalar(ptr + 2), load_scalar(ptr + 3));
   }
 
   RAJA_INLINE
@@ -362,7 +359,7 @@ public:
     element_type lanes[s_num_elem];
     store_register(lanes, m_value);
     lanes[i] = value;
-    m_value = load_register(lanes);
+    m_value  = load_register(lanes);
     return *this;
   }
 
@@ -400,10 +397,7 @@ public:
   RAJA_HOST_DEVICE
 
   RAJA_INLINE
-  self_type& copy(self_type const& src)
-  {
-    return assign_register(src.m_value);
-  }
+  self_type& copy(self_type const& src) { return assign_register(src.m_value); }
 
   RAJA_HOST_DEVICE
 

--- a/include/RAJA/policy/tensor/arch/avx2/avx2_double.hpp
+++ b/include/RAJA/policy/tensor/arch/avx2/avx2_double.hpp
@@ -24,6 +24,7 @@
 
 #include "RAJA/config.hpp"
 #include "RAJA/util/macros.hpp"
+#include "RAJA/util/builtin_compat.hpp"
 #include "RAJA/pattern/tensor/internal/RegisterBase.hpp"
 
 // Include SIMD intrinsics header file
@@ -54,6 +55,15 @@ private:
   register_type m_value;
 
   RAJA_INLINE
+  static register_type make_register(element_type x0,
+                                     element_type x1,
+                                     element_type x2,
+                                     element_type x3)
+  {
+    return _mm256_set_pd(x3, x2, x1, x0);
+  }
+
+  RAJA_INLINE
   __m256i createMask(camp::idx_t N) const
   {
     // Generate a mask
@@ -66,6 +76,44 @@ private:
   {
     // Generate a strided offset list
     return _mm256_set_epi64x(3 * stride, 2 * stride, stride, 0);
+  }
+
+  static RAJA_NOINLINE element_type load_scalar(
+      element_type const* ptr)
+  {
+    element_type value;
+    RAJA_BUILTIN_MEMCPY(&value, ptr, sizeof(value));
+    return value;
+  }
+
+  RAJA_INLINE
+  static register_type load_register(element_type const* ptr)
+  {
+    return make_register(load_scalar(ptr + 0),
+                         load_scalar(ptr + 1),
+                         load_scalar(ptr + 2),
+                         load_scalar(ptr + 3));
+  }
+
+  RAJA_INLINE
+  static void store_register(element_type* ptr, register_type value)
+  {
+    _mm256_storeu_pd(ptr, value);
+  }
+
+  RAJA_INLINE
+  self_type& assign_register(register_type value)
+  {
+    RAJA_BUILTIN_MEMCPY(&m_value, &value, sizeof(m_value));
+    return *this;
+  }
+
+  RAJA_INLINE
+  static element_type lane(register_type value, camp::idx_t i)
+  {
+    element_type lanes[s_num_elem];
+    store_register(lanes, value);
+    return lanes[i];
   }
 
 public:
@@ -95,7 +143,10 @@ public:
    * @brief Copy constructor
    */
   RAJA_INLINE
-  Register(self_type const& c) : base_type(c), m_value(c.m_value) {}
+  Register(self_type const& c) : base_type(c), m_value(_mm256_setzero_pd())
+  {
+    assign_register(c.m_value);
+  }
 
   /*!
    * @brief Copy assignment constructor
@@ -103,8 +154,7 @@ public:
   RAJA_INLINE
   self_type& operator=(self_type const& c)
   {
-    m_value = c.m_value;
-    return *this;
+    return assign_register(c.m_value);
   }
 
   /*!
@@ -130,8 +180,7 @@ public:
 #ifdef RAJA_ENABLE_VECTOR_STATS
     RAJA::tensor_stats::num_vector_load_packed++;
 #endif
-    m_value = _mm256_loadu_pd(ptr);
-    return *this;
+    return assign_register(load_register(ptr));
   }
 
   /*!
@@ -236,7 +285,7 @@ public:
 #ifdef RAJA_ENABLE_VECTOR_STATS
     RAJA::tensor_stats::num_vector_store_packed++;
 #endif
-    _mm256_storeu_pd(ptr, m_value);
+    store_register(ptr, m_value);
     return *this;
   }
 
@@ -264,9 +313,11 @@ public:
 #ifdef RAJA_ENABLE_VECTOR_STATS
     RAJA::tensor_stats::num_vector_store_strided++;
 #endif
+    element_type lanes[s_num_elem];
+    store_register(lanes, m_value);
     for (camp::idx_t i = 0; i < 4; ++i)
     {
-      ptr[i * stride] = m_value[i];
+      ptr[i * stride] = lanes[i];
     }
     return *this;
   }
@@ -283,9 +334,11 @@ public:
 #ifdef RAJA_ENABLE_VECTOR_STATS
     RAJA::tensor_stats::num_vector_store_strided_n++;
 #endif
+    element_type lanes[s_num_elem];
+    store_register(lanes, m_value);
     for (camp::idx_t i = 0; i < N; ++i)
     {
-      ptr[i * stride] = m_value[i];
+      ptr[i * stride] = lanes[i];
     }
     return *this;
   }
@@ -296,7 +349,7 @@ public:
    * @return Returns scalar value at i
    */
   RAJA_INLINE
-  element_type get(camp::idx_t i) const { return m_value[i]; }
+  element_type get(camp::idx_t i) const { return lane(m_value, i); }
 
   /*!
    * @brief Set scalar value in vector register
@@ -306,7 +359,10 @@ public:
   RAJA_INLINE
   self_type& set(element_type value, camp::idx_t i)
   {
-    m_value[i] = value;
+    element_type lanes[s_num_elem];
+    store_register(lanes, m_value);
+    lanes[i] = value;
+    m_value = load_register(lanes);
     return *this;
   }
 
@@ -346,8 +402,7 @@ public:
   RAJA_INLINE
   self_type& copy(self_type const& src)
   {
-    m_value = src.m_value;
-    return *this;
+    return assign_register(src.m_value);
   }
 
   RAJA_HOST_DEVICE
@@ -421,7 +476,7 @@ public:
   {
     auto sh1  = _mm256_permute_pd(m_value, 0x5);
     auto red1 = _mm256_add_pd(m_value, sh1);
-    return red1[0] + red1[2];
+    return lane(red1, 0) + lane(red1, 2);
   }
 
   /*!
@@ -445,7 +500,7 @@ public:
       register_type b = _mm256_max_pd(m_value, a);
 
       // now take the maximum of a lower and upper halves
-      return RAJA::max<element_type>(b[0], b[2]);
+      return RAJA::max<element_type>(lane(b, 0), lane(b, 2));
     }
     else if (N == 3)
     {
@@ -463,15 +518,15 @@ public:
       register_type b = _mm256_max_pd(m_value, a);
 
       // now take the maximum of a lower and upper lane
-      return RAJA::max<element_type>(b[0], b[2]);
+      return RAJA::max<element_type>(lane(b, 0), lane(b, 2));
     }
     else if (N == 2)
     {
-      return RAJA::max<element_type>(m_value[0], m_value[1]);
+      return RAJA::max<element_type>(get(0), get(1));
     }
     else if (N == 1)
     {
-      return m_value[0];
+      return get(0);
     }
     return RAJA::operators::limits<double>::min();
   }
@@ -505,7 +560,7 @@ public:
     register_type b = _mm256_min_pd(m_value, a);
 
     // now take the minimum of a lower and upper halves
-    return RAJA::min<element_type>(b[0], b[2]);
+    return RAJA::min<element_type>(lane(b, 0), lane(b, 2));
   }
 
   /*!
@@ -529,7 +584,7 @@ public:
       register_type b = _mm256_min_pd(m_value, a);
 
       // now take the minimum of a lower and upper halves
-      return std::min<element_type>(b[0], b[2]);
+      return std::min<element_type>(lane(b, 0), lane(b, 2));
     }
     else if (N == 3)
     {
@@ -547,15 +602,15 @@ public:
       register_type b = _mm256_min_pd(m_value, a);
 
       // now take the minimum of a lower and upper lane
-      return std::min<element_type>(b[0], b[2]);
+      return std::min<element_type>(lane(b, 0), lane(b, 2));
     }
     else if (N == 2)
     {
-      return std::min<element_type>(m_value[0], m_value[1]);
+      return std::min<element_type>(get(0), get(1));
     }
     else if (N == 1)
     {
-      return m_value[0];
+      return get(0);
     }
     return RAJA::operators::limits<double>::max();
   }

--- a/include/RAJA/policy/tensor/arch/avx2/avx2_float.hpp
+++ b/include/RAJA/policy/tensor/arch/avx2/avx2_float.hpp
@@ -24,6 +24,7 @@
 
 #include "RAJA/config.hpp"
 #include "RAJA/util/macros.hpp"
+#include "RAJA/util/builtin_compat.hpp"
 #include "RAJA/pattern/tensor/internal/RegisterBase.hpp"
 
 // Include SIMD intrinsics header file
@@ -52,6 +53,19 @@ public:
 
 private:
   register_type m_value;
+
+  RAJA_INLINE
+  static register_type make_register(element_type x0,
+                                     element_type x1,
+                                     element_type x2,
+                                     element_type x3,
+                                     element_type x4,
+                                     element_type x5,
+                                     element_type x6,
+                                     element_type x7)
+  {
+    return _mm256_set_ps(x7, x6, x5, x4, x3, x2, x1, x0);
+  }
 
   RAJA_INLINE
   __m256i createMask(camp::idx_t N) const
@@ -88,6 +102,48 @@ private:
                             N >= 4 ? 3 : 0, N >= 2 ? 2 : 0);
   }
 
+  static RAJA_NOINLINE element_type load_scalar(
+      element_type const* ptr)
+  {
+    element_type value;
+    RAJA_BUILTIN_MEMCPY(&value, ptr, sizeof(value));
+    return value;
+  }
+
+  RAJA_INLINE
+  static register_type load_register(element_type const* ptr)
+  {
+    return make_register(load_scalar(ptr + 0),
+                         load_scalar(ptr + 1),
+                         load_scalar(ptr + 2),
+                         load_scalar(ptr + 3),
+                         load_scalar(ptr + 4),
+                         load_scalar(ptr + 5),
+                         load_scalar(ptr + 6),
+                         load_scalar(ptr + 7));
+  }
+
+  RAJA_INLINE
+  static void store_register(element_type* ptr, register_type value)
+  {
+    _mm256_storeu_ps(ptr, value);
+  }
+
+  RAJA_INLINE
+  self_type& assign_register(register_type value)
+  {
+    RAJA_BUILTIN_MEMCPY(&m_value, &value, sizeof(m_value));
+    return *this;
+  }
+
+  RAJA_INLINE
+  static element_type lane(register_type value, camp::idx_t i)
+  {
+    element_type lanes[s_num_elem];
+    store_register(lanes, value);
+    return lanes[i];
+  }
+
 public:
   static constexpr camp::idx_t s_num_elem = 8;
 
@@ -122,7 +178,10 @@ public:
    * @brief Copy constructor
    */
   RAJA_INLINE
-  Register(self_type const& c) : base_type(c), m_value(c.m_value) {}
+  Register(self_type const& c) : base_type(c), m_value(_mm256_setzero_ps())
+  {
+    assign_register(c.m_value);
+  }
 
   /*!
    * @brief Copy assignment constructor
@@ -130,8 +189,7 @@ public:
   RAJA_INLINE
   self_type& operator=(self_type const& c)
   {
-    m_value = c.m_value;
-    return *this;
+    return assign_register(c.m_value);
   }
 
   /*!
@@ -154,8 +212,7 @@ public:
   RAJA_INLINE
   self_type& load_packed(element_type const* ptr)
   {
-    m_value = _mm256_loadu_ps(ptr);
-    return *this;
+    return assign_register(load_register(ptr));
   }
 
   /*!
@@ -227,9 +284,11 @@ public:
   RAJA_INLINE
   self_type const& store_strided(element_type* ptr, camp::idx_t stride) const
   {
+    element_type lanes[s_num_elem];
+    store_register(lanes, m_value);
     for (camp::idx_t i = 0; i < 8; ++i)
     {
-      ptr[i * stride] = m_value[i];
+      ptr[i * stride] = lanes[i];
     }
     return *this;
   }
@@ -243,9 +302,11 @@ public:
                                    camp::idx_t stride,
                                    camp::idx_t N) const
   {
+    element_type lanes[s_num_elem];
+    store_register(lanes, m_value);
     for (camp::idx_t i = 0; i < N; ++i)
     {
-      ptr[i * stride] = m_value[i];
+      ptr[i * stride] = lanes[i];
     }
     return *this;
   }
@@ -256,7 +317,7 @@ public:
    * @return Returns scalar value at i
    */
   RAJA_INLINE
-  element_type get(camp::idx_t i) const { return m_value[i]; }
+  element_type get(camp::idx_t i) const { return lane(m_value, i); }
 
   /*!
    * @brief Set scalar value in vector register
@@ -266,7 +327,10 @@ public:
   RAJA_INLINE
   self_type& set(element_type value, camp::idx_t i)
   {
-    m_value[i] = value;
+    element_type lanes[s_num_elem];
+    store_register(lanes, m_value);
+    lanes[i] = value;
+    m_value = load_register(lanes);
     return *this;
   }
 
@@ -284,8 +348,7 @@ public:
   RAJA_INLINE
   self_type& copy(self_type const& src)
   {
-    m_value = src.m_value;
-    return *this;
+    return assign_register(src.m_value);
   }
 
   RAJA_HOST_DEVICE
@@ -367,7 +430,7 @@ public:
     auto sh2  = _mm256_permute_ps(red1, 0x4E);
     auto red2 = _mm256_add_ps(red1, sh2);
 
-    return red2[0] + red2[4];
+    return lane(red2, 0) + lane(red2, 4);
   }
 
   /*!
@@ -386,7 +449,7 @@ public:
     auto sh2  = _mm256_permutevar8x32_ps(red1, createPermute2(8));
     auto red2 = _mm256_max_ps(red1, sh2);
 
-    return std::max<element_type>(red2[0], red2[4]);
+    return std::max<element_type>(lane(red2, 0), lane(red2, 4));
   }
 
   /*!
@@ -403,11 +466,11 @@ public:
     }
     if (N == 1)
     {
-      return m_value[0];
+      return get(0);
     }
     if (N == 2)
     {
-      return std::max<element_type>(m_value[0], m_value[1]);
+      return std::max<element_type>(get(0), get(1));
     }
 
     // swap odd-even pairs and add
@@ -416,18 +479,18 @@ public:
 
     if (N == 3)
     {
-      return std::max<element_type>(red1[0], m_value[2]);
+      return std::max<element_type>(lane(red1, 0), get(2));
     }
     if (N == 4)
     {
-      return std::max<element_type>(red1[0], red1[2]);
+      return std::max<element_type>(lane(red1, 0), lane(red1, 2));
     }
 
     // swap odd-even quads and add
     auto sh2  = _mm256_permutevar8x32_ps(red1, createPermute2(N));
     auto red2 = _mm256_max_ps(red1, sh2);
 
-    return std::max<element_type>(red2[0], red2[4]);
+    return std::max<element_type>(lane(red2, 0), lane(red2, 4));
   }
 
   /*!
@@ -456,7 +519,7 @@ public:
     auto sh2  = _mm256_permutevar8x32_ps(red1, createPermute2(8));
     auto red2 = _mm256_min_ps(red1, sh2);
 
-    return std::min<element_type>(red2[0], red2[4]);
+    return std::min<element_type>(lane(red2, 0), lane(red2, 4));
   }
 
   /*!
@@ -473,11 +536,11 @@ public:
     }
     if (N == 1)
     {
-      return m_value[0];
+      return get(0);
     }
     if (N == 2)
     {
-      return std::min<element_type>(m_value[0], m_value[1]);
+      return std::min<element_type>(get(0), get(1));
     }
 
     // swap odd-even pairs and add
@@ -486,18 +549,18 @@ public:
 
     if (N == 3)
     {
-      return std::min<element_type>(red1[0], m_value[2]);
+      return std::min<element_type>(lane(red1, 0), get(2));
     }
     if (N == 4)
     {
-      return std::min<element_type>(red1[0], red1[2]);
+      return std::min<element_type>(lane(red1, 0), lane(red1, 2));
     }
 
     // swap odd-even quads and add
     auto sh2  = _mm256_permutevar8x32_ps(red1, createPermute2(N));
     auto red2 = _mm256_min_ps(red1, sh2);
 
-    return std::min<element_type>(red2[0], red2[4]);
+    return std::min<element_type>(lane(red2, 0), lane(red2, 4));
   }
 
   /*!

--- a/include/RAJA/policy/tensor/arch/avx2/avx2_float.hpp
+++ b/include/RAJA/policy/tensor/arch/avx2/avx2_float.hpp
@@ -102,8 +102,7 @@ private:
                             N >= 4 ? 3 : 0, N >= 2 ? 2 : 0);
   }
 
-  static RAJA_NOINLINE element_type load_scalar(
-      element_type const* ptr)
+  static RAJA_NOINLINE element_type load_scalar(element_type const* ptr)
   {
     element_type value;
     RAJA_BUILTIN_MEMCPY(&value, ptr, sizeof(value));
@@ -113,14 +112,10 @@ private:
   RAJA_INLINE
   static register_type load_register(element_type const* ptr)
   {
-    return make_register(load_scalar(ptr + 0),
-                         load_scalar(ptr + 1),
-                         load_scalar(ptr + 2),
-                         load_scalar(ptr + 3),
-                         load_scalar(ptr + 4),
-                         load_scalar(ptr + 5),
-                         load_scalar(ptr + 6),
-                         load_scalar(ptr + 7));
+    return make_register(load_scalar(ptr + 0), load_scalar(ptr + 1),
+                         load_scalar(ptr + 2), load_scalar(ptr + 3),
+                         load_scalar(ptr + 4), load_scalar(ptr + 5),
+                         load_scalar(ptr + 6), load_scalar(ptr + 7));
   }
 
   RAJA_INLINE
@@ -330,7 +325,7 @@ public:
     element_type lanes[s_num_elem];
     store_register(lanes, m_value);
     lanes[i] = value;
-    m_value = load_register(lanes);
+    m_value  = load_register(lanes);
     return *this;
   }
 
@@ -346,10 +341,7 @@ public:
   RAJA_HOST_DEVICE
 
   RAJA_INLINE
-  self_type& copy(self_type const& src)
-  {
-    return assign_register(src.m_value);
-  }
+  self_type& copy(self_type const& src) { return assign_register(src.m_value); }
 
   RAJA_HOST_DEVICE
 

--- a/include/RAJA/policy/tensor/arch/avx2/avx2_int32.hpp
+++ b/include/RAJA/policy/tensor/arch/avx2/avx2_int32.hpp
@@ -24,6 +24,7 @@
 
 #include "RAJA/config.hpp"
 #include "RAJA/util/macros.hpp"
+#include "RAJA/util/builtin_compat.hpp"
 #include "RAJA/pattern/tensor/internal/RegisterBase.hpp"
 
 // Include SIMD intrinsics header file
@@ -53,6 +54,19 @@ public:
 
 private:
   register_type m_value;
+
+  RAJA_INLINE
+  static register_type make_register(element_type x0,
+                                     element_type x1,
+                                     element_type x2,
+                                     element_type x3,
+                                     element_type x4,
+                                     element_type x5,
+                                     element_type x6,
+                                     element_type x7)
+  {
+    return _mm256_set_epi32(x7, x6, x5, x4, x3, x2, x1, x0);
+  }
 
   RAJA_INLINE
   __m256i createMask(camp::idx_t N) const
@@ -89,6 +103,40 @@ private:
                             N >= 4 ? 3 : 0, N >= 2 ? 2 : 0);
   }
 
+  static RAJA_NOINLINE element_type load_scalar(
+      element_type const* ptr)
+  {
+    element_type value;
+    RAJA_BUILTIN_MEMCPY(&value, ptr, sizeof(value));
+    return value;
+  }
+
+  RAJA_INLINE
+  static register_type load_register(element_type const* ptr)
+  {
+    return make_register(load_scalar(ptr + 0),
+                         load_scalar(ptr + 1),
+                         load_scalar(ptr + 2),
+                         load_scalar(ptr + 3),
+                         load_scalar(ptr + 4),
+                         load_scalar(ptr + 5),
+                         load_scalar(ptr + 6),
+                         load_scalar(ptr + 7));
+  }
+
+  RAJA_INLINE
+  static void store_register(element_type* ptr, register_type value)
+  {
+    _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), value);
+  }
+
+  RAJA_INLINE
+  self_type& assign_register(register_type value)
+  {
+    RAJA_BUILTIN_MEMCPY(&m_value, &value, sizeof(m_value));
+    return *this;
+  }
+
 public:
   static constexpr camp::idx_t s_num_elem = 8;
 
@@ -123,7 +171,10 @@ public:
    * @brief Copy constructor
    */
   RAJA_INLINE
-  Register(self_type const& c) : base_type(c), m_value(c.m_value) {}
+  Register(self_type const& c) : base_type(c), m_value(_mm256_setzero_si256())
+  {
+    assign_register(c.m_value);
+  }
 
   /*!
    * @brief Copy assignment constructor
@@ -131,8 +182,7 @@ public:
   RAJA_INLINE
   self_type& operator=(self_type const& c)
   {
-    m_value = c.m_value;
-    return *this;
+    return assign_register(c.m_value);
   }
 
   /*!
@@ -155,8 +205,7 @@ public:
   RAJA_INLINE
   self_type& load_packed(element_type const* ptr)
   {
-    m_value = _mm256_loadu_si256((__m256i const*)ptr);
-    return *this;
+    return assign_register(load_register(ptr));
   }
 
   /*!
@@ -336,8 +385,7 @@ public:
   RAJA_INLINE
   self_type& copy(self_type const& src)
   {
-    m_value = src.m_value;
-    return *this;
+    return assign_register(src.m_value);
   }
 
   RAJA_HOST_DEVICE

--- a/include/RAJA/policy/tensor/arch/avx2/avx2_int32.hpp
+++ b/include/RAJA/policy/tensor/arch/avx2/avx2_int32.hpp
@@ -103,8 +103,7 @@ private:
                             N >= 4 ? 3 : 0, N >= 2 ? 2 : 0);
   }
 
-  static RAJA_NOINLINE element_type load_scalar(
-      element_type const* ptr)
+  static RAJA_NOINLINE element_type load_scalar(element_type const* ptr)
   {
     element_type value;
     RAJA_BUILTIN_MEMCPY(&value, ptr, sizeof(value));
@@ -114,14 +113,10 @@ private:
   RAJA_INLINE
   static register_type load_register(element_type const* ptr)
   {
-    return make_register(load_scalar(ptr + 0),
-                         load_scalar(ptr + 1),
-                         load_scalar(ptr + 2),
-                         load_scalar(ptr + 3),
-                         load_scalar(ptr + 4),
-                         load_scalar(ptr + 5),
-                         load_scalar(ptr + 6),
-                         load_scalar(ptr + 7));
+    return make_register(load_scalar(ptr + 0), load_scalar(ptr + 1),
+                         load_scalar(ptr + 2), load_scalar(ptr + 3),
+                         load_scalar(ptr + 4), load_scalar(ptr + 5),
+                         load_scalar(ptr + 6), load_scalar(ptr + 7));
   }
 
   RAJA_INLINE
@@ -383,10 +378,7 @@ public:
   RAJA_HOST_DEVICE
 
   RAJA_INLINE
-  self_type& copy(self_type const& src)
-  {
-    return assign_register(src.m_value);
-  }
+  self_type& copy(self_type const& src) { return assign_register(src.m_value); }
 
   RAJA_HOST_DEVICE
 

--- a/include/RAJA/policy/tensor/arch/avx2/avx2_int64.hpp
+++ b/include/RAJA/policy/tensor/arch/avx2/avx2_int64.hpp
@@ -89,8 +89,7 @@ private:
     return _mm256_castpd_si256(_mm256_permute_pd(_mm256_castsi256_pd(x), perm));
   }
 
-  static RAJA_NOINLINE element_type load_scalar(
-      element_type const* ptr)
+  static RAJA_NOINLINE element_type load_scalar(element_type const* ptr)
   {
     element_type value;
     RAJA_BUILTIN_MEMCPY(&value, ptr, sizeof(value));
@@ -100,10 +99,8 @@ private:
   RAJA_INLINE
   static register_type load_register(element_type const* ptr)
   {
-    return make_register(load_scalar(ptr + 0),
-                         load_scalar(ptr + 1),
-                         load_scalar(ptr + 2),
-                         load_scalar(ptr + 3));
+    return make_register(load_scalar(ptr + 0), load_scalar(ptr + 1),
+                         load_scalar(ptr + 2), load_scalar(ptr + 3));
   }
 
   RAJA_INLINE
@@ -385,10 +382,7 @@ public:
   RAJA_HOST_DEVICE
 
   RAJA_INLINE
-  self_type& copy(self_type const& src)
-  {
-    return assign_register(src.m_value);
-  }
+  self_type& copy(self_type const& src) { return assign_register(src.m_value); }
 
   RAJA_HOST_DEVICE
 

--- a/include/RAJA/policy/tensor/arch/avx2/avx2_int64.hpp
+++ b/include/RAJA/policy/tensor/arch/avx2/avx2_int64.hpp
@@ -24,6 +24,7 @@
 
 #include "RAJA/config.hpp"
 #include "RAJA/util/macros.hpp"
+#include "RAJA/util/builtin_compat.hpp"
 #include "RAJA/pattern/tensor/internal/RegisterBase.hpp"
 
 // Include SIMD intrinsics header file
@@ -53,6 +54,15 @@ private:
   register_type m_value;
 
   RAJA_INLINE
+  static register_type make_register(element_type x0,
+                                     element_type x1,
+                                     element_type x2,
+                                     element_type x3)
+  {
+    return _mm256_set_epi64x(x3, x2, x1, x0);
+  }
+
+  RAJA_INLINE
   __m256i createMask(camp::idx_t N) const
   {
     // Generate a mask
@@ -77,6 +87,36 @@ private:
   RAJA_INLINE __m256i permute(__m256i x) const
   {
     return _mm256_castpd_si256(_mm256_permute_pd(_mm256_castsi256_pd(x), perm));
+  }
+
+  static RAJA_NOINLINE element_type load_scalar(
+      element_type const* ptr)
+  {
+    element_type value;
+    RAJA_BUILTIN_MEMCPY(&value, ptr, sizeof(value));
+    return value;
+  }
+
+  RAJA_INLINE
+  static register_type load_register(element_type const* ptr)
+  {
+    return make_register(load_scalar(ptr + 0),
+                         load_scalar(ptr + 1),
+                         load_scalar(ptr + 2),
+                         load_scalar(ptr + 3));
+  }
+
+  RAJA_INLINE
+  static void store_register(element_type* ptr, register_type value)
+  {
+    _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), value);
+  }
+
+  RAJA_INLINE
+  self_type& assign_register(register_type value)
+  {
+    RAJA_BUILTIN_MEMCPY(&m_value, &value, sizeof(m_value));
+    return *this;
   }
 
 public:
@@ -106,7 +146,10 @@ public:
    * @brief Copy constructor
    */
   RAJA_INLINE
-  Register(self_type const& c) : base_type(c), m_value(c.m_value) {}
+  Register(self_type const& c) : base_type(c), m_value(_mm256_setzero_si256())
+  {
+    assign_register(c.m_value);
+  }
 
   /*!
    * @brief Copy assignment constructor
@@ -114,8 +157,7 @@ public:
   RAJA_INLINE
   self_type& operator=(self_type const& c)
   {
-    m_value = c.m_value;
-    return *this;
+    return assign_register(c.m_value);
   }
 
   /*!
@@ -138,8 +180,7 @@ public:
   RAJA_INLINE
   self_type& load_packed(element_type const* ptr)
   {
-    m_value = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(ptr));
-    return *this;
+    return assign_register(load_register(ptr));
   }
 
   /*!
@@ -235,7 +276,7 @@ public:
   RAJA_INLINE
   self_type const& store_packed(element_type* ptr) const
   {
-    _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), m_value);
+    store_register(ptr, m_value);
     return *this;
   }
 
@@ -260,7 +301,7 @@ public:
   {
     for (camp::idx_t i = 0; i < 4; ++i)
     {
-      ptr[i * stride] = m_value[i];
+      ptr[i * stride] = get(i);
     }
     return *this;
   }
@@ -276,7 +317,7 @@ public:
   {
     for (camp::idx_t i = 0; i < N; ++i)
     {
-      ptr[i * stride] = m_value[i];
+      ptr[i * stride] = get(i);
     }
     return *this;
   }
@@ -346,8 +387,7 @@ public:
   RAJA_INLINE
   self_type& copy(self_type const& src)
   {
-    m_value = src.m_value;
-    return *this;
+    return assign_register(src.m_value);
   }
 
   RAJA_HOST_DEVICE

--- a/include/RAJA/util/builtin_compat.hpp
+++ b/include/RAJA/util/builtin_compat.hpp
@@ -24,7 +24,7 @@
 #if defined(_MSC_VER)
 #include <cstring>
 #define RAJA_BUILTIN_MEMCPY(a, b, c) std::memcpy(a, b, c)
-   
+
 #else
 #define RAJA_BUILTIN_MEMCPY(a, b, c) __builtin_memcpy(a, b, c)
 #endif

--- a/include/RAJA/util/builtin_compat.hpp
+++ b/include/RAJA/util/builtin_compat.hpp
@@ -1,0 +1,32 @@
+/*!
+ ******************************************************************************
+ *
+ * \file
+ *
+ * \brief   RAJA header file for handling builtin function differences for
+ *          different compilers.
+ *
+ ******************************************************************************
+ */
+
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef RAJA_util_builtin_compat_HPP
+#define RAJA_util_builtin_compat_HPP
+
+#if defined(_MSC_VER)
+#include <cstring>
+#define RAJA_BUILTIN_MEMCPY(a, b, c) std::memcpy(a, b, c)
+   
+#else
+#define RAJA_BUILTIN_MEMCPY(a, b, c) __builtin_memcpy(a, b, c)
+#endif
+
+#endif  // RAJA_util_builtin_compat_HPP


### PR DESCRIPTION
# Summary

- This PR squashes several GNU and Clang compiler warnings related to tensor vectorization stuff.
- Also added a builtin_compat.hpp header file to deal with MSVC compatibility issues.

This  PR resolves the remaining issues described in https://github.com/llnl/RAJA/issues/1905

Note: Codex CLI was consulted in resolving these warnings.
