### PR TITLE
Support nonarithmetic types, generic comparison operators, and non-pointer iterators in gpu sort

### DIFF
--- a/docs/sphinx/user_guide/feature/sort.rst
+++ b/docs/sphinx/user_guide/feature/sort.rst
@@ -30,13 +30,17 @@ A few important notes:
 
 Also:
 
-.. note:: For sorts using the CUDA or HIP back-end, RAJA implementation uses
-          the NVIDIA CUB library or AMD rocPRIM library, respectively.
-          Typically, the CMake variable ``CUB_DIR`` or ``ROCPRIM_DIR`` will
-          be automatically set to the location of the CUB or rocPRIM library
-          for the CUDA or rocPRIM installation specified when either back-end
-          is enabled. More details for configuring the CUB or rocPRIM library
-          for a RAJA build can be found :ref:`getting_started_depend-label`.
+.. note:: * For sorts using the CUDA or HIP back-end, RAJA implementation uses
+            the NVIDIA CUB library or AMD rocPRIM library, respectively.
+            Typically, the CMake variable ``CUB_DIR`` or ``ROCPRIM_DIR`` will
+            be automatically set to the location of the CUB or rocPRIM library
+            for the CUDA or rocPRIM installation specified when either back-end
+            is enabled. More details for configuring the CUB or rocPRIM library
+            for a RAJA build can be found :ref:`getting_started_depend-label`.
+          * The RAJA CUDA and HIP sort back-ends support user provided operators,
+            but special case the RAJA operators 'less' and 'greater' when used
+            with raw pointers to arithmetic types for performance as a more
+            performant radix sort implementation is available in those cases.
 
 Please see the following tutorial sections for detailed examples that use
 RAJA scan operations:

--- a/docs/sphinx/user_guide/feature/sort.rst
+++ b/docs/sphinx/user_guide/feature/sort.rst
@@ -30,7 +30,7 @@ A few important notes:
 
 Also:
 
-.. note:: * For sorts using the CUDA or HIP back-end, RAJA implementation uses
+.. note:: * For sorts using the CUDA or HIP back-end, RAJA uses
             the NVIDIA CUB library or AMD rocPRIM library, respectively.
             Typically, the CMake variable ``CUB_DIR`` or ``ROCPRIM_DIR`` will
             be automatically set to the location of the CUB or rocPRIM library

--- a/docs/sphinx/user_guide/tutorial/sort.rst
+++ b/docs/sphinx/user_guide/tutorial/sort.rst
@@ -171,9 +171,7 @@ non-increasing order in the output array::
 .. note:: * The only operators provided by RAJA that are valid to use in sort
             because they enforce a strict weak ordering of elements for 
             arithmetic types are 'less' and 'greater'. Users may provide other
-            operators for different sorting operations. 
-          * Also the RAJA CUDA sort back-end only supports RAJA operators 
-            'less' and 'greater' because it uses the NVIDIA CUB library.
+            operators for different sorting operations.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Sort Pairs

--- a/include/RAJA/policy/cuda/sort.hpp
+++ b/include/RAJA/policy/cuda/sort.hpp
@@ -84,7 +84,8 @@ resources::EventProxy<resources::Cuda> sort(
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
 
-  auto call_impl = [&, tmp_begin = static_cast<R*>(nullptr)](auto phase) mutable {
+  auto call_impl = [&,
+                    tmp_begin = static_cast<R*>(nullptr)](auto phase) mutable {
     RAJA_UNUSED_VAR(phase);
     RAJA_UNUSED_VAR(tmp_begin);
 
@@ -213,7 +214,8 @@ resources::EventProxy<resources::Cuda> sort_pairs(
   size_t temp_storage_bytes = 0;
 
   auto call_impl = [&, tmp_keys_begin = static_cast<K*>(nullptr),
-                    tmp_vals_begin = static_cast<V*>(nullptr)](auto phase) mutable {
+                    tmp_vals_begin =
+                        static_cast<V*>(nullptr)](auto phase) mutable {
     RAJA_UNUSED_VAR(phase);
     RAJA_UNUSED_VAR(tmp_keys_begin);
     RAJA_UNUSED_VAR(tmp_vals_begin);
@@ -230,8 +232,10 @@ resources::EventProxy<resources::Cuda> sort_pairs(
       // Setup temporary storage for the output arrays
       if constexpr (phase == 0)
       {
-        tmp_keys_begin = cuda::device_mempool_type::getInstance().malloc<K>(len);
-        tmp_vals_begin = cuda::device_mempool_type::getInstance().malloc<V>(len);
+        tmp_keys_begin =
+            cuda::device_mempool_type::getInstance().malloc<K>(len);
+        tmp_vals_begin =
+            cuda::device_mempool_type::getInstance().malloc<V>(len);
       }
 
       // Use DoubleBuffers to reduce temporary memory requirements
@@ -259,7 +263,8 @@ resources::EventProxy<resources::Cuda> sort_pairs(
       if constexpr (phase == 1)
       {
         // copy keys and values back if necessary
-        if (d_keys.Current() == tmp_keys_begin && d_vals.Current() == tmp_vals_begin)
+        if (d_keys.Current() == tmp_keys_begin &&
+            d_vals.Current() == tmp_vals_begin)
         {
           // Copy keys and values back via kernel for performance
           forall_impl(

--- a/include/RAJA/policy/cuda/sort.hpp
+++ b/include/RAJA/policy/cuda/sort.hpp
@@ -268,7 +268,7 @@ resources::EventProxy<resources::Cuda> sort_pairs(
                   IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM,
                   true> {},
               TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-              ::RAJA::detail::Copy2Functor {keys_begin, d_keys_out, vals_begin,
+              ::RAJA::detail::TwoCopiesFunctor {keys_begin, d_keys_out, vals_begin,
                                             d_vals_out},
               expt::get_empty_forall_param_pack());
         }

--- a/include/RAJA/policy/cuda/sort.hpp
+++ b/include/RAJA/policy/cuda/sort.hpp
@@ -399,7 +399,7 @@ resources::EventProxy<resources::Cuda> stable_pairs(
 }
 
 /*!
-        \brief stable sort given range of pairs in order of keys
+        \brief unstable sort given range of pairs in order of keys
 */
 template<typename IterationMapping,
          typename IterationGetter,

--- a/include/RAJA/policy/cuda/sort.hpp
+++ b/include/RAJA/policy/cuda/sort.hpp
@@ -75,99 +75,95 @@ resources::EventProxy<resources::Cuda> sort(
 
   using R = RAJA::detail::IterVal<Iter>;
 
-  int len       = std::distance(begin, end);
-  int begin_bit = 0;
-  int end_bit   = sizeof(R) * CHAR_BIT;
+  using IndexType = camp::decay<decltype(std::distance(begin, end))>;
 
-  // Allocate temporary storage for the output array
-  R* d_out = cuda::device_mempool_type::getInstance().malloc<R>(len);
+  const IndexType len     = std::distance(begin, end);
+  constexpr int begin_bit = 0;
+  constexpr int end_bit   = sizeof(R) * CHAR_BIT;
 
-  // use cub double buffer to reduce temporary memory requirements
-  // by allowing cub to write to the begin buffer
-  cub::DoubleBuffer<R> d_keys(begin, d_out);
-
-  // Determine temporary device storage requirements
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
-  if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
-                std::is_same_v<std::decay_t<Compare>, operators::less<R>>)
+
+  auto call_impl = [&, d_out = static_cast<R*>(nullptr)](auto phase) mutable
   {
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeys,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   len, begin_bit, end_bit, stream);
-  }
-  else if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
-                     std::is_same_v<std::decay_t<Compare>,
-                                    operators::greater<R>>)
-  {
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeysDescending,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   len, begin_bit, end_bit, stream);
-  }
-  else
-  {
-    if (Stable)
+    RAJA_UNUSED_VAR(phase);
+    RAJA_UNUSED_VAR(d_out);
+
+    if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
+                  ( std::is_same_v<std::decay_t<Compare>, operators::less<R>> ||
+                    std::is_same_v<std::decay_t<Compare>, operators::greater<R>> ))
     {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortKeys,
-                                     d_temp_storage, temp_storage_bytes,
-                                     d_keys.Current(), len, comp, stream);
+      // The begin iterator is a pointer in this constexpr conditional
+      // so we can use DoubleBuffer
+
+      // Setup temporary storage for the output array
+      if constexpr (phase == 0) {
+        d_out = cuda::device_mempool_type::getInstance().malloc<R>(len);
+      }
+
+      // Use DoubleBuffers to reduce temporary memory requirements
+      // by allowing cub to write to the begin buffer
+      cub::DoubleBuffer<R> d_keys(begin, d_out);
+
+      if constexpr (std::is_same_v<std::decay_t<Compare>, operators::less<R>>)
+      {
+        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeys,
+                                       d_temp_storage, temp_storage_bytes, d_keys,
+                                       len, begin_bit, end_bit, stream);
+      }
+      else if constexpr (std::is_same_v<std::decay_t<Compare>, operators::greater<R>>)
+      {
+        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeysDescending,
+                                       d_temp_storage, temp_storage_bytes, d_keys,
+                                       len, begin_bit, end_bit, stream);
+      }
+
+      // Tear-down temporary storage for the output array
+      if constexpr (phase == 1)
+      {
+        // Copy result back if necessary
+        if (d_keys.Current() == d_out)
+        {
+          CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, begin, d_out,
+                                         len * sizeof(R), cudaMemcpyDefault, stream);
+        }
+
+        // Free temporary output array
+        cuda::device_mempool_type::getInstance().free(d_out);
+      }
     }
     else
     {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::SortKeys,
-                                     d_temp_storage, temp_storage_bytes,
-                                     d_keys.Current(), len, comp, stream);
+      if (Stable)
+      {
+        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortKeys,
+                                       d_temp_storage, temp_storage_bytes,
+                                       begin, len, comp, stream);
+      }
+      else
+      {
+        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::SortKeys,
+                                       d_temp_storage, temp_storage_bytes,
+                                       begin, len, comp, stream);
+      }
     }
-  }
+  };
+
+  // Determine temporary device storage requirements
+  call_impl(std::integral_constant<int, 0>{});
+
   // Allocate temporary storage
   d_temp_storage =
       cuda::device_mempool_type::getInstance().malloc<unsigned char>(
           temp_storage_bytes);
 
   // Run
-  if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
-                std::is_same_v<std::decay_t<Compare>, operators::less<R>>)
-  {
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeys,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   len, begin_bit, end_bit, stream);
-  }
-  else if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
-                     std::is_same_v<std::decay_t<Compare>,
-                                    operators::greater<R>>)
-  {
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeysDescending,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   len, begin_bit, end_bit, stream);
-  }
-  else
-  {
-    if (Stable)
-    {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortKeys,
-                                     d_temp_storage, temp_storage_bytes,
-                                     d_keys.Current(), len, comp, stream);
-    }
-    else
-    {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::SortKeys,
-                                     d_temp_storage, temp_storage_bytes,
-                                     d_keys.Current(), len, comp, stream);
-    }
-  }
+  call_impl(std::integral_constant<int, 1>{});
+
   // Free temporary storage
   cuda::device_mempool_type::getInstance().free(d_temp_storage);
 
-  if (d_keys.Current() == d_out)
-  {
-
-    // copy
-    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, begin, d_out,
-                                   len * sizeof(R), cudaMemcpyDefault, stream);
-  }
-
-  cuda::device_mempool_type::getInstance().free(d_out);
-
+  // Mark kernel launches done by this resource/stream
   cuda::launch(cuda_res, Async);
 
   return resources::EventProxy<resources::Cuda>(cuda_res);
@@ -204,115 +200,121 @@ resources::EventProxy<resources::Cuda> sort_pairs(
   using K = RAJA::detail::IterVal<KeyIter>;
   using V = RAJA::detail::IterVal<ValIter>;
 
-  int len       = std::distance(keys_begin, keys_end);
-  int begin_bit = 0;
-  int end_bit   = sizeof(K) * CHAR_BIT;
+  using IndexType = camp::decay<decltype(std::distance(keys_begin, keys_end))>;
 
-  // Allocate temporary storage for the output arrays
-  K* d_keys_out = cuda::device_mempool_type::getInstance().malloc<K>(len);
-  V* d_vals_out = cuda::device_mempool_type::getInstance().malloc<V>(len);
+  const IndexType len     = std::distance(keys_begin, keys_end);
+  constexpr int begin_bit = 0;
+  constexpr int end_bit   = sizeof(K) * CHAR_BIT;
 
-  // use cub double buffer to reduce temporary memory requirements
-  // by allowing cub to write to the keys_begin and vals_begin buffers
-  cub::DoubleBuffer<K> d_keys(keys_begin, d_keys_out);
-  cub::DoubleBuffer<V> d_vals(vals_begin, d_vals_out);
-
-  // Determine temporary device storage requirements
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
-  if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
-                std::is_pointer_v<ValIter> &&
-                std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
+
+  auto call_impl = [&, d_keys_out = static_cast<K*>(nullptr),
+                       d_vals_out = static_cast<V*>(nullptr)](auto phase) mutable
   {
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   d_vals, len, begin_bit, end_bit, stream);
-  }
-  else if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
-                     std::is_pointer_v<ValIter> &&
-                     std::is_same_v<std::decay_t<Compare>,
-                                    operators::greater<K>>)
-  {
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   d_vals, len, begin_bit, end_bit, stream);
-  }
-  else
-  {
-    if (Stable)
+    RAJA_UNUSED_VAR(phase);
+    RAJA_UNUSED_VAR(d_keys_out);
+    RAJA_UNUSED_VAR(d_vals_out);
+
+    if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
+                  std::is_pointer_v<ValIter> &&
+                  ( std::is_same_v<std::decay_t<Compare>, operators::less<K>> ||
+                    std::is_same_v<std::decay_t<Compare>, operators::greater<K>> ))
     {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortPairs,
-                                     d_temp_storage, temp_storage_bytes,
-                                     d_keys.Current(), d_vals.Current(), len,
-                                     comp, stream);
+      // The begin iterators are pointers in this constexpr conditional
+      // so we can use DoubleBuffer
+
+      // Setup temporary storage for the output arrays
+      if constexpr (phase == 0) {
+        d_keys_out = cuda::device_mempool_type::getInstance().malloc<K>(len);
+        d_vals_out = cuda::device_mempool_type::getInstance().malloc<V>(len);
+      }
+
+      // Use DoubleBuffers to reduce temporary memory requirements
+      // by allowing cub to write to the keys_begin and vals_begin buffers
+      cub::DoubleBuffer<K> d_keys(keys_begin, d_keys_out);
+      cub::DoubleBuffer<V> d_vals(vals_begin, d_vals_out);
+
+      if constexpr (std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
+      {
+        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
+                                       d_temp_storage, temp_storage_bytes, d_keys,
+                                       d_vals, len, begin_bit, end_bit, stream);
+      }
+      else if constexpr (std::is_same_v<std::decay_t<Compare>, operators::greater<K>>)
+      {
+        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
+                                       d_temp_storage, temp_storage_bytes, d_keys,
+                                       d_vals, len, begin_bit, end_bit, stream);
+      }
+
+      // Tear-down temporary storage for the output array
+      if constexpr (phase == 1)
+      {
+        // copy keys and values back if necessary
+        if (d_keys.Current() == d_keys_out && d_vals.Current() == d_vals_out)
+        {
+          // Copy keys and values back via kernel for performance
+          forall_impl(cuda_res,
+              ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
+                                                       IterationGetter,
+                                                       Concretizer,
+                                                       BLOCKS_PER_SM,
+                                                       true>{},
+              TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
+              ::RAJA::detail::Copy2Functor{keys_begin, d_keys_out,
+                                           vals_begin, d_vals_out},
+              expt::get_empty_forall_param_pack());
+        }
+        else if (d_keys.Current() == d_keys_out)
+        {
+          CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, keys_begin, d_keys_out,
+                                         len * sizeof(K), cudaMemcpyDefault, stream);
+        }
+        else if (d_vals.Current() == d_vals_out)
+        {
+          CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, vals_begin, d_vals_out,
+                                         len * sizeof(V), cudaMemcpyDefault, stream);
+        }
+
+        // Free temporary output arrays
+        cuda::device_mempool_type::getInstance().free(d_keys_out);
+        cuda::device_mempool_type::getInstance().free(d_vals_out);
+      }
     }
     else
     {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(
-          ::cub::DeviceMergeSort::SortPairs, d_temp_storage, temp_storage_bytes,
-          d_keys.Current(), d_vals.Current(), len, comp, stream);
+      if (Stable)
+      {
+        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortPairs,
+                                       d_temp_storage, temp_storage_bytes,
+                                       keys_begin, vals_begin, len,
+                                       comp, stream);
+      }
+      else
+      {
+        CAMP_CUDA_API_INVOKE_AND_CHECK(
+            ::cub::DeviceMergeSort::SortPairs, d_temp_storage, temp_storage_bytes,
+            keys_begin, vals_begin, len, comp, stream);
+      }
     }
-  }
+  };
+
+  // Determine temporary device storage requirements
+  call_impl(std::integral_constant<int, 0>{});
+
   // Allocate temporary storage
   d_temp_storage =
       cuda::device_mempool_type::getInstance().malloc<unsigned char>(
           temp_storage_bytes);
 
   // Run
-  if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
-                std::is_pointer_v<ValIter> &&
-                std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
-  {
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   d_vals, len, begin_bit, end_bit, stream);
-  }
-  else if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
-                     std::is_pointer_v<ValIter> &&
-                     std::is_same_v<std::decay_t<Compare>,
-                                    operators::greater<K>>)
-  {
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   d_vals, len, begin_bit, end_bit, stream);
-  }
-  else
-  {
-    if (Stable)
-    {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortPairs,
-                                     d_temp_storage, temp_storage_bytes,
-                                     d_keys.Current(), d_vals.Current(), len,
-                                     comp, stream);
-    }
-    else
-    {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(
-          ::cub::DeviceMergeSort::SortPairs, d_temp_storage, temp_storage_bytes,
-          d_keys.Current(), d_vals.Current(), len, comp, stream);
-    }
-  }
+  call_impl(std::integral_constant<int, 1>{});
+
   // Free temporary storage
   cuda::device_mempool_type::getInstance().free(d_temp_storage);
 
-  if (d_keys.Current() == d_keys_out)
-  {
-
-    // copy keys
-    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, keys_begin, d_keys_out,
-                                   len * sizeof(K), cudaMemcpyDefault, stream);
-  }
-  if (d_vals.Current() == d_vals_out)
-  {
-
-    // copy vals
-    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, vals_begin, d_vals_out,
-                                   len * sizeof(V), cudaMemcpyDefault, stream);
-  }
-
-  cuda::device_mempool_type::getInstance().free(d_keys_out);
-  cuda::device_mempool_type::getInstance().free(d_vals_out);
-
+  // Mark kernel launches done by this resource/stream
   cuda::launch(cuda_res, Async);
 
   return resources::EventProxy<resources::Cuda>(cuda_res);

--- a/include/RAJA/policy/cuda/sort.hpp
+++ b/include/RAJA/policy/cuda/sort.hpp
@@ -268,8 +268,8 @@ resources::EventProxy<resources::Cuda> sort_pairs(
                   IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM,
                   true> {},
               TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-              ::RAJA::detail::TwoCopiesFunctor {keys_begin, d_keys_out, vals_begin,
-                                            d_vals_out},
+              ::RAJA::detail::TwoCopiesFunctor {keys_begin, d_keys_out,
+                                                vals_begin, d_vals_out},
               expt::get_empty_forall_param_pack());
         }
         else if (d_keys.Current() == d_keys_out)
@@ -404,7 +404,7 @@ resources::EventProxy<resources::Cuda> stable_pairs(
 {
   constexpr bool require_stable = true;
   return detail::sort_pairs<require_stable>(cuda_res, p, keys_begin, keys_end,
-                                    vals_begin, comp);
+                                            vals_begin, comp);
 }
 
 /*!
@@ -432,7 +432,7 @@ resources::EventProxy<resources::Cuda> unstable_pairs(
 {
   constexpr bool require_stable = true;
   return detail::sort_pairs<!require_stable>(cuda_res, p, keys_begin, keys_end,
-                                     vals_begin, comp);
+                                             vals_begin, comp);
 }
 
 }  // namespace sort

--- a/include/RAJA/policy/cuda/sort.hpp
+++ b/include/RAJA/policy/cuda/sort.hpp
@@ -109,14 +109,14 @@ resources::EventProxy<resources::Cuda> sort(
     if (Stable)
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortKeys,
-                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
-                                     len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes,
+                                     d_keys.Current(), len, comp, stream);
     }
     else
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::SortKeys,
-                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
-                                     len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes,
+                                     d_keys.Current(), len, comp, stream);
     }
   }
   // Allocate temporary storage
@@ -145,14 +145,14 @@ resources::EventProxy<resources::Cuda> sort(
     if (Stable)
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortKeys,
-                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
-                                     len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes,
+                                     d_keys.Current(), len, comp, stream);
     }
     else
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::SortKeys,
-                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
-                                     len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes,
+                                     d_keys.Current(), len, comp, stream);
     }
   }
   // Free temporary storage
@@ -242,14 +242,15 @@ resources::EventProxy<resources::Cuda> sort_pairs(
     if (Stable)
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortPairs,
-                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
-                                     d_vals.Current(), len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes,
+                                     d_keys.Current(), d_vals.Current(), len,
+                                     comp, stream);
     }
     else
     {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::SortPairs,
-                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
-                                     d_vals.Current(), len, comp, stream);
+      CAMP_CUDA_API_INVOKE_AND_CHECK(
+          ::cub::DeviceMergeSort::SortPairs, d_temp_storage, temp_storage_bytes,
+          d_keys.Current(), d_vals.Current(), len, comp, stream);
     }
   }
   // Allocate temporary storage
@@ -280,14 +281,15 @@ resources::EventProxy<resources::Cuda> sort_pairs(
     if (Stable)
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortPairs,
-                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
-                                     d_vals.Current(), len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes,
+                                     d_keys.Current(), d_vals.Current(), len,
+                                     comp, stream);
     }
     else
     {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::SortPairs,
-                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
-                                     d_vals.Current(), len, comp, stream);
+      CAMP_CUDA_API_INVOKE_AND_CHECK(
+          ::cub::DeviceMergeSort::SortPairs, d_temp_storage, temp_storage_bytes,
+          d_keys.Current(), d_vals.Current(), len, comp, stream);
     }
   }
   // Free temporary storage

--- a/include/RAJA/policy/cuda/sort.hpp
+++ b/include/RAJA/policy/cuda/sort.hpp
@@ -50,7 +50,7 @@ namespace detail
 /*!
         \brief sort given range
 */
-template<bool Stable,
+template<bool RequireStable,
          typename IterationMapping,
          typename IterationGetter,
          typename Concretizer,
