### PR TITLE
Draft: Runtime support for Multi-Reduce  

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -38,6 +38,10 @@ raja_add_executable(
   SOURCES forall_multi-reductions.cpp)
 
 raja_add_executable(
+  NAME runtime-multi-reductions
+  SOURCES runtime-multi-reductions.cpp)
+
+raja_add_executable(
   NAME launch-param-reductions
   SOURCES launch-param-reductions.cpp)
 

--- a/examples/runtime-multi-reductions.cpp
+++ b/examples/runtime-multi-reductions.cpp
@@ -1,0 +1,236 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "RAJA/RAJA.hpp"
+
+/*
+ *  Runtime MultiReduction Example
+ *
+ *  This example illustrates runtime selection between host and device
+ *  execution while selecting the same multi-reduction policy for both paths.
+ *
+ *  RAJA features shown:
+ *    - `dynamic_forall` loop iteration template method
+ *    -  Index range segment
+ *    -  Runtime resource selection
+ *    -  MultiReduction types
+ *
+ */
+
+constexpr int N = 1000000;
+constexpr int NumBins = 10;
+constexpr int BlockSize = 256;
+
+#if defined(RAJA_ENABLE_OPENMP)
+using host_exec_policy = RAJA::omp_parallel_for_exec;
+#else
+using host_exec_policy = RAJA::seq_exec;
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
+using device_exec_policy = RAJA::cuda_exec_async<BlockSize>;
+#elif defined(RAJA_ENABLE_HIP)
+using device_exec_policy = RAJA::hip_exec_async<BlockSize>;
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
+using multi_reduce_policy = RAJA::cuda_multi_reduce_atomic;
+#elif defined(RAJA_ENABLE_HIP)
+using multi_reduce_policy = RAJA::hip_multi_reduce_atomic;
+#elif defined(RAJA_ENABLE_OPENMP)
+using multi_reduce_policy = RAJA::omp_multi_reduce;
+#else
+using multi_reduce_policy = RAJA::seq_multi_reduce;
+#endif
+
+using exec_policy_list = camp::list<host_exec_policy
+#if defined(RAJA_ENABLE_CUDA) || defined(RAJA_ENABLE_HIP)
+                                    , device_exec_policy
+#endif
+                                    >;
+
+int main(int argc, char *argv[])
+{
+
+  if(argc != 2) {
+    RAJA_ABORT_OR_THROW("Usage ./runtime-multi-reductions host or ./runtime-multi-reductions device");
+  }
+
+  //
+  // Run time policy section is demonstrated in this example by specifying
+  // kernel exection space as a command line argument (host or device).
+  // Example usage ./runtime-multi-reductions host or ./runtime-multi-reductions device
+  //
+  std::string exec_space = argv[1];
+  if(!(exec_space.compare("host") == 0 || exec_space.compare("device") == 0 )){
+    RAJA_ABORT_OR_THROW("Usage ./runtime-multi-reductions host or ./runtime-multi-reductions device");
+    return 0;
+  }
+
+  RAJA::ExecPlace select_cpu_or_gpu;
+  if(exec_space.compare("host") == 0)
+    { select_cpu_or_gpu = RAJA::ExecPlace::HOST; printf("Running RAJA runtime multi-reductions example on the host \n"); }
+  if(exec_space.compare("device") == 0)
+    { select_cpu_or_gpu = RAJA::ExecPlace::DEVICE; printf("Running RAJA runtime multi-reductions example on the device \n"); }
+
+  // _multi_reductions_array_init_start
+//
+// Define array length
+//
+  const int num_values = N;
+
+//
+// Allocate array data and initialize data to alternating sequence of 1, -1.
+//
+  RAJA::resources::Host host_res;
+
+  int* host_bins = host_res.allocate<int>(num_values);
+  int* host_vals = host_res.allocate<int>(num_values);
+
+  for (int i = 0; i < num_values; ++i) {
+    host_bins[i] = i % NumBins;
+    host_vals[i] = (i % (2 * NumBins)) - NumBins;
+  }
+  // _multi_reductions_array_init_end
+
+//
+// Note: with this data initialization scheme, the following results will
+//       be observed for all reduction kernels below:
+//
+// for bin in [0, num_bins)
+//  - the sum will be (bin - num_bins/2) * N / num_bins
+//  - the min will be bin - num_bins
+//  - the max will be bin
+//  - the and will be min & max
+//  - the or  will be min | max
+//
+
+//
+// Define index range for iterating over a elements in all examples
+//
+  // _multi_reductions_range_start
+  RAJA::RangeSegment arange(0, num_values);
+  // _multi_reductions_range_end
+
+//----------------------------------------------------------------------------//
+
+#if defined(RAJA_ENABLE_CUDA)
+  RAJA::resources::Cuda device_res;
+#elif defined(RAJA_ENABLE_HIP)
+  RAJA::resources::Hip device_res;
+#elif defined(RAJA_ENABLE_SYCL)
+  RAJA::resources::Sycl device_res;
+#endif
+
+  // The reducer policy is selected at compile time, but the storage backend
+  // follows the runtime resource chosen here.
+  RAJA::resources::Resource res =
+#if defined(RAJA_ENABLE_CUDA)
+      RAJA::Get_Runtime_Resource(host_res, device_res, select_cpu_or_gpu);
+#elif defined(RAJA_ENABLE_HIP)
+      RAJA::Get_Runtime_Resource(host_res, device_res, select_cpu_or_gpu);
+#elif defined(RAJA_ENABLE_SYCL)
+      RAJA::Get_Runtime_Resource(host_res, device_res, select_cpu_or_gpu);
+#else
+      RAJA::Get_Host_Resource(host_res, select_cpu_or_gpu);
+#endif
+
+  // Memory follows the selected runtime resource:
+  // host path uses host allocations, device path uses device allocations.
+  // These are the input buffers read by the kernel on the selected backend.
+  int* bins = res.allocate<int>(num_values);
+  int* vals = res.allocate<int>(num_values);
+  res.memcpy(bins, host_bins, sizeof(int) * num_values);
+  res.memcpy(vals, host_vals, sizeof(int) * num_values);
+
+  bool ok = false;
+
+  int policy_index = 0;
+  char const* label = "host runtime path";
+  if (select_cpu_or_gpu == RAJA::ExecPlace::DEVICE)
+  {
+#if defined(RAJA_ENABLE_CUDA) || defined(RAJA_ENABLE_HIP)
+    policy_index = 1;
+    label        = "device runtime path";
+#else
+    RAJA_ABORT_OR_THROW("Device runtime path requires a GPU-enabled build");
+#endif
+  }
+
+  // Passing `res` keeps the reducer storage on the same host/device backend
+  // as the input buffers, so the device path uses device-resident tally
+  // storage while the host path stays on host memory.
+  //
+  // Device-side flow:
+  //   1. `res.allocate(...)` places `bins` and `vals` in device memory.
+  //   2. `MultiReduce(..., res, NumBins)` allocates its tally storage from
+  //      the same backend; CUDA uses managed memory with device preference
+  //      for the tally pool, while HIP uses device allocation.
+  //   3. The kernel reads the device buffers and updates the device-side
+  //      reducer state.
+  //   4. `get()` synchronizes and returns the reduced values to the host.
+  RAJA::MultiReduceSum<multi_reduce_policy, int> multi_reduce_sum(res,
+                                                                  NumBins);
+  RAJA::MultiReduceMin<multi_reduce_policy, int> multi_reduce_min(res,
+                                                                  NumBins);
+  RAJA::MultiReduceMax<multi_reduce_policy, int> multi_reduce_max(res,
+                                                                  NumBins);
+  RAJA::MultiReduceBitAnd<multi_reduce_policy, int> multi_reduce_and(
+      res, NumBins);
+  RAJA::MultiReduceBitOr<multi_reduce_policy, int> multi_reduce_or(res,
+                                                                   NumBins);
+
+  std::cout << "Running " << label << '\n';
+
+  RAJA::dynamic_forall<exec_policy_list>(
+      policy_index, arange, [=] RAJA_HOST_DEVICE(int i) {
+        int bin = bins[i];
+
+        multi_reduce_sum[bin] += vals[i];
+        multi_reduce_min[bin].min(vals[i]);
+        multi_reduce_max[bin].max(vals[i]);
+        multi_reduce_and[bin] &= vals[i];
+        multi_reduce_or[bin] |= vals[i];
+      });
+
+  ok = true;
+  const int expected_sum_scale = N / NumBins;
+  for (int bin = 0; bin < NumBins; ++bin) {
+    const int expected_sum = (bin - (NumBins / 2)) * expected_sum_scale;
+    const int expected_min = bin - NumBins;
+    const int expected_max = bin;
+    const int expected_and = expected_min & expected_max;
+    const int expected_or = expected_min | expected_max;
+
+    ok = ok && (multi_reduce_sum.get(bin) == expected_sum);
+    ok = ok && (multi_reduce_min.get(bin) == expected_min);
+    ok = ok && (multi_reduce_max.get(bin) == expected_max);
+    ok = ok && (multi_reduce_and.get(bin) == expected_and);
+    ok = ok && (multi_reduce_or.get(bin) == expected_or);
+  }
+
+  std::cout << (ok ? "\tresult -- PASS\n" : "\tresult -- FAIL\n");
+
+//----------------------------------------------------------------------------//
+
+//
+// Clean up.
+//
+  res.deallocate(vals);
+  res.deallocate(bins);
+  host_res.deallocate(host_vals);
+  host_res.deallocate(host_bins);
+
+  std::cout << "\n DONE!...\n";
+  return ok ? 0 : 1;
+}

