### PR TITLE
Fix ambiguous unqualified partition call in util/sort.hpp

### DIFF
--- a/include/RAJA/util/sort.hpp
+++ b/include/RAJA/util/sort.hpp
@@ -391,7 +391,7 @@ RAJA_HOST_DEVICE inline void intro_sort_depth(Iter begin,
     }
 
     // partition
-    mid = partition(begin, last, [&](Iter it) {
+    mid = detail::partition(begin, last, [&](Iter it) {
       return comp(*it, *pivot);
     });
 


### PR DESCRIPTION
# Summary

- This PR is a: bugfix
- It does the following:
  - Adds a `detail::` qualifier to the `partition` call within `util/sort.hpp` to avoid a naming conflict with `std::partition`. Without this change, we (over in Conduit) encounter a compilation error when leveraging RAJA for CPU-based sorting, since `std::vector` brings `std::partition` into scope which creates ambiguity.