@@ -69,7 +69,7 @@ resources::EventProxy<resources::Cuda> sort(
     Iter end,
     Compare comp)
 {
-  RAJA_UNUSED_VAR(Stable);
+  RAJA_UNUSED_VAR(RequireStable);
 
   cudaStream_t stream = cuda_res.get_stream();
 
@@ -137,7 +137,7 @@ resources::EventProxy<resources::Cuda> sort(
     }
     else
     {
-      if constexpr (Stable)
+      if constexpr (RequireStable)
       {
         CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortKeys,
                                        d_temp_storage, temp_storage_bytes,
@@ -175,7 +175,7 @@ resources::EventProxy<resources::Cuda> sort(
 /*!
         \brief sort given range of pairs in order of keys
 */
-template<bool Stable,
+template<bool RequireStable,
          typename IterationMapping,
          typename IterationGetter,
          typename Concretizer,
@@ -196,7 +196,7 @@ resources::EventProxy<resources::Cuda> sort_pairs(
     ValIter vals_begin,
     Compare comp)
 {
-  RAJA_UNUSED_VAR(Stable);
+  RAJA_UNUSED_VAR(RequireStable);
 
   cudaStream_t stream = cuda_res.get_stream();
 
@@ -292,7 +292,7 @@ resources::EventProxy<resources::Cuda> sort_pairs(
     }
     else
     {
-      if constexpr (Stable)
+      if constexpr (RequireStable)
       {
         CAMP_CUDA_API_INVOKE_AND_CHECK(
             ::cub::DeviceMergeSort::StableSortPairs, d_temp_storage,
@@ -350,8 +350,8 @@ resources::EventProxy<resources::Cuda> stable(
     Iter end,
     Compare comp)
 {
-  constexpr bool stable = true;
-  return detail::sort<stable>(cuda_res, p, begin, end, comp);
+  constexpr bool require_stable = true;
+  return detail::sort<require_stable>(cuda_res, p, begin, end, comp);
 }
 
 /*!
@@ -375,8 +375,8 @@ resources::EventProxy<resources::Cuda> unstable(
     Iter end,
     Compare comp)
 {
-  constexpr bool stable = true;
-  return detail::sort<!stable>(cuda_res, p, begin, end, comp);
+  constexpr bool require_stable = true;
+  return detail::sort<!require_stable>(cuda_res, p, begin, end, comp);
 }
 
 /*!
@@ -402,8 +402,8 @@ resources::EventProxy<resources::Cuda> stable_pairs(
     ValIter vals_begin,
     Compare comp)
 {
-  constexpr bool stable = true;
-  return detail::sort_pairs<stable>(cuda_res, p, keys_begin, keys_end,
+  constexpr bool require_stable = true;
+  return detail::sort_pairs<require_stable>(cuda_res, p, keys_begin, keys_end,
                                     vals_begin, comp);
 }
 
@@ -430,8 +430,8 @@ resources::EventProxy<resources::Cuda> unstable_pairs(
     ValIter vals_begin,
     Compare comp)
 {
-  constexpr bool stable = true;
-  return detail::sort_pairs<!stable>(cuda_res, p, keys_begin, keys_end,
+  constexpr bool require_stable = true;
+  return detail::sort_pairs<!require_stable>(cuda_res, p, keys_begin, keys_end,
                                      vals_begin, comp);
 }
 

--- a/include/RAJA/policy/cuda/sort.hpp
+++ b/include/RAJA/policy/cuda/sort.hpp
@@ -44,17 +44,21 @@ namespace impl
 namespace sort
 {
 
+namespace detail
+{
+
 /*!
-        \brief stable sort given range
+        \brief sort given range
 */
-template<typename IterationMapping,
+template<bool Stable,
+         typename IterationMapping,
          typename IterationGetter,
          typename Concretizer,
          size_t BLOCKS_PER_SM,
          bool Async,
          typename Iter,
          typename Compare>
-resources::EventProxy<resources::Cuda> stable(
+resources::EventProxy<resources::Cuda> sort(
     resources::Cuda cuda_res,
     ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
                                              IterationGetter,
@@ -65,6 +69,8 @@ resources::EventProxy<resources::Cuda> stable(
     Iter end,
     Compare comp)
 {
+  RAJA_UNUSED_VAR(Stable);
+
   cudaStream_t stream = cuda_res.get_stream();
 
   using R = RAJA::detail::IterVal<Iter>;
@@ -100,9 +106,18 @@ resources::EventProxy<resources::Cuda> stable(
   }
   else
   {
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortKeys,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   len, comp, stream);
+    if (Stable)
+    {
+      CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortKeys,
+                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     len, comp, stream);
+    }
+    else
+    {
+      CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::SortKeys,
+                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     len, comp, stream);
+    }
   }
   // Allocate temporary storage
   d_temp_storage =
@@ -127,9 +142,18 @@ resources::EventProxy<resources::Cuda> stable(
   }
   else
   {
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortKeys,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   len, comp, stream);
+    if (Stable)
+    {
+      CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortKeys,
+                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     len, comp, stream);
+    }
+    else
+    {
+      CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::SortKeys,
+                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     len, comp, stream);
+    }
   }
   // Free temporary storage
   cuda::device_mempool_type::getInstance().free(d_temp_storage);
@@ -150,33 +174,10 @@ resources::EventProxy<resources::Cuda> stable(
 }
 
 /*!
-        \brief sort given range
+        \brief sort given range of pairs in order of keys
 */
-template<typename IterationMapping,
-         typename IterationGetter,
-         typename Concretizer,
-         size_t BLOCKS_PER_SM,
-         bool Async,
-         typename Iter,
-         typename Compare>
-resources::EventProxy<resources::Cuda> unstable(
-    resources::Cuda cuda_res,
-    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
-                                             IterationGetter,
-                                             Concretizer,
-                                             BLOCKS_PER_SM,
-                                             Async> p,
-    Iter begin,
-    Iter end,
-    Compare comp)
-{
-  return stable(cuda_res, p, begin, end, comp);
-}
-
-/*!
-        \brief stable sort given range of pairs in order of keys
-*/
-template<typename IterationMapping,
+template<bool Stable,
+         typename IterationMapping,
          typename IterationGetter,
          typename Concretizer,
          size_t BLOCKS_PER_SM,
@@ -184,7 +185,7 @@ template<typename IterationMapping,
          typename KeyIter,
          typename ValIter,
          typename Compare>
-resources::EventProxy<resources::Cuda> stable_pairs(
+resources::EventProxy<resources::Cuda> sort_pairs(
     resources::Cuda cuda_res,
     ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
                                              IterationGetter,
@@ -196,6 +197,8 @@ resources::EventProxy<resources::Cuda> stable_pairs(
     ValIter vals_begin,
     Compare comp)
 {
+  RAJA_UNUSED_VAR(Stable);
+
   cudaStream_t stream = cuda_res.get_stream();
 
   using K = RAJA::detail::IterVal<KeyIter>;
@@ -236,9 +239,18 @@ resources::EventProxy<resources::Cuda> stable_pairs(
   }
   else
   {
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortPairs,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   d_vals, len, comp, stream);
+    if (Stable)
+    {
+      CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortPairs,
+                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     d_vals, len, comp, stream);
+    }
+    else
+    {
+      CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::SortPairs,
+                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     d_vals, len, comp, stream);
+    }
   }
   // Allocate temporary storage
   d_temp_storage =
@@ -265,9 +277,18 @@ resources::EventProxy<resources::Cuda> stable_pairs(
   }
   else
   {
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortPairs,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   d_vals, len, comp, stream);
+    if (Stable)
+    {
+      CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortPairs,
+                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     d_vals, len, comp, stream);
+    }
+    else
+    {
+      CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::SortPairs,
+                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     d_vals, len, comp, stream);
+    }
   }
   // Free temporary storage
   cuda::device_mempool_type::getInstance().free(d_temp_storage);
@@ -295,6 +316,86 @@ resources::EventProxy<resources::Cuda> stable_pairs(
   return resources::EventProxy<resources::Cuda>(cuda_res);
 }
 
+}  // namespace detail
+
+/*!
+        \brief sort given range
+*/
+template<typename IterationMapping,
+         typename IterationGetter,
+         typename Concretizer,
+         size_t BLOCKS_PER_SM,
+         bool Async,
+         typename Iter,
+         typename Compare>
+resources::EventProxy<resources::Cuda> stable(
+    resources::Cuda cuda_res,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
+                                             IterationGetter,
+                                             Concretizer,
+                                             BLOCKS_PER_SM,
+                                             Async> p,
+    Iter begin,
+    Iter end,
+    Compare comp)
+{
+  constexpr bool stable = true;
+  return detail::sort<stable>(cuda_res, p, begin, end, comp);
+}
+
+/*!
+        \brief sort given range
+*/
+template<typename IterationMapping,
+         typename IterationGetter,
+         typename Concretizer,
+         size_t BLOCKS_PER_SM,
+         bool Async,
+         typename Iter,
+         typename Compare>
+resources::EventProxy<resources::Cuda> unstable(
+    resources::Cuda cuda_res,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
+                                             IterationGetter,
+                                             Concretizer,
+                                             BLOCKS_PER_SM,
+                                             Async> p,
+    Iter begin,
+    Iter end,
+    Compare comp)
+{
+  constexpr bool stable = true;
+  return detail::sort<!stable>(cuda_res, p, begin, end, comp);
+}
+
+/*!
+        \brief stable sort given range of pairs in order of keys
+*/
+template<typename IterationMapping,
+         typename IterationGetter,
+         typename Concretizer,
+         size_t BLOCKS_PER_SM,
+         bool Async,
+         typename KeyIter,
+         typename ValIter,
+         typename Compare>
+resources::EventProxy<resources::Cuda> stable_pairs(
+    resources::Cuda cuda_res,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
+                                             IterationGetter,
+                                             Concretizer,
+                                             BLOCKS_PER_SM,
+                                             Async> p,
+    KeyIter keys_begin,
+    KeyIter keys_end,
+    ValIter vals_begin,
+    Compare comp)
+{
+  constexpr bool stable = true;
+  return detail::sort_pairs<stable>(cuda_res, p, keys_begin, keys_end,
+                                    vals_begin, comp);
+}
+
 /*!
         \brief stable sort given range of pairs in order of keys
 */
@@ -318,7 +419,9 @@ resources::EventProxy<resources::Cuda> unstable_pairs(
     ValIter vals_begin,
     Compare comp)
 {
-  return stable_pairs(cuda_res, p, keys_begin, keys_end, vals_begin, comp);
+  constexpr bool stable = true;
+  return detail::sort_pairs<!stable>(cuda_res, p, keys_begin, keys_end,
+                                     vals_begin, comp);
 }
 
 }  // namespace sort

--- a/include/RAJA/policy/cuda/sort.hpp
+++ b/include/RAJA/policy/cuda/sort.hpp
@@ -84,20 +84,21 @@ resources::EventProxy<resources::Cuda> sort(
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
 
-  auto call_impl = [&, d_out = static_cast<R*>(nullptr)](auto phase) mutable
-  {
+  auto call_impl = [&, d_out = static_cast<R*>(nullptr)](auto phase) mutable {
     RAJA_UNUSED_VAR(phase);
     RAJA_UNUSED_VAR(d_out);
 
     if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
-                  ( std::is_same_v<std::decay_t<Compare>, operators::less<R>> ||
-                    std::is_same_v<std::decay_t<Compare>, operators::greater<R>> ))
+                  (std::is_same_v<std::decay_t<Compare>, operators::less<R>> ||
+                   std::is_same_v<std::decay_t<Compare>,
+                                  operators::greater<R>>))
     {
       // The begin iterator is a pointer in this constexpr conditional
       // so we can use DoubleBuffer
 
       // Setup temporary storage for the output array
-      if constexpr (phase == 0) {
+      if constexpr (phase == 0)
+      {
         d_out = cuda::device_mempool_type::getInstance().malloc<R>(len);
       }
 
@@ -108,14 +109,15 @@ resources::EventProxy<resources::Cuda> sort(
       if constexpr (std::is_same_v<std::decay_t<Compare>, operators::less<R>>)
       {
         CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeys,
-                                       d_temp_storage, temp_storage_bytes, d_keys,
-                                       len, begin_bit, end_bit, stream);
+                                       d_temp_storage, temp_storage_bytes,
+                                       d_keys, len, begin_bit, end_bit, stream);
       }
-      else if constexpr (std::is_same_v<std::decay_t<Compare>, operators::greater<R>>)
+      else if constexpr (std::is_same_v<std::decay_t<Compare>,
+                                        operators::greater<R>>)
       {
-        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeysDescending,
-                                       d_temp_storage, temp_storage_bytes, d_keys,
-                                       len, begin_bit, end_bit, stream);
+        CAMP_CUDA_API_INVOKE_AND_CHECK(
+            ::cub::DeviceRadixSort::SortKeysDescending, d_temp_storage,
+            temp_storage_bytes, d_keys, len, begin_bit, end_bit, stream);
       }
 
       // Tear-down temporary storage for the output array
@@ -125,7 +127,8 @@ resources::EventProxy<resources::Cuda> sort(
         if (d_keys.Current() == d_out)
         {
           CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, begin, d_out,
-                                         len * sizeof(R), cudaMemcpyDefault, stream);
+                                         len * sizeof(R), cudaMemcpyDefault,
+                                         stream);
         }
 
         // Free temporary output array
@@ -150,7 +153,7 @@ resources::EventProxy<resources::Cuda> sort(
   };
 
   // Determine temporary device storage requirements
-  call_impl(std::integral_constant<int, 0>{});
+  call_impl(std::integral_constant<int, 0> {});
 
   // Allocate temporary storage
   d_temp_storage =
@@ -158,7 +161,7 @@ resources::EventProxy<resources::Cuda> sort(
           temp_storage_bytes);
 
   // Run
-  call_impl(std::integral_constant<int, 1>{});
+  call_impl(std::integral_constant<int, 1> {});
 
   // Free temporary storage
   cuda::device_mempool_type::getInstance().free(d_temp_storage);
@@ -210,22 +213,23 @@ resources::EventProxy<resources::Cuda> sort_pairs(
   size_t temp_storage_bytes = 0;
 
   auto call_impl = [&, d_keys_out = static_cast<K*>(nullptr),
-                       d_vals_out = static_cast<V*>(nullptr)](auto phase) mutable
-  {
+                    d_vals_out = static_cast<V*>(nullptr)](auto phase) mutable {
     RAJA_UNUSED_VAR(phase);
     RAJA_UNUSED_VAR(d_keys_out);
     RAJA_UNUSED_VAR(d_vals_out);
 
     if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
                   std::is_pointer_v<ValIter> &&
-                  ( std::is_same_v<std::decay_t<Compare>, operators::less<K>> ||
-                    std::is_same_v<std::decay_t<Compare>, operators::greater<K>> ))
+                  (std::is_same_v<std::decay_t<Compare>, operators::less<K>> ||
+                   std::is_same_v<std::decay_t<Compare>,
+                                  operators::greater<K>>))
     {
       // The begin iterators are pointers in this constexpr conditional
       // so we can use DoubleBuffer
 
       // Setup temporary storage for the output arrays
-      if constexpr (phase == 0) {
+      if constexpr (phase == 0)
+      {
         d_keys_out = cuda::device_mempool_type::getInstance().malloc<K>(len);
         d_vals_out = cuda::device_mempool_type::getInstance().malloc<V>(len);
       }
@@ -238,14 +242,17 @@ resources::EventProxy<resources::Cuda> sort_pairs(
       if constexpr (std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
       {
         CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
-                                       d_temp_storage, temp_storage_bytes, d_keys,
-                                       d_vals, len, begin_bit, end_bit, stream);
+                                       d_temp_storage, temp_storage_bytes,
+                                       d_keys, d_vals, len, begin_bit, end_bit,
+                                       stream);
       }
-      else if constexpr (std::is_same_v<std::decay_t<Compare>, operators::greater<K>>)
+      else if constexpr (std::is_same_v<std::decay_t<Compare>,
+                                        operators::greater<K>>)
       {
-        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
-                                       d_temp_storage, temp_storage_bytes, d_keys,
-                                       d_vals, len, begin_bit, end_bit, stream);
+        CAMP_CUDA_API_INVOKE_AND_CHECK(
+            ::cub::DeviceRadixSort::SortPairsDescending, d_temp_storage,
+            temp_storage_bytes, d_keys, d_vals, len, begin_bit, end_bit,
+            stream);
       }
 
       // Tear-down temporary storage for the output array
@@ -255,26 +262,27 @@ resources::EventProxy<resources::Cuda> sort_pairs(
         if (d_keys.Current() == d_keys_out && d_vals.Current() == d_vals_out)
         {
           // Copy keys and values back via kernel for performance
-          forall_impl(cuda_res,
-              ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
-                                                       IterationGetter,
-                                                       Concretizer,
-                                                       BLOCKS_PER_SM,
-                                                       true>{},
+          forall_impl(
+              cuda_res,
+              ::RAJA::policy::cuda::cuda_exec_explicit<
+                  IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM,
+                  true> {},
               TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-              ::RAJA::detail::Copy2Functor{keys_begin, d_keys_out,
-                                           vals_begin, d_vals_out},
+              ::RAJA::detail::Copy2Functor {keys_begin, d_keys_out, vals_begin,
+                                            d_vals_out},
               expt::get_empty_forall_param_pack());
         }
         else if (d_keys.Current() == d_keys_out)
         {
-          CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, keys_begin, d_keys_out,
-                                         len * sizeof(K), cudaMemcpyDefault, stream);
+          CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, keys_begin,
+                                         d_keys_out, len * sizeof(K),
+                                         cudaMemcpyDefault, stream);
         }
         else if (d_vals.Current() == d_vals_out)
         {
-          CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, vals_begin, d_vals_out,
-                                         len * sizeof(V), cudaMemcpyDefault, stream);
+          CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, vals_begin,
+                                         d_vals_out, len * sizeof(V),
+                                         cudaMemcpyDefault, stream);
         }
 
         // Free temporary output arrays
@@ -286,22 +294,21 @@ resources::EventProxy<resources::Cuda> sort_pairs(
     {
       if (Stable)
       {
-        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortPairs,
-                                       d_temp_storage, temp_storage_bytes,
-                                       keys_begin, vals_begin, len,
-                                       comp, stream);
+        CAMP_CUDA_API_INVOKE_AND_CHECK(
+            ::cub::DeviceMergeSort::StableSortPairs, d_temp_storage,
+            temp_storage_bytes, keys_begin, vals_begin, len, comp, stream);
       }
       else
       {
         CAMP_CUDA_API_INVOKE_AND_CHECK(
-            ::cub::DeviceMergeSort::SortPairs, d_temp_storage, temp_storage_bytes,
-            keys_begin, vals_begin, len, comp, stream);
+            ::cub::DeviceMergeSort::SortPairs, d_temp_storage,
+            temp_storage_bytes, keys_begin, vals_begin, len, comp, stream);
       }
     }
   };
 
   // Determine temporary device storage requirements
-  call_impl(std::integral_constant<int, 0>{});
+  call_impl(std::integral_constant<int, 0> {});
 
   // Allocate temporary storage
   d_temp_storage =
@@ -309,7 +316,7 @@ resources::EventProxy<resources::Cuda> sort_pairs(
           temp_storage_bytes);
 
   // Run
-  call_impl(std::integral_constant<int, 1>{});
+  call_impl(std::integral_constant<int, 1> {});
 
   // Free temporary storage
   cuda::device_mempool_type::getInstance().free(d_temp_storage);

--- a/include/RAJA/policy/cuda/sort.hpp
+++ b/include/RAJA/policy/cuda/sort.hpp
@@ -29,6 +29,7 @@
 #include <type_traits>
 
 #include "cub/device/device_radix_sort.cuh"
+#include "cub/device/device_merge_sort.cuh"
 
 #include "RAJA/util/concepts.hpp"
 #include "RAJA/util/Operators.hpp"
@@ -44,7 +45,7 @@ namespace sort
 {
 
 /*!
-        \brief static assert unimplemented stable sort
+        \brief stable sort given range
 */
 template<typename IterationMapping,
          typename IterationGetter,
@@ -53,62 +54,16 @@ template<typename IterationMapping,
          bool Async,
          typename Iter,
          typename Compare>
-concepts::enable_if_t<
-    resources::EventProxy<resources::Cuda>,
-    concepts::negate<concepts::all_of<
-        type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
-        std::is_pointer<Iter>,
-        concepts::any_of<
-            camp::is_same<Compare,
-                          operators::less<RAJA::detail::IterVal<Iter>>>,
-            camp::is_same<Compare,
-                          operators::greater<RAJA::detail::IterVal<Iter>>>>>>>
-stable(resources::Cuda cuda_res,
-       ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
-                                                IterationGetter,
-                                                Concretizer,
-                                                BLOCKS_PER_SM,
-                                                Async>,
-       Iter,
-       Iter,
-       Compare)
-{
-  static_assert(std::is_pointer<Iter>::value,
-                "stable_sort<cuda_exec> is only implemented for pointers");
-  using iterval = RAJA::detail::IterVal<Iter>;
-  static_assert(
-      type_traits::is_arithmetic<iterval>::value,
-      "stable_sort<cuda_exec> is only implemented for arithmetic types");
-  static_assert(concepts::any_of<
-                    camp::is_same<Compare, operators::less<iterval>>,
-                    camp::is_same<Compare, operators::greater<iterval>>>::value,
-                "stable_sort<cuda_exec> is only implemented for "
-                "RAJA::operators::less or RAJA::operators::greater");
-
-  return resources::EventProxy<resources::Cuda>(cuda_res);
-}
-
-/*!
-        \brief stable sort given range in ascending order
-*/
-template<typename IterationMapping,
-         typename IterationGetter,
-         typename Concretizer,
-         size_t BLOCKS_PER_SM,
-         bool Async,
-         typename Iter>
-concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
-                      type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
-                      std::is_pointer<Iter>>
-stable(resources::Cuda cuda_res,
-       ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
-                                                IterationGetter,
-                                                Concretizer,
-                                                BLOCKS_PER_SM,
-                                                Async>,
-       Iter begin,
-       Iter end,
-       operators::less<RAJA::detail::IterVal<Iter>>)
+resources::EventProxy<resources::Cuda> stable(
+    resources::Cuda cuda_res,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
+                                             IterationGetter,
+                                             Concretizer,
+                                             BLOCKS_PER_SM,
+                                             Async>,
+    Iter begin,
+    Iter end,
+    Compare comp)
 {
   cudaStream_t stream = cuda_res.get_stream();
 
@@ -128,18 +83,54 @@ stable(resources::Cuda cuda_res,
   // Determine temporary device storage requirements
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
-  CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeys,
-                                 d_temp_storage, temp_storage_bytes, d_keys,
-                                 len, begin_bit, end_bit, stream);
+  if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
+                std::is_same_v<std::decay_t<Compare>, operators::less<R>>)
+  {
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeys,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   len, begin_bit, end_bit, stream);
+  }
+  else if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
+                     std::is_same_v<std::decay_t<Compare>,
+                                    operators::greater<R>>)
+  {
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeysDescending,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   len, begin_bit, end_bit, stream);
+  }
+  else
+  {
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortKeys,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   len, comp, stream);
+  }
   // Allocate temporary storage
   d_temp_storage =
       cuda::device_mempool_type::getInstance().malloc<unsigned char>(
           temp_storage_bytes);
 
   // Run