--- a/examples/runtime-multi-reductions.cpp
+++ b/examples/runtime-multi-reductions.cpp
@@ -29,7 +29,10 @@
 
 constexpr int N = 1000000;
 constexpr int NumBins = 10;
+
+#if defined(RAJA_ENABLE_CUDA) || defined(RAJA_ENABLE_HIP)
 constexpr int BlockSize = 256;
+#endif
 
 #if defined(RAJA_ENABLE_OPENMP)
 using host_exec_policy = RAJA::omp_parallel_for_exec;
@@ -59,29 +62,42 @@ using exec_policy_list = camp::list<host_exec_policy
 #endif
                                     >;
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
 
-  if(argc != 2) {
-    RAJA_ABORT_OR_THROW("Usage ./runtime-multi-reductions host or ./runtime-multi-reductions device");
+  if (argc != 2)
+  {
+    RAJA_ABORT_OR_THROW(
+        "Usage ./runtime-multi-reductions host or "
+        "./runtime-multi-reductions device");
   }
 
   //
-  // Run time policy section is demonstrated in this example by specifying
-  // kernel exection space as a command line argument (host or device).
+  // Runtime policy selection is demonstrated by specifying kernel execution
+  // space as a command line argument (host or device).
   // Example usage ./runtime-multi-reductions host or ./runtime-multi-reductions device
   //
-  std::string exec_space = argv[1];
-  if(!(exec_space.compare("host") == 0 || exec_space.compare("device") == 0 )){
-    RAJA_ABORT_OR_THROW("Usage ./runtime-multi-reductions host or ./runtime-multi-reductions device");
-    return 0;
+  const std::string exec_space = argv[1];
+  if (exec_space != "host" && exec_space != "device")
+  {
+    RAJA_ABORT_OR_THROW(
+        "Usage ./runtime-multi-reductions host or "
+        "./runtime-multi-reductions device");
   }
 
-  RAJA::ExecPlace select_cpu_or_gpu;
-  if(exec_space.compare("host") == 0)
-    { select_cpu_or_gpu = RAJA::ExecPlace::HOST; printf("Running RAJA runtime multi-reductions example on the host \n"); }
-  if(exec_space.compare("device") == 0)
-    { select_cpu_or_gpu = RAJA::ExecPlace::DEVICE; printf("Running RAJA runtime multi-reductions example on the device \n"); }
+  RAJA::ExecPlace select_cpu_or_gpu = RAJA::ExecPlace::HOST;
+  if (exec_space == "device")
+  {
+#if defined(RAJA_ENABLE_CUDA) || defined(RAJA_ENABLE_HIP)
+    select_cpu_or_gpu = RAJA::ExecPlace::DEVICE;
+#else
+    RAJA_ABORT_OR_THROW(
+        "Device runtime path requires a CUDA or HIP enabled build");
+#endif
+  }
+
+  std::cout << "Running RAJA runtime multi-reductions example on the "
+            << exec_space << '\n';
 
   // _multi_reductions_array_init_start
 //
@@ -97,7 +113,8 @@ int main(int argc, char *argv[])
   int* host_bins = host_res.allocate<int>(num_values);
   int* host_vals = host_res.allocate<int>(num_values);
 
-  for (int i = 0; i < num_values; ++i) {
+  for (int i = 0; i < num_values; ++i)
+  {
     host_bins[i] = i % NumBins;
     host_vals[i] = (i % (2 * NumBins)) - NumBins;
   }
@@ -132,8 +149,9 @@ int main(int argc, char *argv[])
   RAJA::resources::Sycl device_res;
 #endif
 
-  // The reducer policy is selected at compile time, but the storage backend
-  // follows the runtime resource chosen here.
+  // The reducer policy is selected at compile time. For policies that support
+  // runtime storage selection, the resource platform chooses host-accessible or
+  // device-accessible reducer tally storage.
   RAJA::resources::Resource res =
 #if defined(RAJA_ENABLE_CUDA)
       RAJA::Get_Runtime_Resource(host_res, device_res, select_cpu_or_gpu);
@@ -162,20 +180,17 @@ int main(int argc, char *argv[])
 #if defined(RAJA_ENABLE_CUDA) || defined(RAJA_ENABLE_HIP)
     policy_index = 1;
     label        = "device runtime path";
-#else
-    RAJA_ABORT_OR_THROW("Device runtime path requires a GPU-enabled build");
 #endif
   }
 
-  // Passing `res` keeps the reducer storage on the same host/device backend
-  // as the input buffers, so the device path uses device-resident tally
-  // storage while the host path stays on host memory.
+  // Passing `res` lets the reducer choose host-accessible or device-accessible
+  // tally storage from the selected resource platform. The reducer does not
+  // allocate directly through `res`; CUDA/HIP use their existing tally mempools.
   //
   // Device-side flow:
   //   1. `res.allocate(...)` places `bins` and `vals` in device memory.
-  //   2. `MultiReduce(..., res, NumBins)` allocates its tally storage from
-  //      the same backend; CUDA uses managed memory with device preference
-  //      for the tally pool, while HIP uses device allocation.
+  //   2. `MultiReduce(..., res, NumBins)` chooses device-accessible tally
+  //      storage because `res` is a device resource.
   //   3. The kernel reads the device buffers and updates the device-side
   //      reducer state.
   //   4. `get()` synchronizes and returns the reduced values to the host.
@@ -204,8 +219,9 @@ int main(int argc, char *argv[])
       });
 
   ok = true;
