### PR TITLE
Fixes CUDA generic atomic operation by fixing atomic load

### DIFF
--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -28,11 +28,6 @@
 #include <type_traits>
 #include <utility>
 
-#if __CUDA__ARCH__ >= 600 && __CUDACC_VER_MAJOR__ >= 11 &&                     \
-    __CUDACC_VER_MINOR__ >= 6
-#define RAJA_ENABLE_CUDA_ATOMIC_REF
-#endif
-
 #include <cuda/atomic>
 
 #include "camp/list.hpp"
@@ -179,10 +174,8 @@ RAJA_INLINE __device__ T cuda_atomicExchange(T* acc, T value)
 }
 
 /*!
- * Atomic load and store
+ * Atomic load
  */
-#if defined(RAJA_ENABLE_CUDA_ATOMIC_REF)
-
 template<typename T>
 RAJA_INLINE __device__ T cuda_atomicLoad(T* acc)
 {
@@ -190,40 +183,15 @@ RAJA_INLINE __device__ T cuda_atomicLoad(T* acc)
       cuda::memory_order_relaxed {});
 }
 
+/*!
+ * Atomic store
+ */
 template<typename T>
 RAJA_INLINE __device__ void cuda_atomicStore(T* acc, T value)
 {
   cuda::atomic_ref<T, cuda::thread_scope_device>(*acc).store(
       value, cuda::memory_order_relaxed {});
 }
-
-#else
-
-template<typename T,
-         std::enable_if_t<cuda_useBuiltinCommon<T>::value, bool> = true>
-RAJA_INLINE __device__ T cuda_atomicLoad(T* acc)
-{
-  return cuda_atomicOr(acc, static_cast<T>(0));
-}
-
-template<typename T,
-         std::enable_if_t<cuda_useReinterpretCommon<T>::value, bool> = true>
-RAJA_INLINE __device__ T cuda_atomicLoad(T* acc)
-{
-  using R = cuda_useReinterpretCommon_t<T>;
-
-  return RAJA::util::reinterp_A_as_B<R, T>(
-      cuda_atomicLoad(reinterpret_cast<R*>(acc)));
-}
-
-template<typename T>
-RAJA_INLINE __device__ void cuda_atomicStore(T* acc, T value)
-{
-  cuda_atomicExchange(acc, value);
-}
-
-#endif
-
 
 /*!
  * Atomic compare and swap

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -179,8 +179,8 @@ RAJA_INLINE __device__ T cuda_atomicExchange(T* acc, T value)
 template<typename T>
 RAJA_INLINE __device__ T cuda_atomicLoad(T* acc)
 {
-  return cuda::atomic_ref<T, cuda::thread_scope_device>(*acc).load(
-      cuda::memory_order_relaxed {});
+  return ::cuda::atomic_ref<T, ::cuda::thread_scope_device>(*acc).load(
+      ::cuda::memory_order_relaxed {});
 }
 
 /*!
@@ -189,8 +189,8 @@ RAJA_INLINE __device__ T cuda_atomicLoad(T* acc)
 template<typename T>
 RAJA_INLINE __device__ void cuda_atomicStore(T* acc, T value)
 {
-  cuda::atomic_ref<T, cuda::thread_scope_device>(*acc).store(
-      value, cuda::memory_order_relaxed {});
+  ::cuda::atomic_ref<T, ::cuda::thread_scope_device>(*acc).store(
+      value, ::cuda::memory_order_relaxed {});
 }
 
 /*!

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -28,6 +28,11 @@
 #include <type_traits>
 #include <utility>
 
+#if __CUDA__ARCH__ >= 600 && __CUDACC_VER_MAJOR__ >= 11 &&                     \
+    __CUDACC_VER_MINOR__ >= 6
+#define RAJA_ENABLE_CUDA_ATOMIC_REF
+#endif
+
 #include <cuda/atomic>
 
 #include "camp/list.hpp"

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -810,17 +810,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(cuda_atomic_explicit<host_policy>,
                                              Operation&& operation)
 {
 #ifdef __CUDA_ARCH__
-  ::cuda::atomic_ref<T, ::cuda::thread_scope_device> ref(*acc);
-  T expected = ref.load(::cuda::std::memory_order_relaxed);
-  while (true)
-  {
-    if (ref.compare_exchange_weak(expected, operation(expected),
-                                  ::cuda::std::memory_order_relaxed,
-                                  ::cuda::std::memory_order_relaxed))
-    {
-      return expected;
-    }
-  }
+  return detail::cuda_atomicCAS_loop(acc, std::forward<Operation>(operation));
 #else
   return RAJA::atomicGeneric(host_policy {}, acc,
                              std::forward<Operation>(operation));

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -28,14 +28,7 @@
 #include <type_traits>
 #include <utility>
 
-#if __CUDA__ARCH__ >= 600 && __CUDACC_VER_MAJOR__ >= 11 &&                     \
-    __CUDACC_VER_MINOR__ >= 6
-#define RAJA_ENABLE_CUDA_ATOMIC_REF
-#endif
-
-#if defined(RAJA_ENABLE_CUDA_ATOMIC_REF)
 #include <cuda/atomic>
-#endif
 
 #include "camp/list.hpp"
 
@@ -844,7 +837,17 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(cuda_atomic_explicit<host_policy>,
                                              Operation&& operation)
 {
 #ifdef __CUDA_ARCH__
-  return detail::cuda_atomicCAS_loop(acc, std::forward<Operation>(operation));
+  ::cuda::atomic_ref<T, ::cuda::thread_scope_device> ref(*acc);
+  T expected = ref.load(::cuda::std::memory_order_relaxed);
+  while (true)
+  {
+    if (ref.compare_exchange_weak(expected, operation(expected),
+                                  ::cuda::std::memory_order_relaxed,
+                                  ::cuda::std::memory_order_relaxed))
+    {
+      return expected;
+    }
+  }
 #else
   return RAJA::atomicGeneric(host_policy {}, acc,
                              std::forward<Operation>(operation));

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -180,7 +180,7 @@ template<typename T>
 RAJA_INLINE __device__ T cuda_atomicLoad(T* acc)
 {
   return ::cuda::atomic_ref<T, ::cuda::thread_scope_device>(*acc).load(
-      ::cuda::memory_order_relaxed {});
+      ::cuda::memory_order_relaxed);
 }
 
 /*!
@@ -190,7 +190,7 @@ template<typename T>
 RAJA_INLINE __device__ void cuda_atomicStore(T* acc, T value)
 {
   ::cuda::atomic_ref<T, ::cuda::thread_scope_device>(*acc).store(
-      value, ::cuda::memory_order_relaxed {});
+      value, ::cuda::memory_order_relaxed);
 }
 
 /*!


### PR DESCRIPTION
# Summary

- This PR is a bugfix from @bechols97 
- It does the following:
  - Uses cuda::atomic_ref::load for atomicLoad instead of atomicOr with a value of 0
  - Uses cuda::atomic_ref::store for atomicStore instead of atomicExchange
  - The old implementation of atomicLoad in CUDA was giving incorrect results in #1832
  - Performance should be equivalent or better using atomic_ref, but even if not, correctness matters most
  - The RAJA_ENABLE_CUDA_ATOMIC_REF was never getting defined as intended, but now that we require CUDA 12, cuda::atomic_ref should always be available. The cuda/atomic header gives a very clear error message if an architecture older than sm_60 is used.
  