-  CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeys,
-                                 d_temp_storage, temp_storage_bytes, d_keys,
-                                 len, begin_bit, end_bit, stream);
+  if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
+                std::is_same_v<std::decay_t<Compare>, operators::less<R>>)
+  {
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeys,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   len, begin_bit, end_bit, stream);
+  }
+  else if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
+                     std::is_same_v<std::decay_t<Compare>,
+                                    operators::greater<R>>)
+  {
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeysDescending,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   len, begin_bit, end_bit, stream);
+  }
+  else
+  {
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortKeys,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   len, comp, stream);
+  }
   // Free temporary storage
   cuda::device_mempool_type::getInstance().free(d_temp_storage);
 
@@ -159,77 +150,7 @@ stable(resources::Cuda cuda_res,
 }
 
 /*!
-        \brief stable sort given range in descending order
-*/
-template<typename IterationMapping,
-         typename IterationGetter,
-         typename Concretizer,
-         size_t BLOCKS_PER_SM,
-         bool Async,
-         typename Iter>
-concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
-                      type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
-                      std::is_pointer<Iter>>
-stable(resources::Cuda cuda_res,
-       ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
-                                                IterationGetter,
-                                                Concretizer,
-                                                BLOCKS_PER_SM,
-                                                Async>,
-       Iter begin,
-       Iter end,
-       operators::greater<RAJA::detail::IterVal<Iter>>)
-{
-  cudaStream_t stream = cuda_res.get_stream();
-
-  using R = RAJA::detail::IterVal<Iter>;
-
-  int len       = std::distance(begin, end);
-  int begin_bit = 0;
-  int end_bit   = sizeof(R) * CHAR_BIT;
-
-  // Allocate temporary storage for the output array
-  R* d_out = cuda::device_mempool_type::getInstance().malloc<R>(len);
-
-  // use cub double buffer to reduce temporary memory requirements
-  // by allowing cub to write to the begin buffer
-  cub::DoubleBuffer<R> d_keys(begin, d_out);
-
-  // Determine temporary device storage requirements
-  void* d_temp_storage      = nullptr;
-  size_t temp_storage_bytes = 0;
-  CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeysDescending,
-                                 d_temp_storage, temp_storage_bytes, d_keys,
-                                 len, begin_bit, end_bit, stream);
-  // Allocate temporary storage
-  d_temp_storage =
-      cuda::device_mempool_type::getInstance().malloc<unsigned char>(
-          temp_storage_bytes);
-
-  // Run
-  CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeysDescending,
-                                 d_temp_storage, temp_storage_bytes, d_keys,
-                                 len, begin_bit, end_bit, stream);
-  // Free temporary storage
-  cuda::device_mempool_type::getInstance().free(d_temp_storage);
-
-  if (d_keys.Current() == d_out)
-  {
-
-    // copy
-    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, begin, d_out,
-                                   len * sizeof(R), cudaMemcpyDefault, stream);
-  }
-
-  cuda::device_mempool_type::getInstance().free(d_out);
-
-  cuda::launch(cuda_res, Async);
-
-  return resources::EventProxy<resources::Cuda>(cuda_res);
-}
-
-/*!
-        \brief static assert unimplemented sort
+        \brief sort given range
 */
 template<typename IterationMapping,
          typename IterationGetter,
@@ -238,92 +159,22 @@ template<typename IterationMapping,
          bool Async,
          typename Iter,
          typename Compare>
-concepts::enable_if_t<
-    resources::EventProxy<resources::Cuda>,
-    concepts::negate<concepts::all_of<
-        type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
-        std::is_pointer<Iter>,
-        concepts::any_of<
-            camp::is_same<Compare,
-                          operators::less<RAJA::detail::IterVal<Iter>>>,
-            camp::is_same<Compare,
-                          operators::greater<RAJA::detail::IterVal<Iter>>>>>>>
-unstable(resources::Cuda cuda_res,
-         ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
-                                                  IterationGetter,
-                                                  Concretizer,
-                                                  BLOCKS_PER_SM,
-                                                  Async>,
-         Iter,
-         Iter,
-         Compare)
-{
-  static_assert(std::is_pointer<Iter>::value,
-                "sort<cuda_exec> is only implemented for pointers");
-  using iterval = RAJA::detail::IterVal<Iter>;
-  static_assert(type_traits::is_arithmetic<iterval>::value,
-                "sort<cuda_exec> is only implemented for arithmetic types");
-  static_assert(concepts::any_of<
-                    camp::is_same<Compare, operators::less<iterval>>,
-                    camp::is_same<Compare, operators::greater<iterval>>>::value,
-                "sort<cuda_exec> is only implemented for RAJA::operators::less "
-                "or RAJA::operators::greater");
-
-  return resources::EventProxy<resources::Cuda>(cuda_res);
-}
-
-/*!
-        \brief sort given range in ascending order
-*/
-template<typename IterationMapping,
-         typename IterationGetter,
-         typename Concretizer,
-         size_t BLOCKS_PER_SM,
-         bool Async,
-         typename Iter>
-concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
-                      type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
-                      std::is_pointer<Iter>>
-unstable(resources::Cuda cuda_res,
-         ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
-                                                  IterationGetter,
-                                                  Concretizer,
-                                                  BLOCKS_PER_SM,
-                                                  Async> p,
-         Iter begin,
-         Iter end,
-         operators::less<RAJA::detail::IterVal<Iter>> comp)
+resources::EventProxy<resources::Cuda> unstable(
+    resources::Cuda cuda_res,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
+                                             IterationGetter,
+                                             Concretizer,
+                                             BLOCKS_PER_SM,
+                                             Async> p,
+    Iter begin,
+    Iter end,
+    Compare comp)
 {
   return stable(cuda_res, p, begin, end, comp);
 }
 
 /*!
-        \brief sort given range in descending order
-*/
-template<typename IterationMapping,
-         typename IterationGetter,
-         typename Concretizer,
-         size_t BLOCKS_PER_SM,
-         bool Async,
-         typename Iter>
-concepts::enable_if_t<resources::EventProxy<resources::Cuda>,
-                      type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
-                      std::is_pointer<Iter>>
-unstable(resources::Cuda cuda_res,
-         ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
-                                                  IterationGetter,
-                                                  Concretizer,
-                                                  BLOCKS_PER_SM,
-                                                  Async> p,
-         Iter begin,
-         Iter end,
-         operators::greater<RAJA::detail::IterVal<Iter>> comp)
-{
-  return stable(cuda_res, p, begin, end, comp);
-}
-
-/*!
-        \brief static assert unimplemented stable sort pairs
+        \brief stable sort given range of pairs in order of keys
 */
 template<typename IterationMapping,
          typename IterationGetter,
@@ -333,73 +184,17 @@ template<typename IterationMapping,
          typename KeyIter,
          typename ValIter,
          typename Compare>
-concepts::enable_if_t<
-    resources::EventProxy<resources::Cuda>,
-    concepts::negate<concepts::all_of<
-        type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
-        std::is_pointer<KeyIter>,
-        std::is_pointer<ValIter>,
-        concepts::any_of<
-            camp::is_same<Compare,
-                          operators::less<RAJA::detail::IterVal<KeyIter>>>,
-            camp::is_same<
-                Compare,
-                operators::greater<RAJA::detail::IterVal<KeyIter>>>>>>>
-stable_pairs(resources::Cuda cuda_res,
-             ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
-                                                      IterationGetter,
-                                                      Concretizer,
-                                                      BLOCKS_PER_SM,
-                                                      Async>,
-             KeyIter,
-             KeyIter,
-             ValIter,
-             Compare)
-{
-  static_assert(
-      std::is_pointer<KeyIter>::value,
-      "stable_sort_pairs<cuda_exec> is only implemented for pointers");
-  static_assert(
-      std::is_pointer<ValIter>::value,
-      "stable_sort_pairs<cuda_exec> is only implemented for pointers");
-  using K = RAJA::detail::IterVal<KeyIter>;
-  static_assert(
-      type_traits::is_arithmetic<K>::value,
-      "stable_sort_pairs<cuda_exec> is only implemented for arithmetic types");
-  static_assert(
-      concepts::any_of<camp::is_same<Compare, operators::less<K>>,
-                       camp::is_same<Compare, operators::greater<K>>>::value,
-      "stable_sort_pairs<cuda_exec> is only implemented for "
-      "RAJA::operators::less or RAJA::operators::greater");
-
-  return resources::EventProxy<resources::Cuda>(cuda_res);
-}
-
-/*!
-        \brief stable sort given range of pairs in ascending order of keys
-*/
-template<typename IterationMapping,
-         typename IterationGetter,
-         typename Concretizer,
-         size_t BLOCKS_PER_SM,
-         bool Async,
-         typename KeyIter,
-         typename ValIter>
-concepts::enable_if_t<
-    resources::EventProxy<resources::Cuda>,
-    type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
-    std::is_pointer<KeyIter>,
-    std::is_pointer<ValIter>>
-stable_pairs(resources::Cuda cuda_res,
-             ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
-                                                      IterationGetter,
-                                                      Concretizer,
-                                                      BLOCKS_PER_SM,
-                                                      Async>,
-             KeyIter keys_begin,
-             KeyIter keys_end,
-             ValIter vals_begin,
-             operators::less<RAJA::detail::IterVal<KeyIter>>)
+resources::EventProxy<resources::Cuda> stable_pairs(
+    resources::Cuda cuda_res,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
+                                             IterationGetter,
+                                             Concretizer,
+                                             BLOCKS_PER_SM,
+                                             Async>,
+    KeyIter keys_begin,
+    KeyIter keys_end,
+    ValIter vals_begin,
+    Compare comp)
 {
   cudaStream_t stream = cuda_res.get_stream();
 
@@ -422,18 +217,58 @@ stable_pairs(resources::Cuda cuda_res,
   // Determine temporary device storage requirements
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
-  CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
-                                 d_temp_storage, temp_storage_bytes, d_keys,
-                                 d_vals, len, begin_bit, end_bit, stream);
+  if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
+                std::is_pointer_v<ValIter> &&
+                std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
+  {
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   d_vals, len, begin_bit, end_bit, stream);
+  }
+  else if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
+                     std::is_pointer_v<ValIter> &&
+                     std::is_same_v<std::decay_t<Compare>,
+                                    operators::greater<K>>)
+  {
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   d_vals, len, begin_bit, end_bit, stream);
+  }
+  else
+  {
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortPairs,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   d_vals, len, comp, stream);
+  }
   // Allocate temporary storage
   d_temp_storage =
       cuda::device_mempool_type::getInstance().malloc<unsigned char>(
           temp_storage_bytes);
 
   // Run
-  CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
-                                 d_temp_storage, temp_storage_bytes, d_keys,
-                                 d_vals, len, begin_bit, end_bit, stream);
+  if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
+                std::is_pointer_v<ValIter> &&
+                std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
+  {
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   d_vals, len, begin_bit, end_bit, stream);
+  }
+  else if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
+                     std::is_pointer_v<ValIter> &&
+                     std::is_same_v<std::decay_t<Compare>,
+                                    operators::greater<K>>)
+  {
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   d_vals, len, begin_bit, end_bit, stream);
+  }
+  else
+  {
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortPairs,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   d_vals, len, comp, stream);
+  }
   // Free temporary storage
   cuda::device_mempool_type::getInstance().free(d_temp_storage);
 
@@ -461,92 +296,7 @@ stable_pairs(resources::Cuda cuda_res,
 }
 
 /*!
-        \brief stable sort given range of pairs in descending order of keys
-*/
-template<typename IterationMapping,
-         typename IterationGetter,
-         typename Concretizer,
-         size_t BLOCKS_PER_SM,
-         bool Async,
-         typename KeyIter,
-         typename ValIter>
-concepts::enable_if_t<
-    resources::EventProxy<resources::Cuda>,
-    type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
-    std::is_pointer<KeyIter>,
-    std::is_pointer<ValIter>>
-stable_pairs(resources::Cuda cuda_res,
-             ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
-                                                      IterationGetter,
-                                                      Concretizer,
-                                                      BLOCKS_PER_SM,
-                                                      Async>,
-             KeyIter keys_begin,
-             KeyIter keys_end,
-             ValIter vals_begin,
-             operators::greater<RAJA::detail::IterVal<KeyIter>>)
-{
-  cudaStream_t stream = cuda_res.get_stream();
-
-  using K = RAJA::detail::IterVal<KeyIter>;
-  using V = RAJA::detail::IterVal<ValIter>;
-
-  int len       = std::distance(keys_begin, keys_end);
-  int begin_bit = 0;
-  int end_bit   = sizeof(K) * CHAR_BIT;
-
-  // Allocate temporary storage for the output arrays
-  K* d_keys_out = cuda::device_mempool_type::getInstance().malloc<K>(len);
-  V* d_vals_out = cuda::device_mempool_type::getInstance().malloc<V>(len);
-
-  // use cub double buffer to reduce temporary memory requirements
-  // by allowing cub to write to the keys_begin and vals_begin buffers
-  cub::DoubleBuffer<K> d_keys(keys_begin, d_keys_out);
-  cub::DoubleBuffer<V> d_vals(vals_begin, d_vals_out);
-
-  // Determine temporary device storage requirements
-  void* d_temp_storage      = nullptr;
-  size_t temp_storage_bytes = 0;
-  CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
-                                 d_temp_storage, temp_storage_bytes, d_keys,
-                                 d_vals, len, begin_bit, end_bit, stream);
-  // Allocate temporary storage
-  d_temp_storage =
-      cuda::device_mempool_type::getInstance().malloc<unsigned char>(
-          temp_storage_bytes);
-
-  // Run
-  CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
-                                 d_temp_storage, temp_storage_bytes, d_keys,
-                                 d_vals, len, begin_bit, end_bit, stream);
-  // Free temporary storage
-  cuda::device_mempool_type::getInstance().free(d_temp_storage);
-
-  if (d_keys.Current() == d_keys_out)
-  {
-
-    // copy keys
-    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, keys_begin, d_keys_out,
-                                   len * sizeof(K), cudaMemcpyDefault, stream);
-  }
-  if (d_vals.Current() == d_vals_out)
-  {
-
-    // copy vals
-    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, vals_begin, d_vals_out,
-                                   len * sizeof(V), cudaMemcpyDefault, stream);
-  }
-
-  cuda::device_mempool_type::getInstance().free(d_keys_out);
-  cuda::device_mempool_type::getInstance().free(d_vals_out);
-
-  cuda::launch(cuda_res, Async);
-
-  return resources::EventProxy<resources::Cuda>(cuda_res);
-}
-
-/*!
-        \brief static assert unimplemented sort pairs
+        \brief stable sort given range of pairs in order of keys
 */
 template<typename IterationMapping,
          typename IterationGetter,
@@ -556,100 +306,17 @@ template<typename IterationMapping,
          typename KeyIter,
          typename ValIter,
          typename Compare>
-concepts::enable_if_t<
-    resources::EventProxy<resources::Cuda>,
-    concepts::negate<concepts::all_of<
-        type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
-        std::is_pointer<KeyIter>,
-        std::is_pointer<ValIter>,
-        concepts::any_of<
-            camp::is_same<Compare,
-                          operators::less<RAJA::detail::IterVal<KeyIter>>>,
-            camp::is_same<
-                Compare,
-                operators::greater<RAJA::detail::IterVal<KeyIter>>>>>>>
-unstable_pairs(resources::Cuda cuda_res,
-               ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
-                                                        IterationGetter,
-                                                        Concretizer,
-                                                        BLOCKS_PER_SM,
-                                                        Async>,
-               KeyIter,
-               KeyIter,
-               ValIter,
-               Compare)
-{
-  static_assert(std::is_pointer<KeyIter>::value,
-                "sort_pairs<cuda_exec> is only implemented for pointers");
-  static_assert(std::is_pointer<ValIter>::value,
-                "sort_pairs<cuda_exec> is only implemented for pointers");
-  using K = RAJA::detail::IterVal<KeyIter>;
-  static_assert(
-      type_traits::is_arithmetic<K>::value,
-      "sort_pairs<cuda_exec> is only implemented for arithmetic types");
-  static_assert(
-      concepts::any_of<camp::is_same<Compare, operators::less<K>>,
-                       camp::is_same<Compare, operators::greater<K>>>::value,
-      "sort_pairs<cuda_exec> is only implemented for RAJA::operators::less or "
-      "RAJA::operators::greater");
-
-  return resources::EventProxy<resources::Cuda>(cuda_res);
-}
-
-/*!
-        \brief stable sort given range of pairs in ascending order of keys
-*/
-template<typename IterationMapping,
-         typename IterationGetter,
-         typename Concretizer,
-         size_t BLOCKS_PER_SM,
-         bool Async,
-         typename KeyIter,
-         typename ValIter>
-concepts::enable_if_t<
-    resources::EventProxy<resources::Cuda>,
-    type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
-    std::is_pointer<KeyIter>,
-    std::is_pointer<ValIter>>
-unstable_pairs(resources::Cuda cuda_res,
-               ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
-                                                        IterationGetter,
-                                                        Concretizer,
-                                                        BLOCKS_PER_SM,
-                                                        Async> p,
-               KeyIter keys_begin,
-               KeyIter keys_end,
-               ValIter vals_begin,
-               operators::less<RAJA::detail::IterVal<KeyIter>> comp)
-{
-  return stable_pairs(cuda_res, p, keys_begin, keys_end, vals_begin, comp);
-}
-
-/*!
-        \brief stable sort given range of pairs in descending order of keys
-*/
-template<typename IterationMapping,
-         typename IterationGetter,
-         typename Concretizer,
-         size_t BLOCKS_PER_SM,
-         bool Async,
-         typename KeyIter,
-         typename ValIter>
-concepts::enable_if_t<
-    resources::EventProxy<resources::Cuda>,
-    type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
-    std::is_pointer<KeyIter>,
-    std::is_pointer<ValIter>>
-unstable_pairs(resources::Cuda cuda_res,
-               ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
-                                                        IterationGetter,
-                                                        Concretizer,
-                                                        BLOCKS_PER_SM,
-                                                        Async> p,
-               KeyIter keys_begin,
-               KeyIter keys_end,
-               ValIter vals_begin,
-               operators::greater<RAJA::detail::IterVal<KeyIter>> comp)
+resources::EventProxy<resources::Cuda> unstable_pairs(
+    resources::Cuda cuda_res,
+    ::RAJA::policy::cuda::cuda_exec_explicit<IterationMapping,
+                                             IterationGetter,
+                                             Concretizer,
+                                             BLOCKS_PER_SM,
+                                             Async> p,
+    KeyIter keys_begin,
+    KeyIter keys_end,
+    ValIter vals_begin,
+    Compare comp)
 {
   return stable_pairs(cuda_res, p, keys_begin, keys_end, vals_begin, comp);
 }

--- a/include/RAJA/policy/cuda/sort.hpp
+++ b/include/RAJA/policy/cuda/sort.hpp
@@ -268,8 +268,8 @@ resources::EventProxy<resources::Cuda> sort_pairs(
                   IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM,
                   true> {},
               TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-              ::RAJA::detail::TwoCopiesFunctor {keys_begin, d_keys_out,
-                                                vals_begin, d_vals_out},
+              ::RAJA::detail::CopyFunctorTwoRanges {keys_begin, d_keys_out,
+                                                    vals_begin, d_vals_out},
               expt::get_empty_forall_param_pack());
         }
         else if (d_keys.Current() == d_keys_out)

--- a/include/RAJA/policy/cuda/sort.hpp
+++ b/include/RAJA/policy/cuda/sort.hpp
@@ -137,7 +137,7 @@ resources::EventProxy<resources::Cuda> sort(
     }
     else
     {
-      if (Stable)
+      if constexpr (Stable)
       {
         CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortKeys,
                                        d_temp_storage, temp_storage_bytes,
@@ -292,7 +292,7 @@ resources::EventProxy<resources::Cuda> sort_pairs(
     }
     else
     {
-      if (Stable)
+      if constexpr (Stable)
       {
         CAMP_CUDA_API_INVOKE_AND_CHECK(
             ::cub::DeviceMergeSort::StableSortPairs, d_temp_storage,

--- a/include/RAJA/policy/cuda/sort.hpp
+++ b/include/RAJA/policy/cuda/sort.hpp
@@ -109,13 +109,13 @@ resources::EventProxy<resources::Cuda> sort(
     if (Stable)
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortKeys,
-                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
                                      len, comp, stream);
     }
     else
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::SortKeys,
-                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
                                      len, comp, stream);
     }
   }
@@ -145,13 +145,13 @@ resources::EventProxy<resources::Cuda> sort(
     if (Stable)
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortKeys,
-                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
                                      len, comp, stream);
     }
     else
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::SortKeys,
-                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
                                      len, comp, stream);
     }
   }
@@ -242,14 +242,14 @@ resources::EventProxy<resources::Cuda> sort_pairs(
     if (Stable)
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortPairs,
-                                     d_temp_storage, temp_storage_bytes, d_keys,
-                                     d_vals, len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
+                                     d_vals.Current(), len, comp, stream);
     }
     else
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::SortPairs,
-                                     d_temp_storage, temp_storage_bytes, d_keys,
-                                     d_vals, len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
+                                     d_vals.Current(), len, comp, stream);
     }
   }
   // Allocate temporary storage
@@ -280,14 +280,14 @@ resources::EventProxy<resources::Cuda> sort_pairs(
     if (Stable)
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortPairs,
-                                     d_temp_storage, temp_storage_bytes, d_keys,
-                                     d_vals, len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
+                                     d_vals.Current(), len, comp, stream);
     }
     else
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::SortPairs,
-                                     d_temp_storage, temp_storage_bytes, d_keys,
-                                     d_vals, len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
+                                     d_vals.Current(), len, comp, stream);
     }
   }
   // Free temporary storage

--- a/include/RAJA/policy/cuda/sort.hpp
+++ b/include/RAJA/policy/cuda/sort.hpp
@@ -152,7 +152,7 @@ resources::EventProxy<resources::Cuda> sort(
     }
   };
 
-  // Determine temporary device storage requirements
+  // Determine temporary storage requirements
   call_impl(std::integral_constant<int, 0> {});
 
   // Allocate temporary storage
