### PR TITLE
Add a way to free internal memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ set (raja_sources
   src/AlignedRangeIndexSetBuilders.cpp
   src/DepGraphNode.cpp
   src/LockFreeIndexSetBuilders.cpp
+  src/Memory.cpp
   src/MemUtils_CUDA.cpp
   src/MemUtils_HIP.cpp
   src/PluginStrategy.cpp)

--- a/docs/sphinx/user_guide/feature/multi-reduction.rst
+++ b/docs/sphinx/user_guide/feature/multi-reduction.rst
@@ -47,6 +47,11 @@ Please see the following cook book sections for guidance on policy usage:
 
  * :ref:`cook-book-multi-reductions-label`.
 
+Some backend multi-reduction implementations may use RAJA internal temporary
+storage. Please see the following section for guidance on releasing unused
+internal memory:
+
+ * :ref:`memory-release-internal-pool-label`.
 
 --------------------
 MultiReduction Types

--- a/docs/sphinx/user_guide/feature/reduction.rst
+++ b/docs/sphinx/user_guide/feature/reduction.rst
@@ -53,6 +53,11 @@ Please see the following cook book sections for guidance on policy usage:
 
  * :ref:`cook-book-reductions-label`.
 
+Some backend reduction implementations may use RAJA internal temporary storage.
+Please see the following section for guidance on releasing unused internal
+memory:
+
+ * :ref:`memory-release-internal-pool-label`.
 
 ----------------
 Reduction Types

--- a/docs/sphinx/user_guide/feature/scan.rst
+++ b/docs/sphinx/user_guide/feature/scan.rst
@@ -43,6 +43,12 @@ RAJA scan operations:
 
  * :ref:`tut-scan-label`.
 
+Some backend scan implementations may use RAJA internal temporary storage.
+Please see the following section for guidance on releasing unused internal
+memory:
+
+ * :ref:`memory-release-internal-pool-label`.
+
 -----------------
 Scan Operations
 -----------------

--- a/docs/sphinx/user_guide/feature/sort.rst
+++ b/docs/sphinx/user_guide/feature/sort.rst
@@ -47,6 +47,12 @@ RAJA scan operations:
 
  * :ref:`tut-sort-label`
 
+Some backend sort implementations may use RAJA internal temporary storage.
+Please see the following section for guidance on releasing unused internal
+memory:
+
+ * :ref:`memory-release-internal-pool-label`.
+
 -----------------
 Sort Operations
 -----------------

--- a/docs/sphinx/user_guide/index.rst
+++ b/docs/sphinx/user_guide/index.rst
@@ -35,5 +35,6 @@ to use RAJA in an application can be found in :ref:`app-considerations-label`.
    features
    cook_book
    profiling_with_caliper
+   memory
    app_considerations
    tutorial

--- a/docs/sphinx/user_guide/memory.rst
+++ b/docs/sphinx/user_guide/memory.rst
@@ -22,9 +22,13 @@ Some RAJA backend operations, including reductions, scans, and sorts, may use
 temporary storage. RAJA keeps some of this storage for reuse in internal memory
 pools. Applications can call ``RAJA::release_unused_internal_memory()`` after
 outstanding RAJA and device work has completed to return unused internal memory
-to the backend allocator.
+to the backend allocator. Typical use is to call the function at application shutdown
+to prevent the internal memory pools from appearing in memory-leak reports. Frequent
+runtime calls are generally unnecessary because the pools are retained for reuse are
+typically not large.
 
 The function returns the number of bytes released and does not synchronize
 CUDA, HIP, or SYCL work. RAJA does not do this automatically during static
 destruction because CUDA and HIP runtime teardown can make late ``cudaFree`` or
-``hipFree`` calls fail.  As such, this function must only be called before the end of main to avoid racing with backend runtime cleanup.
+``hipFree`` calls fail. As such, this function must only be called before the
+end of main to avoid racing with backend runtime cleanup.

--- a/docs/sphinx/user_guide/memory.rst
+++ b/docs/sphinx/user_guide/memory.rst
@@ -27,4 +27,4 @@ to the backend allocator.
 The function returns the number of bytes released and does not synchronize
 CUDA, HIP, or SYCL work. RAJA does not do this automatically during static
 destruction because CUDA and HIP runtime teardown can make late ``cudaFree`` or
