### PR TITLE
Support forall params with icount and update clang-format in build scripts

### DIFF
--- a/include/RAJA/pattern/forall.hpp
+++ b/include/RAJA/pattern/forall.hpp
@@ -119,7 +119,8 @@ struct icount_adapter
   template<typename T, typename... Params>
   RAJA_HOST_DEVICE void operator()(T const& i, Params&&... params) const
   {
-    body(static_cast<index_type>(i + icount), begin_it[i], std::forward<Params>(params)...);
+    body(static_cast<index_type>(i + icount), begin_it[i],
+         std::forward<Params>(params)...);
   }
 };
 

--- a/include/RAJA/pattern/forall.hpp
+++ b/include/RAJA/pattern/forall.hpp
@@ -116,10 +116,10 @@ struct icount_adapter
   }
 
   RAJA_SUPPRESS_HD_WARN
-  template<typename T>
-  RAJA_HOST_DEVICE void operator()(T const& i) const
+  template<typename T, typename... Params>
+  RAJA_HOST_DEVICE void operator()(T const& i, Params&&... params) const
   {
-    body(static_cast<index_type>(i + icount), begin_it[i]);
+    body(static_cast<index_type>(i + icount), begin_it[i], std::forward<Params>(params)...);
   }
 };
 

--- a/scripts/lc-builds/corona_sycl.sh
+++ b/scripts/lc-builds/corona_sycl.sh
@@ -62,7 +62,7 @@ cmake \
   -DENABLE_OPENMP=Off \
   -DENABLE_CUDA=Off \
   -DENABLE_CLANGFORMAT=On \
-  -DCLANGFORMAT_EXECUTABLE=/usr/tce/packages/clang/clang-14.0.6/bin/clang-format \
+  -DCLANGFORMAT_EXECUTABLE=/usr/tce/packages/clang/clang-19.1.3/bin/clang-format \
   -DRAJA_ENABLE_TARGET_OPENMP=Off \
   -DENABLE_ALL_WARNINGS=Off \
   -DRAJA_ENABLE_SYCL=On \

--- a/scripts/lc-builds/toss4_clang.sh
+++ b/scripts/lc-builds/toss4_clang.sh
@@ -52,7 +52,7 @@ cmake \
   -DCMAKE_CXX_COMPILER=/usr/tce/packages/clang/clang-${COMP_VER}/bin/clang++ \
   -DBLT_CXX_STD=c++20 \
   -DENABLE_CLANGFORMAT=On \
-  -DCLANGFORMAT_EXECUTABLE=/usr/tce/packages/clang/clang-14.0.6/bin/clang-format \
+  -DCLANGFORMAT_EXECUTABLE=/usr/tce/packages/clang/clang-19.1.3/bin/clang-format \
   -C ../host-configs/lc-builds/toss4/clang_X.cmake \
   -DENABLE_OPENMP=On \
   -DENABLE_BENCHMARKS=On \

--- a/scripts/lc-builds/toss4_clang_san.sh
+++ b/scripts/lc-builds/toss4_clang_san.sh
@@ -61,7 +61,7 @@ cmake \
   -DCMAKE_CXX_COMPILER=/usr/tce/packages/clang/clang-${COMP_VER}/bin/clang++ \
   -DBLT_CXX_STD=c++20 \
   -DENABLE_CLANGFORMAT=On \
-  -DCLANGFORMAT_EXECUTABLE=/usr/tce/packages/clang/clang-14.0.6/bin/clang-format \
+  -DCLANGFORMAT_EXECUTABLE=/usr/tce/packages/clang/clang-19.1.3/bin/clang-format \
   -C ../host-configs/lc-builds/toss4/clang_X_${SAN_VER}.cmake \
   -DENABLE_OPENMP=On \
   -DENABLE_BENCHMARKS=ON \

--- a/scripts/lc-builds/toss4_gcc.sh
+++ b/scripts/lc-builds/toss4_gcc.sh
@@ -52,7 +52,7 @@ cmake \
   -DCMAKE_CXX_COMPILER=/usr/tce/packages/gcc/gcc-${COMP_VER}/bin/g++ \
   -DBLT_CXX_STD=c++20 \
   -DENABLE_CLANGFORMAT=On \