-  const int expected_sum_scale = N / NumBins;
-  for (int bin = 0; bin < NumBins; ++bin) {
+  const int expected_sum_scale = num_values / NumBins;
+  for (int bin = 0; bin < NumBins; ++bin)
+  {
     const int expected_sum = (bin - (NumBins / 2)) * expected_sum_scale;
     const int expected_min = bin - NumBins;
     const int expected_max = bin;

--- a/include/RAJA/pattern/detail/multi_reduce.hpp
+++ b/include/RAJA/pattern/detail/multi_reduce.hpp
@@ -65,6 +65,21 @@ namespace reduce
 namespace detail
 {
 
+template<typename...>
+using void_t = void;
+
+template<typename MultiReduceData, typename = void>
+struct supports_runtime_resource_storage : std::false_type
+{};
+
+template<typename MultiReduceData>
+struct supports_runtime_resource_storage<
+    MultiReduceData,
+    void_t<decltype(MultiReduceData::supports_runtime_resource_storage)>>
+    : std::integral_constant<bool,
+                             MultiReduceData::supports_runtime_resource_storage>
+{};
+
 template<typename t_MultiReduceData>
 struct BaseMultiReduce
 {
@@ -227,7 +242,7 @@ private:
                                    Container const& container,
                                    value_type identity)
   {
-    if constexpr (MultiReduceData::supports_runtime_resource_storage)
+    if constexpr (supports_runtime_resource_storage<MultiReduceData>::value)
     {
       return MultiReduceData(container, identity, use_device_storage(res));
     }

--- a/include/RAJA/pattern/detail/multi_reduce.hpp
+++ b/include/RAJA/pattern/detail/multi_reduce.hpp
@@ -22,8 +22,11 @@
 
 #include "RAJA/pattern/detail/forall.hpp"
 
+#include <type_traits>
+
 #include "RAJA/util/macros.hpp"
 #include "RAJA/util/Operators.hpp"
+#include "RAJA/util/resource.hpp"
 #include "RAJA/util/types.hpp"
 #include "RAJA/util/RepeatView.hpp"
 
@@ -79,15 +82,63 @@ struct BaseMultiReduce
       : BaseMultiReduce {RepeatView<value_type>(init_val, num_bins), identity}
   {}
 
+  BaseMultiReduce(RAJA::resources::Resource const& res,
+                  size_t num_bins,
+                  value_type init_val = MultiReduceOp::identity(),
+                  value_type identity = MultiReduceOp::identity())
+      : data {make_data(res,
+                        RepeatView<value_type>(init_val, num_bins),
+                        identity)}
+  {}
+
+  template<typename Resource,
+           std::enable_if_t<type_traits::is_resource<
+               std::decay_t<Resource>>::value>* = nullptr>
+  BaseMultiReduce(Resource const& res,
+                  size_t num_bins,
+                  value_type init_val = MultiReduceOp::identity(),
+                  value_type identity = MultiReduceOp::identity())
+      : data {make_data(res,
+                        RepeatView<value_type>(init_val, num_bins),
+                        identity)}
+  {}
+
   template<typename Container,
-           concepts::enable_if_t<
-               type_traits::is_range<Container>,
-               concepts::negate<std::is_convertible<Container, size_t>>,
-               concepts::negate<std::is_base_of<BaseMultiReduce, Container>>>* =
-               nullptr>
+           std::enable_if_t<
+               type_traits::is_range<Container>::value &&
+               !std::is_same<std::decay_t<Container>,
+                             camp::resources::Resource>::value &&
+               !std::is_convertible<Container, size_t>::value &&
+               !std::is_base_of<BaseMultiReduce, Container>::value>* = nullptr>
   explicit BaseMultiReduce(Container const& container,
                            value_type identity = MultiReduceOp::identity())
       : data {container, identity}
+  {}
+
+  template<typename Container,
+           std::enable_if_t<
+               type_traits::is_range<Container>::value &&
+               !std::is_same<std::decay_t<Container>,
+                             camp::resources::Resource>::value &&
+               !std::is_convertible<Container, size_t>::value &&
+               !std::is_base_of<BaseMultiReduce, Container>::value>* = nullptr>
+  explicit BaseMultiReduce(RAJA::resources::Resource const& res,
+                           Container const& container,
+                           value_type identity = MultiReduceOp::identity())
+      : data {make_data(res, container, identity)}
+  {}
+
+  template<typename Resource,
+           typename Container,
+           std::enable_if_t<
+               type_traits::is_resource<std::decay_t<Resource>>::value &&
+               type_traits::is_range<Container>::value &&
+               !std::is_convertible<Container, size_t>::value &&
+               !std::is_base_of<BaseMultiReduce, Container>::value>* = nullptr>
+  explicit BaseMultiReduce(Resource const& res,
+                           Container const& container,
+                           value_type identity = MultiReduceOp::identity())
+      : data {container, identity, use_device_storage(res)}
   {}
 
   RAJA_SUPPRESS_HD_WARN
@@ -160,6 +211,32 @@ struct BaseMultiReduce
   }
 
 private:
+  template<typename Resource>
+  static bool use_device_storage(Resource const& res)
+  {
+    return res.get_platform() != camp::resources::Platform::host;
+  }
+
+  static bool use_device_storage(RAJA::resources::Resource const& res)
+  {
+    return res.get_platform() != camp::resources::Platform::host;
+  }
+
+  template<typename Resource, typename Container>
+  static MultiReduceData make_data(Resource const& res,
+                                   Container const& container,
+                                   value_type identity)
+  {
+    if constexpr (MultiReduceData::supports_runtime_resource_storage)
+    {
+      return MultiReduceData(container, identity, use_device_storage(res));
+    }
+    else
+    {
+      return MultiReduceData(container, identity);
+    }
+  }
+
   MultiReduceData mutable data;
 };
 

--- a/include/RAJA/policy/cuda/multi_reduce.hpp
+++ b/include/RAJA/policy/cuda/multi_reduce.hpp
@@ -221,20 +221,14 @@ struct MultiReduceGridAtomicHostInit_TallyData
   MultiReduceGridAtomicHostInit_TallyData(Container const& container,
                                           T const& identity)
       : m_tally_mem(nullptr),
-        m_host_tally_mem(nullptr),
-        m_device_tally_mem(nullptr),
         m_identity(identity),
         m_num_bins(container.size()),
         m_tally_bins(get_tally_bins(m_num_bins)),
         m_tally_replication(get_tally_replication()),
-        m_host_valid(true),
-        m_device_valid(false),
         m_use_device_storage(true)
   {
     m_tally_mem = create_tally(container, identity, m_num_bins, m_tally_bins,
                                m_tally_replication, true);
-    m_host_tally_mem   = m_tally_mem;
-    m_device_tally_mem = nullptr;
   }
 
   template<typename Container>
@@ -242,20 +236,14 @@ struct MultiReduceGridAtomicHostInit_TallyData
                                           T const& identity,
                                           bool use_device_storage)
       : m_tally_mem(nullptr),
-        m_host_tally_mem(nullptr),
-        m_device_tally_mem(nullptr),
         m_identity(identity),
         m_num_bins(container.size()),
         m_tally_bins(get_tally_bins(m_num_bins)),
         m_tally_replication(get_tally_replication()),
-        m_host_valid(true),
-        m_device_valid(false),
         m_use_device_storage(use_device_storage)
   {
     m_tally_mem = create_tally(container, identity, m_num_bins, m_tally_bins,
                                m_tally_replication, use_device_storage);
-    m_host_tally_mem   = m_tally_mem;
-    m_device_tally_mem = nullptr;
   }
 
   MultiReduceGridAtomicHostInit_TallyData() = delete;
@@ -282,10 +270,6 @@ struct MultiReduceGridAtomicHostInit_TallyData
       m_tally_replication = get_tally_replication();
       m_tally_mem = create_tally(container, identity, m_num_bins, m_tally_bins,
                                  m_tally_replication, m_use_device_storage);
-      m_host_tally_mem   = m_tally_mem;
-      m_device_tally_mem = nullptr;
-      m_host_valid       = true;
-      m_device_valid     = false;
     }
     else
     {
@@ -307,7 +291,6 @@ struct MultiReduceGridAtomicHostInit_TallyData
                                         m_tally_replication)] = identity;
         }
       }