@@ -160,7 +160,7 @@ resources::EventProxy<resources::Cuda> sort(
       cuda::device_mempool_type::getInstance().malloc<unsigned char>(
           temp_storage_bytes);
 
-  // Run
+  // Run implementation
   call_impl(std::integral_constant<int, 1> {});
 
   // Free temporary storage

--- a/include/RAJA/policy/cuda/sort.hpp
+++ b/include/RAJA/policy/cuda/sort.hpp
@@ -84,9 +84,9 @@ resources::EventProxy<resources::Cuda> sort(
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
 
-  auto call_impl = [&, d_out = static_cast<R*>(nullptr)](auto phase) mutable {
+  auto call_impl = [&, tmp_begin = static_cast<R*>(nullptr)](auto phase) mutable {
     RAJA_UNUSED_VAR(phase);
-    RAJA_UNUSED_VAR(d_out);
+    RAJA_UNUSED_VAR(tmp_begin);
 
     if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
                   (std::is_same_v<std::decay_t<Compare>, operators::less<R>> ||
@@ -99,12 +99,12 @@ resources::EventProxy<resources::Cuda> sort(
       // Setup temporary storage for the output array
       if constexpr (phase == 0)
       {
-        d_out = cuda::device_mempool_type::getInstance().malloc<R>(len);
+        tmp_begin = cuda::device_mempool_type::getInstance().malloc<R>(len);
       }
 
       // Use DoubleBuffers to reduce temporary memory requirements
       // by allowing cub to write to the begin buffer
-      ::cub::DoubleBuffer<R> d_keys(begin, d_out);
+      ::cub::DoubleBuffer<R> d_keys(begin, tmp_begin);
 
       if constexpr (std::is_same_v<std::decay_t<Compare>, operators::less<R>>)
       {
@@ -124,15 +124,15 @@ resources::EventProxy<resources::Cuda> sort(
       if constexpr (phase == 1)
       {
         // Copy result back if necessary
-        if (d_keys.Current() == d_out)
+        if (d_keys.Current() == tmp_begin)
         {
-          CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, begin, d_out,
+          CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, begin, tmp_begin,
                                          len * sizeof(R), cudaMemcpyDefault,
                                          stream);
         }
 
         // Free temporary output array
-        cuda::device_mempool_type::getInstance().free(d_out);
+        cuda::device_mempool_type::getInstance().free(tmp_begin);
       }
     }
     else
@@ -212,11 +212,11 @@ resources::EventProxy<resources::Cuda> sort_pairs(
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
 
-  auto call_impl = [&, d_keys_out = static_cast<K*>(nullptr),
-                    d_vals_out = static_cast<V*>(nullptr)](auto phase) mutable {
+  auto call_impl = [&, tmp_keys_begin = static_cast<K*>(nullptr),
+                    tmp_vals_begin = static_cast<V*>(nullptr)](auto phase) mutable {
     RAJA_UNUSED_VAR(phase);
-    RAJA_UNUSED_VAR(d_keys_out);
-    RAJA_UNUSED_VAR(d_vals_out);
+    RAJA_UNUSED_VAR(tmp_keys_begin);
+    RAJA_UNUSED_VAR(tmp_vals_begin);
 
     if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
                   std::is_pointer_v<ValIter> &&
@@ -230,14 +230,14 @@ resources::EventProxy<resources::Cuda> sort_pairs(
       // Setup temporary storage for the output arrays
       if constexpr (phase == 0)
       {
-        d_keys_out = cuda::device_mempool_type::getInstance().malloc<K>(len);
-        d_vals_out = cuda::device_mempool_type::getInstance().malloc<V>(len);
+        tmp_keys_begin = cuda::device_mempool_type::getInstance().malloc<K>(len);
+        tmp_vals_begin = cuda::device_mempool_type::getInstance().malloc<V>(len);
       }
 
       // Use DoubleBuffers to reduce temporary memory requirements
       // by allowing cub to write to the keys_begin and vals_begin buffers
-      ::cub::DoubleBuffer<K> d_keys(keys_begin, d_keys_out);
-      ::cub::DoubleBuffer<V> d_vals(vals_begin, d_vals_out);
+      ::cub::DoubleBuffer<K> d_keys(keys_begin, tmp_keys_begin);
+      ::cub::DoubleBuffer<V> d_vals(vals_begin, tmp_vals_begin);
 
       if constexpr (std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
       {
@@ -259,7 +259,7 @@ resources::EventProxy<resources::Cuda> sort_pairs(
       if constexpr (phase == 1)
       {
         // copy keys and values back if necessary
-        if (d_keys.Current() == d_keys_out && d_vals.Current() == d_vals_out)
+        if (d_keys.Current() == tmp_keys_begin && d_vals.Current() == tmp_vals_begin)
         {
           // Copy keys and values back via kernel for performance
           forall_impl(
@@ -268,26 +268,26 @@ resources::EventProxy<resources::Cuda> sort_pairs(
                   IterationMapping, IterationGetter, Concretizer, BLOCKS_PER_SM,
                   true> {},
               TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-              ::RAJA::detail::CopyFunctorTwoRanges {keys_begin, d_keys_out,
-                                                    vals_begin, d_vals_out},
+              ::RAJA::detail::CopyFunctorTwoRanges {keys_begin, tmp_keys_begin,
+                                                    vals_begin, tmp_vals_begin},
               expt::get_empty_forall_param_pack());
         }
-        else if (d_keys.Current() == d_keys_out)
+        else if (d_keys.Current() == tmp_keys_begin)
         {
           CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, keys_begin,
-                                         d_keys_out, len * sizeof(K),
+                                         tmp_keys_begin, len * sizeof(K),
                                          cudaMemcpyDefault, stream);
         }
-        else if (d_vals.Current() == d_vals_out)
+        else if (d_vals.Current() == tmp_vals_begin)
         {
           CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMemcpyAsync, vals_begin,
-                                         d_vals_out, len * sizeof(V),
+                                         tmp_vals_begin, len * sizeof(V),
                                          cudaMemcpyDefault, stream);
         }
 
         // Free temporary output arrays
-        cuda::device_mempool_type::getInstance().free(d_keys_out);
-        cuda::device_mempool_type::getInstance().free(d_vals_out);
+        cuda::device_mempool_type::getInstance().free(tmp_keys_begin);
+        cuda::device_mempool_type::getInstance().free(tmp_vals_begin);
       }
     }
     else

--- a/include/RAJA/policy/cuda/sort.hpp
+++ b/include/RAJA/policy/cuda/sort.hpp
@@ -104,7 +104,7 @@ resources::EventProxy<resources::Cuda> sort(
 
       // Use DoubleBuffers to reduce temporary memory requirements
       // by allowing cub to write to the begin buffer
-      cub::DoubleBuffer<R> d_keys(begin, d_out);
+      ::cub::DoubleBuffer<R> d_keys(begin, d_out);
 
       if constexpr (std::is_same_v<std::decay_t<Compare>, operators::less<R>>)
       {
@@ -236,8 +236,8 @@ resources::EventProxy<resources::Cuda> sort_pairs(
 
       // Use DoubleBuffers to reduce temporary memory requirements
       // by allowing cub to write to the keys_begin and vals_begin buffers
-      cub::DoubleBuffer<K> d_keys(keys_begin, d_keys_out);
-      cub::DoubleBuffer<V> d_vals(vals_begin, d_vals_out);
+      ::cub::DoubleBuffer<K> d_keys(keys_begin, d_keys_out);
+      ::cub::DoubleBuffer<V> d_vals(vals_begin, d_vals_out);
 
       if constexpr (std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
       {

--- a/include/RAJA/policy/hip/sort.hpp
+++ b/include/RAJA/policy/hip/sort.hpp
@@ -200,13 +200,13 @@ resources::EventProxy<resources::Hip> sort(
 #elif defined(__CUDACC__)
       if constexpr (Stable)
       {
-        CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortKeys,
+        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortKeys,
                                        d_temp_storage, temp_storage_bytes,
                                        begin, len, comp, stream);
       }
       else
       {
-        CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::SortKeys,
+        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::SortKeys,
                                        d_temp_storage, temp_storage_bytes,
                                        begin, len, comp, stream);
       }
@@ -397,13 +397,13 @@ resources::EventProxy<resources::Hip> sort_pairs(
       if constexpr (Stable)
       {
         CAMP_CUDA_API_INVOKE_AND_CHECK(
-            cub::DeviceMergeSort::StableSortPairs, d_temp_storage,
+            ::cub::DeviceMergeSort::StableSortPairs, d_temp_storage,
             temp_storage_bytes, keys_begin, vals_begin, len, comp, stream);
       }
       else
       {
         CAMP_CUDA_API_INVOKE_AND_CHECK(
-            cub::DeviceMergeSort::SortPairs, d_temp_storage, temp_storage_bytes,
+            ::cub::DeviceMergeSort::SortPairs, d_temp_storage, temp_storage_bytes,
             keys_begin, vals_begin, len, comp, stream);
       }
 #endif

--- a/include/RAJA/policy/hip/sort.hpp
+++ b/include/RAJA/policy/hip/sort.hpp
@@ -142,20 +142,20 @@ resources::EventProxy<resources::Hip> sort(
   {
 #if defined(__HIPCC__)
     CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                  temp_storage_bytes, d_keys.current(), d_keys.alternate(), len, comp,
-                                  stream);
+                                  temp_storage_bytes, d_keys.current(),
+                                  d_keys.alternate(), len, comp, stream);
 #elif defined(__CUDACC__)
     if constexpr (Stable)
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortKeys,
-                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
-                                     len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes,
+                                     d_keys.Current(), len, comp, stream);
     }
     else
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::SortKeys,
-                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
-                                     len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes,
+                                     d_keys.Current(), len, comp, stream);
     }
 #endif
   }
@@ -196,21 +196,21 @@ resources::EventProxy<resources::Hip> sort(
   {
 #if defined(__HIPCC__)
     CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                  temp_storage_bytes, d_keys.current(), d_keys.alternate(), len, comp,
-                                  stream);
+                                  temp_storage_bytes, d_keys.current(),
+                                  d_keys.alternate(), len, comp, stream);
     d_keys.swap();
 #elif defined(__CUDACC__)
     if constexpr (Stable)
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortKeys,
-                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
-                                     len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes,
+                                     d_keys.Current(), len, comp, stream);
     }
     else
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::SortKeys,
-                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
-                                     len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes,
+                                     d_keys.Current(), len, comp, stream);
     }
 #endif
   }
@@ -308,21 +308,22 @@ resources::EventProxy<resources::Hip> sort_pairs(
   {
 #if defined(__HIPCC__)
     CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                  temp_storage_bytes, d_keys.current(), d_keys.alternate(),
-                                  d_vals.current(), d_vals.alternate(), len, comp,
-                                  stream);
+                                  temp_storage_bytes, d_keys.current(),
+                                  d_keys.alternate(), d_vals.current(),
+                                  d_vals.alternate(), len, comp, stream);
 #elif defined(__CUDACC__)
     if constexpr (Stable)
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortPairs,
-                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
-                                     d_vals.Current(), len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes,
+                                     d_keys.Current(), d_vals.Current(), len,
+                                     comp, stream);
     }
     else
     {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::SortPairs,
-                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
-                                     d_vals.Current(), len, comp, stream);
+      CAMP_CUDA_API_INVOKE_AND_CHECK(
+          cub::DeviceMergeSort::SortPairs, d_temp_storage, temp_storage_bytes,
+          d_keys.Current(), d_vals.Current(), len, comp, stream);
     }
 #endif
   }
@@ -365,23 +366,24 @@ resources::EventProxy<resources::Hip> sort_pairs(
   {
 #if defined(__HIPCC__)
     CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                  temp_storage_bytes, d_keys.current(), d_keys.alternate(),
-                                  d_vals.current(), d_vals.alternate(), len, comp,
-                                  stream);
+                                  temp_storage_bytes, d_keys.current(),
+                                  d_keys.alternate(), d_vals.current(),
+                                  d_vals.alternate(), len, comp, stream);
     d_keys.swap();
     d_vals.swap();
 #elif defined(__CUDACC__)
     if constexpr (Stable)
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortPairs,
-                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
-                                     d_vals.Current(), len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes,
+                                     d_keys.Current(), d_vals.Current(), len,
+                                     comp, stream);
     }
     else
     {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::SortPairs,
-                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
-                                     d_vals.Current(), len, comp, stream);
+      CAMP_CUDA_API_INVOKE_AND_CHECK(
+          cub::DeviceMergeSort::SortPairs, d_temp_storage, temp_storage_bytes,
+          d_keys.Current(), d_vals.Current(), len, comp, stream);
     }
 #endif
   }

--- a/include/RAJA/policy/hip/sort.hpp
+++ b/include/RAJA/policy/hip/sort.hpp
@@ -393,7 +393,7 @@ resources::EventProxy<resources::Hip> sort_pairs(
 
         // Free temporary output arrays
         hip::device_mempool_type::getInstance().free(tmp_keys_begin);
-        hip::device_mempool_type::getInstance().free(dst_vals_begin);
+        hip::device_mempool_type::getInstance().free(tmp_vals_begin);
       }
 #elif defined(__CUDACC__)
       if constexpr (RequireStable)

--- a/include/RAJA/policy/hip/sort.hpp
+++ b/include/RAJA/policy/hip/sort.hpp
@@ -191,7 +191,7 @@ resources::EventProxy<resources::Hip> sort(
             ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter,
                                           Concretizer, true> {},
             TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-            ::RAJA::detail::Copy1Functor {begin, d_out},
+            ::RAJA::detail::OneCopyFunctor {begin, d_out},
             expt::get_empty_forall_param_pack());
 
         // Free temporary output array
@@ -339,7 +339,7 @@ resources::EventProxy<resources::Hip> sort_pairs(
               ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter,
                                             Concretizer, true> {},
               TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-              ::RAJA::detail::Copy2Functor {keys_begin, d_keys_out, vals_begin,
+              ::RAJA::detail::TwoCopiesFunctor {keys_begin, d_keys_out, vals_begin,
                                             d_vals_out},
               expt::get_empty_forall_param_pack());
         }
@@ -385,7 +385,7 @@ resources::EventProxy<resources::Hip> sort_pairs(
             ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter,
                                           Concretizer, true> {},
             TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-            ::RAJA::detail::Copy2Functor {keys_begin, d_keys_out, vals_begin,
+            ::RAJA::detail::TwoCopiesFunctor {keys_begin, d_keys_out, vals_begin,
                                           d_vals_out},
             expt::get_empty_forall_param_pack());
 

--- a/include/RAJA/policy/hip/sort.hpp
+++ b/include/RAJA/policy/hip/sort.hpp
@@ -142,19 +142,19 @@ resources::EventProxy<resources::Hip> sort(
   {
 #if defined(__HIPCC__)
     CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                  temp_storage_bytes, d_keys, len, comp,
+                                  temp_storage_bytes, d_keys.current(), d_keys.alternate(), len, comp,
                                   stream);
 #elif defined(__CUDACC__)
     if constexpr (Stable)
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortKeys,
-                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
                                      len, comp, stream);
     }
     else
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::SortKeys,
-                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
                                      len, comp, stream);
     }
 #endif
@@ -196,19 +196,20 @@ resources::EventProxy<resources::Hip> sort(
   {
 #if defined(__HIPCC__)
     CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                  temp_storage_bytes, d_keys, len, comp,
+                                  temp_storage_bytes, d_keys.current(), d_keys.alternate(), len, comp,
                                   stream);
+    d_keys.swap();
 #elif defined(__CUDACC__)
     if constexpr (Stable)
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortKeys,
-                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
                                      len, comp, stream);
     }
     else
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::SortKeys,
-                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
                                      len, comp, stream);
     }
 #endif
@@ -307,20 +308,21 @@ resources::EventProxy<resources::Hip> sort_pairs(
   {
 #if defined(__HIPCC__)
     CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                  temp_storage_bytes, d_keys, d_vals, len, comp,
+                                  temp_storage_bytes, d_keys.current(), d_keys.alternate(),
+                                  d_vals.current(), d_vals.alternate(), len, comp,
                                   stream);
 #elif defined(__CUDACC__)
     if constexpr (Stable)
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortPairs,
-                                     d_temp_storage, temp_storage_bytes, d_keys,
-                                     d_vals, len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
+                                     d_vals.Current(), len, comp, stream);
     }
     else
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::SortPairs,
-                                     d_temp_storage, temp_storage_bytes, d_keys,
-                                     d_vals, len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
+                                     d_vals.Current(), len, comp, stream);
     }
 #endif
   }
@@ -363,20 +365,23 @@ resources::EventProxy<resources::Hip> sort_pairs(
   {
 #if defined(__HIPCC__)
     CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                  temp_storage_bytes, d_keys, d_vals, len, comp,
+                                  temp_storage_bytes, d_keys.current(), d_keys.alternate(),
+                                  d_vals.current(), d_vals.alternate(), len, comp,
                                   stream);
+    d_keys.swap();
+    d_vals.swap();
 #elif defined(__CUDACC__)
     if constexpr (Stable)
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortPairs,
-                                     d_temp_storage, temp_storage_bytes, d_keys,
-                                     d_vals, len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
+                                     d_vals.Current(), len, comp, stream);
     }
     else
     {
       CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::SortPairs,
-                                     d_temp_storage, temp_storage_bytes, d_keys,
-                                     d_vals, len, comp, stream);
+                                     d_temp_storage, temp_storage_bytes, d_keys.Current(),
+                                     d_vals.Current(), len, comp, stream);
     }
 #endif
   }

--- a/include/RAJA/policy/hip/sort.hpp
+++ b/include/RAJA/policy/hip/sort.hpp
@@ -33,8 +33,10 @@
 #define ROCPRIM_HIP_API 1
 #include "rocprim/device/device_transform.hpp"
 #include "rocprim/device/device_radix_sort.hpp"
+#include "rocprim/device/device_merge_sort.hpp"
 #elif defined(__CUDACC__)
 #include "cub/device/device_radix_sort.cuh"
+#include "cub/device/device_merge_sort.cuh"
 #endif
 
 #include "RAJA/util/concepts.hpp"
@@ -74,7 +76,7 @@ R* get_current(double_buffer<R>& d_bufs)
 }  // namespace detail
 
 /*!
-        \brief static assert unimplemented stable sort
+        \brief stable sort given range
 */
 template<typename IterationMapping,
          typename IterationGetter,
@@ -82,64 +84,21 @@ template<typename IterationMapping,
          bool Async,
          typename Iter,
          typename Compare>
-concepts::enable_if_t<
-    resources::EventProxy<resources::Hip>,
-    concepts::negate<concepts::all_of<
-        type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
-        std::is_pointer<Iter>,
-        concepts::any_of<
-            camp::is_same<Compare,
-                          operators::less<RAJA::detail::IterVal<Iter>>>,
-            camp::is_same<Compare,
-                          operators::greater<RAJA::detail::IterVal<Iter>>>>>>>
-stable(resources::Hip hip_res,
-       ::RAJA::policy::hip::
-           hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
-       Iter,
-       Iter,
-       Compare)
-{
-  static_assert(
-      concepts::all_of<
-          type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
-          std::is_pointer<Iter>,
-          concepts::any_of<
-              camp::is_same<Compare,
-                            operators::less<RAJA::detail::IterVal<Iter>>>,
-              camp::is_same<Compare, operators::greater<
-                                         RAJA::detail::IterVal<Iter>>>>>::value,
-      "RAJA stable_sort<hip_exec> is only implemented for pointers to "
-      "arithmetic types and RAJA::operators::less and "
-      "RAJA::operators::greater.");
-
-  return resources::EventProxy<resources::Hip>(hip_res);
-}
-
-/*!
-        \brief stable sort given range in ascending order
-*/
-template<typename IterationMapping,
-         typename IterationGetter,
-         typename Concretizer,
-         bool Async,
-         typename Iter>
-concepts::enable_if_t<resources::EventProxy<resources::Hip>,
-                      type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
-                      std::is_pointer<Iter>>
-stable(resources::Hip hip_res,
-       ::RAJA::policy::hip::
-           hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
-       Iter begin,
-       Iter end,
-       operators::less<RAJA::detail::IterVal<Iter>>)
+resources::EventProxy<resources::Hip> stable(
+    resources::Hip hip_res,
+    ::RAJA::policy::hip::
+        hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
+    Iter begin,
+    Iter end,
+    Compare comp)
 {
   hipStream_t stream = hip_res.get_stream();
 
   using R = RAJA::detail::IterVal<Iter>;
 
-  int len       = std::distance(begin, end);
-  int begin_bit = 0;
-  int end_bit   = sizeof(R) * CHAR_BIT;
+  const int len           = std::distance(begin, end);
+  constexpr int begin_bit = 0;
+  constexpr int end_bit   = sizeof(R) * CHAR_BIT;
 
   // Allocate temporary storage for the output array
   R* d_out = hip::device_mempool_type::getInstance().malloc<R>(len);
@@ -151,30 +110,90 @@ stable(resources::Hip hip_res,
   // Determine temporary device storage requirements
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
+  if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
+                std::is_same_v<std::decay_t<Compare>, operators::less<R>>)
+  {
 #if defined(__HIPCC__)
-  CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_keys, d_temp_storage,
-                                temp_storage_bytes, d_keys, len, begin_bit,
-                                end_bit, stream);
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_keys, d_temp_storage,
+                                  temp_storage_bytes, d_keys, len, begin_bit,
+                                  end_bit, stream);
 #elif defined(__CUDACC__)
-  CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeys,
-                                 d_temp_storage, temp_storage_bytes, d_keys,
-                                 len, begin_bit, end_bit, stream);
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeys,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   len, begin_bit, end_bit, stream);
 #endif
+  }
+  else if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
+                     std::is_same_v<std::decay_t<Compare>,
+                                    operators::greater<R>>)
+  {
+#if defined(__HIPCC__)
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_keys_desc,
+                                  d_temp_storage, temp_storage_bytes, d_keys,
+                                  len, begin_bit, end_bit, stream);
+#elif defined(__CUDACC__)
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeysDescending,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   len, begin_bit, end_bit, stream);
+#endif
+  }
+  else
+  {
+#if defined(__HIPCC__)
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
+                                  temp_storage_bytes, d_keys, len, comp,
+                                  stream);
+#elif defined(__CUDACC__)
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortKeys,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   len, comp, stream);
+#endif
+  }
   // Allocate temporary storage
   d_temp_storage =
       hip::device_mempool_type::getInstance().malloc<unsigned char>(
           temp_storage_bytes);
 
   // Run
+  if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
+                std::is_same_v<std::decay_t<Compare>, operators::less<R>>)
+  {
 #if defined(__HIPCC__)
-  CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_keys, d_temp_storage,
-                                temp_storage_bytes, d_keys, len, begin_bit,
-                                end_bit, stream);
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_keys, d_temp_storage,
+                                  temp_storage_bytes, d_keys, len, begin_bit,
+                                  end_bit, stream);
 #elif defined(__CUDACC__)
-  CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeys,
-                                 d_temp_storage, temp_storage_bytes, d_keys,
-                                 len, begin_bit, end_bit, stream);
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeys,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   len, begin_bit, end_bit, stream);
 #endif
+  }
+  else if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
+                     std::is_same_v<std::decay_t<Compare>,
+                                    operators::greater<R>>)
+  {
+#if defined(__HIPCC__)
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_keys_desc,
+                                  d_temp_storage, temp_storage_bytes, d_keys,
+                                  len, begin_bit, end_bit, stream);
+#elif defined(__CUDACC__)
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeysDescending,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   len, begin_bit, end_bit, stream);
+#endif
+  }
+  else
+  {
+#if defined(__HIPCC__)
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
+                                  temp_storage_bytes, d_keys, len, comp,
+                                  stream);
+#elif defined(__CUDACC__)
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortKeys,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   len, comp, stream);
+#endif
+  }
   // Free temporary storage
   hip::device_mempool_type::getInstance().free(d_temp_storage);
 