-  -DCLANGFORMAT_EXECUTABLE=/usr/tce/packages/clang/clang-14.0.6/bin/clang-format \
+  -DCLANGFORMAT_EXECUTABLE=/usr/tce/packages/clang/clang-19.1.3/bin/clang-format \
   -C ../host-configs/lc-builds/toss4/gcc_X.cmake \
   -DENABLE_OPENMP=On \
   -DENABLE_BENCHMARKS=On \

--- a/scripts/lc-builds/toss4_icpc-classic.sh
+++ b/scripts/lc-builds/toss4_icpc-classic.sh
@@ -40,7 +40,7 @@ cmake \
   -DCMAKE_CXX_COMPILER=/usr/tce/packages/intel-classic/intel-classic-${COMP_VER}/bin/icpc \
   -DCMAKE_C_COMPILER=/usr/tce/packages/intel-classic/intel-classic-${COMP_VER}/bin/icc \
   -DENABLE_CLANGFORMAT=On \
-  -DCLANGFORMAT_EXECUTABLE=/usr/tce/packages/clang/clang-14.0.6/bin/clang-format \
+  -DCLANGFORMAT_EXECUTABLE=/usr/tce/packages/clang/clang-19.1.3/bin/clang-format \
   -DBLT_CXX_STD=c++20 \
   -C ../host-configs/lc-builds/toss4/icpc-classic_X.cmake \
   -DRAJA_ENABLE_FORCEINLINE_RECURSIVE=Off \

--- a/scripts/lc-builds/toss4_icpc.sh
+++ b/scripts/lc-builds/toss4_icpc.sh
@@ -40,7 +40,7 @@ cmake \
   -DCMAKE_CXX_COMPILER=/usr/tce/packages/intel/intel-${COMP_VER}/bin/icpc \
   -DCMAKE_C_COMPILER=/usr/tce/packages/intel/intel-${COMP_VER}/bin/icc \
   -DENABLE_CLANGFORMAT=On \
-  -DCLANGFORMAT_EXECUTABLE=/usr/tce/packages/clang/clang-14.0.6/bin/clang-format \
+  -DCLANGFORMAT_EXECUTABLE=/usr/tce/packages/clang/clang-19.1.3/bin/clang-format \
   -DBLT_CXX_STD=c++20 \
   -C ../host-configs/lc-builds/toss4/icpc_X.cmake \
   -DRAJA_ENABLE_FORCEINLINE_RECURSIVE=Off \

--- a/scripts/lc-builds/toss4_icpx.sh
+++ b/scripts/lc-builds/toss4_icpx.sh
@@ -67,7 +67,7 @@ cmake \
   -C ../host-configs/lc-builds/toss4/icpx_X.cmake \
   -DRAJA_ENABLE_FORCEINLINE_RECURSIVE=Off \
   -DENABLE_CLANGFORMAT=On \
-  -DCLANGFORMAT_EXECUTABLE=/usr/tce/packages/clang/clang-14.0.6/bin/clang-format \
+  -DCLANGFORMAT_EXECUTABLE=/usr/tce/packages/clang/clang-19.1.3/bin/clang-format \
   -DENABLE_OPENMP=On \
   -DENABLE_BENCHMARKS=On \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \

--- a/scripts/lc-builds/toss4_nvcc_clang.sh
+++ b/scripts/lc-builds/toss4_nvcc_clang.sh
@@ -64,7 +64,7 @@ cmake \
   -DBLT_CXX_STD=c++20 \
   -C ../host-configs/lc-builds/toss4/nvcc_clang_X.cmake \
   -DENABLE_CLANGFORMAT=Off \
-  -DCLANGFORMAT_EXECUTABLE=/usr/tce/packages/clang/clang-14.0.6/bin/clang-format \
+  -DCLANGFORMAT_EXECUTABLE=/usr/tce/packages/clang/clang-19.1.3/bin/clang-format \
   -DENABLE_OPENMP=On \
   -DENABLE_CUDA=On \
   -DRAJA_ENABLE_NVTX=On \


### PR DESCRIPTION
# Summary

Support forall params with `forall_Icount` by adding support to pass an arbitrary number of extra parameters through the `icount_adapter`.
Also update the version of clang-format in the build scripts.

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes something that obviously noone is using.