-      m_host_valid = true;
     }
     m_identity = identity;
   }
@@ -317,18 +300,14 @@ struct MultiReduceGridAtomicHostInit_TallyData
   {
     destroy_tally(m_tally_mem, m_num_bins, m_tally_bins, m_tally_replication,
                   m_use_device_storage);
-    m_tally_mem        = nullptr;
-    m_host_tally_mem   = nullptr;
-    m_device_tally_mem = nullptr;
-    m_host_valid       = false;
-    m_device_valid     = false;
+    m_tally_mem = nullptr;
   }
 
-  //! setup per launch, switch tally storage to device memory
-  void setup_launch() { m_tally_mem = m_host_tally_mem; }
+  //! setup per launch, no tally changes needed for global atomic storage
+  void setup_launch() {}
 
-  //! teardown per launch, restore host tally storage
-  void teardown_launch() { m_tally_mem = m_host_tally_mem; }
+  //! teardown per launch, no tally changes needed for global atomic storage
+  void teardown_launch() {}
 
   //! get value for bin, assumes synchronization occurred elsewhere
   T get(int bin) const
@@ -437,12 +416,6 @@ private:
     return tally_mem;
   }
 
-  size_t tally_bytes() const
-  {
-    return static_cast<size_t>(m_tally_replication) *
-           static_cast<size_t>(m_tally_bins) * sizeof(T);
-  }
-
   static void destroy_tally(T*& tally_mem,
                             int num_bins,
                             int tally_bins,
@@ -479,15 +452,11 @@ protected:
   using GetTallyOffset = typename GetTallyOffset_rebind::template rebind<int>;
 
   T* m_tally_mem;
-  T* m_host_tally_mem;
-  T* m_device_tally_mem;
   T m_identity;
   int m_num_bins;
   int m_tally_bins;
   int m_tally_replication;  // power of 2, at least the max number of omp
                             // threads
-  bool m_host_valid;
-  bool m_device_valid;
   bool m_use_device_storage;
 };
 
@@ -510,13 +479,13 @@ struct MultiReduceGridAtomicHostInit_Data
   using TallyData::TallyData;
   using TallyData::teardown_permanent;
 
-  //! setup per launch, switch tally storage to device memory
+  //! setup per launch, no tally changes needed for global atomic storage
   void setup_launch(size_t RAJA_UNUSED_ARG(block_size))
   {
     TallyData::setup_launch();
   }
 
-  //! teardown per launch, restore host tally storage
+  //! teardown per launch, no tally changes needed for global atomic storage
   void teardown_launch() { TallyData::teardown_launch(); }
 
   //! setup on device, do nothing
@@ -837,8 +806,7 @@ public:
       if (setupReducers())
       {
         add_resource_to_synchronization_list(currentResource());
-        m_parent->m_data.setup_launch(currentBlockSize());
-        m_data            = m_parent->m_data;
+        m_data.setup_launch(currentBlockSize());
         m_own_launch_data = true;
         m_parent          = nullptr;
       }
@@ -874,7 +842,6 @@ public:
     {
       if (m_own_launch_data)
       {
-        synchronize_resources_and_clear_list();
         m_data.teardown_launch();
         m_own_launch_data = false;
       }

--- a/include/RAJA/policy/cuda/multi_reduce.hpp
+++ b/include/RAJA/policy/cuda/multi_reduce.hpp
@@ -37,6 +37,7 @@
 #include <cuda.h>
 
 #include "RAJA/util/macros.hpp"
+#include "RAJA/util/basic_mempool.hpp"
 #include "RAJA/util/math.hpp"
 #include "RAJA/util/types.hpp"
 #include "RAJA/util/reduce.hpp"
@@ -220,13 +221,41 @@ struct MultiReduceGridAtomicHostInit_TallyData
   MultiReduceGridAtomicHostInit_TallyData(Container const& container,
                                           T const& identity)
       : m_tally_mem(nullptr),
+        m_host_tally_mem(nullptr),
+        m_device_tally_mem(nullptr),
         m_identity(identity),
         m_num_bins(container.size()),
         m_tally_bins(get_tally_bins(m_num_bins)),
-        m_tally_replication(get_tally_replication())
+        m_tally_replication(get_tally_replication()),
+        m_host_valid(true),
+        m_device_valid(false),
+        m_use_device_storage(true)
   {
     m_tally_mem = create_tally(container, identity, m_num_bins, m_tally_bins,
-                               m_tally_replication);
+                               m_tally_replication, true);
+    m_host_tally_mem   = m_tally_mem;
+    m_device_tally_mem = nullptr;
+  }
+
+  template<typename Container>
+  MultiReduceGridAtomicHostInit_TallyData(Container const& container,
+                                          T const& identity,
+                                          bool use_device_storage)
+      : m_tally_mem(nullptr),
+        m_host_tally_mem(nullptr),
+        m_device_tally_mem(nullptr),
+        m_identity(identity),
+        m_num_bins(container.size()),
+        m_tally_bins(get_tally_bins(m_num_bins)),
+        m_tally_replication(get_tally_replication()),
+        m_host_valid(true),
+        m_device_valid(false),
+        m_use_device_storage(use_device_storage)
+  {
+    m_tally_mem = create_tally(container, identity, m_num_bins, m_tally_bins,
+                               m_tally_replication, use_device_storage);
+    m_host_tally_mem   = m_tally_mem;
+    m_device_tally_mem = nullptr;
   }
 
   MultiReduceGridAtomicHostInit_TallyData() = delete;