@@ -194,85 +213,7 @@ stable(resources::Hip hip_res,
 }
 
 /*!
-        \brief stable sort given range in descending order
-*/
-template<typename IterationMapping,
-         typename IterationGetter,
-         typename Concretizer,
-         bool Async,
-         typename Iter>
-concepts::enable_if_t<resources::EventProxy<resources::Hip>,
-                      type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
-                      std::is_pointer<Iter>>
-stable(resources::Hip hip_res,
-       ::RAJA::policy::hip::
-           hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
-       Iter begin,
-       Iter end,
-       operators::greater<RAJA::detail::IterVal<Iter>>)
-{
-  hipStream_t stream = hip_res.get_stream();
-
-  using R = RAJA::detail::IterVal<Iter>;
-
-  int len       = std::distance(begin, end);
-  int begin_bit = 0;
-  int end_bit   = sizeof(R) * CHAR_BIT;
-
-  // Allocate temporary storage for the output array
-  R* d_out = hip::device_mempool_type::getInstance().malloc<R>(len);
-
-  // use cub double buffer to reduce temporary memory requirements
-  // by allowing cub to write to the begin buffer
-  detail::double_buffer<R> d_keys(begin, d_out);
-
-  // Determine temporary device storage requirements
-  void* d_temp_storage      = nullptr;
-  size_t temp_storage_bytes = 0;
-#if defined(__HIPCC__)
-  CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_keys_desc, d_temp_storage,
-                                temp_storage_bytes, d_keys, len, begin_bit,
-                                end_bit, stream);
-#elif defined(__CUDACC__)
-  CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeysDescending,
-                                 d_temp_storage, temp_storage_bytes, d_keys,
-                                 len, begin_bit, end_bit, stream);
-#endif
-  // Allocate temporary storage
-  d_temp_storage =
-      hip::device_mempool_type::getInstance().malloc<unsigned char>(
-          temp_storage_bytes);
-
-  // Run
-#if defined(__HIPCC__)
-  CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_keys_desc, d_temp_storage,
-                                temp_storage_bytes, d_keys, len, begin_bit,
-                                end_bit, stream);
-#elif defined(__CUDACC__)
-  CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeysDescending,
-                                 d_temp_storage, temp_storage_bytes, d_keys,
-                                 len, begin_bit, end_bit, stream);
-#endif
-  // Free temporary storage
-  hip::device_mempool_type::getInstance().free(d_temp_storage);
-
-  if (detail::get_current(d_keys) == d_out)
-  {
-
-    // copy
-    CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, begin, d_out, len * sizeof(R),
-                                  hipMemcpyDefault, stream);
-  }
-
-  hip::device_mempool_type::getInstance().free(d_out);
-
-  hip::launch(hip_res, Async);
-
-  return resources::EventProxy<resources::Hip>(hip_res);
-}
-
-/*!
-        \brief static assert unimplemented sort
+        \brief sort given range
 */
 template<typename IterationMapping,
          typename IterationGetter,
@@ -280,82 +221,19 @@ template<typename IterationMapping,
          bool Async,
          typename Iter,
          typename Compare>
-concepts::enable_if_t<
-    resources::EventProxy<resources::Hip>,
-    concepts::negate<concepts::all_of<
-        type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
-        std::is_pointer<Iter>,
-        concepts::any_of<
-            camp::is_same<Compare,
-                          operators::less<RAJA::detail::IterVal<Iter>>>,
-            camp::is_same<Compare,
-                          operators::greater<RAJA::detail::IterVal<Iter>>>>>>>
-unstable(resources::Hip hip_res,
-         ::RAJA::policy::hip::
-             hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
-         Iter,
-         Iter,
-         Compare)
-{
-  static_assert(
-      concepts::all_of<
-          type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
-          std::is_pointer<Iter>,
-          concepts::any_of<
-              camp::is_same<Compare,
-                            operators::less<RAJA::detail::IterVal<Iter>>>,
-              camp::is_same<Compare, operators::greater<
-                                         RAJA::detail::IterVal<Iter>>>>>::value,
-      "RAJA sort<hip_exec> is only implemented for pointers to arithmetic "
-      "types and RAJA::operators::less and RAJA::operators::greater.");
-
-  return resources::EventProxy<resources::Hip>(hip_res);
-}
-
-/*!
-        \brief sort given range in ascending order
-*/
-template<typename IterationMapping,
-         typename IterationGetter,
-         typename Concretizer,
-         bool Async,
-         typename Iter>
-concepts::enable_if_t<resources::EventProxy<resources::Hip>,
-                      type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
-                      std::is_pointer<Iter>>
-unstable(resources::Hip hip_res,
-         ::RAJA::policy::hip::
-             hip_exec<IterationMapping, IterationGetter, Concretizer, Async> p,
-         Iter begin,
-         Iter end,
-         operators::less<RAJA::detail::IterVal<Iter>> comp)
+resources::EventProxy<resources::Hip> unstable(
+    resources::Hip hip_res,
+    ::RAJA::policy::hip::
+        hip_exec<IterationMapping, IterationGetter, Concretizer, Async> p,
+    Iter begin,
+    Iter end,
+    Compare comp)
 {
   return stable(hip_res, p, begin, end, comp);
 }
 
 /*!
-        \brief sort given range in descending order
-*/
-template<typename IterationMapping,
-         typename IterationGetter,
-         typename Concretizer,
-         bool Async,
-         typename Iter>
-concepts::enable_if_t<resources::EventProxy<resources::Hip>,
-                      type_traits::is_arithmetic<RAJA::detail::IterVal<Iter>>,
-                      std::is_pointer<Iter>>
-unstable(resources::Hip hip_res,
-         ::RAJA::policy::hip::
-             hip_exec<IterationMapping, IterationGetter, Concretizer, Async> p,
-         Iter begin,
-         Iter end,
-         operators::greater<RAJA::detail::IterVal<Iter>> comp)
-{
-  return stable(hip_res, p, begin, end, comp);
-}
-
-/*!
-        \brief static assert unimplemented stable sort pairs
+        \brief stable sort given range of pairs in order of keys
 */
 template<typename IterationMapping,
          typename IterationGetter,
@@ -364,75 +242,23 @@ template<typename IterationMapping,
          typename KeyIter,
          typename ValIter,
          typename Compare>
-concepts::enable_if_t<
-    resources::EventProxy<resources::Hip>,
-    concepts::negate<concepts::all_of<
-        type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
-        std::is_pointer<KeyIter>,
-        std::is_pointer<ValIter>,
-        concepts::any_of<
-            camp::is_same<Compare,
-                          operators::less<RAJA::detail::IterVal<KeyIter>>>,
-            camp::is_same<
-                Compare,
-                operators::greater<RAJA::detail::IterVal<KeyIter>>>>>>>
-stable_pairs(
-    resources::Hip hip_res,
-    ::RAJA::policy::hip::
-        hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
-    KeyIter,
-    KeyIter,
-    ValIter,
-    Compare)
-{
-  static_assert(std::is_pointer<KeyIter>::value,
-                "stable_sort_pairs<hip_exec> is only implemented for pointers");
-  static_assert(std::is_pointer<ValIter>::value,
-                "stable_sort_pairs<hip_exec> is only implemented for pointers");
-  using K = RAJA::detail::IterVal<KeyIter>;
-  static_assert(
-      type_traits::is_arithmetic<K>::value,
-      "stable_sort_pairs<hip_exec> is only implemented for arithmetic types");
-  static_assert(
-      concepts::any_of<camp::is_same<Compare, operators::less<K>>,
-                       camp::is_same<Compare, operators::greater<K>>>::value,
-      "stable_sort_pairs<hip_exec> is only implemented for "
-      "RAJA::operators::less or RAJA::operators::greater");
-
-  return resources::EventProxy<resources::Hip>(hip_res);
-}
-
-/*!
-        \brief stable sort given range of pairs in ascending order of keys
-*/
-template<typename IterationMapping,
-         typename IterationGetter,
-         typename Concretizer,
-         bool Async,
-         typename KeyIter,
-         typename ValIter>
-concepts::enable_if_t<
-    resources::EventProxy<resources::Hip>,
-    type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
-    std::is_pointer<KeyIter>,
-    std::is_pointer<ValIter>>
-stable_pairs(
+resources::EventProxy<resources::Hip> stable_pairs(
     resources::Hip hip_res,
     ::RAJA::policy::hip::
         hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
     KeyIter keys_begin,
     KeyIter keys_end,
     ValIter vals_begin,
-    operators::less<RAJA::detail::IterVal<KeyIter>>)
+    Compare comp)
 {
   hipStream_t stream = hip_res.get_stream();
 
   using K = RAJA::detail::IterVal<KeyIter>;
   using V = RAJA::detail::IterVal<ValIter>;
 
-  int len       = std::distance(keys_begin, keys_end);
-  int begin_bit = 0;
-  int end_bit   = sizeof(K) * CHAR_BIT;
+  const int len           = std::distance(keys_begin, keys_end);
+  constexpr int begin_bit = 0;
+  constexpr int end_bit   = sizeof(K) * CHAR_BIT;
 
   // Allocate temporary storage for the output arrays
   K* d_keys_out = hip::device_mempool_type::getInstance().malloc<K>(len);
@@ -446,30 +272,94 @@ stable_pairs(
   // Determine temporary device storage requirements
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
+  if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
+                std::is_pointer_v<ValIter> &&
+                std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
+  {
 #if defined(__HIPCC__)
-  CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs, d_temp_storage,
-                                temp_storage_bytes, d_keys, d_vals, len,
-                                begin_bit, end_bit, stream);
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs, d_temp_storage,
+                                  temp_storage_bytes, d_keys, d_vals, len,
+                                  begin_bit, end_bit, stream);
 #elif defined(__CUDACC__)
-  CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
-                                 d_temp_storage, temp_storage_bytes, d_keys,
-                                 d_vals, len, begin_bit, end_bit, stream);
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   d_vals, len, begin_bit, end_bit, stream);
 #endif
+  }
+  else if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
+                     std::is_pointer_v<ValIter> &&
+                     std::is_same_v<std::decay_t<Compare>,
+                                    operators::greater<K>>)
+  {
+#if defined(__HIPCC__)
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs_desc,
+                                  d_temp_storage, temp_storage_bytes, d_keys,
+                                  d_vals, len, begin_bit, end_bit, stream);
+#elif defined(__CUDACC__)
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   d_vals, len, begin_bit, end_bit, stream);
+#endif
+  }
+  else
+  {
+#if defined(__HIPCC__)
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
+                                  temp_storage_bytes, d_keys, d_vals, len, comp,
+                                  stream);
+#elif defined(__CUDACC__)
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortPairs,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   d_vals, len, comp, stream);
+#endif
+  }
   // Allocate temporary storage
   d_temp_storage =
       hip::device_mempool_type::getInstance().malloc<unsigned char>(
           temp_storage_bytes);
 
   // Run
+  if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
+                std::is_pointer_v<ValIter> &&
+                std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
+  {
 #if defined(__HIPCC__)
-  CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs, d_temp_storage,
-                                temp_storage_bytes, d_keys, d_vals, len,
-                                begin_bit, end_bit, stream);
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs, d_temp_storage,
+                                  temp_storage_bytes, d_keys, d_vals, len,
+                                  begin_bit, end_bit, stream);
 #elif defined(__CUDACC__)
-  CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
-                                 d_temp_storage, temp_storage_bytes, d_keys,
-                                 d_vals, len, begin_bit, end_bit, stream);
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   d_vals, len, begin_bit, end_bit, stream);
 #endif
+  }
+  else if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
+                     std::is_pointer_v<ValIter> &&
+                     std::is_same_v<std::decay_t<Compare>,
+                                    operators::greater<K>>)
+  {
+#if defined(__HIPCC__)
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs_desc,
+                                  d_temp_storage, temp_storage_bytes, d_keys,
+                                  d_vals, len, begin_bit, end_bit, stream);
+#elif defined(__CUDACC__)
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   d_vals, len, begin_bit, end_bit, stream);
+#endif
+  }
+  else
+  {
+#if defined(__HIPCC__)
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
+                                  temp_storage_bytes, d_keys, d_vals, len, comp,
+                                  stream);
+#elif defined(__CUDACC__)
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortPairs,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   d_vals, len, comp, stream);
+#endif
+  }
   // Free temporary storage
   hip::device_mempool_type::getInstance().free(d_temp_storage);
 
@@ -497,101 +387,7 @@ stable_pairs(
 }
 
 /*!
-        \brief stable sort given range of pairs in descending order of keys
-*/
-template<typename IterationMapping,
-         typename IterationGetter,
-         typename Concretizer,
-         bool Async,
-         typename KeyIter,
-         typename ValIter>
-concepts::enable_if_t<
-    resources::EventProxy<resources::Hip>,
-    type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
-    std::is_pointer<KeyIter>,
-    std::is_pointer<ValIter>>
-stable_pairs(
-    resources::Hip hip_res,
-    ::RAJA::policy::hip::
-        hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
-    KeyIter keys_begin,
-    KeyIter keys_end,
-    ValIter vals_begin,
-    operators::greater<RAJA::detail::IterVal<KeyIter>>)
-{
-  hipStream_t stream = hip_res.get_stream();
-
-  using K = RAJA::detail::IterVal<KeyIter>;
-  using V = RAJA::detail::IterVal<ValIter>;
-
-  int len       = std::distance(keys_begin, keys_end);
-  int begin_bit = 0;
-  int end_bit   = sizeof(K) * CHAR_BIT;
-
-  // Allocate temporary storage for the output arrays
-  K* d_keys_out = hip::device_mempool_type::getInstance().malloc<K>(len);
-  V* d_vals_out = hip::device_mempool_type::getInstance().malloc<V>(len);
-
-  // use cub double buffer to reduce temporary memory requirements
-  // by allowing cub to write to the keys_begin and vals_begin buffers
-  detail::double_buffer<K> d_keys(keys_begin, d_keys_out);
-  detail::double_buffer<V> d_vals(vals_begin, d_vals_out);
-
-  // Determine temporary device storage requirements
-  void* d_temp_storage      = nullptr;
-  size_t temp_storage_bytes = 0;
-#if defined(__HIPCC__)
-  CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs_desc,
-                                d_temp_storage, temp_storage_bytes, d_keys,
-                                d_vals, len, begin_bit, end_bit, stream);
-#elif defined(__CUDACC__)
-  CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
-                                 d_temp_storage, temp_storage_bytes, d_keys,
-                                 d_vals, len, begin_bit, end_bit, stream);
-#endif
-  // Allocate temporary storage
-  d_temp_storage =
-      hip::device_mempool_type::getInstance().malloc<unsigned char>(
-          temp_storage_bytes);
-
-  // Run
-#if defined(__HIPCC__)
-  CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs_desc,
-                                d_temp_storage, temp_storage_bytes, d_keys,
-                                d_vals, len, begin_bit, end_bit, stream);
-#elif defined(__CUDACC__)
-  CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
-                                 d_temp_storage, temp_storage_bytes, d_keys,
-                                 d_vals, len, begin_bit, end_bit, stream);
-#endif
-  // Free temporary storage
-  hip::device_mempool_type::getInstance().free(d_temp_storage);
-
-  if (detail::get_current(d_keys) == d_keys_out)
-  {
-
-    // copy keys
-    CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, keys_begin, d_keys_out,
-                                  len * sizeof(K), hipMemcpyDefault, stream);
-  }
-  if (detail::get_current(d_vals) == d_vals_out)
-  {
-
-    // copy vals
-    CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, vals_begin, d_vals_out,
-                                  len * sizeof(V), hipMemcpyDefault, stream);
-  }
-
-  hip::device_mempool_type::getInstance().free(d_keys_out);
-  hip::device_mempool_type::getInstance().free(d_vals_out);
-
-  hip::launch(hip_res, Async);
-
-  return resources::EventProxy<resources::Hip>(hip_res);
-}
-
-/*!
-        \brief static assert unimplemented sort pairs
+        \brief stable sort given range of pairs in order of keys
 */
 template<typename IterationMapping,
          typename IterationGetter,
@@ -600,92 +396,14 @@ template<typename IterationMapping,
          typename KeyIter,
          typename ValIter,
          typename Compare>
-concepts::enable_if_t<
-    resources::EventProxy<resources::Hip>,
-    concepts::negate<concepts::all_of<
-        type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
-        std::is_pointer<KeyIter>,
-        std::is_pointer<ValIter>,
-        concepts::any_of<
-            camp::is_same<Compare,
-                          operators::less<RAJA::detail::IterVal<KeyIter>>>,
-            camp::is_same<
-                Compare,
-                operators::greater<RAJA::detail::IterVal<KeyIter>>>>>>>
-unstable_pairs(
-    resources::Hip hip_res,
-    ::RAJA::policy::hip::
-        hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
-    KeyIter,
-    KeyIter,
-    ValIter,
-    Compare)
-{
-  static_assert(std::is_pointer<KeyIter>::value,
-                "sort_pairs<hip_exec> is only implemented for pointers");
-  static_assert(std::is_pointer<ValIter>::value,
-                "sort_pairs<hip_exec> is only implemented for pointers");
-  using K = RAJA::detail::IterVal<KeyIter>;
-  static_assert(
-      type_traits::is_arithmetic<K>::value,
-      "sort_pairs<hip_exec> is only implemented for arithmetic types");
-  static_assert(
-      concepts::any_of<camp::is_same<Compare, operators::less<K>>,
-                       camp::is_same<Compare, operators::greater<K>>>::value,
-      "sort_pairs<hip_exec> is only implemented for RAJA::operators::less or "
-      "RAJA::operators::greater");
-
-  return resources::EventProxy<resources::Hip>(hip_res);
-}
-
-/*!
-        \brief stable sort given range of pairs in ascending order of keys
-*/
-template<typename IterationMapping,
-         typename IterationGetter,
-         typename Concretizer,
-         bool Async,
-         typename KeyIter,
-         typename ValIter>
-concepts::enable_if_t<
-    resources::EventProxy<resources::Hip>,
-    type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
-    std::is_pointer<KeyIter>,
-    std::is_pointer<ValIter>>
-unstable_pairs(
+resources::EventProxy<resources::Hip> unstable_pairs(
     resources::Hip hip_res,
     ::RAJA::policy::hip::
         hip_exec<IterationMapping, IterationGetter, Concretizer, Async> p,
     KeyIter keys_begin,
     KeyIter keys_end,
     ValIter vals_begin,
-    operators::less<RAJA::detail::IterVal<KeyIter>> comp)
-{
-  return stable_pairs(hip_res, p, keys_begin, keys_end, vals_begin, comp);
-}
-
-/*!
-        \brief stable sort given range of pairs in descending order of keys
-*/
-template<typename IterationMapping,
-         typename IterationGetter,
-         typename Concretizer,
-         bool Async,
-         typename KeyIter,
-         typename ValIter>
-concepts::enable_if_t<
-    resources::EventProxy<resources::Hip>,
-    type_traits::is_arithmetic<RAJA::detail::IterVal<KeyIter>>,
-    std::is_pointer<KeyIter>,
-    std::is_pointer<ValIter>>
-unstable_pairs(
-    resources::Hip hip_res,
-    ::RAJA::policy::hip::
-        hip_exec<IterationMapping, IterationGetter, Concretizer, Async> p,
-    KeyIter keys_begin,
-    KeyIter keys_end,
-    ValIter vals_begin,
-    operators::greater<RAJA::detail::IterVal<KeyIter>> comp)
+    Compare comp)
 {
   return stable_pairs(hip_res, p, keys_begin, keys_end, vals_begin, comp);
 }

--- a/include/RAJA/policy/hip/sort.hpp
+++ b/include/RAJA/policy/hip/sort.hpp
@@ -106,20 +106,21 @@ resources::EventProxy<resources::Hip> sort(
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
 
-  auto call_impl = [&, d_out = static_cast<R*>(nullptr)](auto phase) mutable
-  {
+  auto call_impl = [&, d_out = static_cast<R*>(nullptr)](auto phase) mutable {
     RAJA_UNUSED_VAR(phase);
     RAJA_UNUSED_VAR(d_out);
 
     if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
-                  ( std::is_same_v<std::decay_t<Compare>, operators::less<R>> ||
-                    std::is_same_v<std::decay_t<Compare>, operators::greater<R>>))
+                  (std::is_same_v<std::decay_t<Compare>, operators::less<R>> ||
+                   std::is_same_v<std::decay_t<Compare>,
+                                  operators::greater<R>>))
     {
       // The begin iterator is a pointer in this constexpr conditional
       // so we can use double_buffer
 
       // Setup temporary storage for the output array
-      if constexpr (phase == 0) {
+      if constexpr (phase == 0)
+      {
         d_out = hip::device_mempool_type::getInstance().malloc<R>(len);
       }
 
@@ -130,25 +131,26 @@ resources::EventProxy<resources::Hip> sort(
       if constexpr (std::is_same_v<std::decay_t<Compare>, operators::less<R>>)
       {
 #if defined(__HIPCC__)
-        CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_keys, d_temp_storage,
-                                      temp_storage_bytes, d_keys, len, begin_bit,
-                                      end_bit, stream);
+        CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_keys,
+                                      d_temp_storage, temp_storage_bytes,
+                                      d_keys, len, begin_bit, end_bit, stream);
 #elif defined(__CUDACC__)
         CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeys,
-                                       d_temp_storage, temp_storage_bytes, d_keys,
-                                       len, begin_bit, end_bit, stream);
+                                       d_temp_storage, temp_storage_bytes,
+                                       d_keys, len, begin_bit, end_bit, stream);
 #endif
       }
-      else if constexpr (std::is_same_v<std::decay_t<Compare>, operators::greater<R>>)
+      else if constexpr (std::is_same_v<std::decay_t<Compare>,
+                                        operators::greater<R>>)
       {
 #if defined(__HIPCC__)
         CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_keys_desc,
-                                      d_temp_storage, temp_storage_bytes, d_keys,
-                                      len, begin_bit, end_bit, stream);
+                                      d_temp_storage, temp_storage_bytes,
+                                      d_keys, len, begin_bit, end_bit, stream);
 #elif defined(__CUDACC__)
-        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeysDescending,
-                                       d_temp_storage, temp_storage_bytes, d_keys,
-                                       len, begin_bit, end_bit, stream);
+        CAMP_CUDA_API_INVOKE_AND_CHECK(
+            ::cub::DeviceRadixSort::SortKeysDescending, d_temp_storage,
+            temp_storage_bytes, d_keys, len, begin_bit, end_bit, stream);
 #endif
       }
 
@@ -158,8 +160,9 @@ resources::EventProxy<resources::Hip> sort(
         // Copy result back if necessary
         if (get_current(d_keys) == d_out)
         {
-          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, begin, d_out, len * sizeof(R),
-                                        hipMemcpyDefault, stream);
+          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, begin, d_out,
+                                        len * sizeof(R), hipMemcpyDefault,
+                                        stream);
         }
 
         // Free temporary output array
