### PR TITLE
Add generic atomic operation with optional early exit

### DIFF
--- a/include/RAJA/pattern/atomic.hpp
+++ b/include/RAJA/pattern/atomic.hpp
@@ -317,8 +317,7 @@ RAJA_SUPPRESS_HD_WARN
 template<typename Policy,
          typename T,
          typename Operation,
-         typename StopPredicate>
-  requires std::predicate<StopPredicate, T>
+         std::predicate<T> StopPredicate>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(T* acc,
                                              Operation&& operation,
                                              StopPredicate&& stop)

--- a/include/RAJA/pattern/atomic.hpp
+++ b/include/RAJA/pattern/atomic.hpp
@@ -22,6 +22,7 @@
 
 #include "RAJA/config.hpp"
 
+#include <concepts>
 #include <utility>
 
 #include "RAJA/policy/atomic_auto.hpp"
@@ -301,6 +302,29 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(T* acc, Operation&& operation)
 {
   return RAJA::atomicGeneric(Policy {}, acc,
                              std::forward<Operation>(operation));
+}
+
+/*!
+ * @brief Generic atomic operation implemented using a CAS loop,
+ *        with optional early exit.
+ * @param acc Pointer to the location to update atomically.
+ * @param operation Callable used to compute the candidate new value
+ *                  from the current value.
+ * @param stop Predicate that returns true when no further update is needed.
+ * @return The old value observed before the successful update,
+ *         or the final value if stopped early.
+ */
+RAJA_SUPPRESS_HD_WARN
+template<typename Policy, typename T, typename Operation, typename StopPredicate>
+requires std::predicate<StopPredicate, T>
+RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(T* acc,
+                                             Operation&& operation,
+                                             StopPredicate&& stop)
+{
+  return RAJA::atomicGeneric(Policy {},
+                             acc,
+                             std::forward<Operation>(operation),
+                             std::forward<StopPredicate>(stop));
 }
 
 /*!

--- a/include/RAJA/pattern/atomic.hpp
+++ b/include/RAJA/pattern/atomic.hpp
@@ -314,15 +314,16 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(T* acc, Operation&& operation)
  * @return The old value observed before the successful update or early exit.
  */
 RAJA_SUPPRESS_HD_WARN
-template<typename Policy, typename T, typename Operation, typename StopPredicate>
-requires std::predicate<StopPredicate, T>
+template<typename Policy,
+         typename T,
+         typename Operation,
+         typename StopPredicate>
+  requires std::predicate<StopPredicate, T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(T* acc,
                                              Operation&& operation,
                                              StopPredicate&& stop)
 {
-  return RAJA::atomicGeneric(Policy {},
-                             acc,
-                             std::forward<Operation>(operation),
+  return RAJA::atomicGeneric(Policy {}, acc, std::forward<Operation>(operation),
                              std::forward<StopPredicate>(stop));
 }
 

--- a/include/RAJA/pattern/atomic.hpp
+++ b/include/RAJA/pattern/atomic.hpp
@@ -311,8 +311,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(T* acc, Operation&& operation)
  * @param operation Callable used to compute the candidate new value
  *                  from the current value.
  * @param stop Predicate that returns true when no further update is needed.
- * @return The old value observed before the successful update,
- *         or the final value if stopped early.
+ * @return The old value observed before the successful update or early exit.
  */
 RAJA_SUPPRESS_HD_WARN
 template<typename Policy, typename T, typename Operation, typename StopPredicate>

--- a/include/RAJA/policy/atomic_auto.hpp
+++ b/include/RAJA/policy/atomic_auto.hpp
@@ -22,6 +22,7 @@
 
 #include "RAJA/config.hpp"
 
+#include <concepts>
 #include <utility>
 
 #include "RAJA/util/macros.hpp"
@@ -165,6 +166,19 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(auto_atomic,
 {
   return atomicGeneric(RAJA_AUTO_ATOMIC, acc,
                        std::forward<Operation>(operation));
+}
+
+template<typename T, typename Operation, typename StopPredicate>
+requires std::predicate<StopPredicate, T>
+RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(auto_atomic,
+                                             T* acc,
+                                             Operation&& operation,
+                                             StopPredicate&& stop)
+{
+  return atomicGeneric(RAJA_AUTO_ATOMIC,
+                       acc,
+                       std::forward<Operation>(operation),
+                       std::forward<StopPredicate>(stop));
 }
 
 }  // namespace RAJA

--- a/include/RAJA/policy/atomic_auto.hpp
+++ b/include/RAJA/policy/atomic_auto.hpp
@@ -168,8 +168,7 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(auto_atomic,
                        std::forward<Operation>(operation));
 }
 