@@ -252,7 +281,11 @@ struct MultiReduceGridAtomicHostInit_TallyData
       m_tally_bins        = get_tally_bins(m_num_bins);
       m_tally_replication = get_tally_replication();
       m_tally_mem = create_tally(container, identity, m_num_bins, m_tally_bins,
-                                 m_tally_replication);
+                                 m_tally_replication, m_use_device_storage);
+      m_host_tally_mem   = m_tally_mem;
+      m_device_tally_mem = nullptr;
+      m_host_valid       = true;
+      m_device_valid     = false;
     }
     else
     {
@@ -274,6 +307,7 @@ struct MultiReduceGridAtomicHostInit_TallyData
                                         m_tally_replication)] = identity;
         }
       }
+      m_host_valid = true;
     }
     m_identity = identity;
   }
@@ -281,8 +315,20 @@ struct MultiReduceGridAtomicHostInit_TallyData
   //! teardown permanent settings, free tally memory
   void teardown_permanent()
   {
-    destroy_tally(m_tally_mem, m_num_bins, m_tally_bins, m_tally_replication);
+    destroy_tally(m_tally_mem, m_num_bins, m_tally_bins, m_tally_replication,
+                  m_use_device_storage);
+    m_tally_mem        = nullptr;
+    m_host_tally_mem   = nullptr;
+    m_device_tally_mem = nullptr;
+    m_host_valid       = false;
+    m_device_valid     = false;
   }
+
+  //! setup per launch, switch tally storage to device memory
+  void setup_launch() { m_tally_mem = m_host_tally_mem; }
+
+  //! teardown per launch, restore host tally storage
+  void teardown_launch() { m_tally_mem = m_host_tally_mem; }
 
   //! get value for bin, assumes synchronization occurred elsewhere
   T get(int bin) const
@@ -310,8 +356,10 @@ private:
   static constexpr size_t s_tally_bunch_size =
       RAJA_DIVIDE_CEILING_INT(s_tally_alignment, sizeof(T));
 
-  using tally_mempool_type = device_pinned_mempool_type;
-  using tally_tuning       = typename tuning::GlobalAtomicReplicationTuning;
+  using tally_mempool_type =
+      basic_mempool::MemPool<basic_mempool::generic_allocator>;
+  using launch_tally_mempool_type = device_pinned_mempool_type;
+  using tally_tuning = typename tuning::GlobalAtomicReplicationTuning;
   using TallyAtomicReplicationConcretizer =
       typename tally_tuning::AtomicReplicationConcretizer;
   using GetTallyOffset_rebind_rebunch = typename tally_tuning::OffsetCalculator;
@@ -343,15 +391,25 @@ private:
                          T const& identity,
                          int num_bins,
                          int tally_bins,
-                         int tally_replication)
+                         int tally_replication,
+                         bool use_device_storage)
   {
     if (num_bins == size_t(0))
     {
       return nullptr;
     }
 
-    T* tally_mem = tally_mempool_type::getInstance().template malloc<T>(
-        tally_replication * tally_bins, s_tally_alignment);
+    T* tally_mem = nullptr;
+    if (use_device_storage)
+    {
+      tally_mem = launch_tally_mempool_type::getInstance().template malloc<T>(
+          tally_replication * tally_bins, s_tally_alignment);
+    }
+    else
+    {
+      tally_mem = tally_mempool_type::getInstance().template malloc<T>(
+          tally_replication * tally_bins, s_tally_alignment);
+    }
 
     if (tally_replication > 0)
     {
@@ -379,10 +437,17 @@ private:
     return tally_mem;
   }
 
+  size_t tally_bytes() const
+  {
+    return static_cast<size_t>(m_tally_replication) *
+           static_cast<size_t>(m_tally_bins) * sizeof(T);
+  }
+
   static void destroy_tally(T*& tally_mem,
                             int num_bins,
                             int tally_bins,
-                            int tally_replication)
+                            int tally_replication,
+                            bool use_device_storage)
   {
     if (num_bins == size_t(0))
     {
@@ -398,7 +463,14 @@ private:
         tally_mem[tally_offset].~T();
       }
     }
-    tally_mempool_type::getInstance().free(tally_mem);
+    if (use_device_storage)
+    {
+      launch_tally_mempool_type::getInstance().free(tally_mem);
+    }
+    else
+    {
+      tally_mempool_type::getInstance().free(tally_mem);
+    }
     tally_mem = nullptr;
   }
 
@@ -407,11 +479,16 @@ protected:
   using GetTallyOffset = typename GetTallyOffset_rebind::template rebind<int>;
 
   T* m_tally_mem;
+  T* m_host_tally_mem;
+  T* m_device_tally_mem;
   T m_identity;
   int m_num_bins;
   int m_tally_bins;
   int m_tally_replication;  // power of 2, at least the max number of omp
                             // threads
+  bool m_host_valid;
+  bool m_device_valid;
+  bool m_use_device_storage;
 };
 
 //! MultiReduction data for Cuda Offload -- stores value, host pointer
@@ -433,11 +510,14 @@ struct MultiReduceGridAtomicHostInit_Data
   using TallyData::TallyData;
   using TallyData::teardown_permanent;
 
-  //! setup per launch, do nothing
-  void setup_launch(size_t RAJA_UNUSED_ARG(block_size)) {}
+  //! setup per launch, switch tally storage to device memory
+  void setup_launch(size_t RAJA_UNUSED_ARG(block_size))
+  {
+    TallyData::setup_launch();
+  }
 
-  //! teardown per launch, do nothing
-  void teardown_launch() {}
+  //! teardown per launch, restore host tally storage
+  void teardown_launch() { TallyData::teardown_launch(); }
 
   //! setup on device, do nothing
   RAJA_DEVICE
@@ -496,6 +576,15 @@ struct MultiReduceBlockThenGridAtomicHostInit_Data
         m_shared_replication(0)
   {}
 
+  template<typename Container>
+  MultiReduceBlockThenGridAtomicHostInit_Data(Container const& container,
+                                              T const& identity,
+                                              bool use_device_storage)
+      : TallyData(container, identity, use_device_storage),
+        m_shared_offset(s_shared_offset_unknown),
+        m_shared_replication(0)
+  {}
+
   MultiReduceBlockThenGridAtomicHostInit_Data() = delete;
   MultiReduceBlockThenGridAtomicHostInit_Data(
       MultiReduceBlockThenGridAtomicHostInit_Data const&) = default;