@@ -170,22 +173,25 @@ resources::EventProxy<resources::Hip> sort(
     {
 #if defined(__HIPCC__)
       // Setup temporary storage for the output array
-      if constexpr (phase == 0) {
+      if constexpr (phase == 0)
+      {
         d_out = hip::device_mempool_type::getInstance().malloc<R>(len);
       }
 
       CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                    temp_storage_bytes, begin, d_out,
-                                    len, comp, stream);
+                                    temp_storage_bytes, begin, d_out, len, comp,
+                                    stream);
 
       // Tear-down temporary storage for the output array
       if constexpr (phase == 1)
       {
         // Copy result back via kernel as begin may not be a pointer
-        forall_impl(hip_res,
-            ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, true>{},
+        forall_impl(
+            hip_res,
+            ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter,
+                                          Concretizer, true> {},
             TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-            ::RAJA::detail::Copy1Functor{begin, d_out},
+            ::RAJA::detail::Copy1Functor {begin, d_out},
             expt::get_empty_forall_param_pack());
 
         // Free temporary output array
@@ -209,7 +215,7 @@ resources::EventProxy<resources::Hip> sort(
   };
 
   // Determine temporary storage requirements
-  call_impl(std::integral_constant<int, 0>{});
+  call_impl(std::integral_constant<int, 0> {});
 
   // Allocate temporary storage
   d_temp_storage =
@@ -217,7 +223,7 @@ resources::EventProxy<resources::Hip> sort(
           temp_storage_bytes);
 
   // Run implementation
-  call_impl(std::integral_constant<int, 1>{});
+  call_impl(std::integral_constant<int, 1> {});
 
   // Free temporary storage
   hip::device_mempool_type::getInstance().free(d_temp_storage);
@@ -265,22 +271,23 @@ resources::EventProxy<resources::Hip> sort_pairs(
   size_t temp_storage_bytes = 0;
 
   auto call_impl = [&, d_keys_out = static_cast<K*>(nullptr),
-                       d_vals_out = static_cast<V*>(nullptr)](auto phase) mutable
-  {
+                    d_vals_out = static_cast<V*>(nullptr)](auto phase) mutable {
     RAJA_UNUSED_VAR(phase);
     RAJA_UNUSED_VAR(d_keys_out);
     RAJA_UNUSED_VAR(d_vals_out);
 
     if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
                   std::is_pointer_v<ValIter> &&
-                  ( std::is_same_v<std::decay_t<Compare>, operators::less<K>> ||
-                    std::is_same_v<std::decay_t<Compare>, operators::greater<K>>))
+                  (std::is_same_v<std::decay_t<Compare>, operators::less<K>> ||
+                   std::is_same_v<std::decay_t<Compare>,
+                                  operators::greater<K>>))
     {
       // The begin iterators are pointers in this constexpr conditional
       // so we can use double_buffer
 
       // Setup temporary storage for the output arrays
-      if constexpr (phase == 0) {
+      if constexpr (phase == 0)
+      {
         d_keys_out = hip::device_mempool_type::getInstance().malloc<K>(len);
         d_vals_out = hip::device_mempool_type::getInstance().malloc<V>(len);
       }
@@ -293,25 +300,29 @@ resources::EventProxy<resources::Hip> sort_pairs(
       if constexpr (std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
       {
 #if defined(__HIPCC__)
-        CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs, d_temp_storage,
-                                      temp_storage_bytes, d_keys, d_vals, len,
-                                      begin_bit, end_bit, stream);
+        CAMP_HIP_API_INVOKE_AND_CHECK(
+            ::rocprim::radix_sort_pairs, d_temp_storage, temp_storage_bytes,
+            d_keys, d_vals, len, begin_bit, end_bit, stream);
 #elif defined(__CUDACC__)
         CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
-                                       d_temp_storage, temp_storage_bytes, d_keys,
-                                       d_vals, len, begin_bit, end_bit, stream);
+                                       d_temp_storage, temp_storage_bytes,
+                                       d_keys, d_vals, len, begin_bit, end_bit,
+                                       stream);
 #endif
       }
-      else if constexpr (std::is_same_v<std::decay_t<Compare>, operators::greater<K>>)
+      else if constexpr (std::is_same_v<std::decay_t<Compare>,
+                                        operators::greater<K>>)
       {
 #if defined(__HIPCC__)
         CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs_desc,
-                                      d_temp_storage, temp_storage_bytes, d_keys,
-                                      d_vals, len, begin_bit, end_bit, stream);
+                                      d_temp_storage, temp_storage_bytes,
+                                      d_keys, d_vals, len, begin_bit, end_bit,
+                                      stream);
 #elif defined(__CUDACC__)
-        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
-                                       d_temp_storage, temp_storage_bytes, d_keys,
-                                       d_vals, len, begin_bit, end_bit, stream);
+        CAMP_CUDA_API_INVOKE_AND_CHECK(
+            ::cub::DeviceRadixSort::SortPairsDescending, d_temp_storage,
+            temp_storage_bytes, d_keys, d_vals, len, begin_bit, end_bit,
+            stream);
 #endif
       }
 
@@ -319,24 +330,30 @@ resources::EventProxy<resources::Hip> sort_pairs(
       if constexpr (phase == 1)
       {
         // copy keys and values back if necessary
-        if (get_current(d_keys) == d_keys_out && get_current(d_vals) == d_vals_out) {
+        if (get_current(d_keys) == d_keys_out &&
+            get_current(d_vals) == d_vals_out)
+        {
           // Copy keys and values back via kernel for performance
-          forall_impl(hip_res,
-              ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, true>{},
+          forall_impl(
+              hip_res,
+              ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter,
+                                            Concretizer, true> {},
               TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-              ::RAJA::detail::Copy2Functor{keys_begin, d_keys_out,
-                                           vals_begin, d_vals_out},
+              ::RAJA::detail::Copy2Functor {keys_begin, d_keys_out, vals_begin,
+                                            d_vals_out},
               expt::get_empty_forall_param_pack());
         }
         else if (get_current(d_keys) == d_keys_out)
         {
-          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, keys_begin, d_keys_out, len * sizeof(K),
-                                        hipMemcpyDefault, stream);
+          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, keys_begin, d_keys_out,
+                                        len * sizeof(K), hipMemcpyDefault,
+                                        stream);
         }
         else if (get_current(d_vals) == d_vals_out)
         {
-          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, vals_begin, d_vals_out, len * sizeof(V),
-                                        hipMemcpyDefault, stream);
+          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, vals_begin, d_vals_out,
+                                        len * sizeof(V), hipMemcpyDefault,
+                                        stream);
         }
 
         // Free temporary output arrays
@@ -348,25 +365,28 @@ resources::EventProxy<resources::Hip> sort_pairs(
     {
 #if defined(__HIPCC__)
       // Setup temporary storage for the output arrays
-      if constexpr (phase == 0) {
+      if constexpr (phase == 0)
+      {
         d_keys_out = hip::device_mempool_type::getInstance().malloc<K>(len);
         d_vals_out = hip::device_mempool_type::getInstance().malloc<V>(len);
       }
 
       CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                    temp_storage_bytes, keys_begin,
-                                    d_keys_out, vals_begin,
-                                    d_vals_out, len, comp, stream);
+                                    temp_storage_bytes, keys_begin, d_keys_out,
+                                    vals_begin, d_vals_out, len, comp, stream);
 
       // Tear-down temporary storage for the output array
       if constexpr (phase == 1)
       {
-        // Copy keys and values back via kernel as iterators may not be a pointer
-        forall_impl(hip_res,
-            ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, true>{},
+        // Copy keys and values back via kernel as iterators may not be a
+        // pointer
+        forall_impl(
+            hip_res,
+            ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter,
+                                          Concretizer, true> {},
             TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-            ::RAJA::detail::Copy2Functor{keys_begin, d_keys_out,
-                                         vals_begin, d_vals_out},
+            ::RAJA::detail::Copy2Functor {keys_begin, d_keys_out, vals_begin,
+                                          d_vals_out},
             expt::get_empty_forall_param_pack());
 
         // Free temporary output arrays
@@ -376,10 +396,9 @@ resources::EventProxy<resources::Hip> sort_pairs(
 #elif defined(__CUDACC__)
       if constexpr (Stable)
       {
-        CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortPairs,
-                                       d_temp_storage, temp_storage_bytes,
-                                       keys_begin, vals_begin, len,
-                                       comp, stream);
+        CAMP_CUDA_API_INVOKE_AND_CHECK(
+            cub::DeviceMergeSort::StableSortPairs, d_temp_storage,
+            temp_storage_bytes, keys_begin, vals_begin, len, comp, stream);
       }
       else
       {
@@ -392,7 +411,7 @@ resources::EventProxy<resources::Hip> sort_pairs(
   };
 
   // Determine temporary device storage requirements
-  call_impl(std::integral_constant<int, 0>{});
+  call_impl(std::integral_constant<int, 0> {});
 
   // Allocate temporary storage
   d_temp_storage =
@@ -400,7 +419,7 @@ resources::EventProxy<resources::Hip> sort_pairs(
           temp_storage_bytes);
 
   // Run
-  call_impl(std::integral_constant<int, 1>{});
+  call_impl(std::integral_constant<int, 1> {});
 
   // Free temporary storage
   hip::device_mempool_type::getInstance().free(d_temp_storage);

--- a/include/RAJA/policy/hip/sort.hpp
+++ b/include/RAJA/policy/hip/sort.hpp
@@ -106,7 +106,8 @@ resources::EventProxy<resources::Hip> sort(
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
 
-  auto call_impl = [&, tmp_begin = static_cast<R*>(nullptr)](auto phase) mutable {
+  auto call_impl = [&,
+                    tmp_begin = static_cast<R*>(nullptr)](auto phase) mutable {
     RAJA_UNUSED_VAR(phase);
     RAJA_UNUSED_VAR(tmp_begin);
 
@@ -179,8 +180,8 @@ resources::EventProxy<resources::Hip> sort(
       }
 
       CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                    temp_storage_bytes, begin, tmp_begin, len, comp,
-                                    stream);
+                                    temp_storage_bytes, begin, tmp_begin, len,
+                                    comp, stream);
 
       // Tear-down temporary storage for the output array
       if constexpr (phase == 1)
@@ -271,7 +272,8 @@ resources::EventProxy<resources::Hip> sort_pairs(
   size_t temp_storage_bytes = 0;
 
   auto call_impl = [&, tmp_keys_begin = static_cast<K*>(nullptr),
-                    tmp_vals_begin = static_cast<V*>(nullptr)](auto phase) mutable {
+                    tmp_vals_begin =
+                        static_cast<V*>(nullptr)](auto phase) mutable {
     RAJA_UNUSED_VAR(phase);
     RAJA_UNUSED_VAR(tmp_keys_begin);
     RAJA_UNUSED_VAR(tmp_vals_begin);
@@ -345,15 +347,15 @@ resources::EventProxy<resources::Hip> sort_pairs(
         }
         else if (get_current(d_keys) == tmp_keys_begin)
         {
-          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, keys_begin, tmp_keys_begin,
-                                        len * sizeof(K), hipMemcpyDefault,
-                                        stream);
+          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, keys_begin,
+                                        tmp_keys_begin, len * sizeof(K),
+                                        hipMemcpyDefault, stream);
         }
         else if (get_current(d_vals) == tmp_vals_begin)
         {
-          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, vals_begin, tmp_vals_begin,
-                                        len * sizeof(V), hipMemcpyDefault,
-                                        stream);
+          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, vals_begin,
+                                        tmp_vals_begin, len * sizeof(V),
+                                        hipMemcpyDefault, stream);
         }
 
         // Free temporary output arrays
@@ -371,9 +373,9 @@ resources::EventProxy<resources::Hip> sort_pairs(
         tmp_vals_begin = hip::device_mempool_type::getInstance().malloc<V>(len);
       }
 
-      CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                    temp_storage_bytes, keys_begin, tmp_keys_begin,
-                                    vals_begin, tmp_vals_begin, len, comp, stream);
+      CAMP_HIP_API_INVOKE_AND_CHECK(
+          ::rocprim::merge_sort, d_temp_storage, temp_storage_bytes, keys_begin,
+          tmp_keys_begin, vals_begin, tmp_vals_begin, len, comp, stream);
 
       // Tear-down temporary storage for the output array
       if constexpr (phase == 1)

--- a/include/RAJA/policy/hip/sort.hpp
+++ b/include/RAJA/policy/hip/sort.hpp
@@ -76,7 +76,7 @@ R* get_current(double_buffer<R>& d_bufs)
 /*!
         \brief sort given range
 */
-template<bool Stable,
+template<bool RequireStable,
          typename IterationMapping,
          typename IterationGetter,
          typename Concretizer,
@@ -91,7 +91,7 @@ resources::EventProxy<resources::Hip> sort(
     Iter end,
     Compare comp)
 {
-  RAJA_UNUSED_VAR(Stable);
+  RAJA_UNUSED_VAR(RequireStable);
 
   hipStream_t stream = hip_res.get_stream();
 
@@ -198,7 +198,7 @@ resources::EventProxy<resources::Hip> sort(
         hip::device_mempool_type::getInstance().free(d_out);
       }
 #elif defined(__CUDACC__)
-      if constexpr (Stable)
+      if constexpr (RequireStable)
       {
         CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceMergeSort::StableSortKeys,
                                        d_temp_storage, temp_storage_bytes,
@@ -237,7 +237,7 @@ resources::EventProxy<resources::Hip> sort(
 /*!
         \brief stable sort given range of pairs in order of keys
 */
-template<bool Stable,
+template<bool RequireStable,
          typename IterationMapping,
          typename IterationGetter,
          typename Concretizer,
@@ -254,7 +254,7 @@ resources::EventProxy<resources::Hip> sort_pairs(
     ValIter vals_begin,
     Compare comp)
 {
-  RAJA_UNUSED_VAR(Stable);
+  RAJA_UNUSED_VAR(RequireStable);
 
   hipStream_t stream = hip_res.get_stream();
 
@@ -394,7 +394,7 @@ resources::EventProxy<resources::Hip> sort_pairs(
         hip::device_mempool_type::getInstance().free(d_vals_out);
       }
 #elif defined(__CUDACC__)
-      if constexpr (Stable)
+      if constexpr (RequireStable)
       {
         CAMP_CUDA_API_INVOKE_AND_CHECK(
             ::cub::DeviceMergeSort::StableSortPairs, d_temp_storage,
@@ -449,8 +449,8 @@ resources::EventProxy<resources::Hip> stable(
     Iter end,
     Compare comp)
 {
-  constexpr bool stable = true;
-  return detail::sort<stable>(hip_res, p, begin, end, comp);
+  constexpr bool require_stable = true;
+  return detail::sort<require_stable>(hip_res, p, begin, end, comp);
 }
 
 /*!
@@ -470,8 +470,8 @@ resources::EventProxy<resources::Hip> unstable(
     Iter end,
     Compare comp)
 {
-  constexpr bool stable = true;
-  return detail::sort<!stable>(hip_res, p, begin, end, comp);
+  constexpr bool require_stable = true;
+  return detail::sort<!require_stable>(hip_res, p, begin, end, comp);
 }
 
 /*!
@@ -493,8 +493,8 @@ resources::EventProxy<resources::Hip> stable_pairs(
     ValIter vals_begin,
     Compare comp)
 {
-  constexpr bool stable = true;
-  return detail::sort_pairs<stable>(hip_res, p, keys_begin, keys_end,
+  constexpr bool require_stable = true;
+  return detail::sort_pairs<require_stable>(hip_res, p, keys_begin, keys_end,
                                     vals_begin, comp);
 }
 
@@ -517,8 +517,8 @@ resources::EventProxy<resources::Hip> unstable_pairs(
     ValIter vals_begin,
     Compare comp)
 {
-  constexpr bool stable = true;
-  return detail::sort_pairs<!stable>(hip_res, p, keys_begin, keys_end,
+  constexpr bool require_stable = true;
+  return detail::sort_pairs<!require_stable>(hip_res, p, keys_begin, keys_end,
                                      vals_begin, comp);
 }
 

--- a/include/RAJA/policy/hip/sort.hpp
+++ b/include/RAJA/policy/hip/sort.hpp
@@ -339,8 +339,8 @@ resources::EventProxy<resources::Hip> sort_pairs(
               ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter,
                                             Concretizer, true> {},
               TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-              ::RAJA::detail::TwoCopiesFunctor {keys_begin, d_keys_out, vals_begin,
-                                            d_vals_out},
+              ::RAJA::detail::TwoCopiesFunctor {keys_begin, d_keys_out,
+                                                vals_begin, d_vals_out},
               expt::get_empty_forall_param_pack());
         }
         else if (get_current(d_keys) == d_keys_out)
@@ -385,8 +385,8 @@ resources::EventProxy<resources::Hip> sort_pairs(
             ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter,
                                           Concretizer, true> {},
             TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-            ::RAJA::detail::TwoCopiesFunctor {keys_begin, d_keys_out, vals_begin,
-                                          d_vals_out},
+            ::RAJA::detail::TwoCopiesFunctor {keys_begin, d_keys_out,
+                                              vals_begin, d_vals_out},
             expt::get_empty_forall_param_pack());
 
         // Free temporary output arrays
@@ -403,8 +403,8 @@ resources::EventProxy<resources::Hip> sort_pairs(
       else
       {
         CAMP_CUDA_API_INVOKE_AND_CHECK(
-            ::cub::DeviceMergeSort::SortPairs, d_temp_storage, temp_storage_bytes,
-            keys_begin, vals_begin, len, comp, stream);
+            ::cub::DeviceMergeSort::SortPairs, d_temp_storage,
+            temp_storage_bytes, keys_begin, vals_begin, len, comp, stream);
       }
 #endif
     }
@@ -495,7 +495,7 @@ resources::EventProxy<resources::Hip> stable_pairs(
 {
   constexpr bool require_stable = true;
   return detail::sort_pairs<require_stable>(hip_res, p, keys_begin, keys_end,
-                                    vals_begin, comp);
+                                            vals_begin, comp);
 }
 
 /*!
@@ -519,7 +519,7 @@ resources::EventProxy<resources::Hip> unstable_pairs(
 {
   constexpr bool require_stable = true;
   return detail::sort_pairs<!require_stable>(hip_res, p, keys_begin, keys_end,
-                                     vals_begin, comp);
+                                             vals_begin, comp);
 }
 
 }  // namespace sort

--- a/include/RAJA/policy/hip/sort.hpp
+++ b/include/RAJA/policy/hip/sort.hpp
@@ -73,18 +73,17 @@ R* get_current(double_buffer<R>& d_bufs)
 #endif
 }
 
-}  // namespace detail
-
 /*!
-        \brief stable sort given range
+        \brief sort given range
 */
-template<typename IterationMapping,
+template<bool Stable,
+         typename IterationMapping,
          typename IterationGetter,
          typename Concretizer,
          bool Async,
          typename Iter,
          typename Compare>
-resources::EventProxy<resources::Hip> stable(
+resources::EventProxy<resources::Hip> sort(
     resources::Hip hip_res,
     ::RAJA::policy::hip::
         hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
@@ -92,6 +91,8 @@ resources::EventProxy<resources::Hip> stable(
     Iter end,
     Compare comp)
 {
+  RAJA_UNUSED_VAR(Stable);
+
   hipStream_t stream = hip_res.get_stream();
 
   using R = RAJA::detail::IterVal<Iter>;
@@ -105,7 +106,7 @@ resources::EventProxy<resources::Hip> stable(
 
   // use cub double buffer to reduce temporary memory requirements
   // by allowing cub to write to the begin buffer
-  detail::double_buffer<R> d_keys(begin, d_out);
+  double_buffer<R> d_keys(begin, d_out);
 
   // Determine temporary device storage requirements
   void* d_temp_storage      = nullptr;
@@ -144,9 +145,18 @@ resources::EventProxy<resources::Hip> stable(
                                   temp_storage_bytes, d_keys, len, comp,
                                   stream);
 #elif defined(__CUDACC__)
-    CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortKeys,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   len, comp, stream);
+    if constexpr (Stable)
+    {
+      CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortKeys,
+                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     len, comp, stream);
+    }
+    else
+    {
+      CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::SortKeys,
+                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     len, comp, stream);
+    }
 #endif
   }
   // Allocate temporary storage
@@ -189,15 +199,24 @@ resources::EventProxy<resources::Hip> stable(
                                   temp_storage_bytes, d_keys, len, comp,
                                   stream);
 #elif defined(__CUDACC__)
-    CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortKeys,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   len, comp, stream);
+    if constexpr (Stable)
+    {
+      CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortKeys,
+                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     len, comp, stream);
+    }
+    else
+    {
+      CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::SortKeys,
+                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     len, comp, stream);
+    }
 #endif
   }
   // Free temporary storage
   hip::device_mempool_type::getInstance().free(d_temp_storage);
 
-  if (detail::get_current(d_keys) == d_out)
+  if (get_current(d_keys) == d_out)
   {
 
     // copy
@@ -210,6 +229,204 @@ resources::EventProxy<resources::Hip> stable(
   hip::launch(hip_res, Async);
 
   return resources::EventProxy<resources::Hip>(hip_res);
+}
+
+/*!
+        \brief stable sort given range of pairs in order of keys
+*/
+template<bool Stable,
+         typename IterationMapping,
+         typename IterationGetter,
+         typename Concretizer,
+         bool Async,
+         typename KeyIter,
+         typename ValIter,
+         typename Compare>
+resources::EventProxy<resources::Hip> sort_pairs(
+    resources::Hip hip_res,
+    ::RAJA::policy::hip::
+        hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
+    KeyIter keys_begin,
+    KeyIter keys_end,
+    ValIter vals_begin,
+    Compare comp)
+{
+  RAJA_UNUSED_VAR(Stable);
+
+  hipStream_t stream = hip_res.get_stream();
+
+  using K = RAJA::detail::IterVal<KeyIter>;
+  using V = RAJA::detail::IterVal<ValIter>;
+
+  const int len           = std::distance(keys_begin, keys_end);
+  constexpr int begin_bit = 0;
+  constexpr int end_bit   = sizeof(K) * CHAR_BIT;
+
+  // Allocate temporary storage for the output arrays
+  K* d_keys_out = hip::device_mempool_type::getInstance().malloc<K>(len);
+  V* d_vals_out = hip::device_mempool_type::getInstance().malloc<V>(len);
+
+  // use cub double buffer to reduce temporary memory requirements
+  // by allowing cub to write to the keys_begin and vals_begin buffers
+  double_buffer<K> d_keys(keys_begin, d_keys_out);
+  double_buffer<V> d_vals(vals_begin, d_vals_out);
+
+  // Determine temporary device storage requirements
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
+                std::is_pointer_v<ValIter> &&
+                std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
+  {
+#if defined(__HIPCC__)
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs, d_temp_storage,
+                                  temp_storage_bytes, d_keys, d_vals, len,
+                                  begin_bit, end_bit, stream);
+#elif defined(__CUDACC__)
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   d_vals, len, begin_bit, end_bit, stream);
+#endif
+  }
+  else if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
+                     std::is_pointer_v<ValIter> &&
+                     std::is_same_v<std::decay_t<Compare>,
+                                    operators::greater<K>>)
+  {
+#if defined(__HIPCC__)
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs_desc,
+                                  d_temp_storage, temp_storage_bytes, d_keys,
+                                  d_vals, len, begin_bit, end_bit, stream);
+#elif defined(__CUDACC__)
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   d_vals, len, begin_bit, end_bit, stream);
+#endif
+  }
+  else
+  {
+#if defined(__HIPCC__)
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
+                                  temp_storage_bytes, d_keys, d_vals, len, comp,
+                                  stream);
+#elif defined(__CUDACC__)
+    if constexpr (Stable)
+    {
+      CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortPairs,
+                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     d_vals, len, comp, stream);
+    }
+    else
+    {
+      CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::SortPairs,
+                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     d_vals, len, comp, stream);
+    }
+#endif
+  }
+  // Allocate temporary storage
+  d_temp_storage =
+      hip::device_mempool_type::getInstance().malloc<unsigned char>(
+          temp_storage_bytes);
+
+  // Run
+  if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
+                std::is_pointer_v<ValIter> &&
+                std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
+  {
+#if defined(__HIPCC__)
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs, d_temp_storage,
+                                  temp_storage_bytes, d_keys, d_vals, len,
+                                  begin_bit, end_bit, stream);
+#elif defined(__CUDACC__)
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   d_vals, len, begin_bit, end_bit, stream);
+#endif
+  }
+  else if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
+                     std::is_pointer_v<ValIter> &&
+                     std::is_same_v<std::decay_t<Compare>,
+                                    operators::greater<K>>)
+  {
+#if defined(__HIPCC__)
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs_desc,
+                                  d_temp_storage, temp_storage_bytes, d_keys,
+                                  d_vals, len, begin_bit, end_bit, stream);
+#elif defined(__CUDACC__)
+    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
+                                   d_temp_storage, temp_storage_bytes, d_keys,
+                                   d_vals, len, begin_bit, end_bit, stream);
+#endif
+  }
+  else
+  {
+#if defined(__HIPCC__)
+    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
+                                  temp_storage_bytes, d_keys, d_vals, len, comp,
+                                  stream);
+#elif defined(__CUDACC__)
+    if constexpr (Stable)
+    {
+      CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortPairs,
+                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     d_vals, len, comp, stream);
+    }
+    else
+    {
+      CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::SortPairs,
+                                     d_temp_storage, temp_storage_bytes, d_keys,
+                                     d_vals, len, comp, stream);
+    }
+#endif
+  }
+  // Free temporary storage
+  hip::device_mempool_type::getInstance().free(d_temp_storage);
+
+  if (get_current(d_keys) == d_keys_out)
+  {
+
+    // copy keys
+    CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, keys_begin, d_keys_out,
+                                  len * sizeof(K), hipMemcpyDefault, stream);
+  }
+  if (get_current(d_vals) == d_vals_out)
+  {
+
+    // copy vals
+    CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, vals_begin, d_vals_out,
+                                  len * sizeof(V), hipMemcpyDefault, stream);
+  }
+
+  hip::device_mempool_type::getInstance().free(d_keys_out);
+  hip::device_mempool_type::getInstance().free(d_vals_out);
+
+  hip::launch(hip_res, Async);
+
+  return resources::EventProxy<resources::Hip>(hip_res);
+}
+
+}  // namespace detail
+
+/*!
+        \brief stable sort given range
+*/
+template<typename IterationMapping,
+         typename IterationGetter,
+         typename Concretizer,
+         bool Async,
+         typename Iter,
+         typename Compare>
+resources::EventProxy<resources::Hip> stable(
+    resources::Hip hip_res,
+    ::RAJA::policy::hip::
+        hip_exec<IterationMapping, IterationGetter, Concretizer, Async> p,
+    Iter begin,
+    Iter end,
+    Compare comp)
+{
+  constexpr bool stable = true;
+  return detail::sort<stable>(hip_res, p, begin, end, comp);
 }
 
 /*!
@@ -229,7 +446,8 @@ resources::EventProxy<resources::Hip> unstable(
     Iter end,
     Compare comp)
 {
-  return stable(hip_res, p, begin, end, comp);
+  constexpr bool stable = true;
+  return detail::sort<!stable>(hip_res, p, begin, end, comp);
 }
 
 /*!
@@ -245,145 +463,15 @@ template<typename IterationMapping,
 resources::EventProxy<resources::Hip> stable_pairs(
     resources::Hip hip_res,
     ::RAJA::policy::hip::
-        hip_exec<IterationMapping, IterationGetter, Concretizer, Async>,
+        hip_exec<IterationMapping, IterationGetter, Concretizer, Async> p,
     KeyIter keys_begin,
     KeyIter keys_end,
     ValIter vals_begin,
     Compare comp)
 {
-  hipStream_t stream = hip_res.get_stream();
-
-  using K = RAJA::detail::IterVal<KeyIter>;
-  using V = RAJA::detail::IterVal<ValIter>;
-
-  const int len           = std::distance(keys_begin, keys_end);
-  constexpr int begin_bit = 0;
-  constexpr int end_bit   = sizeof(K) * CHAR_BIT;
-
-  // Allocate temporary storage for the output arrays
-  K* d_keys_out = hip::device_mempool_type::getInstance().malloc<K>(len);
-  V* d_vals_out = hip::device_mempool_type::getInstance().malloc<V>(len);
-
-  // use cub double buffer to reduce temporary memory requirements
-  // by allowing cub to write to the keys_begin and vals_begin buffers
-  detail::double_buffer<K> d_keys(keys_begin, d_keys_out);
-  detail::double_buffer<V> d_vals(vals_begin, d_vals_out);
-
-  // Determine temporary device storage requirements
-  void* d_temp_storage      = nullptr;
-  size_t temp_storage_bytes = 0;
-  if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
-                std::is_pointer_v<ValIter> &&
-                std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
-  {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs, d_temp_storage,
-                                  temp_storage_bytes, d_keys, d_vals, len,
-                                  begin_bit, end_bit, stream);
-#elif defined(__CUDACC__)
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   d_vals, len, begin_bit, end_bit, stream);
-#endif
-  }
-  else if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
-                     std::is_pointer_v<ValIter> &&
-                     std::is_same_v<std::decay_t<Compare>,
-                                    operators::greater<K>>)
-  {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs_desc,
-                                  d_temp_storage, temp_storage_bytes, d_keys,
-                                  d_vals, len, begin_bit, end_bit, stream);
-#elif defined(__CUDACC__)
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   d_vals, len, begin_bit, end_bit, stream);
-#endif
-  }
-  else
-  {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                  temp_storage_bytes, d_keys, d_vals, len, comp,
-                                  stream);
-#elif defined(__CUDACC__)
-    CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortPairs,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   d_vals, len, comp, stream);
-#endif
-  }
-  // Allocate temporary storage
-  d_temp_storage =
-      hip::device_mempool_type::getInstance().malloc<unsigned char>(
-          temp_storage_bytes);
-
-  // Run
-  if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
-                std::is_pointer_v<ValIter> &&
-                std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
-  {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs, d_temp_storage,
-                                  temp_storage_bytes, d_keys, d_vals, len,
-                                  begin_bit, end_bit, stream);
-#elif defined(__CUDACC__)
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   d_vals, len, begin_bit, end_bit, stream);
-#endif
-  }
-  else if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
-                     std::is_pointer_v<ValIter> &&
-                     std::is_same_v<std::decay_t<Compare>,
-                                    operators::greater<K>>)
-  {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs_desc,
-                                  d_temp_storage, temp_storage_bytes, d_keys,
-                                  d_vals, len, begin_bit, end_bit, stream);
-#elif defined(__CUDACC__)
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   d_vals, len, begin_bit, end_bit, stream);
-#endif
-  }
-  else
-  {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                  temp_storage_bytes, d_keys, d_vals, len, comp,
-                                  stream);
-#elif defined(__CUDACC__)
-    CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortPairs,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   d_vals, len, comp, stream);
-#endif
-  }
-  // Free temporary storage
-  hip::device_mempool_type::getInstance().free(d_temp_storage);
-
-  if (detail::get_current(d_keys) == d_keys_out)
-  {
-
-    // copy keys
-    CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, keys_begin, d_keys_out,
-                                  len * sizeof(K), hipMemcpyDefault, stream);
-  }
-  if (detail::get_current(d_vals) == d_vals_out)
-  {
-
-    // copy vals
-    CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, vals_begin, d_vals_out,
-                                  len * sizeof(V), hipMemcpyDefault, stream);
-  }
-
-  hip::device_mempool_type::getInstance().free(d_keys_out);
-  hip::device_mempool_type::getInstance().free(d_vals_out);
-
-  hip::launch(hip_res, Async);
-
-  return resources::EventProxy<resources::Hip>(hip_res);
+  constexpr bool stable = true;
+  return detail::sort_pairs<stable>(hip_res, p, keys_begin, keys_end,
+                                    vals_begin, comp);
 }
 
 /*!
@@ -405,7 +493,9 @@ resources::EventProxy<resources::Hip> unstable_pairs(
     ValIter vals_begin,
     Compare comp)
 {
-  return stable_pairs(hip_res, p, keys_begin, keys_end, vals_begin, comp);
+  constexpr bool stable = true;
+  return detail::sort_pairs<!stable>(hip_res, p, keys_begin, keys_end,
+                                     vals_begin, comp);
 }
 
 }  // namespace sort

--- a/include/RAJA/policy/hip/sort.hpp
+++ b/include/RAJA/policy/hip/sort.hpp
@@ -97,136 +97,132 @@ resources::EventProxy<resources::Hip> sort(
 
   using R = RAJA::detail::IterVal<Iter>;
 
-  const int len           = std::distance(begin, end);
+  using IndexType = camp::decay<decltype(std::distance(begin, end))>;
+
+  const IndexType len     = std::distance(begin, end);
   constexpr int begin_bit = 0;
   constexpr int end_bit   = sizeof(R) * CHAR_BIT;
 
-  // Allocate temporary storage for the output array
-  R* d_out = hip::device_mempool_type::getInstance().malloc<R>(len);
-
-  // use cub double buffer to reduce temporary memory requirements
-  // by allowing cub to write to the begin buffer
-  double_buffer<R> d_keys(begin, d_out);
-
-  // Determine temporary device storage requirements
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
-  if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
-                std::is_same_v<std::decay_t<Compare>, operators::less<R>>)
+
+  auto call_impl = [&, d_out = static_cast<R*>(nullptr)](auto phase) mutable
   {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_keys, d_temp_storage,
-                                  temp_storage_bytes, d_keys, len, begin_bit,
-                                  end_bit, stream);
-#elif defined(__CUDACC__)
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeys,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   len, begin_bit, end_bit, stream);
-#endif
-  }
-  else if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
-                     std::is_same_v<std::decay_t<Compare>,
-                                    operators::greater<R>>)
-  {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_keys_desc,
-                                  d_temp_storage, temp_storage_bytes, d_keys,
-                                  len, begin_bit, end_bit, stream);
-#elif defined(__CUDACC__)
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeysDescending,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   len, begin_bit, end_bit, stream);
-#endif
-  }
-  else
-  {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                  temp_storage_bytes, d_keys.current(),
-                                  d_keys.alternate(), len, comp, stream);
-#elif defined(__CUDACC__)
-    if constexpr (Stable)
+    RAJA_UNUSED_VAR(phase);
+    RAJA_UNUSED_VAR(d_out);
+
+    if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
+                  ( std::is_same_v<std::decay_t<Compare>, operators::less<R>> ||
+                    std::is_same_v<std::decay_t<Compare>, operators::greater<R>>))
     {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortKeys,
-                                     d_temp_storage, temp_storage_bytes,
-                                     d_keys.Current(), len, comp, stream);
+      // The begin iterator is a pointer in this constexpr conditional
+      // so we can use double_buffer
+
+      // Setup temporary storage for the output array
+      if constexpr (phase == 0) {
+        d_out = hip::device_mempool_type::getInstance().malloc<R>(len);
+      }
+
+      // Use double_buffers to reduce temporary memory requirements
+      // by allowing cub to write to the begin buffer
+      double_buffer<R> d_keys(begin, d_out);
+
+      if constexpr (std::is_same_v<std::decay_t<Compare>, operators::less<R>>)
+      {
+#if defined(__HIPCC__)
+        CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_keys, d_temp_storage,
+                                      temp_storage_bytes, d_keys, len, begin_bit,
+                                      end_bit, stream);
+#elif defined(__CUDACC__)
+        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeys,
+                                       d_temp_storage, temp_storage_bytes, d_keys,
+                                       len, begin_bit, end_bit, stream);
+#endif
+      }
+      else if constexpr (std::is_same_v<std::decay_t<Compare>, operators::greater<R>>)
+      {
+#if defined(__HIPCC__)
+        CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_keys_desc,
+                                      d_temp_storage, temp_storage_bytes, d_keys,
+                                      len, begin_bit, end_bit, stream);
+#elif defined(__CUDACC__)
+        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeysDescending,
+                                       d_temp_storage, temp_storage_bytes, d_keys,
+                                       len, begin_bit, end_bit, stream);
+#endif
+      }
+
+      // Tear-down temporary storage for the output array
+      if constexpr (phase == 1)
+      {
+        // Copy result back if necessary
+        if (get_current(d_keys) == d_out)
+        {
+          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, begin, d_out, len * sizeof(R),
+                                        hipMemcpyDefault, stream);
+        }
+
+        // Free temporary output array
+        hip::device_mempool_type::getInstance().free(d_out);
+      }
     }
     else
     {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::SortKeys,
-                                     d_temp_storage, temp_storage_bytes,
-                                     d_keys.Current(), len, comp, stream);
-    }
+#if defined(__HIPCC__)
+      // Setup temporary storage for the output array
+      if constexpr (phase == 0) {
+        d_out = hip::device_mempool_type::getInstance().malloc<R>(len);
+      }
+
+      CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
+                                    temp_storage_bytes, begin, d_out,
+                                    len, comp, stream);
+
+      // Tear-down temporary storage for the output array
+      if constexpr (phase == 1)
+      {
+        // Copy result back via kernel as begin may not be a pointer
+        forall_impl(hip_res,
+            ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, true>{},
+            TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
+            ::RAJA::detail::Copy1Functor{begin, d_out},
+            expt::get_empty_forall_param_pack());
+
+        // Free temporary output array
+        hip::device_mempool_type::getInstance().free(d_out);
+      }
+#elif defined(__CUDACC__)
+      if constexpr (Stable)
+      {
+        CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortKeys,
+                                       d_temp_storage, temp_storage_bytes,
+                                       begin, len, comp, stream);
+      }
+      else
+      {
+        CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::SortKeys,
+                                       d_temp_storage, temp_storage_bytes,
+                                       begin, len, comp, stream);
+      }
 #endif
-  }
+    }
+  };
+
+  // Determine temporary storage requirements
+  call_impl(std::integral_constant<int, 0>{});
+
   // Allocate temporary storage
   d_temp_storage =
       hip::device_mempool_type::getInstance().malloc<unsigned char>(
           temp_storage_bytes);
 
-  // Run
-  if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
-                std::is_same_v<std::decay_t<Compare>, operators::less<R>>)
-  {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_keys, d_temp_storage,
-                                  temp_storage_bytes, d_keys, len, begin_bit,
-                                  end_bit, stream);
-#elif defined(__CUDACC__)
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeys,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   len, begin_bit, end_bit, stream);
-#endif
-  }
-  else if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
-                     std::is_same_v<std::decay_t<Compare>,
-                                    operators::greater<R>>)
-  {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_keys_desc,
-                                  d_temp_storage, temp_storage_bytes, d_keys,
-                                  len, begin_bit, end_bit, stream);
-#elif defined(__CUDACC__)
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortKeysDescending,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   len, begin_bit, end_bit, stream);
-#endif
-  }
-  else
-  {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                  temp_storage_bytes, d_keys.current(),
-                                  d_keys.alternate(), len, comp, stream);
-    d_keys.swap();
-#elif defined(__CUDACC__)
-    if constexpr (Stable)
-    {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortKeys,
-                                     d_temp_storage, temp_storage_bytes,
-                                     d_keys.Current(), len, comp, stream);
-    }
-    else
-    {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::SortKeys,
-                                     d_temp_storage, temp_storage_bytes,
-                                     d_keys.Current(), len, comp, stream);
-    }
-#endif
-  }
+  // Run implementation
+  call_impl(std::integral_constant<int, 1>{});
+
   // Free temporary storage
   hip::device_mempool_type::getInstance().free(d_temp_storage);
 
-  if (get_current(d_keys) == d_out)
-  {
-
-    // copy
-    CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, begin, d_out, len * sizeof(R),
-                                  hipMemcpyDefault, stream);
-  }
-
-  hip::device_mempool_type::getInstance().free(d_out);
-
+  // Mark kernel launches done by this resource/stream
   hip::launch(hip_res, Async);
 
   return resources::EventProxy<resources::Hip>(hip_res);
@@ -259,155 +255,157 @@ resources::EventProxy<resources::Hip> sort_pairs(
   using K = RAJA::detail::IterVal<KeyIter>;
   using V = RAJA::detail::IterVal<ValIter>;
 
-  const int len           = std::distance(keys_begin, keys_end);
+  using IndexType = camp::decay<decltype(std::distance(keys_begin, keys_end))>;
+
+  const IndexType len     = std::distance(keys_begin, keys_end);
   constexpr int begin_bit = 0;
   constexpr int end_bit   = sizeof(K) * CHAR_BIT;
 
-  // Allocate temporary storage for the output arrays
-  K* d_keys_out = hip::device_mempool_type::getInstance().malloc<K>(len);
-  V* d_vals_out = hip::device_mempool_type::getInstance().malloc<V>(len);
-
-  // use cub double buffer to reduce temporary memory requirements
-  // by allowing cub to write to the keys_begin and vals_begin buffers
-  double_buffer<K> d_keys(keys_begin, d_keys_out);
-  double_buffer<V> d_vals(vals_begin, d_vals_out);
-
-  // Determine temporary device storage requirements
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
-  if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
-                std::is_pointer_v<ValIter> &&
-                std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
+
+  auto call_impl = [&, d_keys_out = static_cast<K*>(nullptr),
+                       d_vals_out = static_cast<V*>(nullptr)](auto phase) mutable
   {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs, d_temp_storage,
-                                  temp_storage_bytes, d_keys, d_vals, len,
-                                  begin_bit, end_bit, stream);
-#elif defined(__CUDACC__)
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   d_vals, len, begin_bit, end_bit, stream);
-#endif
-  }
-  else if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
-                     std::is_pointer_v<ValIter> &&
-                     std::is_same_v<std::decay_t<Compare>,
-                                    operators::greater<K>>)
-  {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs_desc,
-                                  d_temp_storage, temp_storage_bytes, d_keys,
-                                  d_vals, len, begin_bit, end_bit, stream);
-#elif defined(__CUDACC__)
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   d_vals, len, begin_bit, end_bit, stream);
-#endif
-  }
-  else
-  {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                  temp_storage_bytes, d_keys.current(),
-                                  d_keys.alternate(), d_vals.current(),
-                                  d_vals.alternate(), len, comp, stream);
-#elif defined(__CUDACC__)
-    if constexpr (Stable)
+    RAJA_UNUSED_VAR(phase);
+    RAJA_UNUSED_VAR(d_keys_out);
+    RAJA_UNUSED_VAR(d_vals_out);
+
+    if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
+                  std::is_pointer_v<ValIter> &&
+                  ( std::is_same_v<std::decay_t<Compare>, operators::less<K>> ||
+                    std::is_same_v<std::decay_t<Compare>, operators::greater<K>>))
     {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortPairs,
-                                     d_temp_storage, temp_storage_bytes,
-                                     d_keys.Current(), d_vals.Current(), len,
-                                     comp, stream);
+      // The begin iterators are pointers in this constexpr conditional
+      // so we can use double_buffer
+
+      // Setup temporary storage for the output arrays
+      if constexpr (phase == 0) {
+        d_keys_out = hip::device_mempool_type::getInstance().malloc<K>(len);
+        d_vals_out = hip::device_mempool_type::getInstance().malloc<V>(len);
+      }
+
+      // Use double_buffers to reduce temporary memory requirements
+      // by allowing cub to write to the keys_begin and vals_begin buffers
+      double_buffer<K> d_keys(keys_begin, d_keys_out);
+      double_buffer<V> d_vals(vals_begin, d_vals_out);
+
+      if constexpr (std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
+      {
+#if defined(__HIPCC__)
+        CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs, d_temp_storage,
+                                      temp_storage_bytes, d_keys, d_vals, len,
+                                      begin_bit, end_bit, stream);
+#elif defined(__CUDACC__)
+        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
+                                       d_temp_storage, temp_storage_bytes, d_keys,
+                                       d_vals, len, begin_bit, end_bit, stream);
+#endif
+      }
+      else if constexpr (std::is_same_v<std::decay_t<Compare>, operators::greater<K>>)
+      {
+#if defined(__HIPCC__)
+        CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs_desc,
+                                      d_temp_storage, temp_storage_bytes, d_keys,
+                                      d_vals, len, begin_bit, end_bit, stream);
+#elif defined(__CUDACC__)
+        CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
+                                       d_temp_storage, temp_storage_bytes, d_keys,
+                                       d_vals, len, begin_bit, end_bit, stream);
+#endif
+      }
+
+      // Tear-down temporary storage for the output array
+      if constexpr (phase == 1)
+      {
+        // copy keys and values back if necessary
+        if (get_current(d_keys) == d_keys_out && get_current(d_vals) == d_vals_out) {
+          // Copy keys and values back via kernel for performance
+          forall_impl(hip_res,
+              ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, true>{},
+              TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
+              ::RAJA::detail::Copy2Functor{keys_begin, d_keys_out,
+                                           vals_begin, d_vals_out},
+              expt::get_empty_forall_param_pack());
+        }
+        else if (get_current(d_keys) == d_keys_out)
+        {
+          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, keys_begin, d_keys_out, len * sizeof(K),
+                                        hipMemcpyDefault, stream);
+        }
+        else if (get_current(d_vals) == d_vals_out)
+        {
+          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, vals_begin, d_vals_out, len * sizeof(V),
+                                        hipMemcpyDefault, stream);
+        }
+
+        // Free temporary output arrays
+        hip::device_mempool_type::getInstance().free(d_keys_out);
+        hip::device_mempool_type::getInstance().free(d_vals_out);
+      }
     }
     else
     {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(
-          cub::DeviceMergeSort::SortPairs, d_temp_storage, temp_storage_bytes,
-          d_keys.Current(), d_vals.Current(), len, comp, stream);
-    }
+#if defined(__HIPCC__)
+      // Setup temporary storage for the output arrays
+      if constexpr (phase == 0) {
+        d_keys_out = hip::device_mempool_type::getInstance().malloc<K>(len);
+        d_vals_out = hip::device_mempool_type::getInstance().malloc<V>(len);
+      }
+
+      CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
+                                    temp_storage_bytes, keys_begin,
+                                    d_keys_out, vals_begin,
+                                    d_vals_out, len, comp, stream);
+
+      // Tear-down temporary storage for the output array
+      if constexpr (phase == 1)
+      {
+        // Copy keys and values back via kernel as iterators may not be a pointer
+        forall_impl(hip_res,
+            ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter, Concretizer, true>{},
+            TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
+            ::RAJA::detail::Copy2Functor{keys_begin, d_keys_out,
+                                         vals_begin, d_vals_out},
+            expt::get_empty_forall_param_pack());
+
+        // Free temporary output arrays
+        hip::device_mempool_type::getInstance().free(d_keys_out);
+        hip::device_mempool_type::getInstance().free(d_vals_out);
+      }
+#elif defined(__CUDACC__)
+      if constexpr (Stable)
+      {
+        CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortPairs,
+                                       d_temp_storage, temp_storage_bytes,
+                                       keys_begin, vals_begin, len,
+                                       comp, stream);
+      }
+      else
+      {
+        CAMP_CUDA_API_INVOKE_AND_CHECK(
+            cub::DeviceMergeSort::SortPairs, d_temp_storage, temp_storage_bytes,
+            keys_begin, vals_begin, len, comp, stream);
+      }
 #endif
-  }
+    }
+  };
+
+  // Determine temporary device storage requirements
+  call_impl(std::integral_constant<int, 0>{});
+
   // Allocate temporary storage
   d_temp_storage =
       hip::device_mempool_type::getInstance().malloc<unsigned char>(
           temp_storage_bytes);
 
   // Run
-  if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
-                std::is_pointer_v<ValIter> &&
-                std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
-  {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs, d_temp_storage,
-                                  temp_storage_bytes, d_keys, d_vals, len,
-                                  begin_bit, end_bit, stream);
-#elif defined(__CUDACC__)
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairs,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   d_vals, len, begin_bit, end_bit, stream);
-#endif
-  }
-  else if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
-                     std::is_pointer_v<ValIter> &&
-                     std::is_same_v<std::decay_t<Compare>,
-                                    operators::greater<K>>)
-  {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::radix_sort_pairs_desc,
-                                  d_temp_storage, temp_storage_bytes, d_keys,
-                                  d_vals, len, begin_bit, end_bit, stream);
-#elif defined(__CUDACC__)
-    CAMP_CUDA_API_INVOKE_AND_CHECK(::cub::DeviceRadixSort::SortPairsDescending,
-                                   d_temp_storage, temp_storage_bytes, d_keys,
-                                   d_vals, len, begin_bit, end_bit, stream);
-#endif
-  }
-  else
-  {
-#if defined(__HIPCC__)
-    CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                  temp_storage_bytes, d_keys.current(),
-                                  d_keys.alternate(), d_vals.current(),
-                                  d_vals.alternate(), len, comp, stream);
-    d_keys.swap();
-    d_vals.swap();
-#elif defined(__CUDACC__)
-    if constexpr (Stable)
-    {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(cub::DeviceMergeSort::StableSortPairs,
-                                     d_temp_storage, temp_storage_bytes,
-                                     d_keys.Current(), d_vals.Current(), len,
-                                     comp, stream);
-    }
-    else
-    {
-      CAMP_CUDA_API_INVOKE_AND_CHECK(
-          cub::DeviceMergeSort::SortPairs, d_temp_storage, temp_storage_bytes,
-          d_keys.Current(), d_vals.Current(), len, comp, stream);
-    }
-#endif
-  }
+  call_impl(std::integral_constant<int, 1>{});
+
   // Free temporary storage
   hip::device_mempool_type::getInstance().free(d_temp_storage);
 
-  if (get_current(d_keys) == d_keys_out)
-  {
-
-    // copy keys
-    CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, keys_begin, d_keys_out,
-                                  len * sizeof(K), hipMemcpyDefault, stream);
-  }
-  if (get_current(d_vals) == d_vals_out)
-  {
-
-    // copy vals
-    CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, vals_begin, d_vals_out,
-                                  len * sizeof(V), hipMemcpyDefault, stream);
-  }
-
-  hip::device_mempool_type::getInstance().free(d_keys_out);
-  hip::device_mempool_type::getInstance().free(d_vals_out);
-
+  // Mark kernel launches done by this resource/stream
   hip::launch(hip_res, Async);
 
   return resources::EventProxy<resources::Hip>(hip_res);

--- a/include/RAJA/policy/hip/sort.hpp
+++ b/include/RAJA/policy/hip/sort.hpp
@@ -191,7 +191,7 @@ resources::EventProxy<resources::Hip> sort(
             ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter,
                                           Concretizer, true> {},
             TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-            ::RAJA::detail::OneCopyFunctor {begin, d_out},
+            ::RAJA::detail::CopyFunctorOneRange {begin, d_out},
             expt::get_empty_forall_param_pack());
 
         // Free temporary output array
@@ -339,8 +339,8 @@ resources::EventProxy<resources::Hip> sort_pairs(
               ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter,
                                             Concretizer, true> {},
               TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-              ::RAJA::detail::TwoCopiesFunctor {keys_begin, d_keys_out,
-                                                vals_begin, d_vals_out},
+              ::RAJA::detail::CopyFunctorTwoRanges {keys_begin, d_keys_out,
+                                                    vals_begin, d_vals_out},
               expt::get_empty_forall_param_pack());
         }
         else if (get_current(d_keys) == d_keys_out)
@@ -385,8 +385,8 @@ resources::EventProxy<resources::Hip> sort_pairs(
             ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter,
                                           Concretizer, true> {},
             TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-            ::RAJA::detail::TwoCopiesFunctor {keys_begin, d_keys_out,
-                                              vals_begin, d_vals_out},
+            ::RAJA::detail::CopyFunctorTwoRanges {keys_begin, d_keys_out,
+                                                  vals_begin, d_vals_out},
             expt::get_empty_forall_param_pack());
 
         // Free temporary output arrays

--- a/include/RAJA/policy/hip/sort.hpp
+++ b/include/RAJA/policy/hip/sort.hpp
@@ -106,9 +106,9 @@ resources::EventProxy<resources::Hip> sort(
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
 
-  auto call_impl = [&, d_out = static_cast<R*>(nullptr)](auto phase) mutable {
+  auto call_impl = [&, tmp_begin = static_cast<R*>(nullptr)](auto phase) mutable {
     RAJA_UNUSED_VAR(phase);
-    RAJA_UNUSED_VAR(d_out);
+    RAJA_UNUSED_VAR(tmp_begin);
 
     if constexpr (std::is_arithmetic_v<R> && std::is_pointer_v<Iter> &&
                   (std::is_same_v<std::decay_t<Compare>, operators::less<R>> ||
@@ -121,12 +121,12 @@ resources::EventProxy<resources::Hip> sort(
       // Setup temporary storage for the output array
       if constexpr (phase == 0)
       {
-        d_out = hip::device_mempool_type::getInstance().malloc<R>(len);
+        tmp_begin = hip::device_mempool_type::getInstance().malloc<R>(len);
       }
 
       // Use double_buffers to reduce temporary memory requirements
       // by allowing cub to write to the begin buffer
-      double_buffer<R> d_keys(begin, d_out);
+      double_buffer<R> d_keys(begin, tmp_begin);
 
       if constexpr (std::is_same_v<std::decay_t<Compare>, operators::less<R>>)
       {
@@ -158,15 +158,15 @@ resources::EventProxy<resources::Hip> sort(
       if constexpr (phase == 1)
       {
         // Copy result back if necessary
-        if (get_current(d_keys) == d_out)
+        if (get_current(d_keys) == tmp_begin)
         {
-          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, begin, d_out,
+          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, begin, tmp_begin,
                                         len * sizeof(R), hipMemcpyDefault,
                                         stream);
         }
 
         // Free temporary output array
-        hip::device_mempool_type::getInstance().free(d_out);
+        hip::device_mempool_type::getInstance().free(tmp_begin);
       }
     }
     else
@@ -175,11 +175,11 @@ resources::EventProxy<resources::Hip> sort(
       // Setup temporary storage for the output array
       if constexpr (phase == 0)
       {
-        d_out = hip::device_mempool_type::getInstance().malloc<R>(len);
+        tmp_begin = hip::device_mempool_type::getInstance().malloc<R>(len);
       }
 
       CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                    temp_storage_bytes, begin, d_out, len, comp,
+                                    temp_storage_bytes, begin, tmp_begin, len, comp,
                                     stream);
 
       // Tear-down temporary storage for the output array
@@ -191,11 +191,11 @@ resources::EventProxy<resources::Hip> sort(
             ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter,
                                           Concretizer, true> {},
             TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-            ::RAJA::detail::CopyFunctorOneRange {begin, d_out},
+            ::RAJA::detail::CopyFunctorOneRange {begin, tmp_begin},
             expt::get_empty_forall_param_pack());
 
         // Free temporary output array
-        hip::device_mempool_type::getInstance().free(d_out);
+        hip::device_mempool_type::getInstance().free(tmp_begin);
       }
 #elif defined(__CUDACC__)
       if constexpr (RequireStable)
@@ -270,11 +270,11 @@ resources::EventProxy<resources::Hip> sort_pairs(
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
 
-  auto call_impl = [&, d_keys_out = static_cast<K*>(nullptr),
-                    d_vals_out = static_cast<V*>(nullptr)](auto phase) mutable {
+  auto call_impl = [&, tmp_keys_begin = static_cast<K*>(nullptr),
+                    tmp_vals_begin = static_cast<V*>(nullptr)](auto phase) mutable {
     RAJA_UNUSED_VAR(phase);
-    RAJA_UNUSED_VAR(d_keys_out);
-    RAJA_UNUSED_VAR(d_vals_out);
+    RAJA_UNUSED_VAR(tmp_keys_begin);
+    RAJA_UNUSED_VAR(tmp_vals_begin);
 
     if constexpr (std::is_arithmetic_v<K> && std::is_pointer_v<KeyIter> &&
                   std::is_pointer_v<ValIter> &&
@@ -288,14 +288,14 @@ resources::EventProxy<resources::Hip> sort_pairs(
       // Setup temporary storage for the output arrays
       if constexpr (phase == 0)
       {
-        d_keys_out = hip::device_mempool_type::getInstance().malloc<K>(len);
-        d_vals_out = hip::device_mempool_type::getInstance().malloc<V>(len);
+        tmp_keys_begin = hip::device_mempool_type::getInstance().malloc<K>(len);
+        tmp_vals_begin = hip::device_mempool_type::getInstance().malloc<V>(len);
       }
 
       // Use double_buffers to reduce temporary memory requirements
       // by allowing cub to write to the keys_begin and vals_begin buffers
-      double_buffer<K> d_keys(keys_begin, d_keys_out);
-      double_buffer<V> d_vals(vals_begin, d_vals_out);
+      double_buffer<K> d_keys(keys_begin, tmp_keys_begin);
+      double_buffer<V> d_vals(vals_begin, tmp_vals_begin);
 
       if constexpr (std::is_same_v<std::decay_t<Compare>, operators::less<K>>)
       {
@@ -330,8 +330,8 @@ resources::EventProxy<resources::Hip> sort_pairs(
       if constexpr (phase == 1)
       {
         // copy keys and values back if necessary
-        if (get_current(d_keys) == d_keys_out &&
-            get_current(d_vals) == d_vals_out)
+        if (get_current(d_keys) == tmp_keys_begin &&
+            get_current(d_vals) == tmp_vals_begin)
         {
           // Copy keys and values back via kernel for performance
           forall_impl(
@@ -339,26 +339,26 @@ resources::EventProxy<resources::Hip> sort_pairs(
               ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter,
                                             Concretizer, true> {},
               TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-              ::RAJA::detail::CopyFunctorTwoRanges {keys_begin, d_keys_out,
-                                                    vals_begin, d_vals_out},
+              ::RAJA::detail::CopyFunctorTwoRanges {keys_begin, tmp_keys_begin,
+                                                    vals_begin, tmp_vals_begin},
               expt::get_empty_forall_param_pack());
         }
-        else if (get_current(d_keys) == d_keys_out)
+        else if (get_current(d_keys) == tmp_keys_begin)
         {
-          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, keys_begin, d_keys_out,
+          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, keys_begin, tmp_keys_begin,
                                         len * sizeof(K), hipMemcpyDefault,
                                         stream);
         }
-        else if (get_current(d_vals) == d_vals_out)
+        else if (get_current(d_vals) == tmp_vals_begin)
         {
-          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, vals_begin, d_vals_out,
+          CAMP_HIP_API_INVOKE_AND_CHECK(hipMemcpyAsync, vals_begin, tmp_vals_begin,
                                         len * sizeof(V), hipMemcpyDefault,
                                         stream);
         }
 
         // Free temporary output arrays
-        hip::device_mempool_type::getInstance().free(d_keys_out);
-        hip::device_mempool_type::getInstance().free(d_vals_out);
+        hip::device_mempool_type::getInstance().free(tmp_keys_begin);
+        hip::device_mempool_type::getInstance().free(tmp_vals_begin);
       }
     }
     else
@@ -367,13 +367,13 @@ resources::EventProxy<resources::Hip> sort_pairs(
       // Setup temporary storage for the output arrays
       if constexpr (phase == 0)
       {
-        d_keys_out = hip::device_mempool_type::getInstance().malloc<K>(len);
-        d_vals_out = hip::device_mempool_type::getInstance().malloc<V>(len);
+        tmp_keys_begin = hip::device_mempool_type::getInstance().malloc<K>(len);
+        tmp_vals_begin = hip::device_mempool_type::getInstance().malloc<V>(len);
       }
 
       CAMP_HIP_API_INVOKE_AND_CHECK(::rocprim::merge_sort, d_temp_storage,
-                                    temp_storage_bytes, keys_begin, d_keys_out,
-                                    vals_begin, d_vals_out, len, comp, stream);
+                                    temp_storage_bytes, keys_begin, tmp_keys_begin,
+                                    vals_begin, tmp_vals_begin, len, comp, stream);
 
       // Tear-down temporary storage for the output array
       if constexpr (phase == 1)
@@ -385,13 +385,13 @@ resources::EventProxy<resources::Hip> sort_pairs(
             ::RAJA::policy::hip::hip_exec<IterationMapping, IterationGetter,
                                           Concretizer, true> {},
             TypedRangeSegment<IndexType>(static_cast<IndexType>(0), len),
-            ::RAJA::detail::CopyFunctorTwoRanges {keys_begin, d_keys_out,
-                                                  vals_begin, d_vals_out},
+            ::RAJA::detail::CopyFunctorTwoRanges {keys_begin, tmp_keys_begin,
+                                                  vals_begin, tmp_vals_begin},
             expt::get_empty_forall_param_pack());
 
         // Free temporary output arrays
-        hip::device_mempool_type::getInstance().free(d_keys_out);
-        hip::device_mempool_type::getInstance().free(d_vals_out);
+        hip::device_mempool_type::getInstance().free(tmp_keys_begin);
+        hip::device_mempool_type::getInstance().free(dst_vals_begin);
       }
 #elif defined(__CUDACC__)
       if constexpr (RequireStable)

--- a/include/RAJA/util/types.hpp
+++ b/include/RAJA/util/types.hpp
@@ -1057,7 +1057,7 @@ private:
  * \brief Functor that copies src to dst.
  */
 template<typename DestIter, typename SrcIter>