-template<typename T, typename Operation, typename StopPredicate>
-  requires std::predicate<StopPredicate, T>
+template<typename T, typename Operation, std::predicate<T> StopPredicate>
 RAJA_INLINE RAJA_HOST_DEVICE T
 atomicGeneric(auto_atomic, T* acc, Operation&& operation, StopPredicate&& stop)
 {

--- a/include/RAJA/policy/atomic_auto.hpp
+++ b/include/RAJA/policy/atomic_auto.hpp
@@ -169,14 +169,11 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(auto_atomic,
 }
 
 template<typename T, typename Operation, typename StopPredicate>
-requires std::predicate<StopPredicate, T>
-RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(auto_atomic,
-                                             T* acc,
-                                             Operation&& operation,
-                                             StopPredicate&& stop)
+  requires std::predicate<StopPredicate, T>
+RAJA_INLINE RAJA_HOST_DEVICE T
+atomicGeneric(auto_atomic, T* acc, Operation&& operation, StopPredicate&& stop)
 {
-  return atomicGeneric(RAJA_AUTO_ATOMIC,
-                       acc,
+  return atomicGeneric(RAJA_AUTO_ATOMIC, acc,
                        std::forward<Operation>(operation),
                        std::forward<StopPredicate>(stop));
 }

--- a/include/RAJA/policy/atomic_builtin.hpp
+++ b/include/RAJA/policy/atomic_builtin.hpp
@@ -997,14 +997,13 @@ RAJA_DEVICE_HIP RAJA_INLINE T atomicGeneric(builtin_atomic,
 }
 
 template<typename T, typename Operation, typename StopPredicate>
-requires std::predicate<StopPredicate, T>
+  requires std::predicate<StopPredicate, T>
 RAJA_DEVICE_HIP RAJA_INLINE T atomicGeneric(builtin_atomic,
                                             T* acc,
                                             Operation&& operation,
                                             StopPredicate&& stop)
 {
-  return detail::builtin_atomicCAS_loop(acc,
-                                        std::forward<Operation>(operation),
+  return detail::builtin_atomicCAS_loop(acc, std::forward<Operation>(operation),
                                         std::forward<StopPredicate>(stop));
 }
 

--- a/include/RAJA/policy/atomic_builtin.hpp
+++ b/include/RAJA/policy/atomic_builtin.hpp
@@ -22,6 +22,7 @@
 
 #include "RAJA/config.hpp"
 
+#include <concepts>
 #include <cstdint>
 #include <utility>
 
@@ -993,6 +994,18 @@ RAJA_DEVICE_HIP RAJA_INLINE T atomicGeneric(builtin_atomic,
 {
   return detail::builtin_atomicCAS_loop(acc,
                                         std::forward<Operation>(operation));
+}
+
+template<typename T, typename Operation, typename StopPredicate>
+requires std::predicate<StopPredicate, T>
+RAJA_DEVICE_HIP RAJA_INLINE T atomicGeneric(builtin_atomic,
+                                            T* acc,
+                                            Operation&& operation,
+                                            StopPredicate&& stop)
+{
+  return detail::builtin_atomicCAS_loop(acc,
+                                        std::forward<Operation>(operation),
+                                        std::forward<StopPredicate>(stop));
 }
 
 

--- a/include/RAJA/policy/atomic_builtin.hpp
+++ b/include/RAJA/policy/atomic_builtin.hpp
@@ -996,8 +996,7 @@ RAJA_DEVICE_HIP RAJA_INLINE T atomicGeneric(builtin_atomic,
                                         std::forward<Operation>(operation));
 }
 
-template<typename T, typename Operation, typename StopPredicate>
-  requires std::predicate<StopPredicate, T>
+template<typename T, typename Operation, std::predicate<T> StopPredicate>
 RAJA_DEVICE_HIP RAJA_INLINE T atomicGeneric(builtin_atomic,
                                             T* acc,
                                             Operation&& operation,

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -851,6 +851,26 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(cuda_atomic_explicit<host_policy>,
 #endif
 }
 
+RAJA_SUPPRESS_HD_WARN
+template<typename T, typename Operation, typename StopPredicate, typename host_policy>
+requires std::predicate<StopPredicate, T>
+RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(cuda_atomic_explicit<host_policy>,
+                                             T* acc,
+                                             Operation&& operation,
+                                             StopPredicate&& stop)
+{
+#ifdef __CUDA_ARCH__
+  return detail::cuda_atomicCAS_loop(acc,
+                                     std::forward<Operation>(operation),
+                                     std::forward<StopPredicate>(stop));
+#else
+  return RAJA::atomicGeneric(host_policy {},
+                             acc,
+                             std::forward<Operation>(operation),
+                             std::forward<StopPredicate>(stop));
+#endif
+}
+
 }  // namespace RAJA
 
 

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -854,9 +854,8 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(cuda_atomic_explicit<host_policy>,
 RAJA_SUPPRESS_HD_WARN
 template<typename T,
          typename Operation,
-         typename StopPredicate,
+         std::predicate<T> StopPredicate,
          typename host_policy>
-  requires std::predicate<StopPredicate, T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(cuda_atomic_explicit<host_policy>,
                                              T* acc,
                                              Operation&& operation,

--- a/include/RAJA/policy/cuda/atomic.hpp
+++ b/include/RAJA/policy/cuda/atomic.hpp
@@ -852,20 +852,21 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(cuda_atomic_explicit<host_policy>,
 }
 
 RAJA_SUPPRESS_HD_WARN
-template<typename T, typename Operation, typename StopPredicate, typename host_policy>
-requires std::predicate<StopPredicate, T>
+template<typename T,
+         typename Operation,
+         typename StopPredicate,
+         typename host_policy>
+  requires std::predicate<StopPredicate, T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(cuda_atomic_explicit<host_policy>,
                                              T* acc,
                                              Operation&& operation,
                                              StopPredicate&& stop)
 {
 #ifdef __CUDA_ARCH__
-  return detail::cuda_atomicCAS_loop(acc,
-                                     std::forward<Operation>(operation),
+  return detail::cuda_atomicCAS_loop(acc, std::forward<Operation>(operation),
                                      std::forward<StopPredicate>(stop));
 #else
-  return RAJA::atomicGeneric(host_policy {},
-                             acc,
+  return RAJA::atomicGeneric(host_policy {}, acc,
                              std::forward<Operation>(operation),
                              std::forward<StopPredicate>(stop));
 #endif

--- a/include/RAJA/policy/desul/atomic.hpp
+++ b/include/RAJA/policy/desul/atomic.hpp
@@ -184,8 +184,7 @@ RAJA_SUPPRESS_HD_WARN
 template<typename AtomicPolicy,
          typename T,
          typename Operation,
-         typename StopPredicate>
-  requires std::predicate<StopPredicate, T>
+         std::predicate<T> StopPredicate>
 RAJA_HOST_DEVICE RAJA_INLINE T
 atomicGeneric(AtomicPolicy, T* acc, Operation&& operation, StopPredicate&& stop)
 {

--- a/include/RAJA/policy/desul/atomic.hpp
+++ b/include/RAJA/policy/desul/atomic.hpp
@@ -14,6 +14,7 @@
 
 #if defined(RAJA_ENABLE_DESUL_ATOMICS)
 
+#include <concepts>
 #include <type_traits>
 
 #include "RAJA/util/macros.hpp"
@@ -175,6 +176,40 @@ RAJA_HOST_DEVICE RAJA_INLINE T atomicGeneric(AtomicPolicy,
                                          raja_default_desul_order {},
                                          raja_default_desul_scope {});
   } while (!RAJA::util::bit_equal(old, expected));
+
+  return old;
+}
+
+RAJA_SUPPRESS_HD_WARN
+template<typename AtomicPolicy, typename T, typename Operation, typename StopPredicate>
+requires std::predicate<StopPredicate, T>
+RAJA_HOST_DEVICE RAJA_INLINE T atomicGeneric(AtomicPolicy,
+                                             T* acc,
+                                             Operation&& operation,
+                                             StopPredicate&& stop)
+{
+  static_assert(std::is_trivially_copyable_v<T>);
+
+  T old = desul::atomic_load(acc, desul::MemoryOrderRelaxed {},
+                             raja_default_desul_scope {});
+
+  if (stop(old))
+  {
+    return old;
+  }
+
+  T expected;
+
+  do
+  {
+    expected = old;
+    old = desul::atomic_compare_exchange(
+        acc,
+        expected,
+        operation(expected),
+        raja_default_desul_order {},
+        raja_default_desul_scope {});
+  } while (!RAJA::util::bit_equal(old, expected) && !stop(old));
 
   return old;
 }

--- a/include/RAJA/policy/desul/atomic.hpp
+++ b/include/RAJA/policy/desul/atomic.hpp
@@ -181,12 +181,13 @@ RAJA_HOST_DEVICE RAJA_INLINE T atomicGeneric(AtomicPolicy,
 }
 
 RAJA_SUPPRESS_HD_WARN
-template<typename AtomicPolicy, typename T, typename Operation, typename StopPredicate>
-requires std::predicate<StopPredicate, T>
-RAJA_HOST_DEVICE RAJA_INLINE T atomicGeneric(AtomicPolicy,
-                                             T* acc,
-                                             Operation&& operation,
-                                             StopPredicate&& stop)
+template<typename AtomicPolicy,
+         typename T,
+         typename Operation,
+         typename StopPredicate>
+  requires std::predicate<StopPredicate, T>
+RAJA_HOST_DEVICE RAJA_INLINE T
+atomicGeneric(AtomicPolicy, T* acc, Operation&& operation, StopPredicate&& stop)
 {
   static_assert(std::is_trivially_copyable_v<T>);
 
@@ -203,12 +204,9 @@ RAJA_HOST_DEVICE RAJA_INLINE T atomicGeneric(AtomicPolicy,
   do
   {
     expected = old;
-    old = desul::atomic_compare_exchange(
-        acc,
-        expected,
-        operation(expected),
-        raja_default_desul_order {},
-        raja_default_desul_scope {});
+    old = desul::atomic_compare_exchange(acc, expected, operation(expected),
+                                         raja_default_desul_order {},
+                                         raja_default_desul_scope {});
   } while (!RAJA::util::bit_equal(old, expected) && !stop(old));
 
   return old;

--- a/include/RAJA/policy/desul/atomic.hpp
+++ b/include/RAJA/policy/desul/atomic.hpp
@@ -163,8 +163,6 @@ RAJA_HOST_DEVICE RAJA_INLINE T atomicGeneric(AtomicPolicy,
                                              T* acc,
                                              Operation&& operation)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
-
   T old = desul::atomic_load(acc, desul::MemoryOrderRelaxed {},
                              raja_default_desul_scope {});
   T expected;
@@ -188,8 +186,6 @@ template<typename AtomicPolicy,
 RAJA_HOST_DEVICE RAJA_INLINE T
 atomicGeneric(AtomicPolicy, T* acc, Operation&& operation, StopPredicate&& stop)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
-
   T old = desul::atomic_load(acc, desul::MemoryOrderRelaxed {},
                              raja_default_desul_scope {});
 

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -897,20 +897,21 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(hip_atomic_explicit<host_policy>,
 }
 
 RAJA_SUPPRESS_HD_WARN
-template<typename T, typename Operation, typename StopPredicate, typename host_policy>
-requires std::predicate<StopPredicate, T>
+template<typename T,
+         typename Operation,
+         typename StopPredicate,
+         typename host_policy>
+  requires std::predicate<StopPredicate, T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(hip_atomic_explicit<host_policy>,
                                              T* acc,
                                              Operation&& operation,
                                              StopPredicate&& stop)
 {
 #if defined(__HIP_DEVICE_COMPILE__)
-  return detail::hip_atomicCAS_loop(acc,
-                                    std::forward<Operation>(operation),
+  return detail::hip_atomicCAS_loop(acc, std::forward<Operation>(operation),
                                     std::forward<StopPredicate>(stop));
 #else
-  return RAJA::atomicGeneric(host_policy {},
-                             acc,
+  return RAJA::atomicGeneric(host_policy {}, acc,
                              std::forward<Operation>(operation),
                              std::forward<StopPredicate>(stop));
 #endif

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -24,6 +24,7 @@
 
 #if defined(RAJA_ENABLE_HIP)
 
+#include <concepts>
 #include <cstdint>
 #include <stdexcept>
 #include <type_traits>
@@ -892,6 +893,26 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(hip_atomic_explicit<host_policy>,
 #else
   return RAJA::atomicGeneric(host_policy {}, acc,
                              std::forward<Operation>(operation));
+#endif
+}
+
+RAJA_SUPPRESS_HD_WARN
+template<typename T, typename Operation, typename StopPredicate, typename host_policy>
+requires std::predicate<StopPredicate, T>
+RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(hip_atomic_explicit<host_policy>,
+                                             T* acc,
+                                             Operation&& operation,
+                                             StopPredicate&& stop)
+{
+#if defined(__HIP_DEVICE_COMPILE__)
+  return detail::hip_atomicCAS_loop(acc,
+                                    std::forward<Operation>(operation),
+                                    std::forward<StopPredicate>(stop));
+#else
+  return RAJA::atomicGeneric(host_policy {},
+                             acc,
+                             std::forward<Operation>(operation),
+                             std::forward<StopPredicate>(stop));
 #endif
 }
 

--- a/include/RAJA/policy/hip/atomic.hpp
+++ b/include/RAJA/policy/hip/atomic.hpp
@@ -899,9 +899,8 @@ RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(hip_atomic_explicit<host_policy>,
 RAJA_SUPPRESS_HD_WARN
 template<typename T,
          typename Operation,
-         typename StopPredicate,
+         std::predicate<T> StopPredicate,
          typename host_policy>
-  requires std::predicate<StopPredicate, T>
 RAJA_INLINE RAJA_HOST_DEVICE T atomicGeneric(hip_atomic_explicit<host_policy>,
                                              T* acc,
                                              Operation&& operation,

--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -245,8 +245,7 @@ RAJA_HOST_DEVICE RAJA_INLINE T atomicGeneric(omp_atomic,
 }
 
 RAJA_SUPPRESS_HD_WARN
-template<typename T, typename Operation, typename StopPredicate>
-  requires std::predicate<StopPredicate, T>
+template<typename T, typename Operation, std::predicate<T> StopPredicate>
 RAJA_HOST_DEVICE RAJA_INLINE T
 atomicGeneric(omp_atomic, T* acc, Operation&& operation, StopPredicate&& stop)
 {

--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -246,15 +246,12 @@ RAJA_HOST_DEVICE RAJA_INLINE T atomicGeneric(omp_atomic,
 
 RAJA_SUPPRESS_HD_WARN
 template<typename T, typename Operation, typename StopPredicate>
-requires std::predicate<StopPredicate, T>
-RAJA_HOST_DEVICE RAJA_INLINE T atomicGeneric(omp_atomic,
-                                             T* acc,
-                                             Operation&& operation,
-                                             StopPredicate&& stop)
+  requires std::predicate<StopPredicate, T>
+RAJA_HOST_DEVICE RAJA_INLINE T
+atomicGeneric(omp_atomic, T* acc, Operation&& operation, StopPredicate&& stop)
 {
   // OpenMP doesn't define a generic atomic operation, so use builtin atomics
-  return RAJA::atomicGeneric(builtin_atomic {},
-                             acc,
+  return RAJA::atomicGeneric(builtin_atomic {}, acc,
                              std::forward<Operation>(operation),
                              std::forward<StopPredicate>(stop));
 }

--- a/include/RAJA/policy/openmp/atomic.hpp
+++ b/include/RAJA/policy/openmp/atomic.hpp
@@ -24,6 +24,7 @@
 
 #if defined(RAJA_ENABLE_OPENMP)
 
+#include <concepts>
 #include <utility>
 
 #include "RAJA/policy/openmp/policy.hpp"
@@ -241,6 +242,21 @@ RAJA_HOST_DEVICE RAJA_INLINE T atomicGeneric(omp_atomic,
   // OpenMP doesn't define a generic atomic operation, so use builtin atomics
   return RAJA::atomicGeneric(builtin_atomic {}, acc,
                              std::forward<Operation>(operation));
+}
+
+RAJA_SUPPRESS_HD_WARN
+template<typename T, typename Operation, typename StopPredicate>
+requires std::predicate<StopPredicate, T>
+RAJA_HOST_DEVICE RAJA_INLINE T atomicGeneric(omp_atomic,
+                                             T* acc,
+                                             Operation&& operation,
+                                             StopPredicate&& stop)
+{
+  // OpenMP doesn't define a generic atomic operation, so use builtin atomics
+  return RAJA::atomicGeneric(builtin_atomic {},
+                             acc,
+                             std::forward<Operation>(operation),
+                             std::forward<StopPredicate>(stop));
 }
 
 #endif  // not defined RAJA_COMPILER_MSVC

--- a/include/RAJA/policy/sequential/atomic.hpp
+++ b/include/RAJA/policy/sequential/atomic.hpp
@@ -173,11 +173,9 @@ RAJA_HOST_DEVICE RAJA_INLINE T atomicGeneric(seq_atomic,
 
 RAJA_SUPPRESS_HD_WARN
 template<typename T, typename Operation, typename StopPredicate>
-requires std::predicate<StopPredicate, T>
-RAJA_HOST_DEVICE RAJA_INLINE T atomicGeneric(seq_atomic,
-                                             T* acc,
-                                             Operation&& operation,
-                                             StopPredicate&& stop)
+  requires std::predicate<StopPredicate, T>
+RAJA_HOST_DEVICE RAJA_INLINE T
+atomicGeneric(seq_atomic, T* acc, Operation&& operation, StopPredicate&& stop)
 {
   T ret = *acc;
 

--- a/include/RAJA/policy/sequential/atomic.hpp
+++ b/include/RAJA/policy/sequential/atomic.hpp
@@ -172,8 +172,7 @@ RAJA_HOST_DEVICE RAJA_INLINE T atomicGeneric(seq_atomic,
 }
 
 RAJA_SUPPRESS_HD_WARN
-template<typename T, typename Operation, typename StopPredicate>
-  requires std::predicate<StopPredicate, T>
+template<typename T, typename Operation, std::predicate<T> StopPredicate>
 RAJA_HOST_DEVICE RAJA_INLINE T
 atomicGeneric(seq_atomic, T* acc, Operation&& operation, StopPredicate&& stop)
 {

--- a/include/RAJA/policy/sequential/atomic.hpp
+++ b/include/RAJA/policy/sequential/atomic.hpp
@@ -23,7 +23,6 @@
 #include "RAJA/config.hpp"
 
 #include <concepts>
-#include <utility>
 
 #include "RAJA/util/macros.hpp"
 
@@ -181,10 +180,12 @@ RAJA_HOST_DEVICE RAJA_INLINE T atomicGeneric(seq_atomic,
                                              StopPredicate&& stop)
 {
   T ret = *acc;
+
   if (!stop(ret))
   {
-    *acc = std::forward<Operation>(operation)(ret);
+    *acc = operation(ret);
   }
+
   return ret;
 }
 

--- a/include/RAJA/policy/sequential/atomic.hpp
+++ b/include/RAJA/policy/sequential/atomic.hpp
@@ -22,6 +22,9 @@
 
 #include "RAJA/config.hpp"
 
+#include <concepts>
+#include <utility>
+
 #include "RAJA/util/macros.hpp"
 
 namespace RAJA
@@ -166,6 +169,22 @@ RAJA_HOST_DEVICE RAJA_INLINE T atomicGeneric(seq_atomic,
 {
   T ret = *acc;
   *acc  = operation(ret);
+  return ret;
+}
+
+RAJA_SUPPRESS_HD_WARN
+template<typename T, typename Operation, typename StopPredicate>
+requires std::predicate<StopPredicate, T>
+RAJA_HOST_DEVICE RAJA_INLINE T atomicGeneric(seq_atomic,
+                                             T* acc,
+                                             Operation&& operation,
+                                             StopPredicate&& stop)
+{
+  T ret = *acc;
+  if (!stop(ret))
+  {
+    *acc = std::forward<Operation>(operation)(ret);
+  }
   return ret;
 }
 

--- a/test/functional/forall/atomic-basic/tests/test-forall-atomic-basic.hpp
+++ b/test/functional/forall/atomic-basic/tests/test-forall-atomic-basic.hpp
@@ -63,7 +63,7 @@ template <typename ExecPolicy,
 void ForallAtomicBasicTestImpl( IdxType seglimit )
 {
   // initialize an array
-  const int len = 13;
+  const int len = 14;
 
   camp::resources::Resource work_res{WorkingRes::get_default()};
 
@@ -94,6 +94,7 @@ void ForallAtomicBasicTestImpl( IdxType seglimit )
   test_array[10] = static_cast<T>(0);
   test_array[11] = static_cast<T>(0);
   test_array[12] = static_cast<T>(1);
+  test_array[13] = static_cast<T>(0);
 
   work_res.memcpy(work_array, test_array, sizeof(T) * len);
 
@@ -126,6 +127,16 @@ void ForallAtomicBasicTestImpl( IdxType seglimit )
                                         }
                                         return old;
                                       });
+
+    // Exercise the stop-aware atomicGeneric overload with a saturating update.
+    constexpr T stop_value = static_cast<T>(7);
+    RAJA::atomicGeneric<AtomicPolicy>(work_array + 13,
+                                      [] (T old) {
+                                        return old + static_cast<T>(1);
+                                      },
+                                      [=] (T current) {
+                                        return current >= stop_value;
+                                      });
   });
 
   work_res.memcpy( check_array, work_array, sizeof(T) * len );
@@ -146,6 +157,7 @@ void ForallAtomicBasicTestImpl( IdxType seglimit )
   EXPECT_EQ(static_cast<T>(4), check_array[10]);
   EXPECT_EQ(static_cast<T>(13), check_array[11]);
   EXPECT_EQ(static_cast<T>(3628800), check_array[12]);
+  EXPECT_EQ(static_cast<T>(7), check_array[13]);
 
   deallocateForallTestData<T>(work_res,
                               work_array,


### PR DESCRIPTION
# Summary

- This PR is a feature
- It does the following:
  - Adds a generic atomic operation taking a predicate used to determine if we can exit early from the CAS loop
  - This implementation already underpins some of our fallback implementations for min/max atomic operations for cuda and hip