@@ -518,6 +607,7 @@ struct MultiReduceBlockThenGridAtomicHostInit_Data
   //! setup per launch, setup shared memory parameters
   void setup_launch(size_t block_size)
   {
+    TallyData::setup_launch();
     if (m_num_bins == size_t(0))
     {
       m_shared_offset = s_shared_offset_invalid;
@@ -671,6 +761,8 @@ private:
 template<typename T, typename t_MultiReduceOp, typename tuning>
 struct MultiReduceDataCuda
 {
+  static constexpr bool supports_runtime_resource_storage = true;
+
   static constexpr bool atomic_available =
       RAJA::reduce::cuda::cuda_atomic_available<T>::value;
 
@@ -712,6 +804,18 @@ public:
         m_own_launch_data(false)
   {}
 
+  template<typename Container,
+           std::enable_if_t<
+               !std::is_same<Container, MultiReduceDataCuda>::value>* = nullptr>
+  MultiReduceDataCuda(Container const& container,
+                      T identity,
+                      bool use_device_storage)
+      : m_parent(this),
+        m_sync_list(new SyncList),
+        m_data(container, identity, use_device_storage),
+        m_own_launch_data(false)
+  {}
+
   //! copy and on host attempt to setup for device
   //  init val_ptr to avoid uninitialized read caused by host copy of
   //  reducer in host device lambda not being used on device.
@@ -720,7 +824,7 @@ public:
 #if !defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
       : m_parent(other.m_parent)
 #else
-      : m_parent(&other)
+      : m_parent(const_cast<MultiReduceDataCuda*>(&other))
 #endif
         ,
         m_sync_list(other.m_sync_list),
@@ -732,9 +836,9 @@ public:
     {
       if (setupReducers())
       {
-        // the copy made in make_launch_body does this setup
         add_resource_to_synchronization_list(currentResource());
-        m_data.setup_launch(currentBlockSize());
+        m_parent->m_data.setup_launch(currentBlockSize());
+        m_data            = m_parent->m_data;
         m_own_launch_data = true;
         m_parent          = nullptr;
       }
@@ -766,15 +870,11 @@ public:
       m_sync_list = nullptr;
       m_data.teardown_permanent();
     }
-    else if (m_parent)
-    {
-      // do nothing
-    }
-    else
+    else if (!m_parent)
     {
       if (m_own_launch_data)
       {
-        // the copy made in make_launch_body, owns launch data
+        synchronize_resources_and_clear_list();
         m_data.teardown_launch();
         m_own_launch_data = false;
       }
@@ -819,7 +919,7 @@ public:
 
 
 private:
-  MultiReduceDataCuda const* m_parent;
+  MultiReduceDataCuda* m_parent;
   SyncList* m_sync_list;
   reduce_data_type m_data;
   bool m_own_launch_data;

--- a/include/RAJA/policy/hip/multi_reduce.hpp
+++ b/include/RAJA/policy/hip/multi_reduce.hpp
@@ -37,6 +37,7 @@
 #include "hip/hip_runtime.h"
 
 #include "RAJA/util/macros.hpp"
+#include "RAJA/util/basic_mempool.hpp"
 #include "RAJA/util/math.hpp"
 #include "RAJA/util/types.hpp"
 #include "RAJA/util/reduce.hpp"
@@ -220,13 +221,41 @@ struct MultiReduceGridAtomicHostInit_TallyData
   MultiReduceGridAtomicHostInit_TallyData(Container const& container,
                                           T const& identity)
       : m_tally_mem(nullptr),
+        m_host_tally_mem(nullptr),
+        m_device_tally_mem(nullptr),
         m_identity(identity),
         m_num_bins(container.size()),
         m_tally_bins(get_tally_bins(m_num_bins)),
-        m_tally_replication(get_tally_replication())
+        m_tally_replication(get_tally_replication()),
+        m_host_valid(true),
+        m_device_valid(false),
+        m_use_device_storage(true)
   {
     m_tally_mem = create_tally(container, identity, m_num_bins, m_tally_bins,
-                               m_tally_replication);
+                               m_tally_replication, true);
+    m_host_tally_mem   = m_tally_mem;
+    m_device_tally_mem = nullptr;
+  }
+
+  template<typename Container>
+  MultiReduceGridAtomicHostInit_TallyData(Container const& container,
+                                          T const& identity,
+                                          bool use_device_storage)
+      : m_tally_mem(nullptr),
+        m_host_tally_mem(nullptr),
+        m_device_tally_mem(nullptr),
+        m_identity(identity),
+        m_num_bins(container.size()),
+        m_tally_bins(get_tally_bins(m_num_bins)),
+        m_tally_replication(get_tally_replication()),
+        m_host_valid(true),
+        m_device_valid(false),
+        m_use_device_storage(use_device_storage)
+  {
+    m_tally_mem = create_tally(container, identity, m_num_bins, m_tally_bins,
+                               m_tally_replication, use_device_storage);
+    m_host_tally_mem   = m_tally_mem;
+    m_device_tally_mem = nullptr;
   }
 
   MultiReduceGridAtomicHostInit_TallyData() = delete;
@@ -252,7 +281,11 @@ struct MultiReduceGridAtomicHostInit_TallyData
       m_tally_bins        = get_tally_bins(m_num_bins);
       m_tally_replication = get_tally_replication();
       m_tally_mem = create_tally(container, identity, m_num_bins, m_tally_bins,
-                                 m_tally_replication);
+                                 m_tally_replication, m_use_device_storage);
+      m_host_tally_mem   = m_tally_mem;
+      m_device_tally_mem = nullptr;
+      m_host_valid       = true;
+      m_device_valid     = false;
     }
     else
     {
@@ -274,6 +307,7 @@ struct MultiReduceGridAtomicHostInit_TallyData
                                         m_tally_replication)] = identity;
         }
       }
+      m_host_valid = true;
     }
     m_identity = identity;
   }
@@ -281,8 +315,20 @@ struct MultiReduceGridAtomicHostInit_TallyData
   //! teardown permanent settings, free tally memory
   void teardown_permanent()
   {
-    destroy_tally(m_tally_mem, m_num_bins, m_tally_bins, m_tally_replication);
+    destroy_tally(m_tally_mem, m_num_bins, m_tally_bins, m_tally_replication,
+                  m_use_device_storage);
+    m_tally_mem        = nullptr;
+    m_host_tally_mem   = nullptr;
+    m_device_tally_mem = nullptr;
+    m_host_valid       = false;
+    m_device_valid     = false;
   }
+
+  //! setup per launch, switch tally storage to device memory
+  void setup_launch() { m_tally_mem = m_host_tally_mem; }
+
+  //! teardown per launch, restore host tally storage
+  void teardown_launch() { m_tally_mem = m_host_tally_mem; }
 
   //! get value for bin, assumes synchronization occurred elsewhere
   T get(int bin) const
@@ -310,8 +356,10 @@ private:
   static constexpr size_t s_tally_bunch_size =
       RAJA_DIVIDE_CEILING_INT(s_tally_alignment, sizeof(T));
 
-  using tally_mempool_type = device_pinned_mempool_type;
-  using tally_tuning       = typename tuning::GlobalAtomicReplicationTuning;
+  using tally_mempool_type =
+      basic_mempool::MemPool<basic_mempool::generic_allocator>;
+  using launch_tally_mempool_type = device_pinned_mempool_type;
+  using tally_tuning = typename tuning::GlobalAtomicReplicationTuning;
   using TallyAtomicReplicationConcretizer =
       typename tally_tuning::AtomicReplicationConcretizer;
   using GetTallyOffset_rebind_rebunch = typename tally_tuning::OffsetCalculator;
@@ -343,15 +391,25 @@ private:
                          T const& identity,
                          int num_bins,
                          int tally_bins,