-``hipFree`` calls fail.
+``hipFree`` calls fail.  As such, this function must only be called before the end of main to avoid racing with backend runtime cleanup.

--- a/docs/sphinx/user_guide/memory.rst
+++ b/docs/sphinx/user_guide/memory.rst
@@ -24,7 +24,7 @@ pools. Applications can call ``RAJA::release_unused_internal_memory()`` after
 outstanding RAJA and device work has completed to return unused internal memory
 to the backend allocator. Typical use is to call the function at application shutdown
 to prevent the internal memory pools from appearing in memory-leak reports. Frequent
-runtime calls are generally unnecessary because the pools are retained for reuse are
+runtime calls are generally unnecessary because the pools retained for reuse are
 typically not large.
 
 The function returns the number of bytes released and does not synchronize

--- a/docs/sphinx/user_guide/memory.rst
+++ b/docs/sphinx/user_guide/memory.rst
@@ -1,0 +1,30 @@
+.. ##
+.. ## Copyright (c) Lawrence Livermore National Security, LLC and other
+.. ## RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+.. ## files for dates and other details. No copyright assignment is required
+.. ## to contribute to RAJA.
+.. ##
+.. ## SPDX-License-Identifier: (BSD-3-Clause)
+.. ##
+
+.. _memory-label:
+
+******
+Memory
+******
+
+.. _memory-release-internal-pool-label:
+
+Releasing RAJA Internal Pool Memory
+===================================
+
+Some RAJA backend operations, including reductions, scans, and sorts, may use
+temporary storage. RAJA keeps some of this storage for reuse in internal memory
+pools. Applications can call ``RAJA::release_unused_internal_memory()`` after
+outstanding RAJA and device work has completed to return unused internal memory
+to the backend allocator.
+
+The function returns the number of bytes released and does not synchronize
+CUDA, HIP, or SYCL work. RAJA does not do this automatically during static
+destruction because CUDA and HIP runtime teardown can make late ``cudaFree`` or
+``hipFree`` calls fail.

--- a/include/RAJA/RAJA.hpp
+++ b/include/RAJA/RAJA.hpp
@@ -158,6 +158,11 @@
 #include "RAJA/util/BitMask.hpp"
 
 //
+// Memory utility routines
+//
+#include "RAJA/util/memory.hpp"
+
+//
 // sort algorithms
 //
 #include "RAJA/util/sort.hpp"

--- a/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
+++ b/include/RAJA/policy/cuda/MemUtils_CUDA.hpp
@@ -185,6 +185,17 @@ using device_pinned_mempool_type =
     basic_mempool::MemPool<DevicePinnedAllocator>;
 using pinned_mempool_type = basic_mempool::MemPool<PinnedAllocator>;
 
+RAJA_INLINE
+size_t release_unused_internal_memory()
+{
+  size_t released = 0;
+  released += device_mempool_type::getInstance().release_unused();
+  released += device_zeroed_mempool_type::getInstance().release_unused();
+  released += device_pinned_mempool_type::getInstance().release_unused();
+  released += pinned_mempool_type::getInstance().release_unused();
+  return released;
+}
+
 namespace detail
 {
 

--- a/include/RAJA/policy/hip/MemUtils_HIP.hpp
+++ b/include/RAJA/policy/hip/MemUtils_HIP.hpp
@@ -162,6 +162,17 @@ using device_pinned_mempool_type =
     basic_mempool::MemPool<DevicePinnedAllocator>;
 using pinned_mempool_type = basic_mempool::MemPool<PinnedAllocator>;
 
+RAJA_INLINE
+size_t release_unused_internal_memory()
+{
+  size_t released = 0;
+  released += device_mempool_type::getInstance().release_unused();
+  released += device_zeroed_mempool_type::getInstance().release_unused();
+  released += device_pinned_mempool_type::getInstance().release_unused();
+  released += pinned_mempool_type::getInstance().release_unused();
+  return released;
+}
+
 namespace detail
 {
 

--- a/include/RAJA/policy/sycl/MemUtils_SYCL.hpp
+++ b/include/RAJA/policy/sycl/MemUtils_SYCL.hpp
@@ -121,6 +121,15 @@ using device_zeroed_mempool_type =
     basic_mempool::MemPool<DeviceZeroedAllocator>;
 using pinned_mempool_type = basic_mempool::MemPool<PinnedAllocator>;
 
+inline size_t release_unused_internal_memory()
+{
+  size_t released = 0;
+  released += device_mempool_type::getInstance().release_unused();
+  released += device_zeroed_mempool_type::getInstance().release_unused();
+  released += pinned_mempool_type::getInstance().release_unused();
+  return released;
+}
+
 }  // namespace sycl
 
 }  // namespace RAJA

