### PR TITLE
bugfix: Use memcpy on device

### DIFF
--- a/include/RAJA/util/TypeConvert.hpp
+++ b/include/RAJA/util/TypeConvert.hpp
@@ -53,7 +53,7 @@ RAJA_INLINE RAJA_HOST_DEVICE constexpr B reinterp_A_as_B(A const& a)
   // TODO: Consider requiring A and B to be trivially copyable
 
   B b;
-  std::memcpy(&b, &a, sizeof(A));
+  memcpy(&b, &a, sizeof(A));
   return b;
 }
 


### PR DESCRIPTION
This PR:
- Fixes a downstream error due to `std::memcpy` instead of `memcpy` on device.

Error message:
```
[100%] Building HIP object axom/spin/tests/CMakeFiles/spin_uniform_grid_test.dir/spin_uniform_grid.cpp.o
In file included from /usr/WS1/han12/axom_codex/src/axom/spin/tests/spin_uniform_grid.cpp:14:
In file included from /usr/WS1/han12/axom_codex/src/axom/core/../../axom/spin/UniformGrid.hpp:11:
In file included from /usr/WS1/han12/axom_codex/src/axom/core/../../axom/core/execution/for_all.hpp:11:
In file included from /usr/WS1/han12/axom_codex/src/axom/core/../../axom/core/execution/execution_space.hpp:111:
In file included from /usr/WS1/han12/axom_codex/src/axom/core/../../axom/core/execution/internal/seq_exec.hpp:15:
In file included from /usr/WS1/han12/axom_codex/uberenv_libs/llvm-amdgpu-6.4.3/raja-develop-hbu2lep7bacs724pnfnxefjefkq64cdd/include/RAJA/RAJA.hpp:77:
In file included from /usr/WS1/han12/axom_codex/uberenv_libs/llvm-amdgpu-6.4.3/raja-develop-hbu2lep7bacs724pnfnxefjefkq64cdd/include/RAJA/policy/hip.hpp:32:
In file included from /usr/WS1/han12/axom_codex/uberenv_libs/llvm-amdgpu-6.4.3/raja-develop-hbu2lep7bacs724pnfnxefjefkq64cdd/include/RAJA/policy/hip/atomic.hpp:37:
In file included from /usr/WS1/han12/axom_codex/uberenv_libs/llvm-amdgpu-6.4.3/raja-develop-hbu2lep7bacs724pnfnxefjefkq64cdd/include/RAJA/policy/atomic_builtin.hpp:33:
/usr/WS1/han12/axom_codex/uberenv_libs/llvm-amdgpu-6.4.3/raja-develop-hbu2lep7bacs724pnfnxefjefkq64cdd/include/RAJA/util/TypeConvert.hpp:56:8: error: reference to __host__ function 'memcpy' in __host__ __device__ function
   56 |   std::memcpy(&b, &a, sizeof(A));
      |        ^
```