-                         int tally_replication)
+                         int tally_replication,
+                         bool use_device_storage)
   {
     if (num_bins == size_t(0))
     {
       return nullptr;
     }
 
-    T* tally_mem = tally_mempool_type::getInstance().template malloc<T>(
-        tally_replication * tally_bins, s_tally_alignment);
+    T* tally_mem = nullptr;
+    if (use_device_storage)
+    {
+      tally_mem = launch_tally_mempool_type::getInstance().template malloc<T>(
+          tally_replication * tally_bins, s_tally_alignment);
+    }
+    else
+    {
+      tally_mem = tally_mempool_type::getInstance().template malloc<T>(
+          tally_replication * tally_bins, s_tally_alignment);
+    }
 
     if (tally_replication > 0)
     {
@@ -379,10 +437,17 @@ private:
     return tally_mem;
   }
 
+  size_t tally_bytes() const
+  {
+    return static_cast<size_t>(m_tally_replication) *
+           static_cast<size_t>(m_tally_bins) * sizeof(T);
+  }
+
   static void destroy_tally(T*& tally_mem,
                             int num_bins,
                             int tally_bins,
-                            int tally_replication)
+                            int tally_replication,
+                            bool use_device_storage)
   {
     if (num_bins == size_t(0))
     {
@@ -398,7 +463,14 @@ private:
         tally_mem[tally_offset].~T();
       }
     }
-    tally_mempool_type::getInstance().free(tally_mem);
+    if (use_device_storage)
+    {
+      launch_tally_mempool_type::getInstance().free(tally_mem);
+    }
+    else
+    {
+      tally_mempool_type::getInstance().free(tally_mem);
+    }
     tally_mem = nullptr;
   }
 
@@ -407,11 +479,16 @@ protected:
   using GetTallyOffset = typename GetTallyOffset_rebind::template rebind<int>;
 
   T* m_tally_mem;
+  T* m_host_tally_mem;
+  T* m_device_tally_mem;
   T m_identity;
   int m_num_bins;
   int m_tally_bins;
   int m_tally_replication;  // power of 2, at least the max number of omp
                             // threads
+  bool m_host_valid;
+  bool m_device_valid;
+  bool m_use_device_storage;
 };
 
 //! MultiReduction data for Hip Offload -- stores value, host pointer
@@ -433,11 +510,14 @@ struct MultiReduceGridAtomicHostInit_Data
   using TallyData::TallyData;
   using TallyData::teardown_permanent;
 
-  //! setup per launch, do nothing
-  void setup_launch(size_t RAJA_UNUSED_ARG(block_size)) {}
+  //! setup per launch, switch tally storage to device memory
+  void setup_launch(size_t RAJA_UNUSED_ARG(block_size))
+  {
+    TallyData::setup_launch();
+  }
 
-  //! teardown per launch, do nothing
-  void teardown_launch() {}
+  //! teardown per launch, restore host tally storage
+  void teardown_launch() { TallyData::teardown_launch(); }
 
   //! setup on device, do nothing
   RAJA_DEVICE
@@ -496,6 +576,15 @@ struct MultiReduceBlockThenGridAtomicHostInit_Data
         m_shared_replication(0)
   {}
 
+  template<typename Container>
+  MultiReduceBlockThenGridAtomicHostInit_Data(Container const& container,
+                                              T const& identity,
+                                              bool use_device_storage)
+      : TallyData(container, identity, use_device_storage),
+        m_shared_offset(s_shared_offset_unknown),
+        m_shared_replication(0)
+  {}
+
   MultiReduceBlockThenGridAtomicHostInit_Data() = delete;
   MultiReduceBlockThenGridAtomicHostInit_Data(
       MultiReduceBlockThenGridAtomicHostInit_Data const&) = default;
@@ -518,6 +607,7 @@ struct MultiReduceBlockThenGridAtomicHostInit_Data
   //! setup per launch, setup shared memory parameters
   void setup_launch(size_t block_size)
   {
+    TallyData::setup_launch();
     if (m_num_bins == size_t(0))
     {
       m_shared_offset = s_shared_offset_invalid;
@@ -553,6 +643,7 @@ struct MultiReduceBlockThenGridAtomicHostInit_Data
   //! teardown per launch, unset shared memory parameters
   void teardown_launch()
   {
+    TallyData::teardown_launch();
     m_shared_replication = 0;
     m_shared_offset      = s_shared_offset_unknown;
   }
@@ -671,6 +762,8 @@ private:
 template<typename T, typename t_MultiReduceOp, typename tuning>
 struct MultiReduceDataHip
 {
+  static constexpr bool supports_runtime_resource_storage = true;
+
   static constexpr bool atomic_available =
       RAJA::reduce::hip::hip_atomic_available<T>::value;
 
@@ -712,6 +805,18 @@ public:
         m_own_launch_data(false)
   {}
 
+  template<typename Container,
+           std::enable_if_t<
+               !std::is_same<Container, MultiReduceDataHip>::value>* = nullptr>
+  MultiReduceDataHip(Container const& container,
+                     T identity,
+                     bool use_device_storage)
+      : m_parent(this),
+        m_sync_list(new SyncList),
+        m_data(container, identity, use_device_storage),
+        m_own_launch_data(false)
+  {}
+
   //! copy and on host attempt to setup for device
   //  init val_ptr to avoid uninitialized read caused by host copy of
   //  reducer in host device lambda not being used on device.
@@ -720,7 +825,7 @@ public:
 #if !defined(RAJA_GPU_DEVICE_COMPILE_PASS_ACTIVE)
       : m_parent(other.m_parent)
 #else
-      : m_parent(&other)
+      : m_parent(const_cast<MultiReduceDataHip*>(&other))
 #endif
         ,
         m_sync_list(other.m_sync_list),
@@ -732,9 +837,9 @@ public:
     {
       if (setupReducers())
       {
-        // the copy made in make_launch_body does this setup
         add_resource_to_synchronization_list(currentResource());
-        m_data.setup_launch(currentBlockSize());
+        m_parent->m_data.setup_launch(currentBlockSize());
+        m_data            = m_parent->m_data;
         m_own_launch_data = true;
         m_parent          = nullptr;
       }
@@ -766,15 +871,11 @@ public:
       m_sync_list = nullptr;
       m_data.teardown_permanent();
     }
-    else if (m_parent)
-    {
-      // do nothing
-    }
-    else
+    else if (!m_parent)
     {
       if (m_own_launch_data)
       {
-        // the copy made in make_launch_body, owns launch data
+        synchronize_resources_and_clear_list();
         m_data.teardown_launch();
         m_own_launch_data = false;
       }
@@ -819,7 +920,7 @@ public:
 
 
 private:
-  MultiReduceDataHip const* m_parent;
+  MultiReduceDataHip* m_parent;
   SyncList* m_sync_list;
   reduce_data_type m_data;
   bool m_own_launch_data;

--- a/include/RAJA/policy/hip/multi_reduce.hpp
+++ b/include/RAJA/policy/hip/multi_reduce.hpp
@@ -221,20 +221,14 @@ struct MultiReduceGridAtomicHostInit_TallyData
   MultiReduceGridAtomicHostInit_TallyData(Container const& container,
                                           T const& identity)
       : m_tally_mem(nullptr),
-        m_host_tally_mem(nullptr),
-        m_device_tally_mem(nullptr),
         m_identity(identity),
         m_num_bins(container.size()),
         m_tally_bins(get_tally_bins(m_num_bins)),
         m_tally_replication(get_tally_replication()),
-        m_host_valid(true),
-        m_device_valid(false),
         m_use_device_storage(true)
   {
     m_tally_mem = create_tally(container, identity, m_num_bins, m_tally_bins,
                                m_tally_replication, true);
-    m_host_tally_mem   = m_tally_mem;
-    m_device_tally_mem = nullptr;
   }
 
   template<typename Container>
@@ -242,20 +236,14 @@ struct MultiReduceGridAtomicHostInit_TallyData
                                           T const& identity,
                                           bool use_device_storage)
       : m_tally_mem(nullptr),
-        m_host_tally_mem(nullptr),
-        m_device_tally_mem(nullptr),
         m_identity(identity),
         m_num_bins(container.size()),
         m_tally_bins(get_tally_bins(m_num_bins)),
         m_tally_replication(get_tally_replication()),
-        m_host_valid(true),
-        m_device_valid(false),
         m_use_device_storage(use_device_storage)
   {
     m_tally_mem = create_tally(container, identity, m_num_bins, m_tally_bins,
                                m_tally_replication, use_device_storage);
-    m_host_tally_mem   = m_tally_mem;
-    m_device_tally_mem = nullptr;
   }
 
   MultiReduceGridAtomicHostInit_TallyData() = delete;
@@ -282,10 +270,6 @@ struct MultiReduceGridAtomicHostInit_TallyData
       m_tally_replication = get_tally_replication();
       m_tally_mem = create_tally(container, identity, m_num_bins, m_tally_bins,
                                  m_tally_replication, m_use_device_storage);
-      m_host_tally_mem   = m_tally_mem;
-      m_device_tally_mem = nullptr;
-      m_host_valid       = true;
-      m_device_valid     = false;
     }
     else
     {
@@ -307,7 +291,6 @@ struct MultiReduceGridAtomicHostInit_TallyData
                                         m_tally_replication)] = identity;
         }
       }