-struct Copy1Functor
+struct OneCopyFunctor
 {
   DestIter dst;
   SrcIter src;
@@ -1070,7 +1070,7 @@ struct Copy1Functor
 };
 
 template<typename DestIter, typename SrcIter>
-Copy1Functor(DestIter, SrcIter) -> Copy1Functor<DestIter, SrcIter>;
+OneCopyFunctor(DestIter, SrcIter) -> OneCopyFunctor<DestIter, SrcIter>;
 
 /*!
  * \brief Functor that copies src1 to dst1 and src2 to dst2.
@@ -1079,7 +1079,7 @@ template<typename DestIter1,
          typename SrcIter1,
          typename DestIter2,
          typename SrcIter2>
-struct Copy2Functor
+struct TwoCopiesFunctor
 {
   DestIter1 dst1;
   SrcIter1 src1;
@@ -1099,8 +1099,8 @@ template<typename DestIter1,
          typename SrcIter1,
          typename DestIter2,
          typename SrcIter2>
-Copy2Functor(DestIter1, SrcIter1, DestIter2, SrcIter2)
-    -> Copy2Functor<DestIter1, SrcIter1, DestIter2, SrcIter2>;
+TwoCopiesFunctor(DestIter1, SrcIter1, DestIter2, SrcIter2)
+    -> TwoCopiesFunctor<DestIter1, SrcIter1, DestIter2, SrcIter2>;
 
 }  // namespace detail
 

--- a/include/RAJA/util/types.hpp
+++ b/include/RAJA/util/types.hpp
@@ -1069,6 +1069,9 @@ struct Copy1Functor
   }
 };
 
+template<typename DestIter, typename SrcIter>
+Copy1Functor(DestIter, SrcIter) -> Copy1Functor<DestIter, SrcIter>;
+
 /*!
  * \brief Functor that copies src1 to dst1 and src2 to dst2.
  */
