### PR TITLE
Construct the ValLoc default location explicitly

### DIFF
--- a/include/RAJA/pattern/params/params_base.hpp
+++ b/include/RAJA/pattern/params/params_base.hpp
@@ -58,7 +58,9 @@ struct ValLoc
   RAJA_HOST_DEVICE void setLoc(IndexType inindex) { loc = inindex; }
 
   value_type val;
-  index_type loc = -1;
+  // Construct explicitly so that strongly typed indices, whose constructor
+  // from the underlying integer is explicit, can be used here as well.
+  index_type loc = index_type(-1);
 };
 
 template<typename T, template<typename, typename, typename> class Op>

--- a/test/unit/pattern/CMakeLists.txt
+++ b/test/unit/pattern/CMakeLists.txt
@@ -14,3 +14,7 @@ raja_add_test(
 raja_add_test(
   NAME test-launch-teams-threads-order
   SOURCES test-launch-teams-threads-order.cpp)
+
+raja_add_test(
+  NAME test-params-valloc
+  SOURCES test-params-valloc.cpp)

--- a/test/unit/pattern/test-params-valloc.cpp
+++ b/test/unit/pattern/test-params-valloc.cpp
@@ -1,0 +1,66 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Source file containing unit tests for RAJA::expt::ValLoc.
+///
+
+#include "RAJA/RAJA.hpp"
+#include "RAJA_gtest.hpp"
+
+RAJA_INDEX_VALUE(ValLocStrongIndex, "ValLocStrongIndex")
+
+TEST(ValLocUnitTest, DefaultLocIsUnsetForPlainIndex)
+{
+  RAJA::expt::ValLoc<double> vl(1.0);
+
+  ASSERT_EQ(vl.getVal(), 1.0);
+  ASSERT_EQ(vl.getLoc(), RAJA::Index_type(-1));
+}
+
+TEST(ValLocUnitTest, DefaultLocIsUnsetForStrongIndex)
+{
+  RAJA::expt::ValLoc<double, ValLocStrongIndex> vl(1.0);
+
+  ASSERT_EQ(vl.getVal(), 1.0);
+  ASSERT_EQ(*vl.getLoc(), -1);
+}
+
+TEST(ValLocUnitTest, StrongIndexCanBeSetAndRead)
+{
+  RAJA::expt::ValLoc<double, ValLocStrongIndex> vl(2.5, ValLocStrongIndex(3));
+
+  ASSERT_EQ(vl.getVal(), 2.5);
+  ASSERT_EQ(*vl.getLoc(), 3);
+
+  vl.set(4.5, ValLocStrongIndex(7));
+
+  ASSERT_EQ(vl.getVal(), 4.5);
+  ASSERT_EQ(*vl.getLoc(), 7);
+}
+
+TEST(ValLocUnitTest, StrongIndexWorksInAForallReduction)
+{
+  constexpr int N = 8;
+  double a[N] = {5.0, 3.0, 9.0, 1.0, 7.0, 2.0, 8.0, 4.0};
+
+  using VL = RAJA::expt::ValLoc<double, ValLocStrongIndex>;
+  using VLOp =
+      RAJA::expt::ValLocOp<double, ValLocStrongIndex, RAJA::operators::minimum>;
+
+  VL result(RAJA::operators::limits<double>::max(), ValLocStrongIndex(0));
+
+  RAJA::forall<RAJA::seq_exec>(
+      RAJA::TypedRangeSegment<ValLocStrongIndex>(0, N),
+      RAJA::expt::Reduce<RAJA::operators::minimum>(&result),
+      [=](ValLocStrongIndex i, VLOp& r) { r.minloc(a[*i], i); });
+
+  ASSERT_EQ(result.getVal(), 1.0);
+  ASSERT_EQ(*result.getLoc(), 3);
+}


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Modifies `RAJA::expt::ValLoc` so the default member initializer for `loc` constructs the index explicitly
  - Adds a `test-params-valloc` unit test covering a plain index, a strongly typed index, and a min-loc reduction over one
  - Fixes #2051

An index declared with `RAJA_INDEX_VALUE` has an explicit constructor from its underlying integer, so `index_type loc = -1;` does not compile once `ValLoc` is given one. Any param reduction carrying a location then fails to build, which is what the issue reports.

The smallest reproduction is a min-loc reduction over a range of a strong index:

```cpp
RAJA_INDEX_VALUE(MyIdx, "MyIdx")
using VL = RAJA::expt::ValLoc<double, MyIdx>;
VL result(RAJA::operators::limits<double>::max(), MyIdx(0));
```

That stops at `params_base.hpp:61` with `no viable conversion from 'int' to 'index_type'`, before any of the reduction machinery is reached.

I also tried adding `StrongIndexType` to `TestIdxTypeList` in the expt reduce tests, since that would cover this more broadly. It doesn't work as a small change: those test bodies index raw arrays with the loop index and compute `sizeof(DATA_TYPE) * data_len` from it, so making them index-type generic is a separate piece of work. The new unit test covers the reported failure without pulling that in.

Built and ran the sequential reducer and expt reduce tests, 12 executables, all passing.