-      m_host_valid = true;
     }
     m_identity = identity;
   }
@@ -317,18 +300,14 @@ struct MultiReduceGridAtomicHostInit_TallyData
   {
     destroy_tally(m_tally_mem, m_num_bins, m_tally_bins, m_tally_replication,
                   m_use_device_storage);
-    m_tally_mem        = nullptr;
-    m_host_tally_mem   = nullptr;
-    m_device_tally_mem = nullptr;
-    m_host_valid       = false;
-    m_device_valid     = false;
+    m_tally_mem = nullptr;
   }
 
-  //! setup per launch, switch tally storage to device memory
-  void setup_launch() { m_tally_mem = m_host_tally_mem; }
+  //! setup per launch, no tally changes needed for global atomic storage
+  void setup_launch() {}
 
-  //! teardown per launch, restore host tally storage
-  void teardown_launch() { m_tally_mem = m_host_tally_mem; }
+  //! teardown per launch, no tally changes needed for global atomic storage
+  void teardown_launch() {}
 
   //! get value for bin, assumes synchronization occurred elsewhere
   T get(int bin) const
@@ -437,12 +416,6 @@ private:
     return tally_mem;
   }
 
-  size_t tally_bytes() const
-  {
-    return static_cast<size_t>(m_tally_replication) *
-           static_cast<size_t>(m_tally_bins) * sizeof(T);
-  }
-
   static void destroy_tally(T*& tally_mem,
                             int num_bins,
                             int tally_bins,
@@ -479,15 +452,11 @@ protected:
   using GetTallyOffset = typename GetTallyOffset_rebind::template rebind<int>;
 
   T* m_tally_mem;
-  T* m_host_tally_mem;
-  T* m_device_tally_mem;
   T m_identity;
   int m_num_bins;
   int m_tally_bins;
   int m_tally_replication;  // power of 2, at least the max number of omp
                             // threads
-  bool m_host_valid;
-  bool m_device_valid;
   bool m_use_device_storage;
 };
 
@@ -510,13 +479,13 @@ struct MultiReduceGridAtomicHostInit_Data
   using TallyData::TallyData;
   using TallyData::teardown_permanent;
 
-  //! setup per launch, switch tally storage to device memory
+  //! setup per launch, no tally changes needed for global atomic storage
   void setup_launch(size_t RAJA_UNUSED_ARG(block_size))
   {
     TallyData::setup_launch();
   }
 
-  //! teardown per launch, restore host tally storage
+  //! teardown per launch, no tally changes needed for global atomic storage
   void teardown_launch() { TallyData::teardown_launch(); }
 
   //! setup on device, do nothing
@@ -838,8 +807,7 @@ public:
       if (setupReducers())
       {
         add_resource_to_synchronization_list(currentResource());
-        m_parent->m_data.setup_launch(currentBlockSize());
-        m_data            = m_parent->m_data;
+        m_data.setup_launch(currentBlockSize());
         m_own_launch_data = true;
         m_parent          = nullptr;
       }
@@ -875,7 +843,6 @@ public:
     {
       if (m_own_launch_data)
       {
-        synchronize_resources_and_clear_list();
         m_data.teardown_launch();
         m_own_launch_data = false;
       }

--- a/include/RAJA/policy/openmp/multi_reduce.hpp
+++ b/include/RAJA/policy/openmp/multi_reduce.hpp
@@ -77,6 +77,8 @@ struct MultiReduceDataOMP<
     RAJA::omp::MultiReduceTuning<
         RAJA::omp::multi_reduce_algorithm::combine_on_destruction>>
 {
+  static constexpr bool supports_runtime_resource_storage = false;
+
   using value_type    = T;
   using MultiReduceOp = t_MultiReduceOp;
 
@@ -212,6 +214,8 @@ struct MultiReduceDataOMP<
     RAJA::omp::MultiReduceTuning<
         RAJA::omp::multi_reduce_algorithm::combine_on_get>>
 {
+  static constexpr bool supports_runtime_resource_storage = false;
+
   using value_type    = T;
   using MultiReduceOp = t_MultiReduceOp;
 

--- a/include/RAJA/policy/sequential/multi_reduce.hpp
+++ b/include/RAJA/policy/sequential/multi_reduce.hpp
@@ -68,6 +68,8 @@ struct MultiReduceDataSeq<
     RAJA::sequential::MultiReduceTuning<
         RAJA::sequential::multi_reduce_algorithm::left_fold>>
 {
+  static constexpr bool supports_runtime_resource_storage = false;
+
   using value_type    = T;
   using MultiReduceOp = t_MultiReduceOp;
 


### PR DESCRIPTION
# Summary

@MrBurmark @tomstitt  -- working with agents -- in support of issue https://github.com/llnl/RAJA/issues/1756 what if we consider using the RAJA::resource to choose the backing of the memory for the multi-reducers?

I acknowledge that the request asks for "dynamically choose their allocator based on the kernel they are captured by, similar to regular GPU RAJA reducer" but perhaps using a resource could work too? 

  - Added runtime-resource-aware MultiReduce constructors so multi-reducers can be initialized with the same runtime-selected resource used for execution/input allocation.
  - Updated CUDA/HIP multi-reduce tally allocation to choose host-accessible or device-accessible storage based on the resource platform.
  - Added a runtime multi-reduction example using dynamic_forall for host/device selection.

  Device Buffer Allocation Behavior

  - Previously, CUDA/HIP multi-reducers always allocated tally buffers from the device-accessible pinned/device mempool, regardless of runtime execution path.
  - Now, CUDA/HIP multi-reducers constructed with a runtime resource choose allocation backend from res.get_platform():
      - device resource: existing device-accessible tally mempool, matching previous device behavior
      - host resource: generic host mempool, avoiding device-style tally allocation for host runtime execution

  - The reducer does not allocate directly through res.allocate(); the resource is used to select the appropriate existing tally buffer backend.