@@ -1091,6 +1094,13 @@ struct Copy2Functor
     dst2[i] = src2[i];
   }
 };
+
+template<typename DestIter1,
+         typename SrcIter1,
+         typename DestIter2,
+         typename SrcIter2>
+Copy2Functor(DestIter1, SrcIter1, DestIter2, SrcIter2)
+    -> Copy2Functor<DestIter1, SrcIter1, DestIter2, SrcIter2>;
 
 }  // namespace detail
 

--- a/include/RAJA/util/types.hpp
+++ b/include/RAJA/util/types.hpp
@@ -1053,6 +1053,45 @@ private:
   T m_prev_val;
 };
 
+/*!
+ * \brief Functor that copies src to dst.
+ */
+template < typename DestIter, typename SrcIter >
+struct Copy1Functor
+{
+  DestIter dst;
+  SrcIter src;
+
+  template < typename IndexType >
+  RAJA_HOST_DEVICE
+  constexpr void operator()(IndexType i) const
+  {
+    dst[i] = src[i];
+  }
+};
+
+/*!
+ * \brief Functor that copies src1 to dst1 and src2 to dst2.
+ */
+template < typename DestIter1, typename SrcIter1,
+           typename DestIter2, typename SrcIter2 >
+struct Copy2Functor
+{
+  DestIter1 dst1;
+  SrcIter1 src1;
+
+  DestIter2 dst2;
+  SrcIter2 src2;
+
+  template < typename IndexType >
+  RAJA_HOST_DEVICE
+  constexpr void operator()(IndexType i) const
+  {
+    dst1[i] = src1[i];
+    dst2[i] = src2[i];
+  }
+};
+
 }  // namespace detail
 
 }  // namespace RAJA

--- a/include/RAJA/util/types.hpp
+++ b/include/RAJA/util/types.hpp
@@ -1056,15 +1056,14 @@ private:
 /*!
  * \brief Functor that copies src to dst.
  */
-template < typename DestIter, typename SrcIter >
+template<typename DestIter, typename SrcIter>
 struct Copy1Functor
 {
   DestIter dst;
   SrcIter src;
 
-  template < typename IndexType >
-  RAJA_HOST_DEVICE
-  constexpr void operator()(IndexType i) const
+  template<typename IndexType>
+  RAJA_HOST_DEVICE constexpr void operator()(IndexType i) const
   {
     dst[i] = src[i];
   }
@@ -1073,8 +1072,10 @@ struct Copy1Functor
 /*!
  * \brief Functor that copies src1 to dst1 and src2 to dst2.
  */
-template < typename DestIter1, typename SrcIter1,
-           typename DestIter2, typename SrcIter2 >
+template<typename DestIter1,
+         typename SrcIter1,
+         typename DestIter2,
+         typename SrcIter2>
 struct Copy2Functor
 {
   DestIter1 dst1;
@@ -1083,9 +1084,8 @@ struct Copy2Functor
   DestIter2 dst2;
   SrcIter2 src2;
 
-  template < typename IndexType >
-  RAJA_HOST_DEVICE
-  constexpr void operator()(IndexType i) const
+  template<typename IndexType>
+  RAJA_HOST_DEVICE constexpr void operator()(IndexType i) const
   {
     dst1[i] = src1[i];
     dst2[i] = src2[i];

--- a/include/RAJA/util/types.hpp
+++ b/include/RAJA/util/types.hpp
@@ -1057,7 +1057,7 @@ private:
  * \brief Functor that copies src to dst.
  */
 template<typename DestIter, typename SrcIter>
-struct OneCopyFunctor
+struct CopyFunctorOneRange
 {
   DestIter dst;
   SrcIter src;
@@ -1070,7 +1070,8 @@ struct OneCopyFunctor
 };
 
 template<typename DestIter, typename SrcIter>
-OneCopyFunctor(DestIter, SrcIter) -> OneCopyFunctor<DestIter, SrcIter>;
+CopyFunctorOneRange(DestIter, SrcIter)
+    -> CopyFunctorOneRange<DestIter, SrcIter>;
 
 /*!
  * \brief Functor that copies src1 to dst1 and src2 to dst2.
@@ -1079,7 +1080,7 @@ template<typename DestIter1,
          typename SrcIter1,
          typename DestIter2,
          typename SrcIter2>
-struct TwoCopiesFunctor
+struct CopyFunctorTwoRanges
 {
   DestIter1 dst1;
   SrcIter1 src1;
@@ -1099,8 +1100,8 @@ template<typename DestIter1,
          typename SrcIter1,
          typename DestIter2,
          typename SrcIter2>
-TwoCopiesFunctor(DestIter1, SrcIter1, DestIter2, SrcIter2)
-    -> TwoCopiesFunctor<DestIter1, SrcIter1, DestIter2, SrcIter2>;
+CopyFunctorTwoRanges(DestIter1, SrcIter1, DestIter2, SrcIter2)
+    -> CopyFunctorTwoRanges<DestIter1, SrcIter1, DestIter2, SrcIter2>;
 
 }  // namespace detail
 

--- a/test/unit/algorithm/tests/test-algorithm-sort-utils.hpp
+++ b/test/unit/algorithm/tests/test-algorithm-sort-utils.hpp
@@ -573,6 +573,9 @@ void testSorterResInterfaces(
   // Sorter does not support resource interface, no tests
 }
 
+template < typename K >
+struct custom_greater : RAJA::operators::greater<K>{};
+
 template <typename Res,
           typename K,
           typename V,
@@ -595,6 +598,8 @@ void testSorterResInterfaces(
   ASSERT_TRUE(testSort("resource+ascending", seed, data, N, RAJA::operators::less<K>{},
       sorter, stability_category{}, pairs_category{}, resource_use_comparator{}));
   ASSERT_TRUE(testSort("resource+descending", seed, data, N, RAJA::operators::greater<K>{},
+      sorter, stability_category{}, pairs_category{}, resource_use_comparator{}));
+  ASSERT_TRUE(testSort("resource+custom_descending", seed, data, N, custom_greater<K>{},
       sorter, stability_category{}, pairs_category{}, resource_use_comparator{}));
 }
 
@@ -620,6 +625,8 @@ void testSorterInterfaces(unsigned seed, RAJA::Index_type MaxN, Sorter sorter, R
   ASSERT_TRUE(testSort("ascending", seed, data, N, RAJA::operators::less<K>{},
       sorter, stability_category{}, pairs_category{}, use_comparator{}));
   ASSERT_TRUE(testSort("descending", seed, data, N, RAJA::operators::greater<K>{},
+      sorter, stability_category{}, pairs_category{}, use_comparator{}));
+  ASSERT_TRUE(testSort("custom_descending", seed, data, N, custom_greater<K>{},
       sorter, stability_category{}, pairs_category{}, use_comparator{}));
 
   testSorterResInterfaces(supports_resource(), seed, data, N, sorter);


### PR DESCRIPTION
# Summary

Adds support non-arithmetic types, generic comparison operators, and non-pointer iterators in the Cuda and Hip `sort` and `sort_pairs` backends.
This uses the cub and rocprim merge sort implementations that were previously unavailable.

- This PR is a bugfix
- It does the following:
  - Fixes #1810 