--- a/include/RAJA/util/basic_mempool.hpp
+++ b/include/RAJA/util/basic_mempool.hpp
@@ -346,7 +346,7 @@ public:
   {
     std::lock_guard<std::mutex> lock(m_mutex);
 
-    size_t released = 0;
+    size_t released                     = 0;
     arena_container_type::iterator iter = m_arenas.begin();
     while (iter != m_arenas.end())
     {

--- a/include/RAJA/util/basic_mempool.hpp
+++ b/include/RAJA/util/basic_mempool.hpp
@@ -341,6 +341,31 @@ public:
     }
   }
 
+  /// Free only backing allocations that contain no live allocations
+  size_t release_unused()
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    size_t released = 0;
+    arena_container_type::iterator iter = m_arenas.begin();
+    while (iter != m_arenas.end())
+    {
+      if (iter->unused())
+      {
+        released += iter->capacity();
+        void* allocation_ptr = iter->get_allocation();
+        m_alloc.free(allocation_ptr);
+        iter = m_arenas.erase(iter);
+      }
+      else
+      {
+        ++iter;
+      }
+    }
+
+    return released;
+  }
+
   size_t arena_size()
   {
     std::lock_guard<std::mutex> lock(m_mutex);

--- a/include/RAJA/util/memory.hpp
+++ b/include/RAJA/util/memory.hpp
@@ -1,0 +1,42 @@
+/*!
+ ******************************************************************************
+ *
+ * \file
+ *
+ * \brief   RAJA memory utility routines.
+ *
+ ******************************************************************************
+ */
+
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef RAJA_memory_HPP
+#define RAJA_memory_HPP
+
+#include "RAJA/config.hpp"
+
+#include <cstddef>
+
+namespace RAJA
+{
+
+/*!
+ * \brief Release unused backing allocations from RAJA internal memory pools.
+ *
+ * This routine does not synchronize backend work. Callers must ensure that
+ * relevant RAJA and device work has completed before calling it.
+ *
+ * \return Total bytes released from enabled backend pools.
+ */
+RAJASHAREDDLL_API size_t release_unused_internal_memory();
+
+}  // namespace RAJA
+
+#endif  // RAJA_memory_HPP

--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -1,0 +1,54 @@
+/*!
+ ******************************************************************************
+ *
+ * \file
+ *
+ * \brief   Implementation file for RAJA memory utility routines.
+ *
+ ******************************************************************************
+ */
+
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "RAJA/util/memory.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+#include "RAJA/policy/cuda/MemUtils_CUDA.hpp"
+#endif
+
+#if defined(RAJA_ENABLE_HIP)
+#include "RAJA/policy/hip/MemUtils_HIP.hpp"
+#endif
+
+#if defined(RAJA_ENABLE_SYCL)
+#include "RAJA/policy/sycl/MemUtils_SYCL.hpp"
+#endif
+
+namespace RAJA
+{
+
+size_t release_unused_internal_memory()
+{
+  size_t released = 0;
+
+#if defined(RAJA_ENABLE_CUDA)
+  released += ::RAJA::cuda::release_unused_internal_memory();
+#endif
+#if defined(RAJA_ENABLE_HIP)
+  released += ::RAJA::hip::release_unused_internal_memory();
+#endif
+#if defined(RAJA_ENABLE_SYCL)
+  released += ::RAJA::sycl::release_unused_internal_memory();
+#endif
+
+  return released;
+}
+
+}  // namespace RAJA

--- a/test/unit/util/CMakeLists.txt
+++ b/test/unit/util/CMakeLists.txt
@@ -32,6 +32,10 @@ raja_add_test(
   SOURCES test-math.cpp)
 
 raja_add_test(
+  NAME test-basic-mempool
+  SOURCES test-basic-mempool.cpp)
+
+raja_add_test(
   NAME test-device-policy-aliases
   SOURCES test-device-policy-aliases.cpp)
 

--- a/test/unit/util/test-basic-mempool.cpp
+++ b/test/unit/util/test-basic-mempool.cpp
@@ -1,0 +1,84 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "RAJA/RAJA.hpp"
+
+#include "RAJA_gtest.hpp"
+
+namespace
+{
+
+using GenericMemPool =
+    RAJA::basic_mempool::MemPool<RAJA::basic_mempool::generic_allocator>;
+
+constexpr size_t test_arena_size = 128;
+
+}  // namespace
+
+TEST(BasicMemPool, release_unused_empty_pool)
+{
+  GenericMemPool pool;
+
+  ASSERT_EQ(pool.release_unused(), size_t {0});
+}
+
+TEST(BasicMemPool, release_unused_after_all_allocations_are_freed)
+{
+  GenericMemPool pool;
+  pool.arena_size(test_arena_size);
+
+  char* ptr = pool.malloc<char>(1);
+  ASSERT_NE(ptr, nullptr);
+  pool.free(ptr);
+
+  ASSERT_GE(pool.release_unused(), test_arena_size);
+  ASSERT_EQ(pool.release_unused(), size_t {0});
+
+  ptr = pool.malloc<char>(1);
+  ASSERT_NE(ptr, nullptr);
+  pool.free(ptr);
+
+  ASSERT_GE(pool.release_unused(), test_arena_size);
+  ASSERT_EQ(pool.release_unused(), size_t {0});
+}
+
+TEST(BasicMemPool, release_unused_keeps_arena_with_live_allocation)
+{
+  GenericMemPool pool;
+  pool.arena_size(test_arena_size);
+
+  char* first  = pool.malloc<char>(32);
+  ASSERT_NE(first, nullptr);
+
+  char* second = pool.malloc<char>(32);
+  ASSERT_NE(second, nullptr);
+  pool.free(second);
+
+  ASSERT_EQ(pool.release_unused(), size_t {0});
+
+  pool.free(first);
+
+  ASSERT_GE(pool.release_unused(), test_arena_size);
+}
+
+TEST(BasicMemPool, release_unused_internal_memory_public_api)
+{
+  const size_t released = RAJA::release_unused_internal_memory();
+  ASSERT_EQ(released, size_t {0});
+
+#if defined(RAJA_CUDA_ACTIVE)
+  (void)RAJA::cuda::release_unused_internal_memory();
+#endif
+#if defined(RAJA_HIP_ACTIVE)
+  (void)RAJA::hip::release_unused_internal_memory();
+#endif
+#if defined(RAJA_SYCL_ACTIVE)
+  (void)RAJA::sycl::release_unused_internal_memory();
+#endif
+}

--- a/test/unit/util/test-basic-mempool.cpp
+++ b/test/unit/util/test-basic-mempool.cpp
@@ -73,12 +73,12 @@ TEST(BasicMemPool, release_unused_internal_memory_public_api)
   ASSERT_EQ(released, size_t {0});
 
 #if defined(RAJA_CUDA_ACTIVE)
-  (void)RAJA::cuda::release_unused_internal_memory();
+  ASSERT_EQ(RAJA::cuda::release_unused_internal_memory(), size_t {0});
 #endif
 #if defined(RAJA_HIP_ACTIVE)
-  (void)RAJA::hip::release_unused_internal_memory();
+  ASSERT_EQ(RAJA::hip::release_unused_internal_memory(), size_t {0});
 #endif
 #if defined(RAJA_SYCL_ACTIVE)
-  (void)RAJA::sycl::release_unused_internal_memory();
+  ASSERT_EQ(RAJA::sycl::release_unused_internal_memory(), size_t {0});
 #endif
 }


### PR DESCRIPTION
# Summary

Add a way to free memory stored in RAJA's internal memory pools. We do not free this memory as routines like `cudaFree` and `hipFree` can not be called after main.

- This PR is a feature
- It does the following:
  - Adds optional memory cleanup at the request of various people over the years