### PR TITLE
Bugfix/smith84/specify windows cmake version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,7 @@ jobs:
       - uses: threeal/cmake-action@v1.3.0
         with:
           build-dir: build
+          generator: 'Visual Studio 17 2022'     # force VS generator so MSVC is used instead of NMake
           options:
             ENABLE_WARNINGS_AS_ERRORS=Off
             BLT_CXX_STD="c++20"
@@ -78,4 +79,4 @@ jobs:
 ## Run tests action
       - uses: threeal/ctest-action@v1.1.0
         with:
-          build-config: Debug
+          build-config: Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         - args: BUILD_SHARED_LIBS=Off
           
 
-    runs-on: windows-2022
+    runs-on: windows-2025
     steps:
       - uses: actions/checkout@v2
         with:
@@ -54,7 +54,7 @@ jobs:
 
 ## Back off version of cmake with known issue
       - name: Install CMake 3.29
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@e690607b2b7d42cf38fbb2ecbb6e568ebcd57291  # v4.4.0
         with:
           cmakeVersion: "~3.29.0"
 
@@ -63,7 +63,7 @@ jobs:
       - uses: threeal/cmake-action@v1.3.0
         with:
           build-dir: build
-          generator: 'Visual Studio 17 2022'     # force VS generator so MSVC is used instead of NMake
+          generator: 'Visual Studio 18 2026'     # force VS generator so MSVC is used instead of NMake
           options:
             ENABLE_WARNINGS_AS_ERRORS=Off
             BLT_CXX_STD="c++20"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,8 @@ jobs:
             CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=On
         - args: BUILD_SHARED_LIBS=Off
           
-    runs-on: windows-latest
+
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: threeal/cmake-action@v1.3.0
         with:
           build-dir: build
-          generator: 'Visual Studio 18 2026'     # force VS generator so MSVC is used instead of NMake
+          generator: 'Visual Studio 17 2022'     # force VS generator so MSVC is used instead of NMake
           options:
             ENABLE_WARNINGS_AS_ERRORS=Off
             BLT_CXX_STD="c++20"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,11 +50,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+
+## Back off version of cmake with known issue
+      - name: Install CMake 3.29
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.29.0"
+
 ## ====================================
 ## Config and build action
       - uses: threeal/cmake-action@v1.3.0
         with:
-          cmake-version: '3.29.x'  # Back off version of cmake with known issue
           build-dir: build
           options:
             ENABLE_WARNINGS_AS_ERRORS=Off

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-	  
+
 ## Back off version of cmake with known issue
       - name: Install CMake 3.29
         uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3  # v4.4.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+	  
+## Back off version of cmake with known issue
+      - name: Install CMake 3.29
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3  # v4.4.0
+        with:
+          cmakeVersion: "~3.29.0"
+
       - uses: threeal/cmake-action@v1.3.0
         with:
           build-dir: build
@@ -54,7 +61,7 @@ jobs:
 
 ## Back off version of cmake with known issue
       - name: Install CMake 3.29
-        uses: lukka/get-cmake@e690607b2b7d42cf38fbb2ecbb6e568ebcd57291  # v4.4.0
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3  # v4.4.0
         with:
           cmakeVersion: "~3.29.0"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,9 +51,14 @@ jobs:
             BUILD_SHARED_LIBS=On 
             CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=On
         - args: BUILD_SHARED_LIBS=Off
-          
 
-    runs-on: windows-2025
+
+# Notes on Windows CI
+# The windows-2025 runner has converted to Visual Studio (VS) 2026.
+# cmake added VS 2026 support in cmake v4.2, we had issues with cmake 4.4 related to JSON parsing.
+# Testing is currently done on the windows-2022 runner with VS 2022 until the issue can
+# be resolved.
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,4 +80,4 @@ jobs:
 ## Run tests action
       - uses: threeal/ctest-action@v1.1.0
         with:
-          build-config: Release
+          build-config: Debug


### PR DESCRIPTION
- This PR is a bugfix, the windows CI jobs were failing intermittently.  Windows job was run multiple times with this patch and failure was not observed.   
  - Pin the cmake version to older 3,28,X due to issue with cmake 4.4 in the windows image
    - Previous change did not change the cmake version https://github.com/llnl/RAJA/commit/637cd1b6352f0132a2cf40a84d1a9f36c99e974f.  The variable did not change the cmake version.
  - Pin the windows image to Visual Studio 2022 
     - windows-latest was updated to Visual Studio 2026

Additional Windows testing is proposed in issue #2067 to add both Visual Studio 2022 and 2026 and CUDA. 



